### PR TITLE
World Cup 2022 Setup

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -35,6 +35,7 @@ class LeagueTableController(
     "Women's Super League",
     "Champions League",
     "Women's Champions League",
+    "World Cup 2022",
     "Europa League",
     "Carabao Cup",
     "International friendlies",

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -138,10 +138,10 @@ object KnockoutSpider {
       ZonedDateTime.of(2022, 12, 5, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 53
       ZonedDateTime.of(2022, 12, 5, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 54
       // ----
-      ZonedDateTime.of(2022, 12, 4, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 51
-      ZonedDateTime.of(2022, 12, 4, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 52
-      // ----
       ZonedDateTime.of(2022, 12, 6, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 55
+      ZonedDateTime.of(2022, 12, 4, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 51
+      // ----
+      ZonedDateTime.of(2022, 12, 4, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 52
       ZonedDateTime.of(2022, 12, 6, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 56
       // ----
       // Quarter Finals
@@ -153,8 +153,8 @@ object KnockoutSpider {
       // ----
       // Semi Finals
       // ----
-      ZonedDateTime.of(2022, 12, 13, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 61
-      ZonedDateTime.of(2022, 12, 14, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 62
+      ZonedDateTime.of(2022, 12, 13, 0, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 61
+      ZonedDateTime.of(2022, 12, 14, 0, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 62
       // ----
       // Final
       // ----

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -128,7 +128,7 @@ object KnockoutSpider {
   val orderings: Map[String, List[ZonedDateTime]] = Map(
     // world cup 2022
     "700" -> List(
-      // Data from https://en.wikipedia.org/wiki/2022_FIFA_World_Cup_knockout_stage (waiting for PA data)
+      // Data from https://en.wikipedia.org/wiki/2022_FIFA_World_Cup_knockout_stage & PA API
       // ----
       // Rounds of 16
       // ----
@@ -153,8 +153,8 @@ object KnockoutSpider {
       // ----
       // Semi Finals
       // ----
-      ZonedDateTime.of(2022, 12, 13, 0, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 61
-      ZonedDateTime.of(2022, 12, 14, 0, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 62
+      ZonedDateTime.of(2022, 12, 13, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 61
+      ZonedDateTime.of(2022, 12, 14, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 62
       // ----
       // Final
       // ----

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -126,24 +126,39 @@ object KnockoutSpider {
    */
 
   val orderings: Map[String, List[ZonedDateTime]] = Map(
-    // world cup 2018
+    // world cup 2022
     "700" -> List(
-      ZonedDateTime.of(2018, 6, 30, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 4044557
-      ZonedDateTime.of(2018, 6, 30, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 4044556
-      ZonedDateTime.of(2018, 7, 2, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 4044560
-      ZonedDateTime.of(2018, 7, 2, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 4044561
-      ZonedDateTime.of(2018, 7, 1, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 4044558
-      ZonedDateTime.of(2018, 7, 1, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 4044559
-      ZonedDateTime.of(2018, 7, 3, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 4044562
-      ZonedDateTime.of(2018, 7, 3, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 4044563
-      ZonedDateTime.of(2018, 7, 6, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final 4044564
-      ZonedDateTime.of(2018, 7, 6, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final 4044565
-      ZonedDateTime.of(2018, 7, 7, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final 4044567
-      ZonedDateTime.of(2018, 7, 7, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final 4044566
-      ZonedDateTime.of(2018, 7, 10, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final 4044568
-      ZonedDateTime.of(2018, 7, 11, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final 4044569
-      ZonedDateTime.of(2018, 7, 14, 15, 0, 0, 0, ZoneId.of("Europe/London")), // 3rd/4th Play-Offs 4044570
-      ZonedDateTime.of(2018, 7, 15, 16, 0, 0, 0, ZoneId.of("Europe/London")), // Final 4044571
+      // Data from https://en.wikipedia.org/wiki/2022_FIFA_World_Cup_knockout_stage (waiting for PA data)
+      // ----
+      // Rounds of 16
+      // ----
+      ZonedDateTime.of(2022, 12, 3, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 49
+      ZonedDateTime.of(2022, 12, 3, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 50
+      // ----
+      ZonedDateTime.of(2022, 12, 5, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 53
+      ZonedDateTime.of(2022, 12, 5, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 54
+      // ----
+      ZonedDateTime.of(2022, 12, 4, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 51
+      ZonedDateTime.of(2022, 12, 4, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 52
+      // ----
+      ZonedDateTime.of(2022, 12, 6, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 55
+      ZonedDateTime.of(2022, 12, 6, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 56
+      // ----
+      // Quarter Finals
+      // ----
+      ZonedDateTime.of(2022, 12, 9, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 57
+      ZonedDateTime.of(2022, 12, 9, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 58
+      ZonedDateTime.of(2022, 12, 10, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 59
+      ZonedDateTime.of(2022, 12, 10, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 60
+      // ----
+      // Semi Finals
+      // ----
+      ZonedDateTime.of(2022, 12, 13, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 61
+      ZonedDateTime.of(2022, 12, 14, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 62
+      // ----
+      // Final
+      // ----
+      ZonedDateTime.of(2022, 12, 18, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 64
     ),
     // women world cup 2019
     "870" -> List(

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -132,33 +132,33 @@ object KnockoutSpider {
       // ----
       // Rounds of 16
       // ----
-      ZonedDateTime.of(2022, 12, 3, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 49
-      ZonedDateTime.of(2022, 12, 3, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 50
+      ZonedDateTime.of(2022, 12, 3, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 49
+      ZonedDateTime.of(2022, 12, 3, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 50
       // ----
-      ZonedDateTime.of(2022, 12, 5, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 53
-      ZonedDateTime.of(2022, 12, 5, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 54
+      ZonedDateTime.of(2022, 12, 5, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 53
+      ZonedDateTime.of(2022, 12, 5, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 54
       // ----
-      ZonedDateTime.of(2022, 12, 4, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 51
-      ZonedDateTime.of(2022, 12, 4, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 52
+      ZonedDateTime.of(2022, 12, 4, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 51
+      ZonedDateTime.of(2022, 12, 4, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 52
       // ----
-      ZonedDateTime.of(2022, 12, 6, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 55
-      ZonedDateTime.of(2022, 12, 6, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 56
+      ZonedDateTime.of(2022, 12, 6, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 55
+      ZonedDateTime.of(2022, 12, 6, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16 - Match 56
       // ----
       // Quarter Finals
       // ----
-      ZonedDateTime.of(2022, 12, 9, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 57
-      ZonedDateTime.of(2022, 12, 9, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 58
-      ZonedDateTime.of(2022, 12, 10, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 59
-      ZonedDateTime.of(2022, 12, 10, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 60
+      ZonedDateTime.of(2022, 12, 9, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 57
+      ZonedDateTime.of(2022, 12, 9, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 58
+      ZonedDateTime.of(2022, 12, 10, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 59
+      ZonedDateTime.of(2022, 12, 10, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Finals - Match 60
       // ----
       // Semi Finals
       // ----
-      ZonedDateTime.of(2022, 12, 13, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 61
-      ZonedDateTime.of(2022, 12, 14, 22, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 62
+      ZonedDateTime.of(2022, 12, 13, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 61
+      ZonedDateTime.of(2022, 12, 14, 19, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 62
       // ----
       // Final
       // ----
-      ZonedDateTime.of(2022, 12, 18, 18, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 64
+      ZonedDateTime.of(2022, 12, 18, 15, 0, 0, 0, ZoneId.of("Europe/London")), // Semi Finals - Match 64
     ),
     // women world cup 2019
     "870" -> List(


### PR DESCRIPTION
## What does this change?

Does 2 things
- Adds world cup 2022 to the league tables page (required after: https://github.com/guardian/frontend/pull/25574)
- Sets up the spider diagram - based off the PA data & wikipedia data

There is some complexity around the spider diagram, due to the naming scheme of the data from both the PA API, and other sources, it's hard to be sure that the correct winners from the QFs are mapped to the correct players for the SFs, I'm pretty sure it's correct, but I think the only way for us to find out will be to wait and see 😬

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

In tables dropdown:
<img width="603" alt="image" src="https://user-images.githubusercontent.com/9575458/197788273-9a38eacd-5e0b-4356-8ea3-5c670fc4baf6.png">

Full tables page:
<img width="899" alt="image" src="https://user-images.githubusercontent.com/9575458/197788532-ac3ee373-24c4-4f4a-ba40-aa1e7c91d7de.png">

Spider diagram (wallchart)
<img width="1334" alt="image" src="https://user-images.githubusercontent.com/9575458/198552329-76b5a13d-2b1c-4148-8de0-2e468e710c94.png">


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally - excluding the spider diagram, as we're waiting on data from PA
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
