### PR TITLE
Surface test percentage in kibana logs for DCR Fronts test

### DIFF
--- a/common/app/experiments/ParticipationGroups.scala
+++ b/common/app/experiments/ParticipationGroups.scala
@@ -5,6 +5,11 @@ import scala.collection.immutable
 
 sealed abstract class ParticipationGroup(val headerName: String) extends EnumEntry {
   override def toString: String = headerName
+
+  val percentage = headerName match {
+    case s"X-GU-Experiment-${percNo}perc-${_}" => percNo
+    case _                                     => "unknown"
+  }
 }
 
 object ParticipationGroups extends enumeratum.Enum[ParticipationGroup] {

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -177,6 +177,7 @@ class FaciaPicker extends GuLogging {
     val properties =
       Map(
         "participatingInTest" -> participatingInTest.toString,
+        "testPercentage" -> DCRFronts.participationGroup.percentage,
         "dcrCouldRender" -> dcrCouldRender.toString,
         "isFront" -> "true",
         "tier" -> tierReadable,


### PR DESCRIPTION
## What does this change?

Include the test % in the logs we send to kibana, so that we can include this in our dashboard for tracking migration progress.

To do this I used string pattern matching to fetch the % from the participation header. I don't know if there's a better way to do this is scala but I quite like it!

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Will go somewhere on this page:
<img width="2023" alt="image" src="https://user-images.githubusercontent.com/9575458/199774914-64b32492-ea2e-434f-9b95-923d2256ec44.png">


## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
