### PR TITLE
Bump content-api-scala-client to 19.0.5 and facia-scala-client to 4.0.3

### DIFF
--- a/common/app/model/CardStyle.scala
+++ b/common/app/model/CardStyle.scala
@@ -7,6 +7,7 @@ sealed trait CardStyle {
 }
 
 case object SpecialReport extends CardStyle { val toneString = fapiutils.CardStyle.specialReport }
+case object SpecialReportAlt extends CardStyle { val toneString = fapiutils.CardStyle.specialReportAlt }
 case object LiveBlog extends CardStyle { val toneString = fapiutils.CardStyle.live }
 case object DeadBlog extends CardStyle { val toneString = fapiutils.CardStyle.dead }
 case object Feature extends CardStyle { val toneString = fapiutils.CardStyle.feature }
@@ -23,6 +24,7 @@ object CardStyle {
   def make(cardStyle: fapiutils.CardStyle): CardStyle =
     cardStyle match {
       case fapiutils.SpecialReport    => SpecialReport
+      case fapiutils.SpecialReportAlt => SpecialReportAlt
       case fapiutils.LiveBlog         => LiveBlog
       case fapiutils.DeadBlog         => DeadBlog
       case fapiutils.Feature          => Feature

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -52,6 +52,7 @@ object CardStyleFormat extends Format[CardStyle] {
   def reads(json: JsValue): JsResult[CardStyle] = {
     (json \ "type").transform[JsString](Reads.JsStringReads) match {
       case JsSuccess(JsString("SpecialReport"), _)    => JsSuccess(SpecialReport)
+      case JsSuccess(JsString("SpecialReportAlt"), _) => JsSuccess(SpecialReportAlt)
       case JsSuccess(JsString("LiveBlog"), _)         => JsSuccess(LiveBlog)
       case JsSuccess(JsString("DeadBlog"), _)         => JsSuccess(DeadBlog)
       case JsSuccess(JsString("Feature"), _)          => JsSuccess(Feature)
@@ -70,6 +71,7 @@ object CardStyleFormat extends Format[CardStyle] {
   def writes(cardStyle: CardStyle): JsObject =
     cardStyle match {
       case SpecialReport    => JsObject(Seq("type" -> JsString("SpecialReport")))
+      case SpecialReportAlt => JsObject(Seq("type" -> JsString("SpecialReportAlt")))
       case LiveBlog         => JsObject(Seq("type" -> JsString("LiveBlog")))
       case DeadBlog         => JsObject(Seq("type" -> JsString("DeadBlog")))
       case Feature          => JsObject(Seq("type" -> JsString("Feature")))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.0.4"
-  val faciaVersion = "4.0.2"
+  val capiVersion = "19.0.5"
+  val faciaVersion = "4.0.3"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?
* Bumps `content-api-scala-client` to `19.0.5` and `facia-scala-client` to `4.0.3`
* Adds the minimum changes needed for frontend to compile

The new clients have the following changes:
* Adds `SpecialReportAltTheme` and `SpecialReportAlt` hashed tag: https://github.com/guardian/content-api-scala-client/pull/371
* Adds `SpecialReportAlt` to `CardStyle`: https://github.com/guardian/facia-scala-client/pull/280 
* Adds `SpecialReportAltPalette`: https://github.com/guardian/facia-scala-client/pull/281

[Another PR is in progress](https://github.com/guardian/frontend/pull/25602) to send the new theme to DCR, add styles for the new cardStyle and the palette.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [x] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
