### PR TITLE
Add SpecialReportAlt card styles

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -4,7 +4,7 @@ import common.{Edition, LinkTo}
 import model.PressedPage
 import model.facia.PressedCollection
 import model.meta.{ItemList, ListItem}
-import model.pressed.{PressedContent, SpecialReportAlt}
+import model.pressed.PressedContent
 import play.api.mvc.RequestHeader
 import slices._
 

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -4,7 +4,7 @@ import common.{Edition, LinkTo}
 import model.PressedPage
 import model.facia.PressedCollection
 import model.meta.{ItemList, ListItem}
-import model.pressed.PressedContent
+import model.pressed.{PressedContent, SpecialReportAlt}
 import play.api.mvc.RequestHeader
 import slices._
 

--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport}
+import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport, SpecialReportAlt}
 import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 import com.gu.targeting.client.{Campaign, ReportFields}
 import com.gu.contentapi.client.model.v1.{Content => CapiContent}
@@ -14,6 +14,7 @@ object CardStylePicker {
     extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
       case _   => SpecialReport
+      case _   => SpecialReportAlt
     }
   }
 
@@ -22,6 +23,7 @@ object CardStylePicker {
     extractCampaigns(tags) match {
       case Nil => FaciaContentUtils.cardStyle(content)
       case _   => SpecialReport
+      case _   => SpecialReportAlt
     }
   }
 

--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -13,7 +13,7 @@ object CardStylePicker {
     val tags = content.tags.map(_.id).toSeq
     extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
-      case campaign:: _ => if(campaign.id.toString.toLowerCase() == "specialReportAlt") SpecialReportAlt else SpecialReport
+      case campaign:: _ => if(campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
       case _   => SpecialReport
     }
   }
@@ -22,7 +22,7 @@ object CardStylePicker {
     val tags = FaciaContentUtils.tags(content).map(_.id)
     extractCampaigns(tags) match {
       case Nil => FaciaContentUtils.cardStyle(content)
-      case campaign:: _ => if(campaign.id.toString.toLowerCase() == "specialReportAlt") SpecialReportAlt else SpecialReport
+      case campaign:: _ => if(campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
       case _   => SpecialReport
     }
   }

--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -13,7 +13,7 @@ object CardStylePicker {
     val tags = content.tags.map(_.id).toSeq
     extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
-//      case campaign:: _ => if(campaign.id.toString == "campaign id") SpecialReportAlt else SpecialReport
+      case campaign:: _ => if(campaign.id.toString.toLowerCase() == "specialReportAlt") SpecialReportAlt else SpecialReport
       case _   => SpecialReport
     }
   }
@@ -22,7 +22,7 @@ object CardStylePicker {
     val tags = FaciaContentUtils.tags(content).map(_.id)
     extractCampaigns(tags) match {
       case Nil => FaciaContentUtils.cardStyle(content)
-//      case campaign:: _ => if(campaign.id.toString == "campaign id") SpecialReportAlt else SpecialReport
+      case campaign:: _ => if(campaign.id.toString.toLowerCase() == "specialReportAlt") SpecialReportAlt else SpecialReport
       case _   => SpecialReport
     }
   }

--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport}
+import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport, SpecialReportAlt}
 import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 import com.gu.targeting.client.{Campaign, ReportFields}
 import com.gu.contentapi.client.model.v1.{Content => CapiContent}
@@ -9,10 +9,11 @@ import commercial.targeting.CampaignAgent
 
 object CardStylePicker {
 
-  def apply(content: CapiContent, trailMetaData: MetaDataCommonFields): CardStyle = {
+  def apply(content: CapiContent): CardStyle = {
     val tags = content.tags.map(_.id).toSeq
     extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
+//      case campaign:: _ => if(campaign.id.toString == "campaign id") SpecialReportAlt else SpecialReport
       case _   => SpecialReport
     }
   }
@@ -21,6 +22,7 @@ object CardStylePicker {
     val tags = FaciaContentUtils.tags(content).map(_.id)
     extractCampaigns(tags) match {
       case Nil => FaciaContentUtils.cardStyle(content)
+//      case campaign:: _ => if(campaign.id.toString == "campaign id") SpecialReportAlt else SpecialReport
       case _   => SpecialReport
     }
   }

--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -13,8 +13,9 @@ object CardStylePicker {
     val tags = content.tags.map(_.id).toSeq
     extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
-      case campaign:: _ => if(campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
-      case _   => SpecialReport
+      case campaign :: _ =>
+        if (campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
+      case _ => SpecialReport
     }
   }
 
@@ -22,8 +23,9 @@ object CardStylePicker {
     val tags = FaciaContentUtils.tags(content).map(_.id)
     extractCampaigns(tags) match {
       case Nil => FaciaContentUtils.cardStyle(content)
-      case campaign:: _ => if(campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
-      case _   => SpecialReport
+      case campaign :: _ =>
+        if (campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
+      case _ => SpecialReport
     }
   }
 

--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport, SpecialReportAlt}
+import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport}
 import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 import com.gu.targeting.client.{Campaign, ReportFields}
 import com.gu.contentapi.client.model.v1.{Content => CapiContent}
@@ -14,7 +14,6 @@ object CardStylePicker {
     extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
       case _   => SpecialReport
-      case _   => SpecialReportAlt
     }
   }
 
@@ -23,7 +22,6 @@ object CardStylePicker {
     extractCampaigns(tags) match {
       case Nil => FaciaContentUtils.cardStyle(content)
       case _   => SpecialReport
-      case _   => SpecialReportAlt
     }
   }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -416,7 +416,7 @@ object Content {
     val apifields = apiContent.fields
     val references: Map[String, String] =
       apiContent.references.map(ref => (ref.`type`, Reference.split(ref.id)._2)).toMap
-    val cardStyle: fapiutils.CardStyle = CardStylePicker(apiContent, TrailMetaData.empty)
+    val cardStyle: fapiutils.CardStyle = CardStylePicker(apiContent)
 
     Content(
       trail = trail,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -286,6 +286,7 @@ object ContentFormat {
       case "CulturePillar"      => CulturePillar
       case "LifestylePillar"    => LifestylePillar
       case "SpecialReportTheme" => SpecialReportTheme
+//      case "SpecialReportAltTheme" => SpecialReportAltTheme
       case "Labs"               => Labs
       case _                    => NewsPillar
     }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -280,15 +280,15 @@ object ContentFormat {
 
   def parseTheme(s: String): Theme =
     s match {
-      case "NewsPillar"         => NewsPillar
-      case "OpinionPillar"      => OpinionPillar
-      case "SportPillar"        => SportPillar
-      case "CulturePillar"      => CulturePillar
-      case "LifestylePillar"    => LifestylePillar
-      case "SpecialReportTheme" => SpecialReportTheme
+      case "NewsPillar"            => NewsPillar
+      case "OpinionPillar"         => OpinionPillar
+      case "SportPillar"           => SportPillar
+      case "CulturePillar"         => CulturePillar
+      case "LifestylePillar"       => LifestylePillar
+      case "SpecialReportTheme"    => SpecialReportTheme
       case "SpecialReportAltTheme" => SpecialReportAltTheme
-      case "Labs"               => Labs
-      case _                    => NewsPillar
+      case "Labs"                  => Labs
+      case _                       => NewsPillar
     }
 
   def parseDisplay(s: String): Display =

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -286,7 +286,7 @@ object ContentFormat {
       case "CulturePillar"      => CulturePillar
       case "LifestylePillar"    => LifestylePillar
       case "SpecialReportTheme" => SpecialReportTheme
-//      case "SpecialReportAltTheme" => SpecialReportAltTheme
+      case "SpecialReportAltTheme" => SpecialReportAltTheme
       case "Labs"               => Labs
       case _                    => NewsPillar
     }

--- a/common/app/services/FaciaContentConvert.scala
+++ b/common/app/services/FaciaContentConvert.scala
@@ -13,7 +13,7 @@ object FaciaContentConvert {
   def contentToFaciaContent(content: Content): PressedContent = {
     val frontendContent = model.Content(content)
     val trailMetaData = TrailMetaData.empty
-    val cardStyle = CardStylePicker(content, trailMetaData)
+    val cardStyle = CardStylePicker(content)
     val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData, cardStyle)
 
     val curated = fapi.CuratedContent(

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -5,6 +5,8 @@
 @import views.support.RenderClasses
 @import conf.switches.Switches.AusRegionSelector
 
+@import views.html.fragments.containers.facia_cards.slice
+@import views.html.fragments.containers.facia_cards.showMoreButton
 @(containerDefinition: layout.FaciaContainer,
   frontProperties: model.FrontProperties,
   maybeContainerModel: Option[ContainerModel],

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -193,6 +193,7 @@ object GetClasses {
     BreakingPalette -> "fc-container--breaking-palette",
     EventPalette -> "fc-container--event-palette",
     EventAltPalette -> "fc-container--event-alt-palette",
+    SpecialReportAltPalette -> "fc-container--special-report-alt-palette",
   )
 
   private def primaryPaletteTag(metadata: Seq[Metadata]): Option[Metadata] = {

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -1,6 +1,17 @@
 package views.support
 
-import com.gu.facia.client.models.{BreakingPalette, EventAltPalette, EventPalette, InvestigationPalette, LongRunningAltPalette, LongRunningPalette, Metadata, SombreAltPalette, SombrePalette}
+import com.gu.facia.client.models.{
+  BreakingPalette,
+  EventAltPalette,
+  EventPalette,
+  InvestigationPalette,
+  LongRunningAltPalette,
+  LongRunningPalette,
+  Metadata,
+  SombreAltPalette,
+  SombrePalette,
+  SpecialReportAltPalette,
+}
 import layout._
 import layout.slices._
 import model.pressed.{Audio, Gallery, SpecialReport, SpecialReportAlt, Video}

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -1,20 +1,9 @@
 package views.support
 
-import com.gu.facia.client.models.{
-  BreakingPalette,
-  EventAltPalette,
-  EventPalette,
-  InvestigationPalette,
-  LongRunningAltPalette,
-  LongRunningPalette,
-  Metadata,
-  SombreAltPalette,
-  SombrePalette,
-}
+import com.gu.facia.client.models.{BreakingPalette, EventAltPalette, EventPalette, InvestigationPalette, LongRunningAltPalette, LongRunningPalette, Metadata, SombreAltPalette, SombrePalette}
 import layout._
 import layout.slices._
-import model.pressed.{Audio, Gallery, SpecialReport, Video}
-import slices.{Dynamic, DynamicSlowMPU}
+import model.pressed.{Audio, Gallery, SpecialReport, SpecialReportAlt, Video}
 import play.api.mvc.RequestHeader
 import model.Pillar.RichPillar
 import model.ContentDesignType.RichContentDesignType
@@ -46,7 +35,7 @@ object GetClasses {
         ("fc-item--pillar-" + item.pillar.nameOrDefault, true),
         ("fc-item--type-" + item.designType.nameOrDefault, true),
         ("fc-item--pillar-special-report", item.cardStyle == SpecialReport),
-//        ("fc-item--pillar-special-report-alt", item.cardStyle == SpecialReportAlt),
+        ("fc-item--pillar-special-report-alt", item.cardStyle == SpecialReportAlt),
         ("fc-item--paid-content", item.branding.exists(_.isPaid)),
         ("fc-item--has-cutout", item.cutOut.isDefined),
         ("fc-item--has-no-image", !item.hasImage),

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -46,6 +46,7 @@ object GetClasses {
         ("fc-item--pillar-" + item.pillar.nameOrDefault, true),
         ("fc-item--type-" + item.designType.nameOrDefault, true),
         ("fc-item--pillar-special-report", item.cardStyle == SpecialReport),
+//        ("fc-item--pillar-special-report-alt", item.cardStyle == SpecialReportAlt),
         ("fc-item--paid-content", item.branding.exists(_.isPaid)),
         ("fc-item--has-cutout", item.cutOut.isDefined),
         ("fc-item--has-no-image", !item.hasImage),

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -77,6 +77,7 @@ object GetClasses {
         (sublinkMediaTypeClass(sublink).getOrElse(""), true),
         ("fc-sublink--pillar-" + sublink.pillar.nameOrDefault, true),
         ("fc-sublink--type-" + sublink.designType.nameOrDefault, true),
+        ("fc-sublink--pillar-special-report-alt", sublink.cardStyle == SpecialReportAlt),
       ),
     )
 

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -114,7 +114,7 @@ $sport-faded:            #f1f8fc;
 $culture-dark:           #6b5840;
 $culture-main:           #a1845c;
 $culture-bright:         #eacca0;
-    $culture-pastel:         #e7d4b9;
+$culture-pastel:         #e7d4b9;
 $culture-faded:          #fbf6ef;
 
 // Lifestyle (magenta)

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -139,6 +139,13 @@ $labs-main:              #69d1ca;
 // Special report ==============================================================
 $special-report-dark:    #3f464a;
 
+// Special report alt ==========================================================
+$special-report-alt-dark:         #2b2b2a;
+$special-report-alt-main:         #b9300a;
+$special-report-alt-bright:       #ff663d;
+$special-report-alt-pastel:       #ebe6e1;
+$special-report-alt-faded:        #f5f0eb;
+
 
 // Social icons ================================================================
 $social-facebook:        #3067a3;

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -114,7 +114,7 @@ $sport-faded:            #f1f8fc;
 $culture-dark:           #6b5840;
 $culture-main:           #a1845c;
 $culture-bright:         #eacca0;
-$culture-pastel:         #e7d4b9;
+    $culture-pastel:         #e7d4b9;
 $culture-faded:          #fbf6ef;
 
 // Lifestyle (magenta)

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -460,12 +460,16 @@ $pillars: (
 
         .fc-item__byline {
             display: inline;
-            color: $special-report-alt-dark;
+            color: $special-report-alt-dark !important;
         }
 
         .fc-item__kicker {
             color: $special-report-alt-dark !important;
 
+        }
+
+        .inline-icon {
+            fill: $special-report-alt-dark !important;
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -82,6 +82,20 @@ $pillars: (
         cutoutBackground: $highlight-main,
         invertedKicker: $highlight-main,
         liveColour: #ffffff
+    ),
+    special-report-alt: (
+        cardBackground: $special-report-alt-pastel,
+        lines: $special-report-alt-main,
+        kicker: $special-report-alt-bright,
+        headline: $special-report-alt-dark,
+        featureHeadline: $special-report-alt-dark,
+        byline: $special-report-alt-bright,
+        commentCount: $special-report-alt-dark,
+        headlineIcon: $special-report-alt-bright,
+        metaText: $special-report-alt-dark,
+        cutoutBackground: $special-report-alt-dark,
+        invertedKicker: $special-report-alt-bright,
+        liveColour: $special-report-alt-pastel
     )
 );
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -84,18 +84,18 @@ $pillars: (
         liveColour: #ffffff
     ),
     special-report-alt: (
-        cardBackground: $special-report-alt-pastel,
-        lines: $special-report-alt-main,
-        kicker: $special-report-alt-bright,
+        cardBackground: $special-report-alt-faded,
+        lines: $special-report-alt-dark,
+        kicker: $brightness-7,
         headline: $special-report-alt-dark,
         featureHeadline: $special-report-alt-dark,
-        byline: $special-report-alt-bright,
+        byline: $special-report-alt-dark,
         commentCount: $special-report-alt-dark,
-        headlineIcon: $special-report-alt-bright,
+        headlineIcon: $special-report-alt-dark,
         metaText: $special-report-alt-dark,
         cutoutBackground: $special-report-alt-dark,
-        invertedKicker: $special-report-alt-bright,
-        liveColour: $special-report-alt-pastel
+        invertedKicker: $brightness-7,
+        liveColour: $special-report-alt-faded
     )
 );
 
@@ -197,7 +197,7 @@ $pillars: (
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--type-immersive.fc-item--has-boosted-title:not(.fc-item--pillar-special-report) .fc-item__standfirst {
+    &.fc-item--type-immersive.fc-item--has-boosted-title:not(.fc-item--pillar-special-report):not(.fc-item--pillar-special-report-alt) .fc-item__standfirst {
         color: $brightness-7;
     }
 
@@ -288,7 +288,7 @@ $pillars: (
         background-color: map-get($palette, kicker);
     }
 
-    &.fc-item--type-comment:not(.fc-item--pillar-special-report) {
+    &.fc-item--type-comment:not(.fc-item--pillar-special-report):not(.fc-item--pillar-special-report-alt) {
 
         background-color: $opinion-faded;
 
@@ -355,7 +355,6 @@ $pillars: (
         .fc-item__content {
             background-color: $special-report-dark;
         }
-
         &:hover {
             .fc-item__content {
                 background-color: darken($special-report-dark, 5%);
@@ -395,5 +394,89 @@ $pillars: (
 
     .fc-sublink__title {
         color: #ffffff;
+    }
+}
+
+
+.fc-item--pillar-special-report-alt,
+.fc-item--pillar-special-report-alt.fc-item--type-feature {
+    &.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile {
+        .fc-item__content {
+            background-color: $special-report-alt-faded;
+        }
+
+        &:hover {
+            .fc-item__content {
+                background-color: $special-report-alt-faded;
+            }
+        }
+    }
+
+
+    &.fc-item--type-media,
+    &.fc-item--type-interview {
+        .inline-video-icon,
+        .inline-volume-high,
+        .inline-camera {
+            svg {
+                fill:  $special-report-alt-faded;
+            }
+
+            &::after {
+                background-color:  $special-report-alt-faded;
+            }
+        }
+    }
+
+    .fc-item__container {
+        &:before {
+            background-color: $special-report-alt-faded;
+        }
+    }
+
+    .fc-item__title {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-item__kicker {
+        color: $special-report-alt-dark;
+    }
+
+    fc-item__headline{
+        color: $special-report-alt-dark;
+    }
+
+    &.fc-item--type-comment {
+
+        .fc-item__byline {
+            display: inline;
+            color: $special-report-alt-dark;
+        }
+
+        .fc-item__kicker {
+            color: $special-report-alt-dark;
+        }
+    }
+
+    &.fc-item--type-media {
+        background-color: $special-report-alt-faded;
+
+        .youtube-media-atom__play-button.vjs-control-text {
+            .inline-play svg {
+                fill: $special-report-alt-faded;
+            }
+        }
+    }
+
+    .fc-item__container.u-faux-block-link--hover {
+        background-color: darken($special-report-alt-faded, 2%);
+    }
+
+    .fc-sublink__kicker {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-sublink__title {
+        color: $special-report-alt-dark;
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -412,6 +412,16 @@ $pillars: (
         }
     }
 
+    background-color: $special-report-alt-faded !important;
+
+    .fc-item__container.u-faux-block-link--hover {
+        background-color: $special-report-alt-faded !important;
+
+        .fc-item__timestamp,
+        .fc-trail__count--commentcount {
+            background-color: $special-report-alt-dark !important;
+        }
+    }
 
     &.fc-item--type-media,
     &.fc-item--type-interview {
@@ -430,7 +440,7 @@ $pillars: (
 
     .fc-item__container {
         &:before {
-            background-color: $special-report-alt-faded;
+            background-color: $special-report-alt-dark !important;
         }
     }
 
@@ -454,7 +464,8 @@ $pillars: (
         }
 
         .fc-item__kicker {
-            color: $special-report-alt-dark;
+            color: $special-report-alt-dark !important;
+
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -442,7 +442,7 @@ $pillars: (
         color: $special-report-alt-dark;
     }
 
-    fc-item__headline{
+    fc-item__headline {
         color: $special-report-alt-dark;
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_sublinks.scss
+++ b/static/src/stylesheets/module/facia-garnett/_sublinks.scss
@@ -56,7 +56,7 @@
         left: 0;
         content: '';
         width: $gs-gutter * 6 + 2px;
-        border-top: 1px solid #3c3c3c4d;
+        border-top: 1px solid rgba(60, 60, 60, .3);
 
         @include mq($from: tablet) {
             width: $gs-column-width * 2;

--- a/static/src/stylesheets/module/facia-garnett/_sublinks.scss
+++ b/static/src/stylesheets/module/facia-garnett/_sublinks.scss
@@ -14,7 +14,7 @@
     }
 }
 
-.fc-sublink__title {
+.fc-sublink__title:not(.fc-sublink--pillar-special-report-alt) {
     @include fs-headline(1);
     color: $brightness-7;
     margin: 0;
@@ -41,6 +41,36 @@
         font-weight: 700;
     }
 }
+
+.fc-sublink__title.fc-sublink--pillar-special-report-alt {
+    @include fs-headline(1);
+    color: $brightness-7;
+    margin: 0;
+    padding: 0;
+    font-weight: 400;
+
+    &:before {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        content: '';
+        width: $gs-gutter * 6 + 2px;
+        border-top: 1px solid #3c3c3c4d;
+
+        @include mq($from: tablet) {
+            width: $gs-column-width * 2;
+        }
+    }
+
+    .fc-sublink__kicker {
+        float: left;
+        margin-right: .2em;
+        font-weight: 700;
+    }
+}
+
+
 
 @mixin fc-sublinks--horizontal {
     .fc-sublinks {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -287,7 +287,7 @@
 
 .fc-item--pillar-special-report-alt {
     .fc-item__container > .fc-item__meta {
-        @include multiline(3, #3c3c3c4d);
+        @include multiline(3, rgba(60, 60, 60, .3));
 
         display: flex;
         position: absolute;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -284,3 +284,43 @@
         @include colours(map-get($pillars, opinion));
     }
 }
+
+.fc-item--pillar-special-report-alt {
+    .fc-item__container > .fc-item__meta {
+        @include multiline(3, #3c3c3c4d);
+
+        display: flex;
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        height: 16px;
+
+        .fc-trail__count,
+        .fc-item__timestamp {
+            position: absolute;
+            padding-top: 2px;
+            padding-right: $gs-gutter * .25;
+            padding-left: $gs-gutter * .25;
+            bottom: 0;
+            top: 0;
+            z-index: 1;
+            line-height: 10px;
+        }
+
+        .fc-trail__count {
+            right: 0;
+
+            .inline-icon {
+                margin-top: 0;
+            }
+        }
+
+        .fc-item__timestamp {
+            left: 0;
+
+            .inline-icon {
+                margin-top: -1px;
+            }
+        }
+    }
+}

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -295,6 +295,10 @@
         width: 100%;
         height: 16px;
 
+        svg {
+            fill: #2b2b2a;
+        }
+
         .fc-trail__count,
         .fc-item__timestamp {
             position: absolute;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
@@ -1,6 +1,6 @@
 // Styles shared by media and interview (video) types
 .fc-item--type-interview.fc-item--video,
-.fc-item--type-media {
+.fc-item--type-media:not(.fc-item--pillar-special-report-alt) {
     background-color: $brightness-20;
 
     .fc-item__video-duration {
@@ -92,5 +92,87 @@
 
     .fc-sublink__link {
         color: #ffffff;
+    }
+}
+
+.fc-item--type-media.fc-item--pillar-special-report-alt {
+
+    .fc-item__video-duration {
+        //ensures the alingment of the timestamp
+        display: inline-block;
+        transform: translateY(-8px);
+    }
+
+    .fc-item__content {
+        justify-content: space-between;
+    }
+
+    .fc-item__standfirst {
+        flex: 0 1 auto;
+    }
+
+    .fc-item__headline {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-item__standfirst {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-sublink__link {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-item__meta-wrapper {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding-top: $gs-baseline / 2;
+        padding-bottom: $gs-baseline / 2;
+
+    }
+
+    .fc-item__footer-meta-wrapper {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+    }
+
+    .fc-item__media-meta,
+    .fc-item__meta {
+        flex: 0 0 auto;
+    }
+
+    .fc-item__media-meta,
+    .fc-item__meta {
+        @include fs-textSans(1);
+        font-weight: 600;
+    }
+
+    .fc-item__media-meta {
+        margin-bottom: -#{$gs-baseline / 2};
+
+        .inline-icon__svg {
+            width: 14px;
+            height: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: 6px;
+            display: block;
+        }
+    }
+
+    .fc-trail__count--commentcount {
+        color: $special-report-alt-dark;
+
+        svg {
+            fill: $special-report-alt-dark;
+        }
+    }
+
+    .fc-sublink__link {
+        color: $special-report-alt-dark;
     }
 }


### PR DESCRIPTION
## What does this change?
* Consumes the new `SpecialReportAltTheme` coming from capi-client 
* Consumes the new `SpecialReportAlt` `CardStyle` coming from facia-client
* Adds `SpecialReportAlt` card styles
* Consumes new `SpecialReportAltPalette` (pending: https://github.com/guardian/interactive-atom-container-colours/pull/4)
* When there is a campaign connected to a specific tag, if the campaign id is "SpecialReportAlt" `facia-press` decides that `CardStyle` will be `SpecialReportAlt`.


## Previous PRs
1. Adds SpecialReportAltTheme and SpecialReportAlt hashed tag to content-api-scala-client: https://github.com/guardian/content-api-scala-client/pull/371
2. Adds SpecialReportAltPalette: https://github.com/guardian/facia-scala-client/pull/281
3. Adds SpecialReportAlt to CardStyle: https://github.com/guardian/facia-scala-client/pull/280 
4. Bump capi and facia client int frontend: https://github.com/guardian/frontend/pull/25640

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

The following PRs have already been merged:
* Consumes the new `SpecialReportAltTheme` and adds SpecialReportAlt articles styles: https://github.com/guardian/dotcom-rendering/pull/6313
* Adds new SpecialReportAlt card styles: https://github.com/guardian/dotcom-rendering/pull/6314
* Consumes the new `SpecialReportAltPalette` and adds styles: https://github.com/guardian/dotcom-rendering/pull/6335

## Screenshots

### Standard type
![image](https://user-images.githubusercontent.com/19683595/200864448-f95eede5-74e0-4b65-9b23-2e15e367618c.png)


### Comment type
![image](https://user-images.githubusercontent.com/19683595/200850298-b0b4a3e9-4563-4826-bb1a-cac2d17e55df.png)

### With media type
![image](https://user-images.githubusercontent.com/19683595/200865122-3b0bd03f-0204-4ccc-b1fe-c8df87ea771e.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

Tested in CODE and verified these changes don't break any existing card styles. 

Further testing: At the moment we have no SpecialReportAlt articles published. Once this gets merged we are planning to do an e2e test "Tools Game" in CODE environment and 

1. create articles of type:
* Comment
* Analysis
* Explainer
* Immersive
* Standard

with different pillars to make sure all are being overridden correctly 

2. Create a container using SpecialReportAltPalette and add SpecialReportAlt articles
3. Create onwards source using SpecialReportAlt articles 


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
