### PR TITLE
Remove edition from ContentApiClient.search calls

### DIFF
--- a/applications/app/services/NewsSiteMap.scala
+++ b/applications/app/services/NewsSiteMap.scala
@@ -1,6 +1,5 @@
 package services
 
-import common.Edition
 import conf.Configuration
 import contentapi.ContentApiClient
 import model.Content
@@ -60,7 +59,7 @@ class NewsSiteMap(contentApiClient: ContentApiClient) {
     val date = DateTime.now(DateTimeZone.UTC).minusDays(2)
 
     val query = contentApiClient
-      .search(Edition.defaultEdition)
+      .search()
       .pageSize(200)
       .tag("-tone/sponsoredfeatures,-type/crossword,-extra/extra,-tone/advertisement-features")
       .orderBy("newest")

--- a/applications/app/services/VideoSiteMap.scala
+++ b/applications/app/services/VideoSiteMap.scala
@@ -1,6 +1,5 @@
 package services
 
-import common.Edition
 import conf.Configuration
 import contentapi.ContentApiClient
 import implicits.Dates.{DateTime2ToCommonDateFormats, jodaToJavaInstant}
@@ -60,7 +59,7 @@ class VideoSiteMap(contentApiClient: ContentApiClient) {
     val date = DateTime.now(DateTimeZone.UTC).minusDays(2)
 
     val query = contentApiClient
-      .search(Edition.defaultEdition)
+      .search()
       .pageSize(200)
       .tag("type/video,-tone/sponsoredfeatures,-tone/advertisement-features")
       .orderBy("newest")

--- a/commercial/app/model/capi/Lookup.scala
+++ b/commercial/app/model/capi/Lookup.scala
@@ -32,7 +32,7 @@ class Lookup(contentApiClient: ContentApiClient) extends GuLogging with implicit
   )(implicit executionContext: ExecutionContext): Future[Seq[ContentType]] = {
     if (shortUrls.nonEmpty) {
       val shortIds = shortUrls.map(ShortUrls.shortUrlToShortId).mkString(",")
-      contentApiClient.getResponse(contentApiClient.search(defaultEdition).ids(shortIds)) map {
+      contentApiClient.getResponse(contentApiClient.search().ids(shortIds)) map {
         _.results.toSeq map (Content(_))
       }
     } else Future.successful(Nil)

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -75,7 +75,6 @@ object QueryDefaults {
 trait ApiQueryDefaults extends GuLogging {
 
   def item(id: String): ItemQuery = CapiContentApiClient.item(id)
-  def search: SearchQuery = CapiContentApiClient.search
 
   def item(id: String, edition: Edition): ItemQuery = item(id, edition.id)
 
@@ -94,8 +93,8 @@ trait ApiQueryDefaults extends GuLogging {
       .showAtoms("media")
 
   //common fields that we use across most queries.
-  def search(edition: Edition): SearchQuery =
-    search
+  def search(): SearchQuery =
+    CapiContentApiClient.search
       .showTags("all")
       .showReferences(QueryDefaults.references)
       .showFields(QueryDefaults.trailFieldsWithMain)

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -29,7 +29,7 @@ trait IndexControllerCommon
   def renderCombiner(leftSide: String, rightSide: String): Action[AnyContent] =
     Action.async { implicit request =>
       logGoogleBot(request)
-      index(Edition(request), leftSide, rightSide, inferPage(request), request.isRss).map {
+      index(leftSide, rightSide, inferPage(request), request.isRss).map {
         case Left(page)   => renderFaciaFront(page)
         case Right(other) => other
       }

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -40,7 +40,7 @@ trait Index extends ConciergeRepository {
 
   }
 
-  def index(edition: Edition, leftSide: String, rightSide: String, page: Int, isRss: Boolean)(implicit
+  def index(leftSide: String, rightSide: String, page: Int, isRss: Boolean)(implicit
       request: RequestHeader,
   ): Future[Either[IndexPage, PlayResult]] = {
 
@@ -66,7 +66,7 @@ trait Index extends ConciergeRepository {
     val promiseOfResponse = contentApiClient
       .getResponse(
         contentApiClient
-          .search(edition)
+          .search()
           .tag(s"$firstTag,$secondTag")
           .page(page)
           .pageSize(IndexPagePagination.pageSize)

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -32,13 +32,13 @@ class MediaInSectionController(
 
   private def renderMedia(mediaType: String, sectionId: String, seriesId: Option[String]): Action[AnyContent] =
     Action.async { implicit request =>
-      val response = lookup(Edition(request), mediaType, sectionId, seriesId) map { seriesItems =>
+      val response = lookup(mediaType, sectionId, seriesId) map { seriesItems =>
         seriesItems map { trail => renderSectionTrails(mediaType, trail, sectionId) }
       }
       response map { _ getOrElse NotFound }
     }
 
-  private def lookup(edition: Edition, mediaType: String, sectionId: String, seriesId: Option[String])(implicit
+  private def lookup(mediaType: String, sectionId: String, seriesId: Option[String])(implicit
       request: RequestHeader,
   ): Future[Option[Seq[RelatedContentItem]]] = {
     val currentShortUrl = request.getQueryString("shortUrl")
@@ -55,7 +55,7 @@ class MediaInSectionController(
     val promiseOrResponse = contentApiClient
       .getResponse(
         contentApiClient
-          .search(edition)
+          .search()
           .section(sectionId)
           .tag(tags)
           .showTags("all")

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import common.`package`._
-import common.{Edition, ImplicitControllerExecutionContext, JsonNotFound}
+import common.{ImplicitControllerExecutionContext, JsonNotFound}
 import contentapi.ContentApiClient
 import feed.MostPopularSocialAutoRefresh
 import layout.{CollectionEssentials, FaciaContainer}
@@ -34,7 +34,7 @@ class MostViewedSocialController(
         case Some(articleIds) if articleIds.nonEmpty =>
           contentApiClient.getResponse(
             contentApiClient
-              .search(Edition(request))
+              .search()
               .ids(articleIds.take(7).map(item => feed.urlToContentPath(item.url)).mkString(",")),
           ) map { response =>
             val items = response.results

--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -18,12 +18,11 @@ class MostViewedVideoController(
   def renderInSeries(series: String): Action[AnyContent] =
     Action.async { implicit request =>
       val page = (request.getQueryString("page") getOrElse "1").toInt
-      val edition = Edition(request)
 
       contentApiClient
         .getResponse(
           contentApiClient
-            .search(edition)
+            .search()
             .tag(series)
             .contentType("video")
             .showTags("series")

--- a/onward/app/controllers/OnwardResponseController.scala
+++ b/onward/app/controllers/OnwardResponseController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent}
+import common.{ImplicitControllerExecutionContext, JsonComponent}
 import feed.MostReadAgent
 import model.{ApplicationContext, Cached}
 import model.dotcomrendering.OnwardCollectionResponse
@@ -22,11 +22,10 @@ class OnwardResponseController(
     with ImplicitControllerExecutionContext {
 
   def popularInTag(tag: String)(implicit request: RequestHeader): Future[OnwardCollectionResponse] = {
-    val edition = Edition(request)
     val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
     val itemViewCounts = mostReadAgent.getViewCounts
 
-    popularInTagService.fetch(edition, tag, excludeTags, itemViewCounts)
+    popularInTagService.fetch(tag, excludeTags, itemViewCounts)
   }
   def popularInTagJson(tag: String): Action[AnyContent] =
     Action.async { implicit request =>

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -25,9 +25,8 @@ class PopularInTag(
 
   def render(tag: String): Action[AnyContent] =
     Action.async { implicit request =>
-      val edition = Edition(request)
       val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
-      getPopularInTag(edition, tag, excludeTags) map {
+      getPopularInTag(tag, excludeTags) map {
         case popular if popular.items.isEmpty => Cached(60)(JsonNotFound())
         case trails                           => renderPopularInTag(trails)
       }

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -23,7 +23,7 @@ class TaggedContentController(
   def renderJson(tag: String): Action[AnyContent] =
     Action.async { implicit request =>
       tagWhitelist.find(_ == tag).map { tag =>
-        lookup(tag, Edition(request)) map {
+        lookup(tag) map {
           case Nil    => Cached(300) { JsonNotFound() }
           case trails => render(trails)
         }
@@ -54,12 +54,12 @@ class TaggedContentController(
     "theguardian/series/guardiancommentcartoon",
   )
 
-  private def lookup(tag: String, edition: Edition)(implicit request: RequestHeader): Future[List[ContentType]] = {
-    log.info(s"Fetching tagged stories for edition ${edition.id}")
+  private def lookup(tag: String)(implicit request: RequestHeader): Future[List[ContentType]] = {
+    log.info(s"Fetching tagged stories")
     contentApiClient
       .getResponse(
         contentApiClient
-          .search(edition)
+          .search()
           .tag(tag)
           .pageSize(3),
       )

--- a/onward/app/feed/MostViewedVideoAgent.scala
+++ b/onward/app/feed/MostViewedVideoAgent.scala
@@ -2,7 +2,6 @@ package feed
 
 import com.gu.contentapi.client
 import common._
-import common.editions.Uk
 import contentapi.ContentApiClient
 import model.{Video, _}
 import play.api.libs.json._
@@ -41,7 +40,7 @@ class MostViewedVideoAgent(contentApiClient: ContentApiClient, ophanApi: OphanAp
       val mostViewed: Future[Seq[Video]] = contentApiClient
         .getResponse(
           contentApiClient
-            .search(Uk)
+            .search()
             .ids(contentIds)
             .pageSize(20),
         )

--- a/onward/app/services/PopularInTagService.scala
+++ b/onward/app/services/PopularInTagService.scala
@@ -1,6 +1,5 @@
 package services
 
-import common.Edition
 import contentapi.ContentApiClient
 import model.RelatedContentItem
 import model.dotcomrendering.{OnwardCollectionResponse, Trail}
@@ -14,14 +13,14 @@ class PopularInTagService(contentApiClient: ContentApiClient)(implicit
   // `itemViewCounts` is a Map[Content.id: String, ViewCount:Int]
   // this is generally fetched from Ophan view the MostPopularAgent, but can come from anywhere
   // and makes this easy to test
-  def fetch(edition: Edition, tag: String, excludeTags: Seq[String], itemViewCounts: Map[String, Int])(implicit
+  def fetch(tag: String, excludeTags: Seq[String], itemViewCounts: Map[String, Int])(implicit
       request: RequestHeader,
   ): Future[OnwardCollectionResponse] = {
     val tags = (tag +: excludeTags.map(t => s"-$t")).mkString(",")
 
     val response = contentApiClient.getResponse(
       contentApiClient
-        .search(edition)
+        .search()
         .tag(tags)
         .pageSize(50),
     )

--- a/onward/app/services/repositories.scala
+++ b/onward/app/services/repositories.scala
@@ -41,13 +41,13 @@ trait Related extends ConciergeRepository {
     }
   }
 
-  def getPopularInTag(edition: Edition, tag: String, excludeTags: Seq[String] = Nil): Future[RelatedContent] = {
+  def getPopularInTag(tag: String, excludeTags: Seq[String] = Nil): Future[RelatedContent] = {
 
     val tags = (tag +: excludeTags.map(t => s"-$t")).mkString(",")
 
     val response = contentApiClient.getResponse(
       contentApiClient
-        .search(edition)
+        .search()
         .tag(tags)
         .pageSize(50),
     )

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -339,7 +339,7 @@ class MoreOnMatchController(
     contentApiClient
       .getResponse(
         contentApiClient
-          .search(Edition(request))
+          .search()
           .section("football")
           .tag(
             "tone/minutebyminute|tone/matchreports|football/series/squad-sheets|football/series/match-previews|football/series/saturday-clockwatch",

--- a/sport/app/rugby/feed/CapiFeed.scala
+++ b/sport/app/rugby/feed/CapiFeed.scala
@@ -1,6 +1,6 @@
 package rugby.feed
 
-import common.{Edition, GuLogging}
+import common.{GuLogging}
 import contentapi.ContentApiClient
 import model.{Content, ContentType}
 import org.joda.time.DateTimeZone
@@ -43,7 +43,7 @@ class CapiFeed(contentApiClient: ContentApiClient) extends GuLogging {
     contentApiClient
       .getResponse(
         contentApiClient
-          .search(Edition.defaultEdition)
+          .search()
           .section("sport")
           .tag(searchTags)
           .fromDate(jodaToJavaInstant(startMatchDayRange))


### PR DESCRIPTION
## What does this change?

The `ContentApiClient.search()` call took a parameter of `Edition`, but doesn't actually use that edition parameter, so we should remove it from the function signature.

In removing this, I also went and refactored all the consuming files to ensure any unneeded references to edition were removed. 

**When did it stop using the `edition` parameter?**

It appears this was removed as part of a migration to a newer version of the content API all the way back in 2014 ... https://github.com/guardian/frontend/pull/6635

Since then, the 'edition' parameter has been hanging around, unused!

----

There is an interesting question here, which is were we under the false impression on any the places consuming `ContentApiClient.search()`, that these queries _were_ editionalised, when they in fact weren't - especially around onwards!

We should look closely at this, but importantly now this function signature is no longer lying about what is does!

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally - Ran dev build, checked some pages
- [ ] On CODE (optional) - TODO

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
