### PR TITLE
Adjust “Most Popular” labels

### DIFF
--- a/common/app/views/fragments/collections/popularExtended.scala.html
+++ b/common/app/views/fragments/collections/popularExtended.scala.html
@@ -18,7 +18,7 @@
                 @popular.zipWithRowInfo.map{ case (section, info) =>
                 <li class="tabs__tab--most-popular@if(info.isFirst){ tabs__tab--selected}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">
                     <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading">
-                        <span class="u-h">Most viewed </span>@Html(Localisation(section.heading.stripPrefix("popular ")))
+                        <span class="u-h">Most viewed </span>@Html(Localisation(section.heading.stripPrefix("popular ").stripPrefix("Most viewed ")))
                     </a>
                 </li>
                 }

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -54,7 +54,7 @@ class MostPopularController(
       val globalPopular: Option[MostPopular] = {
         val globalPopularContent = mostPopularAgent.mostPopular(edition)
         if (globalPopularContent.nonEmpty)
-          Some(MostPopular("Across The&nbsp;Guardian", "", globalPopularContent.map(_.faciaContent)))
+          Some(MostPopular("Across the&nbsp;Guardian", "", globalPopularContent.map(_.faciaContent)))
         else
           None
       }
@@ -104,7 +104,7 @@ class MostPopularController(
       val headers = request.headers.toSimpleMap
       val countryCode = headers.getOrElse("X-GU-GeoLocation", "country:row").replace("country:", "")
       val countryPopular =
-        MostPopular("Across The&nbsp;Guardian", "", geoMostPopularAgent.mostPopular(countryCode).map(_.faciaContent))
+        MostPopular("Across the&nbsp;Guardian", "", geoMostPopularAgent.mostPopular(countryCode).map(_.faciaContent))
 
       if (request.forceDCR) {
         jsonResponse(countryPopular, countryCode)
@@ -261,7 +261,7 @@ class MostPopularController(
       if (path == "film") capiItem.dateParam("from-date", Instant.now.minus(180, ChronoUnit.DAYS)) else capiItem
 
     contentApiClient.getResponse(capiItemWithDate).map { response =>
-      val heading = response.section.map(s => "in " + s.webTitle).getOrElse("Across The&nbsp;Guardian")
+      val heading = response.section.map(s => "in " + s.webTitle).getOrElse("Across the&nbsp;Guardian")
       val popular = response.mostViewed.getOrElse(Nil) take 10 map (RelatedContentItem(_))
       if (popular.isEmpty) None else Some(MostPopular(heading, path, popular.map(_.faciaContent).toSeq))
     }


### PR DESCRIPTION
## What does this change?

- Removes the duplicate “Most viewed” prefix from the tab label.
- Keep the capitalisation of the Guardian consistent

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No – This is already [how it looks](https://www.theguardian.com/technology/2022/nov/02/twitter-departures-elon-musk-layoffs)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/199711894-077ba63d-066e-4046-8f86-f6758c43ee9b.png
[after]: https://user-images.githubusercontent.com/76776/199711778-10e72b49-3a0b-4139-a0c8-e38ddbe00807.png

## What is the value of this and can you measure success?

Screen readers will stop reading “Most viewed most viewed in technology”.

We are no longer capitalising “The” before “Guardian”, as per 

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
