### PR TITLE
Skip header bidding in Canada

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -134,4 +134,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2022, 12, 30)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-remove-prebid-a9-canada",
+    "Remove the initialisation of Prebid and A9 in the Canada region",
+    owners = Seq(Owner.withGithub("domlander")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 1, 31)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.spec.ts
@@ -1,4 +1,8 @@
 import { isInCanada } from 'common/modules/commercial/geo-utils';
+import {
+	isInABTestSynchronous,
+	isInVariantSynchronous,
+} from 'common/modules/experiments/ab';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
 import { a9 } from '../header-bidding/a9/a9';
 import { dfpEnv } from './dfp-env';
@@ -8,6 +12,11 @@ const { setupA9 } = _;
 
 jest.mock('../../../common/modules/commercial/geo-utils', () => ({
 	isInCanada: jest.fn(() => false),
+}));
+
+jest.mock('common/modules/experiments/ab', () => ({
+	isInABTestSynchronous: jest.fn().mockReturnValue(false),
+	isInVariantSynchronous: jest.fn().mockReturnValue(false),
 }));
 
 jest.mock('../../../common/modules/commercial/commercial-features', () => ({
@@ -44,7 +53,7 @@ const fakeUserAgent = (userAgent?: string) => {
 
 describe('init', () => {
 	beforeEach(() => {
-		jest.clearAllMocks();
+		jest.resetAllMocks();
 		fakeUserAgent();
 	});
 
@@ -56,17 +65,48 @@ describe('init', () => {
 		dfpEnv.hbImpl = { a9: true, prebid: false };
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
+
 		await setupA9();
+
 		expect(a9.initialise).toBeCalled();
 	});
 
-	it('should NOT initialise A9 when in Canada', async () => {
+	it('should NOT initialise A9 when in Canada and NOT in test', async () => {
 		dfpEnv.hbImpl = { a9: true, prebid: false };
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		(isInCanada as jest.Mock).mockReturnValueOnce(true);
+		(isInABTestSynchronous as jest.Mock).mockReturnValueOnce(false);
+
 		await setupA9();
+
 		expect(a9.initialise).not.toBeCalled();
+	});
+
+	it('should NOT initialise A9 when in Canada and in test control', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		(isInCanada as jest.Mock).mockReturnValueOnce(true);
+		(isInABTestSynchronous as jest.Mock).mockReturnValueOnce(true);
+		(isInVariantSynchronous as jest.Mock).mockReturnValueOnce(false);
+
+		await setupA9();
+
+		expect(a9.initialise).not.toBeCalled();
+	});
+
+	it('should initialise A9 when in Canada and when in test variant', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		(isInCanada as jest.Mock).mockReturnValueOnce(true);
+		(isInABTestSynchronous as jest.Mock).mockReturnValueOnce(true);
+		(isInVariantSynchronous as jest.Mock).mockReturnValueOnce(true);
+
+		await setupA9();
+
+		expect(a9.initialise).toBeCalled();
 	});
 
 	it('should initialise A9 when both prebid and a9 switches are ON and advertising is on and ad-free is off', async () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.ts
@@ -6,6 +6,10 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import type { TCFv2ConsentState } from '@guardian/consent-management-platform/dist/types/tcfv2';
 import { log } from '@guardian/libs';
 import { isInCanada } from 'common/modules/commercial/geo-utils';
+import {
+	isInABTestSynchronous,
+	isInVariantSynchronous,
+} from 'common/modules/experiments/ab';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
 import { prebid } from '../header-bidding/prebid/prebid';
 import { dfpEnv } from './dfp-env';
@@ -15,6 +19,11 @@ const { setupPrebid } = _;
 
 jest.mock('common/modules/commercial/geo-utils', () => ({
 	isInCanada: jest.fn(() => false),
+}));
+
+jest.mock('common/modules/experiments/ab', () => ({
+	isInABTestSynchronous: jest.fn().mockReturnValue(false),
+	isInVariantSynchronous: jest.fn().mockReturnValue(false),
 }));
 
 jest.mock('../../../../lib/raven');
@@ -126,7 +135,7 @@ const fakeUserAgent = (userAgent?: string) => {
 
 describe('init', () => {
 	beforeEach(() => {
-		jest.clearAllMocks();
+		jest.resetAllMocks();
 		fakeUserAgent();
 	});
 
@@ -170,7 +179,21 @@ describe('init', () => {
 		expect(prebid.initialise).not.toBeCalled();
 	});
 
-	it('should NOT initialise Prebid when in Canada', async () => {
+	it('should initialise Prebid when NOT in Canada', async () => {
+		expect.hasAssertions();
+
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		mockOnConsent(tcfv2WithConsent);
+		mockGetConsentFor(true);
+		(isInCanada as jest.Mock).mockReturnValueOnce(false);
+
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
+	});
+
+	it('should NOT initialise Prebid when in Canada and NOT in test', async () => {
 		expect.hasAssertions();
 
 		dfpEnv.hbImpl = { prebid: true, a9: false };
@@ -179,10 +202,43 @@ describe('init', () => {
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
 		(isInCanada as jest.Mock).mockReturnValueOnce(true);
+		(isInABTestSynchronous as jest.Mock).mockReturnValueOnce(false);
+		(isInVariantSynchronous as jest.Mock).mockReturnValueOnce(false);
 
 		await setupPrebid();
-
 		expect(prebid.initialise).not.toBeCalled();
+	});
+
+	it('should NOT initialise Prebid when in Canada and when in test control', async () => {
+		expect.hasAssertions();
+
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		mockOnConsent(tcfv2WithConsent);
+		mockGetConsentFor(true);
+		(isInCanada as jest.Mock).mockReturnValueOnce(true);
+		(isInABTestSynchronous as jest.Mock).mockReturnValueOnce(true);
+		(isInVariantSynchronous as jest.Mock).mockReturnValueOnce(false);
+
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
+
+	it('should initialise Prebid when in Canada and when in test variant', async () => {
+		expect.hasAssertions();
+
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		mockOnConsent(tcfv2WithConsent);
+		mockGetConsentFor(true);
+		(isInCanada as jest.Mock).mockReturnValueOnce(true);
+		(isInABTestSynchronous as jest.Mock).mockReturnValueOnce(true);
+		(isInVariantSynchronous as jest.Mock).mockReturnValueOnce(true);
+
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
 	});
 
 	it('should not initialise Prebid when advertising is switched off', async () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
@@ -5,33 +5,30 @@ import {
 import type { Framework } from '@guardian/consent-management-platform/dist/types';
 import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
+import { isInCanada } from 'common/modules/commercial/geo-utils';
 import { isGoogleProxy } from 'lib/detect-google-proxy';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
 import { prebid } from '../header-bidding/prebid/prebid';
 import { shouldIncludeOnlyA9 } from '../header-bidding/utils';
 import { dfpEnv } from './dfp-env';
 
+const shouldLoadPrebid = () =>
+	!isGoogleProxy() &&
+	dfpEnv.hbImpl.prebid &&
+	commercialFeatures.dfpAdvertising &&
+	!commercialFeatures.adFree &&
+	!window.guardian.config.page.hasPageSkin &&
+	!shouldIncludeOnlyA9 &&
+	!isInCanada();
+
 const loadPrebid = async (framework: Framework): Promise<void> => {
-	// TODO: Understand why we want to skip Prebid for Google Proxy
-	if (isGoogleProxy()) return;
-
-	if (
-		!dfpEnv.hbImpl.prebid ||
-		!commercialFeatures.dfpAdvertising ||
-		commercialFeatures.adFree ||
-		window.guardian.config.page.hasPageSkin ||
-		shouldIncludeOnlyA9
-	)
-		return;
-
-	await import(
-		// @ts-expect-error -- there’s no types for Prebid.js
-		/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid'
-	);
-
-	prebid.initialise(window, framework);
-
-	return;
+	if (shouldLoadPrebid()) {
+		await import(
+			// @ts-expect-error -- there’s no types for Prebid.js
+			/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid'
+		);
+		prebid.initialise(window, framework);
+	}
 };
 
 const setupPrebid = (): Promise<void> =>

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,9 +1,11 @@
 import type { ABTest } from '@guardian/ab-core';
 import { getUrlVars } from 'lib/url';
 import { isInABTestSynchronous } from '../experiments/ab';
+import { removePrebidA9Canada } from '../experiments/tests/removePrebidA9Canada';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
+	removePrebidA9Canada,
 ];
 
 const serverSideTests: ServerSideABTest[] = [

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -3,6 +3,7 @@ import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { integrateIMA } from './tests/integrate-ima';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
+import { removePrebidA9Canada } from './tests/removePrebidA9Canada';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 import {
@@ -33,4 +34,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMandatoryLongTestVariantNa,
 	signInGateMandatoryLongTestVariantEu,
 	signInGateMandatoryLongTestVariantUk,
+	removePrebidA9Canada,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/removePrebidA9Canada.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/removePrebidA9Canada.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const removePrebidA9Canada: ABTest = {
+	id: 'RemovePrebidA9Canada',
+	author: '@commercial-dev',
+	start: '2022-11-01',
+	expiry: '2023-01-31',
+	audience: 10 / 100,
+	audienceOffset: 20 / 100,
+	audienceCriteria: 'Canada users only',
+	successMeasure:
+		'There are significant benefits of not initialising Prebid and A9 in Canada',
+	description:
+		'Testing the benefits of not initialising Prebid and A9 in Canada',
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/removePrebidA9Canada.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/removePrebidA9Canada.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { isInCanada } from 'common/modules/commercial/geo-utils';
 import { noop } from '../../../../../lib/noop';
 
 export const removePrebidA9Canada: ABTest = {
@@ -17,5 +18,5 @@ export const removePrebidA9Canada: ABTest = {
 		{ id: 'control', test: noop },
 		{ id: 'variant', test: noop },
 	],
-	canRun: () => true,
+	canRun: () => isInCanada(),
 };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -290,7 +290,8 @@
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/header-bidding/a9/a9.ts",
   "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/commercial/geo-utils.ts"
  ],
  "../projects/commercial/modules/dfp/prepare-googletag.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
@@ -333,7 +334,8 @@
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
   "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/commercial/geo-utils.ts"
  ],
  "../projects/commercial/modules/dfp/queue-advert.ts": [
   "../projects/commercial/modules/dfp/Advert.ts",


### PR DESCRIPTION
Co-authored-by: @domlander

## What does this change?

Removes the calls to Prebid and Amazon A9 for users in Canada.
Introduces an AB test so we can't test the benefits of this change. Only Canada users will be involved in this AB test. The variant and the control groups will each comprise of 5% of users.

## What is the value of this and can you measure success?

In Canada, we have a partnership in which we pass all of our impressions at the highest sponsorship priority. We don't require Prebid or A9, so we should not call them.
The AB test will measure the value of this change.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (PR: _incoming_ )

### Tested

- [x] Locally
- [ ] On CODE (optional)
