### PR TITLE
replace dual 'Contribute' and 'Subscribe' CTAs with single 'Support' CTA

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -151,17 +151,7 @@
             data-link-name="footer : contribute-cta"
             data-edition="@{editionId}"
             href="@getReaderRevenueUrl(SupportContribute, Footer)">
-            Contribute
-            @fragments.inlineSvg("arrow-right", "icon")
-        </a>
-
-        <a class="cta-bar__cta js-subscribe js-acquisition-link"
-        data-link-name="footer : subscribe-cta"
-        data-edition="@{
-            editionId
-        }"
-        href="@getReaderRevenueUrl(SupportSubscribe, Footer)">
-            Subscribe
+            Support
             @fragments.inlineSvg("arrow-right", "icon")
         </a>
     </div>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -140,7 +140,7 @@
     <div class="colophon__list">
         <div class="cta-bar__text">
             <div class="cta-bar__heading">
-                Support The&nbsp;Guardian
+                Support the&nbsp;Guardian
             </div>
             <div class="cta-bar__subheading">
                 Available for everyone, funded by readers
@@ -151,7 +151,7 @@
             data-link-name="footer : contribute-cta"
             data-edition="@{editionId}"
             href="@getReaderRevenueUrl(SupportContribute, Footer)">
-            Support
+            Support us
             @fragments.inlineSvg("arrow-right", "icon")
         </a>
     </div>


### PR DESCRIPTION
## What does this change?
Replaces the normal twin CTAs in the page footer, ie. 'Contribute' and 'Subscribe', with a single CTA. The single CTA is labelled 'Support' and points to the Contributions landing page, as per the requirements for the new product launch.

## Does this change need to be reproduced in dotcom-rendering ?
- [ ] No
- [x] Yes, see https://github.com/guardian/dotcom-rendering/pull/6396

## Screenshots
| Before      | After      |
|-------------|------------|
| <img width="1728" alt="frontend-before" src="https://user-images.githubusercontent.com/25020231/200570596-dc71999c-bc64-4928-9174-089c4d730db0.png"> | <img width="1728" alt="frontend-footer-after" src="https://user-images.githubusercontent.com/25020231/201082518-9f657fba-1e44-4b96-bbb3-ba4bd0b10638.png"> |

## What is the value of this and can you measure success?
N/A

## Checklist
N/A

### Does this affect other platforms?
- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?
- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?
- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

NB: None of the above have been manually tested, but I am confident that this change will not have any effect on accessibility.

### Tested
- [x] Locally
- [x] On CODE (optional)
