### PR TITLE
Ditch the facebook pixel

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -3,7 +3,6 @@
 @(page: HostedArticlePage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import model.hosted.HostedAmp.ampify
 @import views.html.hosted._
-@import views.support.FBPixel
 @import model.hosted.HostedArticleQuotes.prepareQuotes
 
 <!doctype html>
@@ -23,7 +22,6 @@
     </head>
     <body>
 
-        <amp-pixel src="//www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1"></amp-pixel>
         <amp-analytics config="https://ophan.theguardian.com/amp.json" @if(context.environment.mode != Mode.Dev) { data-credentials="include" }></amp-analytics>
 
         @fragments.amp.hostedGoogleAnalytics(page)

--- a/commercial/app/views/hosted/guardianAmpHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedGallery.scala.html
@@ -7,7 +7,6 @@
 @(page: HostedGalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.html.hosted._
 @import conf.Configuration
-@import views.support.FBPixel
 
 <!doctype html>
 <html AMP>
@@ -33,8 +32,6 @@
         <amp-pixel src="@{
             Configuration.debug.beaconUrl
         }/count/pv.gif"></amp-pixel>
-
-        <amp-pixel src="//www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1"></amp-pixel>
 
         <amp-analytics config="https://ophan.theguardian.com/amp.json" @if(context.environment.mode != Mode.Dev) { data-credentials="include" }></amp-analytics>
         @fragments.amp.hostedGoogleAnalytics(page)

--- a/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
@@ -1,6 +1,5 @@
 @import common.commercial.hosted.HostedVideoPage
 @import views.html.hosted._
-@import views.support.FBPixel
 @import conf.Configuration.environment
 @import conf.Configuration.site.host
 @import play.api.Mode
@@ -26,8 +25,6 @@
     <script src="https://cdn.ampproject.org/v0.js" async></script>
     </head>
     <body>
-
-    <amp-pixel src="//www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1"></amp-pixel>
 
     <amp-analytics config="https://ophan.theguardian.com/amp.json" @if(context.environment.mode != Mode.Dev) { data-credentials="include" }></amp-analytics>
     @fragments.amp.hostedGoogleAnalytics(page)

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -248,16 +248,6 @@ trait CommercialSwitches {
     exposeClientSide = false,
   )
 
-  val facebookTrackingPixel: Switch = Switch(
-    group = Commercial,
-    name = "facebook-tracking-pixel",
-    description = "Facebook's PageView tracking to improve ad targeting",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val confiantAdVerification: Switch = Switch(
     group = Commercial,
     name = "confiant-ad-verification",

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -3,7 +3,7 @@
 @import conf.Static
 @import conf.Configuration
 @import play.api.libs.json.Json
-@import views.support.{CamelCase, JavaScriptPage, GoogleAnalyticsAccount, FBPixel}
+@import views.support.{CamelCase, JavaScriptPage, GoogleAnalyticsAccount}
 @import conf.Configuration.environment
 @import navigation.NavMenu
 
@@ -58,8 +58,7 @@
             "googletag": "@{Configuration.javascript.config("googletagJsUrl")}",
             "cmp": { "fullVendorDataUrl": "/commercial/cmp/vendorlist.json",
                      "shortVendorDataUrl": "/commercial/cmp/shortvendorlist.json"
-            },
-            "facebookAccountId": "@FBPixel.account"
+            }
         }
     }
 }

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -1,8 +1,6 @@
 @()(implicit page: model.Page, request:RequestHeader, context: model.ApplicationContext)
 @import conf.Configuration
 @import conf.Static
-@import views.support.FBPixel
-
 
 @if(!page.metadata.isSecureContact) {
 

--- a/common/app/views/support/FBPixel.scala
+++ b/common/app/views/support/FBPixel.scala
@@ -1,5 +1,0 @@
-package views.support
-
-object FBPixel {
-  val account: String = "279880532344561"
-}

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.ts
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.ts
@@ -1,7 +1,6 @@
 /* A regionalised container for all the commercial tags. */
 
 import {
-	fbPixel,
 	ias,
 	inizio,
 	permutive,
@@ -95,10 +94,6 @@ const loadOther = (): Promise<void> => {
 			shouldRun: window.guardian.config.switches.iasAdTargeting ?? false,
 		}),
 		inizio({ shouldRun: window.guardian.config.switches.inizio ?? false }),
-		fbPixel({
-			shouldRun:
-				window.guardian.config.switches.facebookTrackingPixel ?? false,
-		}),
 		twitter({
 			shouldRun: window.guardian.config.switches.twitterUwt ?? false,
 		}),


### PR DESCRIPTION
## What does this change?
Rejoice! We no longer need/want the Facebook tracking pixel, sorry Zuck.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (in AMP pages P: https://github.com/guardian/dotcom-rendering/pull/6294)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
We're no longer giving data to facebook/meta.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
