### PR TITLE
Add `adtestInLabels` to allowlist of query params

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -60,6 +60,7 @@ class DevParametersHttpRequestHandler(
   val commercialParams = Seq(
     "ad-unit", // allows overriding of the ad unit
     "adtest", // used to set ad-test cookie from admin domain
+    "adtestInLabels", // used to enable the display of the "adtest" cookie in ad labels
     "pbtest", // used to test Prebid adapters in isolation
     "adrefresh", // force adrefresh to be off with adrefresh=false in the URL
     "forceads", // shows ads even if they have been disabled for this content


### PR DESCRIPTION
## What does this change?

Adds `adtestInLabels` to allowlist of query params

This was missed from https://github.com/guardian/frontend/pull/25650

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Right now we can't access this query param on production because it hasn't been explicitly allowed

### Tested

- [ ] Locally
- [ ] On CODE (optional)

