### PR TITLE
Bump commercial core to 4.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^7.4.0",
-		"@guardian/commercial-core": "4.18.0",
+		"@guardian/commercial-core": "4.21.0",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/libs": "^7.1.4",
 		"@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
@@ -2,7 +2,6 @@ import { buildPageTargetingConsentless } from '@guardian/commercial-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { loadScript } from '@guardian/libs';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { getSynchronousParticipations } from 'common/modules/experiments/ab';
 
 function initConsentless(consentState: ConsentState): Promise<void> {
 	// Stub the command queue
@@ -21,7 +20,6 @@ function initConsentless(consentState: ConsentState): Promise<void> {
 			buildPageTargetingConsentless(
 				consentState,
 				commercialFeatures.adFree,
-				getSynchronousParticipations(),
 			),
 		).forEach(([key, value]) => {
 			if (!value) {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
@@ -9,9 +9,6 @@ const buildPageTargeting = buildPageTargeting_ as jest.MockedFunction<
 jest.mock('../../../../lib/geolocation', () => ({
 	getCountryCode: jest.fn(),
 }));
-jest.mock('../experiments/ab', () => ({
-	getSynchronousParticipations: jest.fn(),
-}));
 jest.mock('@guardian/commercial-core', () => ({
 	buildPageTargeting: jest.fn(),
 }));

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -4,7 +4,6 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
 import { removeFalseyValues } from '../../../commercial/modules/header-bidding/utils';
-import { getSynchronousParticipations } from '../experiments/ab';
 import { commercialFeatures } from './commercial-features';
 
 const formatAppNexusTargeting = (obj: Record<string, string | string[]>) => {
@@ -47,7 +46,6 @@ const getPageTargeting = (consentState: ConsentState): PageTargeting => {
 	const pageTargeting = buildPageTargeting(
 		consentState,
 		commercialFeatures.adFree,
-		getSynchronousParticipations(),
 	);
 
 	// third-parties wish to access our page targeting, before the googletag script is loaded.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,10 +2089,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.4.0.tgz#cccd1e39156a12ca4304bfb4f6113d41521af753"
   integrity sha512-r3+yM/qh45g1gI/FCD1ooCwOntcHnemcjo/E+phgYLvXGGDG82l6AzdMVyC8c4ZGfeFu2EnUPhHALUMyaT/qdg==
 
-"@guardian/commercial-core@4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.18.0.tgz#af629686bf5e88e1bdf9dfccf518cf13e8d882da"
-  integrity sha512-vDPx3sGQLSEoQJomnOvxnXlUySicKfK6FHaC93dZjWi8doVG5NlB9AWB+8W+/BtSPpa8M+sU2KQnkvLy8cHk0w==
+"@guardian/commercial-core@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.21.0.tgz#d6ad678a563bd82c3ed738bc4f77a0c7494a5120"
+  integrity sha512-OpME2iB6Dosvdu7MF8npzgIeRFOPWwdeSVNaUI3aB1wqU+FQh47cozGk1BASgCXlsUwhhGvQbx5vTBkDiptsgQ==
 
 "@guardian/consent-management-platform@^10.11.1":
   version "10.11.1"


### PR DESCRIPTION
## What does this change?

Bumps `commercial-core` to `4.21.0`. 

Stops building `clientSideParticipations` and passing them into `buildPageTargeting` (see: https://github.com/guardian/commercial-core/pull/699)

This bump will also pull in changes from:

- https://github.com/guardian/commercial-core/pull/700 (@Jakeii)
- https://github.com/guardian/commercial-core/pull/703 (@arelra)

But that should be fine.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

More commercial logic moved from `frontend` to `commercial-core`!

### Tested

- [ ] Locally
- [x] On CODE (I opted into various server-side and client-side tests and observed they were correctly included against the `ab` targeting key)
