### PR TITLE
Most viewed container on fronts

### DIFF
--- a/common/app/feed/MostViewed.scala
+++ b/common/app/feed/MostViewed.scala
@@ -70,9 +70,9 @@ object MostViewed extends GuLogging {
 
   // This function takes a sequence of items and a function that maps each item to a future.
   // Each future carries a map, all the maps are collapsed into one using a reduce
-  def refreshAll[A](as: Seq[A])(
-    refreshOne: A => Future[Map[Country, Seq[RelatedContentItem]]],
-  )(implicit ec: ExecutionContext): Future[Map[Country, Seq[RelatedContentItem]]] = {
+  def refreshAll[A, B](as: Seq[A])(
+    refreshOne: A => Future[Map[B, Seq[RelatedContentItem]]],
+  )(implicit ec: ExecutionContext): Future[Map[B, Seq[RelatedContentItem]]] = {
     as.map(refreshOne)
       .reduce((itemsF, otherItemsF) =>
         for {

--- a/common/app/feed/MostViewed.scala
+++ b/common/app/feed/MostViewed.scala
@@ -25,7 +25,7 @@ object Country {
       case "in" => IN
       case "ng" => NG
       case "nz" => NZ
-      case _ => ROW
+      case _    => ROW
     }
 }
 case object GB extends Country {
@@ -71,7 +71,7 @@ object MostViewed extends GuLogging {
   // This function takes a sequence of items and a function that maps each item to a future.
   // Each future carries a map, all the maps are collapsed into one using a reduce
   def refreshAll[A, B](as: Seq[A])(
-    refreshOne: A => Future[Map[B, Seq[RelatedContentItem]]],
+      refreshOne: A => Future[Map[B, Seq[RelatedContentItem]]],
   )(implicit ec: ExecutionContext): Future[Map[B, Seq[RelatedContentItem]]] = {
     as.map(refreshOne)
       .reduce((itemsF, otherItemsF) =>

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -115,6 +115,8 @@ trait Requests {
 
     // slot machine
     lazy val slotMachineFlags = r.getQueryString("slot-machine-flags").getOrElse("")
+
+    lazy val countryCode = r.headers.toSimpleMap.getOrElse("X-GU-GeoLocation", "country:row").replace("country:", "")
   }
 
 }

--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -4,8 +4,10 @@ import common.Edition
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import conf.Configuration
+import com.gu.contentapi.client.model.v1.Content
 import experiments.ActiveExperiments
-import model.PressedPage
+import layout.ContentCard
+import model.{PressedPage, RelatedContentItem}
 import navigation.{FooterLinks, Nav}
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.RequestHeader
@@ -25,12 +27,22 @@ case class DotcomFrontsRenderingDataModel(
     pageFooter: PageFooter,
     isAdFreeUser: Boolean,
     isNetworkFront: Boolean,
+    mostViewed: Seq[Trail],
+    mostCommented: Option[Trail],
+    mostShared: Option[Trail],
 )
 
 object DotcomFrontsRenderingDataModel {
   implicit val writes = Json.writes[DotcomFrontsRenderingDataModel]
 
-  def apply(page: PressedPage, request: RequestHeader, pageType: PageType): DotcomFrontsRenderingDataModel = {
+  def apply(
+      page: PressedPage,
+      request: RequestHeader,
+      pageType: PageType,
+      mostViewed: Seq[RelatedContentItem],
+      mostCommented: Option[Content],
+      mostShared: Option[Content],
+  ): DotcomFrontsRenderingDataModel = {
     val edition = Edition.edition(request)
     val nav = Nav(page, edition)
 
@@ -73,6 +85,9 @@ object DotcomFrontsRenderingDataModel {
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),
       isAdFreeUser = views.support.Commercial.isAdFree(request),
       isNetworkFront = page.isNetworkFront,
+      mostViewed = mostViewed.map(content => Trail.pressedContentToTrail(content.faciaContent)(request)),
+      mostCommented = mostCommented.flatMap(ContentCard.fromApiContent).flatMap(Trail.contentCardToTrail),
+      mostShared = mostShared.flatMap(ContentCard.fromApiContent).flatMap(Trail.contentCardToTrail),
     )
   }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -1,7 +1,7 @@
 package renderers
 
 import akka.actor.ActorSystem
-import com.gu.contentapi.client.model.v1.{Block, Blocks}
+import com.gu.contentapi.client.model.v1.{Block, Blocks, Content}
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
@@ -24,6 +24,7 @@ import model.{
   NoCache,
   PageWithStoryPackage,
   PressedPage,
+  RelatedContentItem,
   Topic,
   TopicResult,
 }
@@ -212,8 +213,18 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       ws: WSClient,
       page: PressedPage,
       pageType: PageType,
+      mostViewed: Seq[RelatedContentItem],
+      mostCommented: Option[Content],
+      mostShared: Option[Content],
   )(implicit request: RequestHeader): Future[Result] = {
-    val dataModel = DotcomFrontsRenderingDataModel(page, request, pageType)
+    val dataModel = DotcomFrontsRenderingDataModel(
+      page,
+      request,
+      pageType,
+      mostViewed,
+      mostCommented,
+      mostShared,
+    )
 
     val json = DotcomFrontsRenderingDataModel.toJson(dataModel)
     post(ws, json, Configuration.rendering.baseURL + "/Front", CacheTime.Facia)

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -8,6 +8,7 @@ import common.dfp.FaciaDfpAgentLifecycle
 import concurrent.BlockingOperations
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
+import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import controllers.{FaciaControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import feed.MostViewedLifecycle
@@ -39,13 +40,17 @@ trait FapiServices {
 
 trait AppComponents extends FrontendComponents with FaciaControllers with FapiServices {
 
+  lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
+  lazy val contentApiClient = wire[ContentApiClient]
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val ophanApi = wire[OphanApi]
   lazy val logbackOperationsPool = wire[LogbackOperationsPool]
   lazy val mostViewedAgent = wire[MostViewedAgent]
 
+
   override lazy val lifecycleComponents = List(
+
     wire[LogstashLifecycle],
     wire[ConfigAgentLifecycle],
     wire[CloudWatchMetricsLifecycle],

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -1,3 +1,4 @@
+import agents.MostViewedAgent
 import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
@@ -9,6 +10,7 @@ import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import controllers.{FaciaControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
+import feed.MostViewedLifecycle
 import http.{CommonFilters, PreloadFilters}
 import model.ApplicationIdentity
 import services.ophan.SurgingContentAgentLifecycle
@@ -41,6 +43,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val ophanApi = wire[OphanApi]
   lazy val logbackOperationsPool = wire[LogbackOperationsPool]
+  lazy val mostViewedAgent = wire[MostViewedAgent]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -51,6 +54,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
     wire[IndexListingsLifecycle],
     wire[SwitchboardLifecycle],
     wire[CachedHealthCheckLifeCycle],
+    wire[MostViewedLifecycle],
   )
 
   lazy val router: Router = wire[Routes]

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -48,9 +48,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   lazy val logbackOperationsPool = wire[LogbackOperationsPool]
   lazy val mostViewedAgent = wire[MostViewedAgent]
 
-
   override lazy val lifecycleComponents = List(
-
     wire[LogstashLifecycle],
     wire[ConfigAgentLifecycle],
     wire[CloudWatchMetricsLifecycle],

--- a/facia/app/agents/MostViewedAgent.scala
+++ b/facia/app/agents/MostViewedAgent.scala
@@ -33,7 +33,7 @@ class MostViewedAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, ws
     implicit val format = Json.format[MostDiscussedItem]
   }
 
-  private def refreshGlobal()(implicit ec: ExecutionContext): Future[(Option[Content],Option[Content])] = {
+  private def refreshGlobal()(implicit ec: ExecutionContext): Future[(Option[Content], Option[Content])] = {
 
     log.info("Pulling most social media shared from Ophan")
 
@@ -82,10 +82,19 @@ class MostViewedAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, ws
   // These are the only country codes passed to us from the fastly service.
   // This allows us to choose carefully the codes that give us the most impact. The trade-off is caching.
   private val countries = Seq(
-    GB, US, CA, AU, NG, NZ, IN, ROW
+    GB,
+    US,
+    CA,
+    AU,
+    NG,
+    NZ,
+    IN,
+    ROW,
   )
 
-  private def refresh(country: Country)(implicit ec: ExecutionContext): Future[Map[Country, Seq[RelatedContentItem]]] = {
+  private def refresh(
+      country: Country,
+  )(implicit ec: ExecutionContext): Future[Map[Country, Seq[RelatedContentItem]]] = {
     val ophanMostViewed = ophanApi.getMostRead(hours = 3, count = 10, country = country.code.toLowerCase)
     MostViewed.relatedContentItems(ophanMostViewed, country.edition)(contentApiClient).flatMap { items =>
       val validItems = items.flatten

--- a/facia/app/agents/MostViewedAgent.scala
+++ b/facia/app/agents/MostViewedAgent.scala
@@ -15,9 +15,14 @@ case class Country(code: String, edition: Edition)
 
 class MostViewedAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, wsClient: WSClient) extends GuLogging {
 
+  private val mostViewedBox = Box[Seq[RelatedContentItem]](Seq.empty)
   private val relatedContentsBox = Box[Map[String, Seq[RelatedContentItem]]](Map.empty)
   private val mostCommentedCardBox = Box[Option[Content]](None)
   private val mostSharedCardBox = Box[Option[Content]](None)
+
+  def mostViewed = mostViewedBox.get()
+  def mostCommented = mostCommentedCardBox.get()
+  def mostShared = mostSharedCardBox.get()
 
   // Container for most_shared and most_commented
   val mostSingleCardsBox = Box[Map[String, Content]](Map.empty)

--- a/facia/app/agents/MostViewedAgent.scala
+++ b/facia/app/agents/MostViewedAgent.scala
@@ -1,0 +1,144 @@
+package feed
+
+import conf.Configuration
+import contentapi.ContentApiClient
+import com.gu.contentapi.client.model.v1.Content
+import common._
+import services.{OphanApi}
+import model.RelatedContentItem
+import play.api.libs.json._
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class Country(code: String, edition: Edition)
+
+class MostViewedAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, wsClient: WSClient) extends GuLogging {
+
+  private val relatedContentsBox = Box[Map[String, Seq[RelatedContentItem]]](Map.empty)
+  private val mostCommentedCardBox = Box[Option[Content]](None)
+  private val mostSharedCardBox = Box[Option[Content]](None)
+
+  // Container for most_shared and most_commented
+  val mostSingleCardsBox = Box[Map[String, Content]](Map.empty)
+
+  // Helper case class to read from the most/comments discussion API call.
+  private case class MostDiscussedItem(key: String, url: String, numberOfComments: Int) {
+    def isLiveBlog: Boolean = url.contains("/live/")
+  }
+
+  private object MostDiscussedItem {
+    implicit val format = Json.format[MostDiscussedItem]
+  }
+
+  private def refreshGlobal()(implicit ec: ExecutionContext): Future[Map[String, Content]] = {
+
+    log.info("Pulling most social media shared from Ophan")
+
+    val sinceHours = 3
+    val sinceTimestamp = System.currentTimeMillis - sinceHours * 60 * 60 * 1000
+
+    val futureMostFaceBook = ophanApi.getMostReadFacebook(sinceHours)
+    val futureMostCommented = mostCommented(wsClient, sinceTimestamp)
+
+    for {
+      mostFacebook <- futureMostFaceBook
+      oneFacebookMostRead = mostFacebook.headOption.get
+      oneFacebookContent <- contentFromUrl(oneFacebookMostRead.url, contentApiClient)
+      _ <- mostSingleCardsBox.alter(_ + ("most_shared" -> oneFacebookContent))
+
+      oneMostCommentedItem <- futureMostCommented
+      oneMostCommentedContent <- contentFromUrl(oneMostCommentedItem.url, contentApiClient)
+      newMap <- mostSingleCardsBox.alter(_ + ("most_commented" -> oneMostCommentedContent))
+    } yield newMap
+  }
+
+  private def mostCommented(wsClient: WSClient, since: Long)(implicit
+      ec: ExecutionContext,
+  ): Future[MostDiscussedItem] = {
+    val dapiURL = Configuration.discussion.apiRoot
+    val params = List("api-key" -> "dotcom", "pageSize" -> "10", "sinceTimestamp" -> since.toString)
+
+    val fResponse = wsClient
+      .url(dapiURL + "/most/comments")
+      .addQueryStringParameters(params: _*)
+      .get()
+
+    fResponse.map { r =>
+      val json = r.json
+      (json \ "discussions").as[List[MostDiscussedItem]].filterNot { _.isLiveBlog }.head
+    }
+  }
+
+  private def contentFromUrl(url: String, capi: ContentApiClient)(implicit ec: ExecutionContext): Future[Content] = {
+    capi
+      .getResponse(capi.item(urlToContentPath(url), ""))
+      .map { itemResponse =>
+        itemResponse.content.get
+      }
+  }
+
+  private def refresh(edition: Edition)(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
+
+    val mostViewedQuery = contentApiClient
+      .item("/", edition)
+      .showMostViewed(true)
+
+    val futureMostViewed = contentApiClient.getResponse(mostViewedQuery)
+
+    for {
+      mostViewedResponse <- futureMostViewed
+      mostViewed = mostViewedResponse.mostViewed.getOrElse(Nil).take(10).map(RelatedContentItem(_)).toSeq
+      newMap <- relatedContentsBox.alter(_ + (edition.id -> mostViewed))
+    } yield newMap
+  }
+
+  def mostPopular(edition: Edition): Seq[RelatedContentItem] = relatedContentsBox().getOrElse(edition.id, Nil)
+
+  // Note that here we are in procedural land here (not functional)
+  def refresh()(implicit ec: ExecutionContext): Unit = {
+    MostPopularRefresh.refreshAll(Edition.allWithBetaEditions)(refresh)
+    refreshGlobal()
+  }
+}
+
+class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
+
+  private val box = Box[Map[String, Seq[RelatedContentItem]]](Map.empty)
+
+  private val defaultCountry: Country = Country("row", Edition.defaultEdition)
+
+  // These are the only country codes (row must be lower-case) passed to us from the fastly service.
+  // This allows us to choose carefully the codes that give us the most impact. The trade-off is caching.
+  private val countries = Seq(
+    Country("GB", editions.Uk),
+    Country("US", editions.Us),
+    Country("AU", editions.Au),
+    Country("CA", editions.Us),
+    Country("IN", Edition.defaultEdition),
+    Country("NG", Edition.defaultEdition),
+    Country("NZ", editions.Au),
+    defaultCountry,
+  )
+
+  private def refresh(country: Country)(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
+    val ophanMostViewed = ophanApi.getMostRead(hours = 3, count = 10, country = country.code.toLowerCase)
+    MostViewed.relatedContentItems(ophanMostViewed, country.edition)(contentApiClient).flatMap { items =>
+      val validItems = items.flatten
+      if (validItems.nonEmpty) {
+        log.info(s"Geo popular ${country.code} updated successfully.")
+      } else {
+        log.info(s"Geo popular update for ${country.code} found nothing.")
+      }
+      box.alter(_ + (country.code -> validItems))
+    }
+  }
+
+  def mostPopular(country: String): Seq[RelatedContentItem] =
+    box().getOrElse(country, box().getOrElse(defaultCountry.code, Nil))
+
+  def refresh()(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
+    log.info("Refreshing most popular for countries.")
+    MostPopularRefresh.refreshAll(countries)(refresh)
+  }
+}

--- a/facia/app/agents/MostViewedAgent.scala
+++ b/facia/app/agents/MostViewedAgent.scala
@@ -1,4 +1,4 @@
-package feed
+package agents
 
 import conf.Configuration
 import contentapi.ContentApiClient

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -206,7 +206,17 @@ trait FaciaController
           if FaciaPicker.getTier(faciaPage) == RemoteRender
             && !request.isJson =>
         val pageType = PageType(faciaPage, request, context)
-        withVaryHeader(remoteRenderer.getFront(ws, faciaPage, pageType)(request), targetedTerritories)
+        withVaryHeader(
+          remoteRenderer.getFront(
+            ws = ws,
+            page = faciaPage,
+            pageType = pageType,
+            mostViewed = mostViewedAgent.mostViewed,
+            mostCommented = mostViewedAgent.mostCommented,
+            mostShared = mostViewedAgent.mostShared,
+          )(request),
+          targetedTerritories,
+        )
       case Some((faciaPage: PressedPage, targetedTerritories)) =>
         val result = successful(
           Cached(CacheTime.Facia)(

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -22,6 +22,7 @@ import implicits.GUHeaders
 import pages.{FrontEmailHtmlPage, FrontHtmlPage}
 import utils.TargetedCollections
 import conf.Configuration
+import contentapi.ContentApiClient
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
@@ -211,7 +212,7 @@ trait FaciaController
             ws = ws,
             page = faciaPage,
             pageType = pageType,
-            mostViewed = mostViewedAgent.mostViewed,
+            mostViewed = mostViewedAgent.mostViewed("GB"), // todo -- pass actual country code
             mostCommented = mostViewedAgent.mostCommented,
             mostShared = mostViewedAgent.mostShared,
           )(request),
@@ -230,6 +231,9 @@ trait FaciaController
                     page = faciaPage,
                     request = request,
                     pageType = PageType(faciaPage, request, context),
+                    mostViewed = mostViewedAgent.mostViewed("GB"), // todo -- pass actual country code
+                    mostCommented = mostViewedAgent.mostCommented,
+                    mostShared = mostViewedAgent.mostShared,
                   ),
                 )
               } else JsonFront(faciaPage)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import common._
 import _root_.html.{BrazeEmailFormatter, HtmlTextExtractor}
+import agents.MostViewedAgent
 import common.JsonComponent.Ok
 import controllers.front._
 import layout.{CollectionEssentials, ContentCard, FaciaCard, FaciaCardAndIndex, FaciaContainer, Front}
@@ -40,9 +41,8 @@ trait FaciaController
 
   val frontJsonFapi: FrontJsonFapi
   val ws: WSClient
+  val mostViewedAgent: MostViewedAgent
   val remoteRenderer: DotcomRenderingService = DotcomRenderingService()
-
-  val mostPopularAgent: Most =
 
   implicit val context: ApplicationContext
 
@@ -490,5 +490,6 @@ class FaciaControllerImpl(
     val frontJsonFapi: FrontJsonFapiLive,
     val controllerComponents: ControllerComponents,
     val ws: WSClient,
+    val mostViewedAgent: MostViewedAgent,
 )(implicit val context: ApplicationContext)
     extends FaciaController

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -27,6 +27,7 @@ import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
 import experiments.{ActiveExperiments, EuropeNetworkFront}
+import feed.Country
 import play.api.http.ContentTypes.JSON
 import services.dotcomrendering.{FaciaPicker, RemoteRender}
 import services.fronts.{FrontJsonFapi, FrontJsonFapiLive}
@@ -212,7 +213,7 @@ trait FaciaController
             ws = ws,
             page = faciaPage,
             pageType = pageType,
-            mostViewed = mostViewedAgent.mostViewed("GB"), // todo -- pass actual country code
+            mostViewed = mostViewedAgent.mostViewed(Country.fromHeaderString(request)),
             mostCommented = mostViewedAgent.mostCommented,
             mostShared = mostViewedAgent.mostShared,
           )(request),
@@ -231,7 +232,7 @@ trait FaciaController
                     page = faciaPage,
                     request = request,
                     pageType = PageType(faciaPage, request, context),
-                    mostViewed = mostViewedAgent.mostViewed("GB"), // todo -- pass actual country code
+                    mostViewed = mostViewedAgent.mostViewed(Country.fromHeaderString(request)),
                     mostCommented = mostViewedAgent.mostCommented,
                     mostShared = mostViewedAgent.mostShared,
                   ),

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -42,6 +42,8 @@ trait FaciaController
   val ws: WSClient
   val remoteRenderer: DotcomRenderingService = DotcomRenderingService()
 
+  val mostPopularAgent: Most =
+
   implicit val context: ApplicationContext
 
   def applicationsRedirect(path: String)(implicit request: RequestHeader): Future[Result] = {

--- a/facia/app/controllers/FaciaControllers.scala
+++ b/facia/app/controllers/FaciaControllers.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import agents.MostViewedAgent
 import com.softwaremill.macwire._
 import model.ApplicationContext
 import play.api.libs.ws.WSClient
@@ -10,6 +11,7 @@ trait FaciaControllers {
   def frontJsonFapiLive: FrontJsonFapiLive
   def controllerComponents: ControllerComponents
   def wsClient: WSClient
+  def mostViewedAgent: MostViewedAgent
   implicit def appContext: ApplicationContext
   lazy val faciaController = wire[FaciaControllerImpl]
 }

--- a/facia/app/feed/MostViewedLifecycle.scala
+++ b/facia/app/feed/MostViewedLifecycle.scala
@@ -1,0 +1,43 @@
+package feed
+
+import agents.MostViewedAgent
+
+import java.util.concurrent.Executors
+import app.LifecycleComponent
+import common.{AkkaAsync, JobScheduler}
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class MostViewedLifecycle(
+                              appLifecycle: ApplicationLifecycle,
+                              jobs: JobScheduler,
+                              akkaAsync: AkkaAsync,
+                              mostViewedAgent: MostViewedAgent,
+                            ) extends LifecycleComponent {
+
+  implicit val executionContext = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+
+  appLifecycle.addStopHook { () =>
+    Future {
+      descheduleAll()
+    }
+  }
+
+  private def descheduleAll(): Unit = {
+    jobs.deschedule("MostViewedAgentsHighFrequencyRefreshJob")
+  }
+
+  override def start(): Unit = {
+
+    descheduleAll()
+
+    jobs.scheduleEveryNMinutes("MostViewedAgentsHighFrequencyRefreshJob", 5) {
+      mostViewedAgent.refresh()
+    }
+
+    akkaAsync.after1s {
+      mostViewedAgent.refresh()
+    }
+  }
+}

--- a/facia/app/feed/MostViewedLifecycle.scala
+++ b/facia/app/feed/MostViewedLifecycle.scala
@@ -10,11 +10,11 @@ import play.api.inject.ApplicationLifecycle
 import scala.concurrent.{ExecutionContext, Future}
 
 class MostViewedLifecycle(
-                              appLifecycle: ApplicationLifecycle,
-                              jobs: JobScheduler,
-                              akkaAsync: AkkaAsync,
-                              mostViewedAgent: MostViewedAgent,
-                            ) extends LifecycleComponent {
+    appLifecycle: ApplicationLifecycle,
+    jobs: JobScheduler,
+    akkaAsync: AkkaAsync,
+    mostViewedAgent: MostViewedAgent,
+) extends LifecycleComponent {
 
   implicit val executionContext = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -41,7 +41,12 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
   lazy val wsClient = mockWsResponse()
 
-  lazy val faciaController = new FaciaControllerImpl(fapi, play.api.test.Helpers.stubControllerComponents(), wsClient, new MostViewedAgent(testContentApiClient, new OphanApi(wsClient), wsClient))
+  lazy val faciaController = new FaciaControllerImpl(
+    fapi,
+    play.api.test.Helpers.stubControllerComponents(),
+    wsClient,
+    new MostViewedAgent(testContentApiClient, new OphanApi(wsClient), wsClient),
+  )
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"
   val callbackName = "aFunction"
   val frontJson = FrontJson(Nil, None, None, None, None, None, None, None, None, None, None, None, None, None)

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -1,5 +1,6 @@
 package test
 
+import agents.MostViewedAgent
 import akka.actor.ActorSystem
 import com.fasterxml.jackson.core.JsonParseException
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
@@ -9,7 +10,7 @@ import concurrent.BlockingOperations
 import play.api.libs.json.JsArray
 import play.api.test._
 import play.api.test.Helpers._
-import services.ConfigAgent
+import services.{ConfigAgent, OphanApi}
 import org.scalatest._
 import controllers.FaciaControllerImpl
 import helpers.FaciaTestData
@@ -35,11 +36,12 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
     with WithMaterializer
     with WithTestApplicationContext
     with MockitoSugar
-    with WithTestFrontJsonFapi {
+    with WithTestFrontJsonFapi
+    with WithTestContentApiClient {
 
   lazy val wsClient = mockWsResponse()
 
-  lazy val faciaController = new FaciaControllerImpl(fapi, play.api.test.Helpers.stubControllerComponents(), wsClient)
+  lazy val faciaController = new FaciaControllerImpl(fapi, play.api.test.Helpers.stubControllerComponents(), wsClient, new MostViewedAgent(testContentApiClient, new OphanApi(wsClient), wsClient))
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"
   val callbackName = "aFunction"
   val frontJson = FrontJson(Nil, None, None, None, None, None, None, None, None, None, None, None, None, None)

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -29,8 +29,7 @@ import test._
     with WithTestWsClient
     with MockitoSugar
     with WithTestFrontJsonFapi
-    with WithTestContentApiClient
-    {
+    with WithTestContentApiClient {
 
   override def beforeAll(): Unit = {
     val refresh = ConfigAgent.refreshWith(
@@ -43,7 +42,12 @@ import test._
     Await.result(refresh, 3.seconds)
   }
 
-  lazy val faciaController = new FaciaControllerImpl(fapi, play.api.test.Helpers.stubControllerComponents(), wsClient, new MostViewedAgent(testContentApiClient, new OphanApi(wsClient), wsClient))
+  lazy val faciaController = new FaciaControllerImpl(
+    fapi,
+    play.api.test.Helpers.stubControllerComponents(),
+    wsClient,
+    new MostViewedAgent(testContentApiClient, new OphanApi(wsClient), wsClient),
+  )
   val frontPath = "music"
 
   it should "Include organisation metadata" in {

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -1,5 +1,6 @@
 package metadata
 
+import agents.MostViewedAgent
 import akka.actor.ActorSystem
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import concurrent.BlockingOperations
@@ -12,7 +13,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json._
 import play.api.test.Helpers._
-import services.ConfigAgent
+import services.{ConfigAgent, OphanApi}
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
@@ -27,7 +28,9 @@ import test._
     with WithMaterializer
     with WithTestWsClient
     with MockitoSugar
-    with WithTestFrontJsonFapi {
+    with WithTestFrontJsonFapi
+    with WithTestContentApiClient
+    {
 
   override def beforeAll(): Unit = {
     val refresh = ConfigAgent.refreshWith(
@@ -40,7 +43,7 @@ import test._
     Await.result(refresh, 3.seconds)
   }
 
-  lazy val faciaController = new FaciaControllerImpl(fapi, play.api.test.Helpers.stubControllerComponents(), wsClient)
+  lazy val faciaController = new FaciaControllerImpl(fapi, play.api.test.Helpers.stubControllerComponents(), wsClient, new MostViewedAgent(testContentApiClient, new OphanApi(wsClient), wsClient))
   val frontPath = "music"
 
   it should "Include organisation metadata" in {

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -35,7 +35,7 @@ class MostViewedSocialController(
           contentApiClient.getResponse(
             contentApiClient
               .search()
-              .ids(articleIds.take(7).map(item => feed.urlToContentPath(item.url)).mkString(",")),
+              .ids(articleIds.take(7).map(item => feed.MostViewed.urlToContentPath(item.url)).mkString(",")),
           ) map { response =>
             val items = response.results
             val container = visuallyPleasingContainerForStories(items.length)

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -102,15 +102,24 @@ class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, w
 
 class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
 
-  private val box = Box[Map[Country, Seq[RelatedContentItem]]](Map.empty)
+  private val box = Box[Map[String, Seq[RelatedContentItem]]](Map.empty)
 
-  // These are the only country codes passed to us from the fastly service.
+  private val defaultCountry: Country = Country("row", Edition.defaultEdition)
+
+  // These are the only country codes (row must be lower-case) passed to us from the fastly service.
   // This allows us to choose carefully the codes that give us the most impact. The trade-off is caching.
   private val countries = Seq(
-    GB, US, CA, AU, NG, NZ, IN, ROW
+    Country("GB", editions.Uk),
+    Country("US", editions.Us),
+    Country("AU", editions.Au),
+    Country("CA", editions.Us),
+    Country("IN", Edition.defaultEdition),
+    Country("NG", Edition.defaultEdition),
+    Country("NZ", editions.Au),
+    defaultCountry,
   )
 
-  private def refresh(country: Country)(implicit ec: ExecutionContext): Future[Map[Country, Seq[RelatedContentItem]]] = {
+  private def refresh(country: Country)(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
     val ophanMostViewed = ophanApi.getMostRead(hours = 3, count = 10, country = country.code.toLowerCase)
     MostViewed.relatedContentItems(ophanMostViewed, country.edition)(contentApiClient).flatMap { items =>
       val validItems = items.flatten
@@ -119,14 +128,14 @@ class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
       } else {
         log.info(s"Geo popular update for ${country.code} found nothing.")
       }
-      box.alter(_ + (country -> validItems))
+      box.alter(_ + (country.code -> validItems))
     }
   }
 
-  def mostPopular(country: Country): Seq[RelatedContentItem] =
-    box().getOrElse(country, Nil) // todo: I've changed the fallback here because we've changed the typing, but is this right?
+  def mostPopular(country: String): Seq[RelatedContentItem] =
+    box().getOrElse(country, box().getOrElse(defaultCountry.code, Nil))
 
-  def refresh()(implicit ec: ExecutionContext): Future[Map[Country, Seq[RelatedContentItem]]] = {
+  def refresh()(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
     log.info("Refreshing most popular for countries.")
     MostViewed.refreshAll(countries)(refresh)
   }
@@ -137,11 +146,14 @@ class DayMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
   private val box = Box[Map[String, Seq[RelatedContentItem]]](Map.empty)
 
   private val countries = Seq(
-    GB, US, AU
+    Country("GB", editions.Uk),
+    Country("US", editions.Us),
+    Country("AU", editions.Au),
   )
+
   def mostPopular(country: String): Seq[RelatedContentItem] = box().getOrElse(country, Nil)
 
-  def refresh()(implicit ec: ExecutionContext): Future[Map[Country, Seq[RelatedContentItem]]] = {
+  def refresh()(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
     log.info("Refreshing most popular for the day.")
     MostViewed.refreshAll(countries)(refresh)
   }

--- a/onward/app/feed/package.scala
+++ b/onward/app/feed/package.scala
@@ -1,8 +1,0 @@
-import java.net.URL
-
-package object feed {
-  def urlToContentPath(url: String): String = {
-    val path = new URL(url).getPath
-    if (path.startsWith("/")) path.substring(1) else path
-  }
-}

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import agents.CuratedContentAgent
+import agents.{CuratedContentAgent, MostViewedAgent}
 import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
@@ -92,6 +92,7 @@ trait PreviewControllerComponents
   lazy val faviconController = wire[FaviconController]
   lazy val itemController = wire[ItemController]
   lazy val oAuthLoginController = wire[OAuthLoginPreviewController]
+  lazy val mostViewedAgent = wire[MostViewedAgent]
 }
 
 trait AppComponents

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import agents.MostViewedAgent
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common.TrailsToShowcase
 import contentapi.{ContentApiClient, SectionsLookUp}
@@ -18,6 +19,7 @@ class FaciaDraftController(
     sectionsLookUp: SectionsLookUp,
     val controllerComponents: ControllerComponents,
     val ws: WSClient,
+    val mostViewedAgent: MostViewedAgent,
 )(implicit val context: ApplicationContext)
     extends FaciaController
     with RendersItemResponse {


### PR DESCRIPTION
## What?

Part of https://github.com/guardian/dotcom-rendering/issues/6247

We're adding the data from the `MostViewedAgent` (based on the [GeoMostPopularAgent](https://github.com/guardian/frontend/blob/main/onward/app/feed/MostPopularAgent.scala#L120)) to the `DotcomFrontsRenderingDataModel`.

This data can then be used, combined with the `PressedPage` `news/most-popular` container data, to render the whole component on the server.

- Moves `MostViewed` from the Onwards app to Common.
- Adds a Countries trait for stronger typing.
- Creates a new `MostViewedAgent`, modelled on the `MostPopularAgent`, that pulls together data on the most viewed, shared and commented stories.
- Adds `mostViewed`, `mostShared` and `mostCommented` to the DotcomRenderingDataModel.

**nb.** This PR touches a lot of files, but a lot of this is due to wiring and imports, as well as the fact that we're moving some existing code.

## DCR

This PR only adds fields to the data that we send to DCR, so it can be deployed as a standalone change. However, in order to actually use the new Most Viewed data, we will need to merge [this DCR PR](https://github.com/guardian/dotcom-rendering/pull/6449).

## Unknowns

We've tested this locally and in CODE, and have found that the agent doesn't seem to load data for `mostCommented`. However, we've noticed similar anomalies in other code that uses this data in CODE, so we think it makes sense to deploy to PROD and fix forward if there are still issues.