### PR TITLE
Annotate ad labels with contents of `adtest` cookie

### DIFF
--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -49,6 +49,7 @@ import { init as initMobileSticky } from '../projects/commercial/modules/mobile-
 import { paidContainers } from '../projects/commercial/modules/paid-containers';
 import { removeDisabledSlots as closeDisabledSlots } from '../projects/commercial/modules/remove-slots';
 import { init as setAdTestCookie } from '../projects/commercial/modules/set-adtest-cookie';
+import { init as setAdTestInLabelsCookie } from '../projects/commercial/modules/set-adtest-in-labels-cookie';
 import { init as initThirdPartyTags } from '../projects/commercial/modules/third-party-tags';
 import { init as initTrackGpcSignal } from '../projects/commercial/modules/track-gpc-signal';
 import { init as initTrackLabsContainer } from '../projects/commercial/modules/track-labs-container';
@@ -92,6 +93,7 @@ const commercialExtraModules: Modules = [
 if (!commercialFeatures.adFree) {
 	commercialBaseModules.push(
 		['cm-setAdTestCookie', setAdTestCookie],
+		['cm-setAdTestInLabelsCookie', setAdTestInLabelsCookie],
 		['cm-prepare-prebid', preparePrebid],
 		// Permutive init code must run before google tag enableServices()
 		// The permutive lib however is loaded async with the third party tags
@@ -224,6 +226,7 @@ const bootConsentless = async (): Promise<void> => {
 
 	await Promise.all([
 		setAdTestCookie(),
+		setAdTestInLabelsCookie(),
 		initSafeframes(),
 		initConsentless(consentState),
 		initFixedSlots(),

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -3,6 +3,7 @@
 -- Nested fastdom measure-mutate promises throw the error:
 -- "Promise returned in function argument where a void return was expected"
 */
+import { getCookie } from '@guardian/libs';
 import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
 
@@ -35,10 +36,33 @@ const createAdCloseDiv = (): HTMLElement => {
 	return closeDiv;
 };
 
+// If `adtest` cookie is set, display its value in the ad label
+// Furthermore, provide a link to clear the cookie
+const createAdTestLabel = (): HTMLElement => {
+	const adTestLabel = document.createElement('span');
+
+	const val = getCookie({ name: 'adtest', shouldMemoize: true });
+
+	if (val) {
+		adTestLabel.innerHTML += ` [?adtest=${val}] `;
+
+		const url = new URL(window.location.href);
+		url.searchParams.set('adtest', 'clear');
+
+		const clearLink = document.createElement('a');
+		clearLink.href = url.href;
+		clearLink.innerHTML = 'clear';
+		adTestLabel.appendChild(clearLink);
+	}
+
+	return adTestLabel;
+};
+
 const createAdLabel = (): HTMLElement => {
 	const adLabel = document.createElement('div');
 	adLabel.className = 'ad-slot__label';
 	adLabel.innerHTML = 'Advertisement';
+	adLabel.appendChild(createAdTestLabel());
 	adLabel.appendChild(createAdCloseDiv());
 	return adLabel;
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -36,14 +36,21 @@ const createAdCloseDiv = (): HTMLElement => {
 	return closeDiv;
 };
 
+const shouldRenderAdTestLabel = (): boolean =>
+	!!getCookie({
+		name: 'adtestInLabels',
+		shouldMemoize: true,
+	});
+
 // If `adtest` cookie is set, display its value in the ad label
 // Furthermore, provide a link to clear the cookie
 const createAdTestLabel = (): HTMLElement => {
 	const adTestLabel = document.createElement('span');
 
+	const shouldRender = shouldRenderAdTestLabel();
 	const val = getCookie({ name: 'adtest', shouldMemoize: true });
 
-	if (val) {
+	if (shouldRender && val) {
 		adTestLabel.innerHTML += ` [?adtest=${val}] `;
 
 		const url = new URL(window.location.href);

--- a/static/src/javascripts/projects/commercial/modules/set-adtest-in-labels-cookie.ts
+++ b/static/src/javascripts/projects/commercial/modules/set-adtest-in-labels-cookie.ts
@@ -1,0 +1,25 @@
+import { removeCookie, setCookie } from '@guardian/libs';
+import { getUrlVars } from '../../../lib/url';
+
+/**
+ * Not to be confused with set-adtest-cookie.ts!
+ * Set or remove `adtestInLabels` cookie
+ * This is used when determining whether or not to display the value of the `adtest` cookie in ad labels
+ * @returns Promise
+ */
+const init = (): Promise<void> => {
+	const queryParams = getUrlVars();
+
+	if (queryParams.adtestInLabels === 'clear') {
+		removeCookie({ name: 'adtestInLabels' });
+	} else if (queryParams.adtestInLabels) {
+		setCookie({
+			name: 'adtestInLabels',
+			value: 'true',
+		});
+	}
+
+	return Promise.resolve();
+};
+
+export { init };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -356,6 +356,7 @@
   "../projects/commercial/modules/dfp/load-advert.ts"
  ],
  "../projects/commercial/modules/dfp/render-advert-label.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/fastdom-promise.ts"
  ],
  "../projects/commercial/modules/dfp/render-advert.ts": [
@@ -536,6 +537,10 @@
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/url.ts"
  ],
+ "../projects/commercial/modules/set-adtest-in-labels-cookie.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/url.ts"
+ ],
  "../projects/commercial/modules/sticky-inlines.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
@@ -677,6 +682,7 @@
   "../projects/commercial/modules/paid-containers.ts",
   "../projects/commercial/modules/remove-slots.ts",
   "../projects/commercial/modules/set-adtest-cookie.ts",
+  "../projects/commercial/modules/set-adtest-in-labels-cookie.ts",
   "../projects/commercial/modules/third-party-tags.ts",
   "../projects/commercial/modules/track-gpc-signal.ts",
   "../projects/commercial/modules/track-labs-container.ts",


### PR DESCRIPTION
## What does this change?

If `adtest` cookie is set, display its value in the ad label. Furthermore, provide a link to clear the cookie.

![Screenshot 2022-11-09 at 09 04 36](https://user-images.githubusercontent.com/7423751/200787614-99d3c6b1-1f77-41b2-a1ff-8ce2a82413a9.png)

Because we share `adtest` links with external agencies, we don't want this to display for all users. Therefore, it has to be enabled once with a new query parameter `adtestInLabels`. To enable:

`?adtestInLabels=true` (actually any value works here)

or to disable:

`?adtestInLabels=clear`

This is backed by a new cookie `adtestInLabels`.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Previously it could be a confusing experience when you accidentally have `adtest` set, now it's obvious and can be reversed easily.

## Known limitations

This doesn't work for ads where the ad label is included in the creative iframe.

### Tested

- [x] Locally
- [ ] On CODE (optional)