### PR TITLE
feat(feature): add headerTopBar switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -3,7 +3,7 @@ package conf.switches
 import conf.switches.Expiry.never
 import java.time.LocalDate
 import conf.switches.Owner.group
-import conf.switches.SwitchGroup.Commercial
+import conf.switches.SwitchGroup.{Commercial, Feature}
 
 trait FeatureSwitches {
 
@@ -489,6 +489,16 @@ trait FeatureSwitches {
     "When ON, facia containers with targeted territories in Australia will include a 'region switcher' for users to change their region",
     owners = Seq(Owner.withName("unknown")),
     safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
+
+  val headerTopBar = Switch(
+    SwitchGroup.Feature,
+    "header-top-bar",
+    "When ON, the header has a thin top bar above containing relevant links",
+    owners = group(Feature),
+    safeState = On,
     sellByDate = never,
     exposeClientSide = false,
   )


### PR DESCRIPTION
## What does this change?

Adds a new switch that controls which header to show. The actual header will be built subsequently.

This switch enables a new design that includes a direct link to our print subscription. This change was prompted by the “single front door” call to action which points to our digital subscriptions.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No – but there’s a PR that depends on this!
- [ ] Yes

## Screenshots

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/76776/200878860-4e3ca1c5-7272-4ce5-ad32-08481f20287b.png">

## What is the value of this and can you measure success?

We rationalise our header and prevent print subscription losses via a dedicated link.

## Checklist

### Does this affect other platforms?

### Tested

- [ ] Locally
- [ ] On CODE (optional)