### PR TITLE
Remove bracket symbol from crossword page

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -6,51 +6,54 @@
 @import views.support.Commercial.{shouldShowAds, isAdFree}
 
 @defining(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage) && !isAdFree(request)) { adsEnabled =>
-    <div class="l-side-margins">
-        <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
-            @crosswordMetaHeader(crosswordPage)
+<div class="l-side-margins">
+    <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
+        @crosswordMetaHeader(crosswordPage)
 
-            <div class="content__main tonal__main tonal__main--tone-news">
-                <div class="gs-container">
-                    <div class="js-content-main-column">
-                        <div class="@if(adsEnabled) {crossword__spacer--ad}">
-                            <div class="js-crossword @if(crosswordPage.hasGroupedClues) {has-grouped-clues}"
+        <div class="content__main tonal__main tonal__main--tone-news">
+            <div class="gs-container">
+                <div class="js-content-main-column">
+                    <div class="@if(adsEnabled) {crossword__spacer--ad}">
+                        <div class="js-crossword @if(crosswordPage.hasGroupedClues) {has-grouped-clues}"
                             data-crossword-data="@Json.stringify(Json.toJson(crosswordPage.crossword))">
 
-                                <div class="crossword__container crossword__container--@crosswordPage.crossword.crosswordType.toString.toLowerCase()">
-                                    @* The following is a fallback for when JavaScript is not enabled *@
-                                    <div class="crossword__container__grid-wrapper">
-                                        <noscript>@crosswordPage.svg</noscript>
-                                    </div>
-
-                                    <noscript>
-                                        <div class="crossword__clues">
-                                            <div class="crossword__clues--across">
-                                                <h3 class="crossword__clues-header">Across</h3>
-                                                @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == "across"))
-                                            </div>
-
-                                            <div class="crossword__clues--down">
-                                                <h3 class="crossword__clues-header">Down</h3>
-                                                @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == "down"))
-                                            </div>
-                                        </div>
-                                    </noscript>
+                            <div
+                                class="crossword__container crossword__container--@crosswordPage.crossword.crosswordType.toString.toLowerCase()">
+                                @* The following is a fallback for when JavaScript is not enabled *@
+                                <div class="crossword__container__grid-wrapper">
+                                    <noscript>@crosswordPage.svg</noscript>
                                 </div>
+
+                                <noscript>
+                                    <div class="crossword__clues">
+                                        <div class="crossword__clues--across">
+                                            <h3 class="crossword__clues-header">Across</h3>
+                                            @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction ==
+                                            "across"))
+                                        </div>
+
+                                        <div class="crossword__clues--down">
+                                            <h3 class="crossword__clues-header">Down</h3>
+                                            @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction ==
+                                            "down"))
+                                        </div>
+                                    </div>
+                                </noscript>
                             </div>
                         </div>
                     </div>
-                    @if(adsEnabled) {
-                        <div class="content__secondary-column hide-until-wide" aria-hidden="true">
-                        @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map()))
-                        </div>
-                        <div class="crossword-banner hide-until-tablet hide-from-wide" aria-hidden="true">
-                        @fragments.commercial.standardAd("crossword-banner", Seq("crossword-banner"), Map())
-                        </div>
-                    }
                 </div>
+                @if(adsEnabled) {
+                <div class="content__secondary-column hide-until-wide" aria-hidden="true">
+                    @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map())
+                </div>
+                <div class="crossword-banner hide-until-tablet hide-from-wide" aria-hidden="true">
+                    @fragments.commercial.standardAd("crossword-banner", Seq("crossword-banner"), Map())
+                </div>
+                }
             </div>
-        </article>
-        @crosswordFooter(crosswordPage)
-    </div>
+        </div>
+    </article>
+    @crosswordFooter(crosswordPage)
+</div>
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
@@ -1,4 +1,4 @@
-import type { AdSize, AdSizeString } from '@guardian/commercial-core';
+import type { AdSizeString } from '@guardian/commercial-core';
 import { outstreamSizes } from '@guardian/commercial-core';
 import type { Advert } from './Advert';
 
@@ -18,7 +18,7 @@ import type { Advert } from './Advert';
  * @param nonRefreshableLineItemIds The array of line item ids for which
  * adverts should not refresh
  */
-export const shouldRefresh = (
+const shouldRefresh = (
 	advert: Advert,
 	nonRefreshableLineItemIds: number[] = [],
 	// This parameter can be removed when we only check refreshing at the slot-viewable point
@@ -32,7 +32,7 @@ export const shouldRefresh = (
 
 	// Outstream adverts should not refresh
 	const isOutstream = Object.values(outstreamSizes)
-		.map((size: AdSize) => size.toString())
+		.map((size) => size.toString())
 		.includes(sizeString as AdSizeString);
 	if (isOutstream) return false;
 
@@ -49,3 +49,5 @@ export const shouldRefresh = (
 	// If none of the other conditions are met then the advert should refresh
 	return true;
 };
+
+export { shouldRefresh };


### PR DESCRIPTION
## What does this change?

Removes a closing bracket symbol underneath an ad on the crosswords page.

May not have been spotted as this is hidden by content when a double MPU loads and doesn't show on mobile.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="1388" alt="Screenshot 2022-10-21 at 12 26 33" src="https://user-images.githubusercontent.com/9574885/197188990-c6b11188-8cfe-44cd-8962-e0dfbfd65a95.png">

## What is the value of this and can you measure success?

- The page looks better without the bracket in my humblest of opinions.
