### PR TITLE
Add 'masterImage' support for onwards trails in DCR model

### DIFF
--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -88,6 +88,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       linkText = linkText,
       showByline = false,
       byline = fields.byline,
+      masterImage = None,
       image = fields.thumbnail,
       carouselImages = Map.empty,
       ageWarning = None,

--- a/common/app/model/dotcomrendering/Trail.scala
+++ b/common/app/model/dotcomrendering/Trail.scala
@@ -16,8 +16,9 @@ case class Trail(
     linkText: String,
     showByline: Boolean,
     byline: Option[String],
-    image: Option[String],
-    carouselImages: Map[String, Option[String]],
+    masterImage: Option[String],
+    image: Option[String], // TODO: This can be deprecated after 'masterImage' is supported in DCR
+    carouselImages: Map[String, Option[String]], // TODO: This can be deprecated after 'masterImage' is supported in DCR
     ageWarning: Option[String],
     isLiveBlog: Boolean,
     pillar: String,
@@ -88,6 +89,13 @@ object Trail {
     images.toMap
   }
 
+  def getMasterUrl(imageMedia: Option[ImageMedia]): Option[String] =
+    for {
+      trailPicture <- imageMedia
+      masterImage <- trailPicture.masterImage
+      url <- masterImage.url
+    } yield url
+
   def contentCardToTrail(contentCard: ContentCard): Option[Trail] = {
     for {
       properties <- contentCard.properties
@@ -105,6 +113,7 @@ object Trail {
       linkText = "",
       showByline = showByline,
       byline = contentCard.byline.map(x => x.get),
+      masterImage = getMasterUrl(maybeContent.trail.trailPicture),
       image = maybeContent.trail.thumbnailPath,
       carouselImages = getImageSources(maybeContent.trail.trailPicture),
       ageWarning = None,
@@ -138,6 +147,7 @@ object Trail {
       linkText = RemoveOuterParaHtml(content.properties.linkText.getOrElse(content.header.headline)).body,
       showByline = content.properties.showByline,
       byline = content.properties.byline,
+      masterImage = getMasterUrl(content.trailPicture),
       image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
       carouselImages = getImageSources(content.trailPicture),
       ageWarning = content.ageWarning,


### PR DESCRIPTION
## What does this change?

Adds the 'masterImage' property to the `Trail` property in the DCR data model, this way master images can be used for the picture elements on onwards cards, avoiding our existing awkward fixes. (e.g https://github.com/guardian/dotcom-rendering/pull/6267)  

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - After this is merged I will update DCR to use the masterImage

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/197753246-4e5a8c59-4135-417f-86a5-1980b445a600.png
[after]: https://user-images.githubusercontent.com/9575458/197752999-b1be3fda-0c6e-4b5e-8e95-4289e0b29cb4.png

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
