### PR TITLE
Opt Out advertising: Remove empty slots

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -1,20 +1,29 @@
+import { log } from '@guardian/libs';
+import fastdom from 'fastdom';
 import { renderConsentlessAdvertLabel } from './render-advert-label';
 
 const defineSlot = (slot: HTMLElement, slotName: string): void => {
 	const slotId = slot.id;
+
+	const filledCallback = () => {
+		log('commercial', `Filled consentless ${slotId}`);
+		void renderConsentlessAdvertLabel(slot);
+	};
+
+	const emptyCallback = () => {
+		log('commercial', `Empty consentless ${slotId}`);
+		fastdom.mutate(() => {
+			slot.remove();
+		});
+	};
 
 	window.ootag.queue.push(() => {
 		window.ootag.defineSlot({
 			adSlot: slotName,
 			targetId: slotId,
 			id: slotId,
-			filledCallback: () => {
-				void renderConsentlessAdvertLabel(slot);
-				console.log(`filled consentless ${slotId}`);
-			},
-			emptyCallback: () => {
-				console.log(`empty consentless ${slotId}`);
-			},
+			filledCallback,
+			emptyCallback,
 		});
 	});
 };

--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -1,16 +1,15 @@
 import { renderConsentlessAdvertLabel } from './render-advert-label';
 
-const defineSlot = (slotId: string, slotName: string): void => {
+const defineSlot = (slot: HTMLElement, slotName: string): void => {
+	const slotId = slot.id;
+
 	window.ootag.queue.push(() => {
 		window.ootag.defineSlot({
 			adSlot: slotName,
 			targetId: slotId,
 			id: slotId,
 			filledCallback: () => {
-				const slotElement = document.getElementById(slotId);
-				if (slotElement) {
-					void renderConsentlessAdvertLabel(slotElement);
-				}
+				void renderConsentlessAdvertLabel(slot);
 				console.log(`filled consentless ${slotId}`);
 			},
 			emptyCallback: () => {

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -68,12 +68,12 @@ const insertAdAtPara = (
 	containerOptions: ContainerOptions = {},
 	inlineId: number,
 ): Promise<void> => {
-	const ad = createAdSlot(type, {
+	const adSlot = createAdSlot(type, {
 		name,
 		classes,
 	});
 
-	const node = wrapSlotInContainer(ad, containerOptions);
+	const node = wrapSlotInContainer(adSlot, containerOptions);
 
 	return fastdom
 		.mutate(() => {
@@ -82,7 +82,7 @@ const insertAdAtPara = (
 			}
 		})
 		.then(() => {
-			defineSlot(ad.id, inlineId === 1 ? 'inline' : 'inline-right');
+			defineSlot(adSlot, inlineId === 1 ? 'inline' : 'inline-right');
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/liveblog-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/liveblog-inline.ts
@@ -88,12 +88,12 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 	const container: HTMLElement = document.createElement('div');
 	container.className = `ad-slot-container`;
 
-	const ad = createAdSlot('inline', {
+	const adSlot = createAdSlot('inline', {
 		name: `inline${AD_COUNTER + 1}`,
 		classes: 'liveblog-inline',
 	});
 
-	container.appendChild(ad);
+	container.appendChild(adSlot);
 
 	return fastdom
 		.mutate(() => {
@@ -103,7 +103,7 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 			}
 		})
 		.then(() => {
-			defineSlot(ad.id, 'inline');
+			defineSlot(adSlot, 'inline');
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/init-fixed-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/init-fixed-slots.ts
@@ -14,7 +14,7 @@ const initFixedSlots = (): Promise<void> => {
 			? 'inline'
 			: slotElement.dataset.name;
 		if (slotName) {
-			defineSlot(slotElement.id, slotName);
+			defineSlot(slotElement, slotName);
 		}
 	});
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -130,6 +130,8 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/consentless/define-slot.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/fastdom/fastdom.d.ts",
   "../projects/commercial/modules/consentless/render-advert-label.ts"
  ],
  "../projects/commercial/modules/consentless/dynamic/article-inline.ts": [


### PR DESCRIPTION
## What does this change?

This PR modifies the consentless advertising stack so that when the ad server indicates it cannot fill a slot we remove it from the DOM.

At this stage this should have the equivalent behaviour of ad-free, on a per-slot basis. For example, any slot that has a container that reserves space will still be present (such as top-above-nav). Slots that have a min-height, such as merchandising, will collapse and not reserve the space.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Note that the merchandising slot collapses, since it's the slot that reserves space, whereas top-above-nav has a container that reserves space so the gap remains. Slots like the right ad slot won't have any visual difference since the space remains empty in both cases.

| Before      | After      |
|-------------|------------|
| <img width="491" alt="before" src="https://user-images.githubusercontent.com/8000415/197731554-a4b9d7f6-f2a3-4830-be01-8d7879a2f518.png"> | <img width="501" alt="after" src="https://user-images.githubusercontent.com/8000415/197731679-0db5878e-dd47-4f37-9dbd-59f74ccfb07d.png"> |

## What is the value of this and can you measure success?

We anticipate that we'll have more unfilled slots when performing consentless advertising.

As an initial attempt to deal with this, we'll remove all of these unfilled slots from the DOM. In the future, we may wish to also fallback to display our own in-house messaging, similar to the Shady Pie / Labs messaging displayed in DCR when we detect an ad-blocker.

### Tested

- [X] Locally
- [ ] On CODE (optional)