### PR TITLE
add `dcrCouldRender` in JS to fronts

### DIFF
--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -13,6 +13,7 @@ import views.html.fragments.page.head._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.{ContentCSSFile, FaciaCSSFile}
+import services.dotcomrendering.FaciaPicker.dcrChecks
 
 object FrontHtmlPage extends HtmlPage[PressedPage] {
 
@@ -41,6 +42,11 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
       override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
     }
 
+  def htmlDcrCouldRender(page: PressedPage)(implicit request: RequestHeader): Html = {
+    val thisDcrCouldRender: Boolean = dcrChecks(page).values.forall(identity)
+    Html(s"<script>window.guardian.config.page.dcrCouldRender = $thisDcrCouldRender</script>")
+  }
+
   def html(page: PressedPage)(implicit request: RequestHeader, applicationContext: ApplicationContext): Html = {
     implicit val p: PressedPage = page
     htmlTag(
@@ -53,6 +59,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
         fixIEReferenceErrors(),
         checkModuleSupport(),
         inlineJSBlocking(),
+        htmlDcrCouldRender(page),
       ),
       bodyTag(classes = defaultBodyClasses())(
         skipToMainContent(),

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -121,9 +121,9 @@ object FrontChecks {
 
 }
 
-class FaciaPicker extends GuLogging {
+object FaciaPicker extends GuLogging {
 
-  private def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
+  def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
     Map(
       ("allCollectionsAreSupported", FrontChecks.allCollectionsAreSupported(faciaPage)),
       ("hasNoWeatherWidget", FrontChecks.hasNoWeatherWidget(faciaPage)),
@@ -139,7 +139,7 @@ class FaciaPicker extends GuLogging {
   def getTier(faciaPage: PressedPage)(implicit request: RequestHeader): RenderType = {
     lazy val participatingInTest = ActiveExperiments.isParticipating(DCRFronts)
     lazy val checks = dcrChecks(faciaPage)
-    lazy val dcrCouldRender = checks.values.forall(checkValue => checkValue == true)
+    lazy val dcrCouldRender = checks.values.forall(checkValue => checkValue)
 
     val tier = decideTier(request.isRss, request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRender)
 
@@ -186,5 +186,3 @@ class FaciaPicker extends GuLogging {
     DotcomFrontsLogger.logger.logRequest(s"front executing in $tierReadable", properties, faciaPage)
   }
 }
-
-object FaciaPicker extends FaciaPicker


### PR DESCRIPTION
## What does this change?
This adds dcrCouldRender to fronts, as we do in [`StoryHtmlPage`](https://github.com/guardian/frontend/blob/main/article/app/pages/StoryHtmlPage.scala#L31-L38).

[This then gets passed through to Ophan](https://github.com/guardian/frontend/blob/main/static/src/javascripts/lib/capture-ophan-info.js#L43-L45) to help us measure commercial metrics.

## Does this change need to be reproduced in dotcom-rendering ?

No - [this is explicitly set on the `window` object. ](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/model/window-guardian.ts#L115).

## Screenshots
<img width="1344" alt="Screenshot 2022-11-08 at 14 50 25" src="https://user-images.githubusercontent.com/31692/200597483-0ee94d6e-b913-415f-9350-5bc6d3d01d76.png">


