### PR TITLE
Fix Safari/chrome on IOS 16 interscroller glitch

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/background.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.ts
@@ -70,7 +70,9 @@ const createParent = (
 			backgroundParent.style.zIndex = '-1';
 			backgroundParent.style.position = 'absolute';
 			backgroundParent.style.inset = '0';
-			backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
+			backgroundParent.style.clipPath =
+				'polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)';
+			backgroundParent.style.overflow = 'hidden';
 
 			background.style.inset = '0';
 			background.style.transition = 'background 100ms ease';


### PR DESCRIPTION
## What does this change?
css `clip` is deprecated in favour of `clip-path`, the new property seems to fix the issue.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| <video src="https://user-images.githubusercontent.com/1731150/198267764-e41571c4-f01f-4295-b7df-b31d4868b782.mov" /> | <video src="https://user-images.githubusercontent.com/1731150/198267804-b95cfcea-b251-4498-abe3-7c0b475c531d.mov" /> |


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
