### PR TITLE
chore: Expose Amp switches to DCR

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -296,7 +296,7 @@ trait FeatureSwitches {
     owners = Seq(Owner.withName("unknown")),
     safeState = On,
     sellByDate = never,
-    exposeClientSide = false,
+    exposeClientSide = true,
   )
 
   val AmpLiveBlogSwitch = Switch(
@@ -306,7 +306,7 @@ trait FeatureSwitches {
     owners = Seq(Owner.withName("unknown")),
     safeState = On,
     sellByDate = never,
-    exposeClientSide = false,
+    exposeClientSide = true,
   )
 
   val R2PagePressServiceSwitch = Switch(


### PR DESCRIPTION
## What does this change?

Expose AMP switches to be used in DCR to decide if an article can be rendered with AMP.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6287