### PR TITLE
Refactor Braze Banner code

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -47,7 +47,8 @@ import {
     addPrivacySettingsLink,
 } from 'common/modules/ui/cmp-ui';
 import { signInGate } from 'common/modules/identity/sign-in-gate';
-import { brazeBanner } from 'common/modules/commercial/braze/brazeBanner';
+import { buildBrazeBanner } from 'common/modules/commercial/braze/brazeBanner';
+import { buildBrazeMessaging } from 'common/modules/commercial/braze/buildBrazeMessaging';
 import { readerRevenueBanner } from 'common/modules/commercial/reader-revenue-banner';
 import { puzzlesBanner } from 'common/modules/commercial/puzzles-banner';
 import { init as initGoogleAnalytics } from 'common/modules/tracking/google-analytics';
@@ -255,6 +256,9 @@ const initPublicApi = () => {
 };
 
 const initialiseBanner = () => {
+    const brazeMessagesPromise = buildBrazeMessaging();
+    const brazeBanner = buildBrazeBanner(brazeMessagesPromise);
+
     const isPreview = config.get('page.isPreview', false)
     // ordered by priority
     // in preview we don't want to show most banners as they are an unnecessary interruption

--- a/static/src/javascripts/projects/common/modules/commercial/braze/brazeMessageInterface.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/brazeMessageInterface.ts
@@ -1,0 +1,14 @@
+// Note on BrazeMessageInterface vs BrazeMessage:
+// BrazeMessage is the actual class which we wrap messages in returned from the
+// Braze SDK (in @guardian/braze-components). BrazeMessageInterface represents
+// the public interface supplied by instances of that class. In the message
+// forcing logic it's hard to create and return a BrazeMessage from the forced
+// json. A better approach would probably be to change the code in
+// @guardian/braze-components to return a BrazeMessageInterface (which an
+// instance of BrazeMessage would conform to) and at least the type definitions
+// would all live in one centralised place.
+export interface BrazeMessageInterface {
+	extras: Record<string, string> | undefined;
+	logImpression: () => void;
+	logButtonClick: (internalButtonId: number) => void;
+}

--- a/static/src/javascripts/projects/common/modules/commercial/braze/buildBrazeMessaging.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/buildBrazeMessaging.ts
@@ -1,0 +1,122 @@
+import type { BrazeMessagesInterface } from '@guardian/braze-components';
+import {
+	BrazeMessages,
+	LocalMessageCache,
+	NullBrazeMessages,
+} from '@guardian/braze-components/logic';
+import { log } from '@guardian/libs';
+import ophan from 'ophan/ng';
+import config from '../../../../../lib/config';
+import { reportError } from '../../../../../lib/report-error';
+import { measureTiming } from '../../../../commercial/modules/measure-timing';
+import { getBrazeUuid } from './getBrazeUuid';
+import {
+	clearHasCurrentBrazeUser,
+	hasCurrentBrazeUser,
+	setHasCurrentBrazeUser,
+} from './hasCurrentBrazeUser';
+import { hasRequiredConsents } from './hasRequiredConsents';
+
+const SDK_OPTIONS = {
+	enableLogging: false,
+	noCookies: true,
+	baseUrl: 'https://sdk.fra-01.braze.eu/api/v3',
+	sessionTimeoutInSeconds: 1,
+	minimumIntervalBetweenTriggerActionsInSeconds: 0,
+	devicePropertyAllowlist: [],
+};
+
+const maybeWipeUserData = async (
+	apiKey: string,
+	brazeUuid: string | undefined,
+	consent: boolean,
+) => {
+	const userHasLoggedOut = !brazeUuid && hasCurrentBrazeUser();
+	const userHasRemovedConsent = !consent && hasCurrentBrazeUser();
+
+	if (userHasLoggedOut || userHasRemovedConsent) {
+		try {
+			const { default: importedAppboy } = await import(
+				/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core'
+			);
+			importedAppboy.initialize(apiKey, SDK_OPTIONS);
+			importedAppboy.wipeData();
+
+			LocalMessageCache.clear();
+
+			clearHasCurrentBrazeUser();
+
+			log('tx', 'Cleared local Braze data');
+		} catch (error) {
+			reportError(error, {}, false);
+		}
+	}
+};
+
+export const buildBrazeMessaging =
+	async (): Promise<BrazeMessagesInterface> => {
+		// Check dependencies
+		const brazeSwitch: string | undefined = config.get(
+			'switches.brazeSwitch',
+		);
+		const apiKey: string | undefined = config.get('page.brazeApiKey');
+		const isBrazeConfigured = brazeSwitch && apiKey;
+		if (!isBrazeConfigured) {
+			log('tx', 'Braze is not configured, not loading Braze SDK');
+			return new NullBrazeMessages();
+		}
+
+		const [brazeUuid, hasGivenConsent] = await Promise.all([
+			getBrazeUuid(),
+			hasRequiredConsents(),
+		]);
+
+		await maybeWipeUserData(apiKey, brazeUuid, hasGivenConsent);
+
+		if (!(brazeUuid && hasGivenConsent)) {
+			log(
+				'tx',
+				"User is not logged in or hasn't given consent, not loading Braze SDK",
+			);
+			return new NullBrazeMessages();
+		}
+
+		// Don't load Braze SDK for paid content
+		if (config.get('page.isPaidContent')) {
+			log('tx', 'Page isPaidContent, not loading Braze SDK');
+			return new NullBrazeMessages();
+		}
+		// End check dependencies
+
+		const sdkLoadTiming = measureTiming('braze-sdk-load');
+		sdkLoadTiming.start();
+
+		// Load and initialize SDK
+		const { default: importedAppboy } = await import(
+			/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core'
+		);
+
+		const sdkLoadTimeTaken = sdkLoadTiming.end();
+		ophan.record({
+			component: 'braze-sdk-load-timing',
+			value: sdkLoadTimeTaken,
+		});
+
+		importedAppboy.initialize(apiKey, SDK_OPTIONS);
+
+		const errorHandler = (error: Error) => {
+			reportError(error, {}, false);
+		};
+		const brazeMessages = new BrazeMessages(
+			importedAppboy,
+			LocalMessageCache,
+			errorHandler,
+		);
+
+		setHasCurrentBrazeUser();
+		importedAppboy.changeUser(brazeUuid);
+		importedAppboy.openSession();
+		// End Load and initialize SDK
+
+		return brazeMessages;
+	};

--- a/static/src/javascripts/projects/common/modules/commercial/braze/checkBrazeDependencies.test.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/checkBrazeDependencies.test.ts
@@ -1,0 +1,206 @@
+import { checkBrazeDependencies } from './checkBrazeDependencies';
+
+let mockBrazeUuid: string | null;
+jest.mock('./getBrazeUuid', () => ({
+	getBrazeUuid: () => {
+		return Promise.resolve(mockBrazeUuid);
+	},
+}));
+
+let mockConsentsPromise: Promise<boolean>;
+jest.mock('./hasRequiredConsents', () => ({
+	hasRequiredConsents: () => {
+		return mockConsentsPromise;
+	},
+}));
+
+let mockConfigRecord: Record<string, string | boolean | undefined>;
+jest.mock('../../../../../lib/config', () => ({
+	get: (key: string) => mockConfigRecord[key],
+}));
+
+describe('checkBrazeDependecies', () => {
+	afterEach(() => {
+		// Wait for any unsettled promises to complete at the end of each test. Once
+		// we encounter a failure in our list of checks we don't need to wait on
+		// subsequent operations to complete which is why there might be unsettled
+		// promises.
+		const flushPromises = new Promise(setImmediate);
+		return flushPromises;
+	});
+
+	it('succeeds if all dependencies are fulfilled', async () => {
+		mockConfigRecord = {
+			'page.brazeApiKey': 'fake-api-key',
+			'page.isPaidContent': false,
+			'switches.brazeSwitch': true,
+		};
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+
+		const got = await checkBrazeDependencies();
+
+		expect(got.isSuccessful).toEqual(true);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			apiKey: 'fake-api-key',
+			consent: true,
+			isNotPaidContent: true,
+			brazeUuid: 'fake-uuid',
+		});
+	});
+
+	it('fails if the switch is disabled', async () => {
+		mockConfigRecord = {
+			'page.brazeApiKey': 'fake-api-key',
+			'page.isPaidContent': false,
+			'switches.brazeSwitch': false,
+		};
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+
+		const got = await checkBrazeDependencies();
+
+		expect(got.isSuccessful).toEqual(false);
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('brazeSwitch');
+			expect(got.failure.data).toEqual(false);
+		}
+	});
+
+	it('returns the apiKey if the switch is disabled', async () => {
+		mockConfigRecord = {
+			'page.brazeApiKey': 'fake-api-key',
+			'page.isPaidContent': false,
+			'switches.brazeSwitch': false,
+		};
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+
+		const got = await checkBrazeDependencies();
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			apiKey: 'fake-api-key',
+		});
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('brazeSwitch');
+		}
+	});
+
+	it('fails if the api key is not set', async () => {
+		mockConfigRecord = {
+			'page.brazeApiKey': undefined,
+			'page.isPaidContent': false,
+			'switches.brazeSwitch': true,
+		};
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+
+		const got = await checkBrazeDependencies();
+
+		expect(got.isSuccessful).toEqual(false);
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('apiKey');
+			expect(got.failure.data).toEqual(undefined);
+		}
+	});
+
+	it('fails if the brazeUuid is not available', async () => {
+		mockConfigRecord = {
+			'page.brazeApiKey': 'fake-api-key',
+			'page.isPaidContent': false,
+			'switches.brazeSwitch': true,
+		};
+		mockBrazeUuid = null;
+		mockConsentsPromise = Promise.resolve(true);
+
+		const got = await checkBrazeDependencies();
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			apiKey: 'fake-api-key',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('brazeUuid');
+			expect(got.failure.data).toEqual(null);
+		}
+	});
+
+	it('fails if the required consents are not given', async () => {
+		mockConfigRecord = {
+			'page.brazeApiKey': 'fake-api-key',
+			'page.isPaidContent': false,
+			'switches.brazeSwitch': true,
+		};
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(false);
+
+		const got = await checkBrazeDependencies();
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			brazeUuid: 'fake-uuid',
+			apiKey: 'fake-api-key',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('consent');
+			expect(got.failure.data).toEqual(false);
+		}
+	});
+
+	it('fails if the page is a paid content page', async () => {
+		mockConfigRecord = {
+			'page.brazeApiKey': 'fake-api-key',
+			'page.isPaidContent': true,
+			'switches.brazeSwitch': true,
+		};
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+
+		const got = await checkBrazeDependencies();
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			apiKey: 'fake-api-key',
+			consent: true,
+			brazeUuid: 'fake-uuid',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('isNotPaidContent');
+			expect(got.failure.data).toEqual(false);
+		}
+	});
+
+	it('fails if any underlying async operation fails', async () => {
+		mockConfigRecord = {
+			'page.brazeApiKey': 'fake-api-key',
+			'page.isPaidContent': false,
+			'switches.brazeSwitch': true,
+		};
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.reject(new Error('something went wrong'));
+
+		const got = await checkBrazeDependencies();
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			brazeUuid: 'fake-uuid',
+			apiKey: 'fake-api-key',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('consent');
+			expect(got.failure.data).toEqual('something went wrong');
+		}
+	});
+});

--- a/static/src/javascripts/projects/common/modules/commercial/braze/checkBrazeDependencies.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/checkBrazeDependencies.ts
@@ -1,0 +1,97 @@
+import config from '../../../../../lib/config';
+import { getBrazeUuid } from './getBrazeUuid';
+import { hasRequiredConsents } from './hasRequiredConsents';
+
+type SuccessResult = {
+	isSuccessful: true;
+	data: ResultData;
+};
+
+type FailureResult = {
+	isSuccessful: false;
+	failure: {
+		field: string;
+		data: DependencyResultValue;
+	};
+	data: ResultData;
+};
+
+type DependenciesResult = SuccessResult | FailureResult;
+
+type ResultData = Record<string, string | boolean>;
+
+type DependencyResultValue = string | boolean | null | undefined | void;
+
+type DependencyResult = {
+	name: string;
+	value: Promise<DependencyResultValue>;
+};
+
+const buildFailureResponse = (
+	name: string,
+	value: DependencyResultValue,
+	data: ResultData,
+) => ({
+	isSuccessful: false,
+	failure: {
+		field: name,
+		data: value,
+	},
+	data,
+});
+
+const buildDependencies = (): DependencyResult[] => {
+	return [
+		{
+			name: 'apiKey',
+			value: Promise.resolve(config.get('page.brazeApiKey')),
+		},
+		{
+			name: 'brazeSwitch',
+			value: Promise.resolve(config.get('switches.brazeSwitch')),
+		},
+		{
+			name: 'brazeUuid',
+			value: getBrazeUuid(),
+		},
+		{
+			name: 'consent',
+			value: hasRequiredConsents(),
+		},
+		{
+			name: 'isNotPaidContent',
+			value: Promise.resolve(!config.get('page.isPaidContent')),
+		},
+	];
+};
+
+const checkBrazeDependencies = async (): Promise<DependenciesResult> => {
+	const dependencies = buildDependencies();
+
+	const data: ResultData = {};
+
+	for (const { name, value } of dependencies) {
+		try {
+			const result = await value;
+
+			if (result) {
+				data[name] = result;
+			} else {
+				return buildFailureResponse(name, result, data);
+			}
+		} catch (error) {
+			return buildFailureResponse(
+				name,
+				error instanceof Error ? error.message : 'Unknown error',
+				data,
+			);
+		}
+	}
+
+	return {
+		isSuccessful: true,
+		data,
+	};
+};
+
+export { checkBrazeDependencies };

--- a/static/src/javascripts/projects/common/modules/commercial/braze/getBrazeUuid.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/getBrazeUuid.ts
@@ -1,0 +1,12 @@
+import { getUserIdentifiersFromApi } from 'common/modules/identity/api';
+
+export const getBrazeUuid = (): Promise<string | undefined> =>
+	new Promise((resolve) => {
+		getUserIdentifiersFromApi((userIdentifiers) => {
+			if (userIdentifiers?.brazeUuid) {
+				resolve(userIdentifiers.brazeUuid);
+			} else {
+				resolve(undefined);
+			}
+		});
+	});

--- a/static/src/javascripts/projects/common/modules/commercial/braze/getMessageFromUrlFragment.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/getMessageFromUrlFragment.ts
@@ -1,0 +1,65 @@
+import { log } from '@guardian/libs';
+import type { BrazeMessageInterface } from './brazeMessageInterface';
+
+const FORCE_BRAZE_ALLOWLIST = [
+	'preview.gutools.co.uk',
+	'preview.code.dev-gutools.co.uk',
+	'localhost',
+	'm.thegulocal.com',
+];
+
+const isExtrasData = (data: unknown): data is Record<string, string> => {
+	if (typeof data === 'object' && data != null) {
+		return Object.values(data).every((value) => typeof value === 'string');
+	}
+	return false;
+};
+
+export const getMessageFromUrlFragment = ():
+	| BrazeMessageInterface
+	| undefined => {
+	if (window.location.hash) {
+		// This is intended for use on development domains for preview purposes.
+		// It won't run in PROD.
+		const key = 'force-braze-message';
+
+		const hashString = window.location.hash;
+
+		if (hashString.includes(key)) {
+			if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
+				log('tx', `${key} is not supported on this domain`);
+				return;
+			}
+
+			const forcedMessage = hashString.slice(
+				hashString.indexOf(`${key}=`) + key.length + 1,
+				hashString.length,
+			);
+
+			try {
+				const dataFromBraze = JSON.parse(
+					decodeURIComponent(forcedMessage),
+				) as unknown;
+
+				if (isExtrasData(dataFromBraze)) {
+					return {
+						extras: dataFromBraze,
+						logImpression: () => {
+							return;
+						},
+						logButtonClick: () => {
+							return;
+						},
+					};
+				}
+			} catch (e) {
+				// Parsing failed. Log a message and fall through.
+				if (e instanceof Error) {
+					log('tx', `There was an error with ${key}:`, e.message);
+				}
+			}
+		}
+	}
+
+	return;
+};


### PR DESCRIPTION
## What does this change?

Following on from #25628 and #25636 continue refactoring the Braze Banner code to make it possible to onboard another slot on frontend powered by Braze (header notifications).

The main changes here are:

* Instead of `brazeBanner.ts` knowing how to get a `BrazeMessages` instance, we create the instance outside and pass it in. This will allow us to use the instance elsewhere.
* We've refactored the logic around checking the required dependencies before loading the Braze SDK, borrowing the approach from DCR, which has worked nicely there.
* General refactoring of functions out of `brazeBanner.js`.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Test Braze Banner showing up successfully in CODE:

<img width="1426" alt="Screenshot 2022-11-10 at 11 27 35" src="https://user-images.githubusercontent.com/379839/201083001-2b8016c4-458d-4ff3-b5dc-222f3d545e34.png">

## What is the value of this and can you measure success?

Refactoring to make onboarding of a new slot on the page powered by Braze possible.

## Checklist

### Tested

- [ ] Locally
- [x] On CODE (optional)