### PR TITLE
Sublinks/Supporting content: use webUrl, not CAPI ID for href

### DIFF
--- a/common/app/model/SupportedUrl.scala
+++ b/common/app/model/SupportedUrl.scala
@@ -17,9 +17,12 @@ object SupportedUrl {
         s"/${curatedContent.properties.webUrl
           .map(_.replaceFirst("^https?://www.theguardian.com/", ""))
           .orElse(curatedContent.properties.href)
-          .getOrElse(fc.card.id)}"
+          .getOrElse(curatedContent.card.id)}"
       case supportingCuratedContent: SupportingCuratedContent =>
-        s"/${supportingCuratedContent.properties.href.getOrElse(fc.card.id)}"
+        s"/${supportingCuratedContent.properties.webUrl
+          .map(_.replaceFirst("^https?://www.theguardian.com/", ""))
+          .orElse(supportingCuratedContent.properties.href)
+          .getOrElse(supportingCuratedContent.card.id)}"
       case linkSnap: LinkSnap => linkSnap.properties.href.getOrElse(linkSnap.card.id)
       case latestSnap: LatestSnap =>
         latestSnap.properties.maybeContent


### PR DESCRIPTION
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

## What does this change?

We've had issues where content which use evolving URLs being featured on fronts (specifically in sublinks) were using the original CAPI Id, and not the weburl to create the href on the front:

<img width="844" alt="image" src="https://user-images.githubusercontent.com/9575458/199001287-dee3bdb6-aac9-4d03-9dff-df96957149d2.png">

This meant we were linking to an old URL which redirected to the new, evolved, URL.

## Does this change need to be reproduced in dotcom-rendering ?

- [] No
- [x] Yes - DCRs enchanceSupportingContent method also uses the wrong data on the PressedCard datamodel and needs updating

## Screenshots

Before, the URL on the front was redirecting: 
<img width="844" alt="image" src="https://user-images.githubusercontent.com/9575458/199001287-dee3bdb6-aac9-4d03-9dff-df96957149d2.png">
<img width="681" alt="image" src="https://user-images.githubusercontent.com/9575458/199001027-a3baa2b9-456f-40ec-acb5-ab677f2a3733.png">

Now, it links to the correct URL, which won't redirect:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/9575458/199001465-30ec66df-1906-42b6-bcd1-9d029c5ca3c6.png">
<img width="587" alt="image" src="https://user-images.githubusercontent.com/9575458/199001587-125002cf-66c1-4d12-976a-83b8e02284cc.png">



## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
