### PR TITLE
Align header Logo with DCR

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -20,9 +20,7 @@
 
             @defining(Edition(request).id.toLowerCase()) { editionId =>
                 <a href="@LinkTo {/}"
-                class="@{if(editionId == "uk") {"new-header__logo news-header__logo-best-website"} else {
-                  "new-header__logo"
-                }}"
+                class="new-header__logo"
                 data-link-name="nav2 : logo">
 
                     <span class="u-h">The Guardian - Back to home</span>

--- a/static/src/stylesheets/layout/nav/_new-header.scss
+++ b/static/src/stylesheets/layout/nav/_new-header.scss
@@ -147,16 +147,18 @@ from scrolling */
 }
 
 .news-header__logo-best-website {
+    margin-top: 10px;
+
     @include mq($until: mobileMedium) {
         margin-bottom: 17px;
     }
 
-    @include mq(mobileMedium) {
-        margin-top: 14px;
-    }
-
     @include mq(tablet) {
         margin-top: 8px;
+    }
+
+    @include mq(desktop) {
+        margin-top: 5px;
     }
 }
 
@@ -208,11 +210,11 @@ from scrolling */
     }
 
     @include mq(tablet) {
-        width: 229px;
+        width: 224px;
     }
 
     @include mq(desktop) {
-        width: 301px;
+        width: 295px;
     }
 }
 

--- a/static/src/stylesheets/layout/nav/_new-header.scss
+++ b/static/src/stylesheets/layout/nav/_new-header.scss
@@ -146,22 +146,6 @@ from scrolling */
     }
 }
 
-.news-header__logo-best-website {
-    margin-top: 10px;
-
-    @include mq($until: mobileMedium) {
-        margin-bottom: 17px;
-    }
-
-    @include mq(tablet) {
-        margin-top: 8px;
-    }
-
-    @include mq(desktop) {
-        margin-top: 5px;
-    }
-}
-
 .inline-the-guardian-roundel__svg {
     height: $veggie-burger;
     width: $veggie-burger;


### PR DESCRIPTION
## What does this change?

Align the logo so it matches DCR’s positioning perfectly.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/199550421-b6e02cfe-76a3-4695-9400-c4d3696a50f9.png
[after]: https://user-images.githubusercontent.com/76776/199550472-6d577145-ef03-4455-81ad-c8784163c576.png

## What is the value of this and can you measure success?

Smoother transition between our apps.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
