### PR TITLE
Add Australia acknowledgement of Country

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -50,7 +50,7 @@
         </div>
 
 
-        <div class="colophon u-cf">
+        <div class="colophon">
             @defining(Edition(request)) { currentEdition =>
                 @if(EmailInlineInFooterSwitch.isSwitchedOn && !page.metadata.isFoundation) {
                     @emailSignUpLink(currentEdition)
@@ -116,6 +116,15 @@
                         @readerRevenueLinks(Edition(request).id.toLowerCase())
                     }
                 </div>
+                @if(currentEdition.id == "AU") {
+                    <div class="colophon__acknowledgment">
+                        Guardian Australia acknowledges the traditional owners and
+                        custodians of Country throughout Australia and their
+                        connections to land, waters and community. We pay respect by
+                        giving voice to social justice, acknowledging our shared
+                        history and valuing the cultures of First Nations.
+                    </div>
+                }
             }
         </div>
         <div class="copyright-container">

--- a/static/src/stylesheets/layout/footer/_colophon.scss
+++ b/static/src/stylesheets/layout/footer/_colophon.scss
@@ -32,7 +32,22 @@
     align-self: end;
     color: $brightness-100;
     font-size: 12px;
-    padding: 36px 0;
+    padding: $gs-baseline * 2 0;
+
+    @include mq($from: desktop, $until: leftCol) {
+        max-width: gs-span(6);
+        position: relative;
+
+        &::after {
+            content: '';
+            position: absolute;
+            background-color:  $brand-pastel;
+            width: 1px;
+            right: -13px;
+            top: -$gs-baseline * 2 ;
+            bottom: $gs-baseline * 2;
+        }
+    }
 }
 
 .colophon__lists-container {

--- a/static/src/stylesheets/layout/footer/_colophon.scss
+++ b/static/src/stylesheets/layout/footer/_colophon.scss
@@ -1,4 +1,6 @@
 .colophon {
+    display: grid;
+
     border-bottom: 1px solid $brand-pastel;
     padding: 0 9px ($gs-baseline * 2);
 
@@ -11,10 +13,31 @@
         border: 1px solid $brand-pastel;
         border-top: 0;
     }
+
+    grid-template-areas:
+    'signup'
+    'links'
+    'acknowledgment';
+
+    @include mq(leftCol) {
+        grid-template-columns: min-content;
+        grid-template-areas:
+        'signup          links'
+        'acknowledgment  links';
+    }
+}
+
+.colophon__acknowledgment {
+    grid-area: acknowledgment;
+    align-self: end;
+    color: $brightness-100;
+    font-size: 12px;
+    padding: 36px 0;
 }
 
 .colophon__lists-container {
     @include fs-textSans(5);
+    grid-area: links;
     line-height: 1.2;
     display: flex;
     flex-direction: row;
@@ -23,7 +46,6 @@
 }
 
 .colophon__list {
-    @include clearfix();
     list-style: none;
     position: relative;
     margin: 0;

--- a/static/src/stylesheets/layout/footer/_email-container.scss
+++ b/static/src/stylesheets/layout/footer/_email-container.scss
@@ -1,4 +1,5 @@
 .footer__email-container {
+    grid-area: signup;
     border-bottom: 1px solid $footer-line-colour;
     padding-top: 8px;
     padding-bottom: 12px;


### PR DESCRIPTION
## What does this change?

In our Australia Edition, adds the following text:

> Guardian Australia acknowledges the traditional owners and custodians of Country throughout Australia and their connections to land, waters and community. We pay respect by giving voice to social justice, acknowledging our shared history and valuing the cultures of First Nations.

Uses CSS grid and removes the clearfix class because it’s widely supported.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/6399

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/200636250-225303f7-008a-4bbf-9337-b3d82dd7ce27.png
[after]: https://user-images.githubusercontent.com/76776/200636191-9a15dd56-d239-47ca-b2be-14a783a83699.png

## What is the value of this and can you measure success?

It is the right thing to do.

Fixes https://github.com/guardian/dotcom-rendering/issues/6353

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
