### PR TITLE
Add AUS personalisedAdvertising boolean to consent component event

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -93,7 +93,13 @@ const go = () => {
                 if (consentState.aus) {
                     const ccpaUUID = getCookie('ccpaUUID') || '';
                     const consentStatus = getCookie('consentStatus') || '';
-                    return ['01:AUS', `06:${ccpaUUID}`, `07:${consentStatus}`];
+                    const personalisedAdvertising = consentState.aus?.personalisedAdvertising ? 'true' : 'false';
+                    return [
+                        '01:AUS',
+                        `06:${ccpaUUID}`,
+                        `07:${consentStatus}`,
+                        `08:${personalisedAdvertising}`,
+                    ];
                 }
                 return [];
             };


### PR DESCRIPTION
## What does this change?
This adds an extra consent attribute to the existing ophan component event that is written on each page view.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation) see https://github.com/guardian/dotcom-rendering/pull/6356

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
https://trello.com/c/uGDFGDCO/852-record-aus-consent-boolean-via-ophan-component-event-dcr-frontend
The [plan](https://docs.google.com/document/d/1fGOxDxcLAv4viBGxEYjDV_N7XS_K0jhALtqn68NkfrM/edit#heading=h.4kpxru711bxf) is to collect consent data for the datalake using ophan's tracker pipeline, instead of routing the data through Sourcepoint. The CCPA data that sourcepoint returns a boolean opt-in value for Austrialia (equivalent to US do not sell) which isn't represented in the existing component event.

## Checklist

### Does this affect other platforms?
Similar changes are required for AMP and Apps and will be covered in future PR's

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

N/A
<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
