### PR TITLE
fix: ensure newsletter for sign up page is not paused or restricted

### DIFF
--- a/common/app/services/NewsletterService.scala
+++ b/common/app/services/NewsletterService.scala
@@ -55,7 +55,9 @@ class NewsletterService(newsletterSignupAgent: NewsletterSignupAgent) {
     newsletterSignupAgent.getNewsletters() match {
       case Left(_) => None
       case Right(list) =>
-        list.find(response => response.signupPage.nonEmpty && response.signupPage.get == "/" + articleId)
+        list
+          .filter(shouldInclude)
+          .find(response => response.signupPage.nonEmpty && response.signupPage.get == "/" + articleId)
     }
   }
 


### PR DESCRIPTION
## What does this change?

Ensure we check if a newsletter is `paused` or `restricted` when fetching for a sign up page using the "old" method ie. matching a sign up page URL to the article URL.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/43961396/197183572-6b41f2d4-b96c-4a99-945c-22bef3edd8be.png
[after]: https://user-images.githubusercontent.com/43961396/197183514-0938906b-65e0-44ed-a9be-8597cda38c83.png


## What is the value of this and can you measure success?

We don't want to promote, and allow new sign ups for newsletters which are not currently being sent.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
