### PR TITLE
Header top nav redesign (support update)

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -493,9 +493,9 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
-  val headerTopBar = Switch(
+  val headerTopNav = Switch(
     SwitchGroup.Feature,
-    "header-top-bar",
+    "header-top-nav",
     "When ON, the header has a thin top bar above containing relevant links",
     owners = group(Feature),
     safeState = On,

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -8,6 +8,7 @@ import views.html.stacked
 import views.html.fragments._
 import views.html.fragments.page.body._
 import views.support.Commercial
+import conf.switches.Switches
 
 trait HtmlPage[P <: model.Page] {
   def html(page: P)(implicit request: RequestHeader, applicationContext: ApplicationContext): Html
@@ -30,7 +31,7 @@ object HtmlPageHelpers {
         .isAdFree(request)
     val headerContent: Html = stacked(
       commercial.topBanner() when showTop && showAds,
-      header() when showTop,
+      if (Switches.headerTopNav.isSwitchedOn) headerTopNav() else header() when showTop,
     )
     bannerAndHeaderDiv(headerContent)
   }

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -2,7 +2,7 @@ package navigation
 
 import common.Edition
 import model.Page
-import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe, SupporterCTA}
+import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe, SupporterCTA, PrintCTA, PrintCTAWeekly}
 import navigation.UrlHelpers._
 import play.api.libs.json.{Json, Writes}
 
@@ -46,7 +46,7 @@ object ReaderRevenueLinks {
     getReaderRevenueUrl(SupportContribute, SideMenu),
     getReaderRevenueUrl(SupportSubscribe, SideMenu),
     getReaderRevenueUrl(Support, SideMenu),
-    getReaderRevenueUrl(SupporterCTA, SideMenu),
+    getReaderRevenueUrl(PrintCTA, SideMenu),
   )
 
   val ampHeaderReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -2,7 +2,14 @@ package navigation
 
 import common.Edition
 import model.Page
-import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe, SupporterCTA, PrintCTA, PrintCTAWeekly}
+import navigation.ReaderRevenueSite.{
+  Support,
+  SupportContribute,
+  SupportSubscribe,
+  SupporterCTA,
+  PrintCTA,
+  PrintCTAWeekly,
+}
 import navigation.UrlHelpers._
 import play.api.libs.json.{Json, Writes}
 

--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -40,4 +40,8 @@ object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
   case object SupporterCTA extends ReaderRevenueSite {
     val url: String = s"${Configuration.id.supportUrl}/subscribe"
   }
+
+  case object SupporterCTAWeekly extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/subscribe/weekly"
+  }
 }

--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -41,7 +41,11 @@ object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
     val url: String = s"${Configuration.id.supportUrl}/subscribe"
   }
 
-  case object SupporterCTAWeekly extends ReaderRevenueSite {
+  case object PrintCTA extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/subscribe"
+  }
+
+  case object PrintCTAWeekly extends ReaderRevenueSite {
     val url: String = s"${Configuration.id.supportUrl}/subscribe/weekly"
   }
 }

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -8,6 +8,7 @@ import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 
 import scala.PartialFunction.condOpt
+import common.Edition
 
 object UrlHelpers {
 
@@ -51,6 +52,11 @@ object UrlHelpers {
       case (SupporterCTA, Footer)                                  => "footer_supporter_cta"
       case (SupporterCTA, AmpFooter)                               => "amp_footer_supporter_cta"
 
+      case (PrintCTA, Header)         => "header_print_cta"
+      case (PrintCTAWeekly, Header)   => "header_print_cta"
+      case (PrintCTA, SideMenu)       => "mobilenav_print_cta"
+      case (PrintCTAWeekly, SideMenu) => "mobilenav_print_cta"
+
       case (_, ManageMyAccountUpsell) => "manage_my_account_upsell"
     }
   }
@@ -64,8 +70,13 @@ object UrlHelpers {
 
   def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
     List(
-      NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
-      NavLink("Subscribe", getReaderRevenueUrl(SupportSubscribe, SideMenu), classList = Seq("js-subscribe")),
+      NavLink("Support us", getReaderRevenueUrl(SupportContribute, SideMenu)),
+      NavLink(
+        "Print subscriptions",
+        if (Edition(request).id == "UK") getReaderRevenueUrl(SupporterCTA, SideMenu)
+        else getReaderRevenueUrl(PrintCTAWeekly, SideMenu),
+        classList = Seq("js-print-subscription"),
+      ),
     )
 
   def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position): String = {

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -6,18 +6,20 @@
 @import navigation.AuthenticationComponentEvent._
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
-@import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, SupporterCTA, SupporterCTAWeekly}
+@import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, PrintCTA, PrintCTAWeekly}
 @import conf.Configuration
 @import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch}
 
 @editionListItem(edition: Edition, isCurrentEdition: Boolean = false) = {
 <li class="dropdown-menu__item">
-    <a data-link-name="nav3 : topbar : edition-picker: @edition.id" href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")"
+    @defining(LinkTo(s"/preference/edition/${edition.id.toLowerCase}")) { href =>
+    <a data-link-name="nav3 : topbar : edition-picker: @edition.id" href="@href"
         class="dropdown-menu__title @if(isCurrentEdition) {dropdown-menu__title--active}">
 
         <span class="u-h">switch to the </span>
         @edition.displayName
     </a>
+    }
 </li>
 }
 
@@ -33,11 +35,11 @@
 
             <div class="header-top-nav__top-bar">
                 @defining(Edition(request).id.toLowerCase()) { editionId =>
-                <div class="header-top-nav__item js-supporter-cta">
+                <div class="header-top-nav__item js-print-cta">
                     <span class="header-top-nav__item--separator hide-until-desktop"></span>
-                    @defining(if (editionId == "uk") getReaderRevenueUrl(SupporterCTA,
-                    Header) else getReaderRevenueUrl(SupporterCTAWeekly, Header)) { href =>
-                    <a class="top-bar__item hide-until-desktop yellow" data-link-name="nav3 : supporter-cta"
+                    @defining(if (editionId == "uk") getReaderRevenueUrl(PrintCTA,
+                    Header) else getReaderRevenueUrl(PrintCTAWeekly, Header)) { href =>
+                    <a class="top-bar__item hide-until-desktop yellow" data-link-name="nav3 : print-cta"
                         data-edition="@{editionId}" href="@href">
                         @fragments.inlineSvg("newspaper", "icon", List("top-bar__item__icon"))
                         Print subscriptions

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -2,32 +2,94 @@
 
 @import common.{LinkTo, Edition}
 @import views.support.RenderClasses
+@import views.support.DropdownMenus.accountDropdownMenu
+@import navigation.AuthenticationComponentEvent._
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
-@import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, SupporterCTA}
+@import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, SupporterCTA, SupporterCTAWeekly}
+@import conf.Configuration
 @import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch}
 
+@editionListItem(edition: Edition, isCurrentEdition: Boolean = false) = {
+<li class="dropdown-menu__item">
+    <a data-link-name="nav3 : topbar : edition-picker: @edition.id" href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")"
+        class="dropdown-menu__title @if(isCurrentEdition) {dropdown-menu__title--active}">
+
+        <span class="u-h">switch to the </span>
+        @edition.displayName
+    </a>
+</li>
+}
+
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
-<header class="@RenderClasses(s" pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "header-top-nav"
+<header class="@RenderClasses(Map(
+    "header-top-nav--slim" -> page.metadata.hasSlimHeader
+), s" pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "header-top-nav"
     )" role="banner">
 
     <div class="header-top-nav__full-width">
         <nav class="header-top-nav__inner gs-container" data-component="nav3" role="navigation"
             aria-label="Guardian sections">
 
-            <div class="header-top-nav__top-bar hide-until-mobile">
+            <div class="header-top-nav__top-bar">
                 @defining(Edition(request).id.toLowerCase()) { editionId =>
-                <div class="top-bar__commercial-items js-supporter-cta is-hidden">
-                    <span class="top-bar__item__seperator hide-until-desktop"></span>
+                <div class="header-top-nav__item js-supporter-cta">
+                    <span class="header-top-nav__item--separator hide-until-desktop"></span>
+                    @defining(if (editionId == "uk") getReaderRevenueUrl(SupporterCTA,
+                    Header) else getReaderRevenueUrl(SupporterCTAWeekly, Header)) { href =>
                     <a class="top-bar__item hide-until-desktop" data-link-name="nav3 : supporter-cta"
-                        data-edition="@{editionId}" href="@getReaderRevenueUrl(SupporterCTA, Header)">
-                        Subscriptions
+                        data-edition="@{editionId}" href="@href">
+                        @fragments.inlineSvg("newspaper", "icon", List("top-bar__item__icon"))
+                        Print subscriptions
                     </a>
+                    }
+                </div>
+
+
+
+                <div class="header-top-nav__item">
+                    <span class="header-top-nav__item--separator hide-until-desktop"></span>
+                    <a class="top-bar__item js-navigation-sign-in my-account" data-link-name="nav3 : topbar : signin"
+                        href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&@createAuthenticationComponentEventParams(SigninHeaderId)">
+                        @fragments.inlineSvg("profile", "icon", List("top-bar__item__icon"))
+                        Sign in
+                    </a>
+
+                    <input type="checkbox" id="my-account-toggle" aria-controls="my-account-dropdown"
+                        class="dropdown-menu-fallback js-enhance-checkbox" data-link-name="nav3 : topbar: my account"
+                        tabindex="-1" />
+
+                    <label
+                        class="top-bar__item popup__toggle js-navigation-account-actions js-user-account-trigger is-hidden"
+                        for="my-account-toggle" data-link-name="nav3 : topbar: my account" tabindex="0">
+                        @fragments.inlineSvg("profile", "icon", List("top-bar__item__icon"))
+                        My account
+                    </label>
+                    <div class="my-account__overlay"></div>
+
+                    <ul class="dropdown-menu dropdown-menu--light js-user-account-dropdown-menu"
+                        id="my-account-dropdown" aria-hidden="true">
+
+                        @for((item)
+                        <- accountDropdownMenu) { @if(item.divider) { <hr />
+                        }
+                        <li class="@{(List(" dropdown-menu__item") ++ item.parentClassList).mkString(" ")}">
+                            <a class="@{(List(" dropdown-menu__title") ++ item.classList).mkString(" ")}"
+                                @if(item.href.isDefined) { href="@item.href" } @if(item.linkName.isDefined) {
+                                data-link-name="nav3 : topbar : @item.linkName" }>
+                                @(item.icon.map { icon =>
+                                views.html.fragments.inlineSvg(icon, "icon", isPresentation = true)
+                                })
+                                @item.label
+                            </a>
+                        </li>
+                        }
+                    </ul>
                 </div>
 
                 @if(editionId != "au" || editionId == "uk") {
-                <div class="top-bar__commercial-items">
-                    <span class="top-bar__item__seperator hide-until-desktop"></span>
+                <div class="header-top-nav__item">
+                    <span class="header-top-nav__item--separator hide-until-desktop"></span>
                     <a class="top-bar__item hide-until-desktop" data-link-name="nav3 : job-cta"
                         data-edition="@{editionId}" href="@getJobUrl(editionId)">
                         Search jobs
@@ -35,86 +97,106 @@
                 </div>
                 }
 
-                @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
-                @fragments.nav.userAccountDropdown()
+
+                <div class="header-top-nav__item">
+                    <span class="header-top-nav__item--separator hide-until-desktop"></span>
+                    <a class="top-bar__item hide-until-desktop"
+                        href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
+                        data-link-name="nav3 : search">
+                        @fragments.inlineSvg("search-36", "icon", List("top-bar__item__icon"))
+                        Search
+                    </a>
+                </div>
+
                 }
 
 
-                <a class="top-bar__item popup__toggle hide-until-desktop js-search-toggle"
-                    href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com" data-is-ajax
-                    data-link-name="nav3 : search" data-toggle="js-search-new">
-                    @fragments.inlineSvg("search-36", "icon", List("top-bar__item__icon"))
-                    Search
-                </a>
+                @if(!page.metadata.hasSlimHeader) {
 
+                <div class="header-top-nav__item hide-until-desktop">
+                    <span class="top-bar__item__seperator"></span>
+
+                    <input type="checkbox" id="edition-picker-toggle" aria-controls="edition-dropdown-menu"
+                        class="u-h dropdown-menu-fallback js-enhance-checkbox"
+                        data-link-name="nav2 : topbar : edition-picker: toggle" tabindex="-1">
+
+                    <ul class="dropdown-menu js-edition-dropdown-menu" id="edition-dropdown-menu" aria-hidden="true">
+
+                        @editionListItem(Edition(request), true)
+
+                        @Edition.others(request).map(e => editionListItem(e))
+                    </ul>
+
+                    <label for="edition-picker-toggle" class="top-bar__item popup__toggle js-edition-picker-trigger"
+                        data-link-name="nav2 : topnav : edition-picker: toggle"
+                        data-display-name="@Edition(request).displayName" tabindex="0">
+
+                        <span class="u-h">current edition: </span>
+                        @Edition(request).displayName
+                    </label>
+
+                </div>
                 }
             </div>
 
-            <div class="popup popup--default popup--search js-search-popup js-search-new is-off" aria-label="search"
-                role="dialog" tabindex="-1" id="search-popup">
-                <div class="js-search-placeholder"></div>
-            </div>
-
-
-            @if(!page.metadata.hasSlimHeader) {
-            @fragments.nav.editionPickerDropdown()
-            }
 
         </nav>
     </div>
 
-    @defining(Edition(request).id.toLowerCase()) { editionId =>
-    <a href="@LinkTo {/}" class="header-top-bar__logo" data-link-name="nav3 : logo">
+    <div class="gs-container">
+        @defining(Edition(request).id.toLowerCase()) { editionId =>
+        <a href="@LinkTo {/}" class="header-top-nav__logo" data-link-name="nav3 : logo">
 
-        <span class="u-h">The Guardian - Back to home</span>
+            <span class="u-h">The Guardian - Back to home</span>
 
-        @{
-        if(editionId == "uk") {
-        fragments.inlineSvg("guardian-best-website-logo", "logo")
-        } else {
-        fragments.inlineSvg("the-guardian-logo", "logo")
-        }
-        }
-    </a>
-    }
-    <div class="header-top-bar__cta-bar"></div>
-
-    @fragments.nav.headerMenu(navMenu)
-
-    <nav>
-        <ul class="pillars">
-            @navMenu.pillars.map { link =>
-            <li class="pillars__item">
-                <a class="@RenderClasses(Map(
-                        " pillar-link--current-section" -> ((link.title ==
-                    navMenu.currentPillar.map(_.title).getOrElse("")) && !page.metadata.hasSlimHeader)
-                    ), "pillar-link", s"pillar-link--${link.title}")"
-                    href="@LinkTo(link.url)"
-                    data-link-name="nav3 : primary : @link.title">
-
-                    @link.title
-                </a>
-            </li>
+            @{
+            if(editionId == "uk") {
+            fragments.inlineSvg("guardian-best-website-logo", "logo")
+            } else {
+            fragments.inlineSvg("the-guardian-logo", "logo")
             }
-        </ul>
+            }
+        </a>
+        }
+        <div class="header-top-bar__cta-bar"></div>
 
-        <input type="checkbox" id="main-menu-toggle" class="veggie-burger-fallback js-enhance-checkbox u-h"
-            data-link-name="nav3 : veggie-burger : show" aria-controls="main-menu" tabindex="-1">
+        @fragments.nav.headerMenu(navMenu)
 
-        <label for="main-menu-toggle" class="js-change-link header-top-bar__menu-toggle"
-            data-link-name="nav3 : veggie-burger : show" tabindex="0">
+        <nav data-component="nav2">
+            <ul class="pillars">
+                @navMenu.pillars.map { link =>
+                <li class="pillars__item">
+                    <a class="@RenderClasses(Map(
+                            " pillar-link--current-section" -> ((link.title ==
+                        navMenu.currentPillar.map(_.title).getOrElse("")) && !page.metadata.hasSlimHeader)
+                        ), "pillar-link", s"pillar-link--${link.title}")"
+                        href="@LinkTo(link.url)"
+                        data-link-name="nav3 : primary : @link.title">
 
-            <span class="veggie-burger hide-from-desktop">
-                <span class="veggie-burger__icon"></span>
-            </span>
+                        @link.title
+                    </a>
+                </li>
+                }
+            </ul>
 
-            <span class="pillar-link pillar-link--dropdown pillar-link--sections hide-until-desktop">
-                <span class="u-h">Show</span>
-                More
-                <i class="pillar-link--dropdown__icon"></i>
-            </span>
-        </label>
-    </nav>
+            <input type="checkbox" id="main-menu-toggle" class="veggie-burger-fallback js-enhance-checkbox u-h"
+                data-link-name="nav3 : veggie-burger : show" aria-controls="main-menu" tabindex="-1">
+
+            <label for="main-menu-toggle" class="js-change-link header-top-bar__menu-toggle"
+                data-link-name="nav3 : veggie-burger : show" tabindex="0">
+
+                <span class="veggie-burger hide-from-desktop">
+                    <span class="veggie-burger__icon"></span>
+                </span>
+
+                <span class="pillar-link pillar-link--dropdown pillar-link--sections hide-until-desktop">
+                    <span class="u-h">Show</span>
+                    More
+                    <i class="pillar-link--dropdown__icon"></i>
+                </span>
+            </label>
+        </nav>
+    </div>
 
     @fragments.nav.subNav(navMenu, page.metadata.designType)
 </header>

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -89,7 +89,7 @@
                     </ul>
                 </div>
 
-                @if(editionId != "au" || editionId == "uk") {
+                @if(editionId != "au") {
                 <div class="header-top-nav__item">
                     <span class="header-top-nav__item--separator hide-until-desktop"></span>
                     <a class="top-bar__item hide-until-desktop" data-link-name="nav3 : job-cta"

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -1,0 +1,121 @@
+@()(implicit page: model.Page, request: RequestHeader)
+
+@import common.{LinkTo, Edition}
+@import views.support.RenderClasses
+@import navigation.NavMenu
+@import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
+@import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, SupporterCTA}
+@import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch}
+
+@defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+<header class="@RenderClasses(s" pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "header-top-nav"
+    )" role="banner">
+
+    <div class="header-top-nav__full-width">
+        <nav class="header-top-nav__inner gs-container" data-component="nav3" role="navigation"
+            aria-label="Guardian sections">
+
+            <div class="header-top-nav__top-bar hide-until-mobile">
+                @defining(Edition(request).id.toLowerCase()) { editionId =>
+                <div class="top-bar__commercial-items js-supporter-cta is-hidden">
+                    <span class="top-bar__item__seperator hide-until-desktop"></span>
+                    <a class="top-bar__item hide-until-desktop" data-link-name="nav3 : supporter-cta"
+                        data-edition="@{editionId}" href="@getReaderRevenueUrl(SupporterCTA, Header)">
+                        Subscriptions
+                    </a>
+                </div>
+
+                @if(editionId != "au" || editionId == "uk") {
+                <div class="top-bar__commercial-items">
+                    <span class="top-bar__item__seperator hide-until-desktop"></span>
+                    <a class="top-bar__item hide-until-desktop" data-link-name="nav3 : job-cta"
+                        data-edition="@{editionId}" href="@getJobUrl(editionId)">
+                        Search jobs
+                    </a>
+                </div>
+                }
+
+                @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
+                @fragments.nav.userAccountDropdown()
+                }
+
+
+                <a class="top-bar__item popup__toggle hide-until-desktop js-search-toggle"
+                    href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com" data-is-ajax
+                    data-link-name="nav3 : search" data-toggle="js-search-new">
+                    @fragments.inlineSvg("search-36", "icon", List("top-bar__item__icon"))
+                    Search
+                </a>
+
+                }
+            </div>
+
+            <div class="popup popup--default popup--search js-search-popup js-search-new is-off" aria-label="search"
+                role="dialog" tabindex="-1" id="search-popup">
+                <div class="js-search-placeholder"></div>
+            </div>
+
+
+            @if(!page.metadata.hasSlimHeader) {
+            @fragments.nav.editionPickerDropdown()
+            }
+
+        </nav>
+    </div>
+
+    @defining(Edition(request).id.toLowerCase()) { editionId =>
+    <a href="@LinkTo {/}" class="header-top-bar__logo" data-link-name="nav3 : logo">
+
+        <span class="u-h">The Guardian - Back to home</span>
+
+        @{
+        if(editionId == "uk") {
+        fragments.inlineSvg("guardian-best-website-logo", "logo")
+        } else {
+        fragments.inlineSvg("the-guardian-logo", "logo")
+        }
+        }
+    </a>
+    }
+    <div class="header-top-bar__cta-bar"></div>
+
+    @fragments.nav.headerMenu(navMenu)
+
+    <nav>
+        <ul class="pillars">
+            @navMenu.pillars.map { link =>
+            <li class="pillars__item">
+                <a class="@RenderClasses(Map(
+                        " pillar-link--current-section" -> ((link.title ==
+                    navMenu.currentPillar.map(_.title).getOrElse("")) && !page.metadata.hasSlimHeader)
+                    ), "pillar-link", s"pillar-link--${link.title}")"
+                    href="@LinkTo(link.url)"
+                    data-link-name="nav3 : primary : @link.title">
+
+                    @link.title
+                </a>
+            </li>
+            }
+        </ul>
+
+        <input type="checkbox" id="main-menu-toggle" class="veggie-burger-fallback js-enhance-checkbox u-h"
+            data-link-name="nav3 : veggie-burger : show" aria-controls="main-menu" tabindex="-1">
+
+        <label for="main-menu-toggle" class="js-change-link header-top-bar__menu-toggle"
+            data-link-name="nav3 : veggie-burger : show" tabindex="0">
+
+            <span class="veggie-burger hide-from-desktop">
+                <span class="veggie-burger__icon"></span>
+            </span>
+
+            <span class="pillar-link pillar-link--dropdown pillar-link--sections hide-until-desktop">
+                <span class="u-h">Show</span>
+                More
+                <i class="pillar-link--dropdown__icon"></i>
+            </span>
+        </label>
+    </nav>
+
+    @fragments.nav.subNav(navMenu, page.metadata.designType)
+</header>
+}

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -161,7 +161,7 @@
             }
         </a>
         }
-        <div class="header-top-bar__cta-bar"></div>
+        <div class="header-top-nav__cta-bar"></div>
 
         @fragments.nav.headerMenu(navMenu)
         <ul class="pillars">

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -23,8 +23,8 @@
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
 <header class="@RenderClasses(Map(
-    "header-top-nav--slim" -> page.metadata.hasSlimHeader
-), s" pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "header-top-nav"
+    " header-top-nav--slim" -> page.metadata.hasSlimHeader
+    ), s" pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "header-top-nav"
     )" role="banner">
 
     <div class="header-top-nav__full-width">
@@ -143,7 +143,10 @@
         </nav>
     </div>
 
-    <div class="gs-container">
+
+
+
+    <nav class="gs-container u-cf" data-component="nav2">
         @defining(Edition(request).id.toLowerCase()) { editionId =>
         <a href="@LinkTo {/}" class="header-top-nav__logo" data-link-name="nav3 : logo">
 
@@ -161,42 +164,40 @@
         <div class="header-top-bar__cta-bar"></div>
 
         @fragments.nav.headerMenu(navMenu)
-
-        <nav data-component="nav2">
-            <ul class="pillars">
-                @navMenu.pillars.map { link =>
-                <li class="pillars__item">
-                    <a class="@RenderClasses(Map(
+        <ul class="pillars">
+            @navMenu.pillars.map { link =>
+            <li class="pillars__item">
+                <a class="@RenderClasses(Map(
                             " pillar-link--current-section" -> ((link.title ==
-                        navMenu.currentPillar.map(_.title).getOrElse("")) && !page.metadata.hasSlimHeader)
-                        ), "pillar-link", s"pillar-link--${link.title}")"
-                        href="@LinkTo(link.url)"
-                        data-link-name="nav3 : primary : @link.title">
+                    navMenu.currentPillar.map(_.title).getOrElse("")) && !page.metadata.hasSlimHeader)
+                    ), "pillar-link", s"pillar-link--${link.title}")"
+                    href="@LinkTo(link.url)"
+                    data-link-name="nav3 : primary : @link.title">
 
-                        @link.title
-                    </a>
-                </li>
-                }
-            </ul>
+                    @link.title
+                </a>
+            </li>
+            }
+        </ul>
 
-            <input type="checkbox" id="main-menu-toggle" class="veggie-burger-fallback js-enhance-checkbox u-h"
-                data-link-name="nav3 : veggie-burger : show" aria-controls="main-menu" tabindex="-1">
+        <input type="checkbox" id="main-menu-toggle" class="veggie-burger-fallback js-enhance-checkbox u-h"
+            data-link-name="nav3 : veggie-burger : show" aria-controls="main-menu" tabindex="-1">
 
-            <label for="main-menu-toggle" class="js-change-link header-top-bar__menu-toggle"
-                data-link-name="nav3 : veggie-burger : show" tabindex="0">
+        <label for="main-menu-toggle" class="js-change-link header-top-bar__menu-toggle"
+            data-link-name="nav3 : veggie-burger : show" tabindex="0">
 
-                <span class="veggie-burger hide-from-desktop">
-                    <span class="veggie-burger__icon"></span>
-                </span>
+            <span class="veggie-burger hide-from-desktop">
+                <span class="veggie-burger__icon"></span>
+            </span>
 
-                <span class="pillar-link pillar-link--dropdown pillar-link--sections hide-until-desktop">
-                    <span class="u-h">Show</span>
-                    More
-                    <i class="pillar-link--dropdown__icon"></i>
-                </span>
-            </label>
-        </nav>
-    </div>
+            <span class="pillar-link pillar-link--dropdown pillar-link--sections hide-until-desktop">
+                <span class="u-h">Show</span>
+                More
+                <i class="pillar-link--dropdown__icon"></i>
+            </span>
+        </label>
+    </nav>
+
 
     @fragments.nav.subNav(navMenu, page.metadata.designType)
 </header>

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -183,7 +183,7 @@
         <input type="checkbox" id="main-menu-toggle" class="veggie-burger-fallback js-enhance-checkbox u-h"
             data-link-name="nav3 : veggie-burger : show" aria-controls="main-menu" tabindex="-1">
 
-        <label for="main-menu-toggle" class="js-change-link header-top-bar__menu-toggle"
+        <label for="main-menu-toggle" class="js-change-link header-top-nav__menu-toggle"
             data-link-name="nav3 : veggie-burger : show" tabindex="0">
 
             <span class="veggie-burger hide-from-desktop">

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -37,7 +37,7 @@
                     <span class="header-top-nav__item--separator hide-until-desktop"></span>
                     @defining(if (editionId == "uk") getReaderRevenueUrl(SupporterCTA,
                     Header) else getReaderRevenueUrl(SupporterCTAWeekly, Header)) { href =>
-                    <a class="top-bar__item hide-until-desktop" data-link-name="nav3 : supporter-cta"
+                    <a class="top-bar__item hide-until-desktop yellow" data-link-name="nav3 : supporter-cta"
                         data-edition="@{editionId}" href="@href">
                         @fragments.inlineSvg("newspaper", "icon", List("top-bar__item__icon"))
                         Print subscriptions

--- a/static/src/inline-svgs/icon/newspaper.svg
+++ b/static/src/inline-svgs/icon/newspaper.svg
@@ -1,0 +1,4 @@
+<svg width="19" height="19" viewBox="0 0 19 19">
+	<circle cx="9.59" cy="9.93" r="9"/>
+	<path fill-rule="evenodd" clip-rule="evenodd" d="M14.20 14.72L13.67 15.27H6.02L5.47 14.72V4.91L6.02 4.36H12.03L14.20 6.54V14.72ZM13.11 7.63H6.56V8.45H13.11V7.63ZM13.11 9.27H6.56V10.09H13.11V9.27ZM10.38 10.91H6.56V11.72H10.38V10.91Z" fill="#052962"/>
+</svg>

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -28,6 +28,7 @@ import { isBreakpoint } from 'lib/detect';
 import config from 'lib/config';
 import { init as initDynamicImport } from 'lib/dynamic-import-init';
 import { newHeaderInit } from 'common/modules/navigation/new-header';
+import { headerTopNavInit } from 'common/modules/navigation/header-top-nav';
 import { fixSecondaryColumn } from 'common/modules/fix-secondary-column';
 import { trackPerformance } from 'common/modules/analytics/google';
 import debounce from 'lodash/debounce';
@@ -220,7 +221,11 @@ const bootStandard = () => {
         handleMembershipAccess();
     }
 
-    newHeaderInit();
+    if(window.guardian.config.switches.headerTopNav) {
+        headerTopNavInit();
+    } else {
+        newHeaderInit();
+    }
 
     const isAtLeastLeftCol = isBreakpoint({ min: 'leftCol' });
 

--- a/static/src/javascripts/projects/common/modules/navigation/header-top-nav.js
+++ b/static/src/javascripts/projects/common/modules/navigation/header-top-nav.js
@@ -1,0 +1,555 @@
+import debounce from 'lodash/debounce';
+import ophan from 'ophan/ng';
+import { isBreakpoint } from 'lib/detect';
+import { mediator } from 'lib/mediator';
+import fastdom from 'lib/fastdom-promise';
+import { storage } from '@guardian/libs';
+import { scrollToElement } from 'lib/scroller';
+import { addEventListener } from 'lib/events';
+import { showMyAccountIfNecessary } from './user-account';
+
+const enhanced = {};
+const clickstreamListeners = {};
+const SEARCH_STORAGE_KEY = 'gu.recent.search';
+const MY_ACCOUNT_ID = 'my-account-toggle';
+const MENU_TOGGLE_ID = 'main-menu-toggle';
+const EDITION_PICKER_TOGGLE_ID = 'edition-picker-toggle';
+
+const getMenu = () => document.getElementsByClassName('js-main-menu')[0];
+
+const getSectionToggleMenuItem = (section) => {
+	const children = Array.from(section.children);
+	return children.find((child) =>
+		child.classList.contains('menu-item__title'),
+	);
+};
+
+const closeMenuSection = (section) => {
+	const toggle = getSectionToggleMenuItem(section);
+
+	if (toggle) {
+		toggle.setAttribute('aria-expanded', 'false');
+	}
+};
+
+const closeAllMenuSections = (exclude) => {
+	const sections = Array.from(
+		document.querySelectorAll('.js-navigation-item'),
+	);
+
+	sections.forEach((section) => {
+		if (section !== exclude) {
+			closeMenuSection(section);
+		}
+	});
+};
+
+const openMenuSection = (section, options = {}) => {
+	const toggle = getSectionToggleMenuItem(section);
+
+	if (toggle) {
+		toggle.setAttribute('aria-expanded', 'true');
+	}
+
+	if (options.scrollIntoView === true) {
+		scrollToElement(section, 0, 'easeInQuad', getMenu());
+	}
+
+	// the sections should behave like an accordion
+	closeAllMenuSections(section);
+};
+
+const isMenuSectionClosed = (section) => {
+	const toggle = getSectionToggleMenuItem(section);
+
+	if (toggle) {
+		return toggle.getAttribute('aria-expanded') === 'false';
+	}
+
+	return true;
+};
+
+const toggleMenuSection = (section) => {
+	if (isMenuSectionClosed(section)) {
+		openMenuSection(section);
+	} else {
+		closeMenuSection(section);
+	}
+};
+
+const removeClickstreamListener = (menuId) => {
+	const clickHandler = clickstreamListeners[menuId];
+	mediator.off('module:clickstream:click', clickHandler);
+	delete clickstreamListeners[menuId];
+};
+
+const registerClickstreamListener = (menuId, clickHandler) => {
+	removeClickstreamListener(menuId);
+	mediator.on('module:clickstream:click', clickHandler);
+	clickstreamListeners[menuId] = clickHandler;
+};
+
+const toggleMenu = () => {
+	const documentElement = document.documentElement;
+	const openClass = 'header-top-nav--open';
+	const globalOpenClass = 'nav-is-open';
+	const trigger = document.querySelector('.veggie-burger');
+	const header = document.querySelector('.header-top-nav');
+	const menuToggle = header && header?.querySelector('.js-change-link');
+	const isOpen = trigger && trigger.getAttribute('aria-expanded') === 'true';
+	const menu = getMenu();
+
+	if (!header || !menu || !menuToggle) {
+		return;
+	}
+
+	const resetItemOrder = () => {
+		const items = Array.from(
+			document.querySelectorAll('.js-navigation-item'),
+		);
+
+		items.forEach((item) => {
+			const listItem = item;
+			listItem.style.order = '';
+		});
+	};
+
+	const focusFirstMenuSection = () => {
+		const firstSection = document.querySelector('.js-navigation-button');
+
+		if (firstSection) {
+			firstSection.focus();
+		}
+	};
+
+	const update = () => {
+		const expandedAttr = isOpen ? 'false' : 'true';
+		const hiddenAttr = isOpen ? 'true' : 'false';
+		const haveToCalcTogglePosition = () =>
+			isBreakpoint({
+				min: 'tablet',
+				max: 'desktop',
+			});
+		const enhanceMenuMargin = () => {
+			const body = document.body;
+
+			if (!body || !haveToCalcTogglePosition()) {
+				return Promise.resolve();
+			}
+
+			return fastdom
+				.measure(() => {
+					const docRect = body.getBoundingClientRect();
+					const rect = menuToggle.getBoundingClientRect();
+					return docRect.right - rect.right + rect.width / 2;
+				})
+				.then((marginRight) =>
+					fastdom.mutate(() => {
+						menu.style.marginRight = `${marginRight}px`;
+					}),
+				);
+		};
+		const debouncedMenuEnhancement = debounce(enhanceMenuMargin, 200);
+		const removeEnhancedMenuMargin = () =>
+			fastdom.mutate(() => {
+				menu.style.marginRight = '';
+			});
+
+		/*
+            Between tablet and desktop the veggie-burger does not have a fixed
+            margin to the right. Therefore we have to calculate it's midpoint
+            and apply it as a margin to the menu.
+            The listeners have to be applied always, because the device
+            orientation could change and force the layout into the next
+            breakpoint.
+        */
+		if (!isOpen) {
+			enhanceMenuMargin().then(() => {
+				addEventListener(window, 'resize', debouncedMenuEnhancement, {
+					passive: true,
+				});
+			});
+
+			// On desktop clicking outside menu should close it
+			if (
+				isBreakpoint({
+					min: 'desktop',
+				})
+			) {
+				const menuId = menu.getAttribute('id');
+				const triggerToggle = (clickSpec) => {
+					const elem = clickSpec ? clickSpec.target : null;
+
+					if (elem !== menu) {
+						toggleMenu();
+						// remove event listener when the menu closes
+						if (menuId) {
+							removeClickstreamListener(menuId);
+						}
+					}
+				};
+				// if anywhere outside the menu is clicked the menu will close
+				if (menuId) {
+					registerClickstreamListener(menuId, triggerToggle);
+				}
+			}
+		} else {
+			removeEnhancedMenuMargin().then(() => {
+				window.removeEventListener('resize', debouncedMenuEnhancement);
+			});
+		}
+
+		menuToggle.setAttribute(
+			'data-link-name',
+			`nav2 : veggie-burger : ${isOpen ? 'show' : 'hide'}`,
+		);
+
+		if (trigger) {
+			trigger.setAttribute('aria-expanded', expandedAttr);
+		}
+
+		menu.setAttribute('aria-hidden', hiddenAttr);
+		header.classList.toggle(openClass, !isOpen);
+
+		if (documentElement) {
+			documentElement.classList.toggle(globalOpenClass, !isOpen);
+		}
+
+		if (isOpen) {
+			resetItemOrder();
+			closeAllMenuSections();
+		} else {
+			focusFirstMenuSection();
+		}
+	};
+
+	fastdom.mutate(update);
+};
+
+const toggleDropdown = (menuAndTriggerEls) => {
+	const documentElement = document.documentElement;
+	const globalOpenClass = 'dropdown--open';
+	const openClass = 'dropdown-menu--open';
+
+	fastdom
+		.measure(() => menuAndTriggerEls)
+		.then((els) => {
+			const { menu, trigger } = els;
+
+			if (!menu) {
+				return;
+			}
+
+			const isOpen = menu.classList.contains(openClass);
+			const expandedAttr = isOpen ? 'false' : 'true';
+			const hiddenAttr = isOpen ? 'true' : 'false';
+
+			return fastdom.mutate(() => {
+				if (trigger) {
+					trigger.setAttribute('aria-expanded', expandedAttr);
+				}
+
+				menu.setAttribute('aria-hidden', hiddenAttr);
+				menu.classList.toggle(openClass, !isOpen);
+
+				if (documentElement) {
+					documentElement.classList.toggle(globalOpenClass, !isOpen);
+				}
+
+				if (!isOpen && document.body) {
+					// Prevents menu from being disconnected with trigger
+					(document.documentElement || document.body).scrollTop = 0;
+
+					const menuId = menu.getAttribute('id');
+					const triggerToggle = (clickSpec) => {
+						const elem = clickSpec ? clickSpec.target : null;
+						if (elem !== menu) {
+							toggleDropdown(menuAndTriggerEls);
+
+							// remove event listener when the dropdown closes
+							if (menuId) {
+								removeClickstreamListener(menuId);
+							}
+						}
+					};
+					// if anywhere outside the menu is clicked the dropdown will close
+					registerClickstreamListener(menuId, triggerToggle);
+				}
+			});
+		});
+};
+
+const returnFocusToButton = (btnId) => {
+	fastdom
+		.measure(() => document.getElementById(btnId))
+		.then((btn) => {
+			if (btn) {
+				btn.focus();
+				/**
+				 * As we're closing the menu with the ESC key we no longer need the
+				 * clickstream listener that toggles the menu on a click outside the menu
+				 * so let's unregister it here
+				 * */
+				const menuId = btn.getAttribute('aria-controls');
+				if (menuId) {
+					removeClickstreamListener(menuId);
+				}
+			}
+		});
+};
+
+const genericToggleMenu = (menuClassName, triggerClassName) => {
+	const menu = document.querySelector(menuClassName);
+
+	const trigger = document.querySelector(triggerClassName);
+
+	if (menu && trigger) {
+		toggleDropdown({
+			menu,
+			trigger,
+		});
+	}
+};
+
+const toggleEditionPicker = () =>
+	genericToggleMenu(
+		'.js-edition-dropdown-menu',
+		'.js-edition-picker-trigger',
+	);
+
+const toggleMyAccountMenu = () =>
+	genericToggleMenu(
+		'.js-user-account-dropdown-menu',
+		'.js-user-account-trigger',
+	);
+
+const buttonClickHandlers = {
+	[MENU_TOGGLE_ID]: toggleMenu,
+	[EDITION_PICKER_TOGGLE_ID]: toggleEditionPicker,
+	[MY_ACCOUNT_ID]: toggleMyAccountMenu,
+};
+
+const menuKeyHandlers = {
+	[MENU_TOGGLE_ID]: (event) => {
+		if (event.key === 'Escape') {
+			toggleMenu();
+			returnFocusToButton(MENU_TOGGLE_ID);
+		}
+	},
+	[EDITION_PICKER_TOGGLE_ID]: (event) => {
+		if (event.key === 'Escape') {
+			toggleEditionPicker();
+			returnFocusToButton(EDITION_PICKER_TOGGLE_ID);
+		}
+	},
+	[MY_ACCOUNT_ID]: (event) => {
+		if (event.key === 'Escape') {
+			toggleMyAccountMenu();
+			returnFocusToButton(MY_ACCOUNT_ID);
+		}
+	},
+};
+
+const enhanceCheckbox = (checkbox) => {
+	fastdom.measure(() => {
+		const button = document.createElement('button');
+		const checkboxId = checkbox.id;
+		const checkboxControls = checkbox.getAttribute('aria-controls');
+		const dataLinkName = checkbox.getAttribute('data-link-name');
+		const label = document.querySelector(`label[for='${checkboxId}']`);
+
+		const enhance = () => {
+			button.setAttribute('id', checkboxId);
+
+			const clickHandler = buttonClickHandlers[checkboxId];
+
+			if (clickHandler) {
+				button.addEventListener('click', clickHandler);
+			}
+
+			button.setAttribute('aria-expanded', 'false');
+
+			if (dataLinkName) {
+				button.setAttribute('data-link-name', dataLinkName);
+			}
+
+			if (checkboxControls) {
+				button.setAttribute('aria-controls', checkboxControls);
+
+				const menu = document.getElementById(checkboxControls);
+				const keyHandler = menuKeyHandlers[checkboxId];
+
+				if (menu && keyHandler) {
+					menu.addEventListener('keyup', keyHandler);
+				}
+			}
+
+			if (label) {
+				label.classList.forEach((className) => {
+					button.classList.add(className);
+				});
+
+				button.classList.add(`${checkboxId}-button`);
+
+				const labelTabIndex = label.getAttribute('tabindex');
+
+				if (labelTabIndex) {
+					button.setAttribute('tabindex', labelTabIndex);
+				}
+
+				button.innerHTML = label.innerHTML;
+
+				label.remove();
+			}
+
+			if (checkbox.parentNode) {
+				checkbox.parentNode.replaceChild(button, checkbox);
+			}
+
+			enhanced[button.id] = true;
+		};
+
+		fastdom.mutate(enhance);
+	});
+};
+
+const enhanceMenuToggles = () => {
+	const checkboxs = Array.from(
+		document.getElementsByClassName('js-enhance-checkbox'),
+	);
+
+	checkboxs.forEach((checkbox) => {
+		if (!enhanced[checkbox.id] && !checkbox.checked) {
+			enhanceCheckbox(checkbox);
+		} else {
+			const closeMenuHandler = () => {
+				enhanceCheckbox(checkbox);
+				checkbox.removeEventListener('click', closeMenuHandler);
+			};
+
+			checkbox.addEventListener('click', closeMenuHandler);
+		}
+	});
+};
+
+const getRecentSearch = () => storage.local.get(SEARCH_STORAGE_KEY);
+
+const clearRecentSearch = () => storage.local.remove(SEARCH_STORAGE_KEY);
+
+const trackRecentSearch = () => {
+	const recent = getRecentSearch();
+
+	if (recent) {
+		ophan.record({
+			component: 'header-top-nav-search',
+			value: recent,
+		});
+
+		clearRecentSearch();
+	}
+};
+
+const saveSearchTerm = (term) => storage.local.set(SEARCH_STORAGE_KEY, term);
+
+const showMoreButton = () => {
+	fastdom
+		.measure(() => {
+			const moreButton = document.querySelector('.js-show-more-button');
+			const subnav = document.querySelector('.js-expand-subnav');
+			const subnavList = document.querySelector(
+				'.js-get-last-child-subnav',
+			);
+
+			if (subnav && subnavList) {
+				const subnavItems = subnavList.querySelectorAll('li');
+				const lastChild = subnavItems[subnavItems.length - 1];
+
+				const lastChildRect = lastChild.getBoundingClientRect();
+				const subnavRect = subnav.getBoundingClientRect();
+
+				return { moreButton, lastChildRect, subnavRect };
+			}
+		})
+		.then((els) => {
+			if (els) {
+				const { moreButton, lastChildRect, subnavRect } = els;
+
+				// +1 to compensate for the border top on the subnav
+				if (subnavRect.top + 1 === lastChildRect.top) {
+					fastdom.mutate(() => {
+						if (moreButton) {
+							moreButton.classList.add('is-hidden');
+						}
+					});
+				}
+			}
+		});
+};
+
+const toggleSubnavSections = (moreButton) => {
+	fastdom
+		.measure(() => document.querySelector('.js-expand-subnav'))
+		.then((subnav) => {
+			if (subnav) {
+				fastdom.mutate(() => {
+					const isOpen =
+						subnav.classList.contains('subnav--expanded');
+
+					subnav.classList.toggle('subnav--expanded');
+
+					moreButton.innerText = isOpen ? 'More' : 'Less';
+				});
+			}
+		});
+};
+
+const addEventHandler = () => {
+	const menu = getMenu();
+	const search = menu && menu.querySelector('.js-menu-search');
+	const toggleWithMoreButton = document.querySelector(
+		'.js-toggle-more-sections',
+	);
+
+	if (menu) {
+		menu.addEventListener('click', (event) => {
+			const selector = '.js-navigation-toggle';
+			const target = event.target;
+
+			if (target.matches(selector)) {
+				const parent = target.parentNode;
+
+				if (parent) {
+					event.preventDefault();
+					event.stopPropagation();
+					toggleMenuSection(parent);
+				}
+			}
+		});
+	}
+
+	if (search) {
+		search.addEventListener('submit', (event) => {
+			const target = event.target.querySelector('.js-menu-search-term');
+
+			if (target) {
+				const term = target.value;
+				saveSearchTerm(term);
+			}
+		});
+	}
+
+	if (toggleWithMoreButton) {
+		toggleWithMoreButton.addEventListener('click', () => {
+			toggleSubnavSections(toggleWithMoreButton);
+		});
+	}
+};
+
+export const headerTopNavInit = () => {
+	enhanceMenuToggles();
+	showMoreButton();
+	addEventHandler();
+	showMyAccountIfNecessary();
+	closeAllMenuSections();
+	trackRecentSearch();
+};

--- a/static/src/javascripts/projects/common/modules/support/header.ts
+++ b/static/src/javascripts/projects/common/modules/support/header.ts
@@ -58,7 +58,9 @@ export const fetchAndRenderHeaderLinks = async (): Promise<void> => {
 		const Header = await dynamicImport(module.url, module.name);
 
 		const el = document.createElement('div');
-		const container = document.querySelector('.new-header__cta-bar');
+		const container =
+			document.querySelector('.new-header__cta-bar') ??
+			document.querySelector('.header-top-bar__cta-bar');
 		if (container) {
 			container.appendChild(el);
 

--- a/static/src/javascripts/projects/common/modules/support/header.ts
+++ b/static/src/javascripts/projects/common/modules/support/header.ts
@@ -60,7 +60,7 @@ export const fetchAndRenderHeaderLinks = async (): Promise<void> => {
 		const el = document.createElement('div');
 		const container =
 			document.querySelector('.new-header__cta-bar') ??
-			document.querySelector('.header-top-bar__cta-bar');
+			document.querySelector('.header-top-nav__cta-bar');
 		if (container) {
 			container.appendChild(el);
 

--- a/static/src/stylesheets/layout/_navigation.scss
+++ b/static/src/stylesheets/layout/_navigation.scss
@@ -1,6 +1,7 @@
 @import 'nav/_variables';
 
 @import 'nav/_new-header';
+@import 'nav/_header-top-nav';
 
 @import 'nav/_menu';
 @import 'nav/_menu-group';

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -26,7 +26,8 @@
         }
     }
 
-    .new-header--slim & {
+    .new-header--slim &,
+    .header-top-nav--slim & {
         padding-top: 8px;
 
         @include mq(tablet) {

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -1,4 +1,5 @@
-.new-header__cta-bar {
+.new-header__cta-bar,
+.header-top-nav__cta-bar {
     padding-top: 39px;
     padding-left: 10px;
     max-width: 340px;

--- a/static/src/stylesheets/layout/nav/_header-top-nav.scss
+++ b/static/src/stylesheets/layout/nav/_header-top-nav.scss
@@ -1,0 +1,215 @@
+/* When the menu is open this class is added to the html to prevent users
+from scrolling */
+.nav-is-open {
+    @include mq($until: desktop) {
+        overflow: hidden;
+        width: 100%;
+    }
+
+    // Prevents horizontal scrollbar https://codepen.io/tigt/post/bust-elements-out-of-containers-with-one-line-of-css#oh-no-a-horizontal-scrollbar-6
+    @include mq(desktop) {
+        overflow-x: hidden;
+    }
+}
+
+.header-top-nav {
+    background-color: $brand-main;
+    position: relative;
+
+    &:not(.header-top-nav--slim) {
+        margin-bottom: 0;
+    }
+
+    @include mq(tablet) {
+        display: block;
+    }
+
+    .has-page-skin & .gs-container {
+        @include mq(wide) {
+            width: gs-span(12) + ($gs-gutter * 2);
+        }
+    }
+}
+
+.header-top-nav__full-width {
+    // background-color: #001536;
+    background-color: #041f4a;
+
+    width: 100%;
+}
+
+.header-top-nav__inner {
+    @include clearfix();
+}
+
+
+.header-top-nav__edition-container {
+    position: absolute;
+    top: 0;
+    // Needs to sit above the menu, and the veggie burger
+    z-index: $zindex-main-menu + 2;
+    transform: translateX(100%);
+
+    @include mq(desktop) {
+        right: 120px;
+        width: 110px;
+    }
+
+    body:not(.has-page-skin) & {
+        @include mq(wide) {
+            right: 197px;
+            width: 197px;
+        }
+    }
+
+    .top-bar__item__seperator {
+        margin-left: 0;
+    }
+}
+
+.header-top-nav__menu-toggle {
+    display: block;
+    outline: 0;
+    position: relative;
+
+    @include mq($until: desktop) {
+        position: absolute;
+        right: $gs-gutter / 4;
+        bottom: 58px;
+
+        @include mq(mobileMedium) {
+            right: $gs-gutter / 4;
+            bottom: -$gs-baseline / 4;
+        }
+
+        @include mq(mobileLandscape) {
+            right: $gs-gutter - 2px;
+        }
+
+        @include mq(tablet) {
+            bottom: $gs-baseline / 4;
+        }
+
+        .header-top-nav--slim & {
+            top: $gs-baseline / 4;
+            bottom: auto;
+        }
+    }
+
+    &:active {
+        outline: 0;
+    }
+}
+
+.header-top-nav__logo {
+    float: right;
+    margin-top: 10px;
+    margin-right: $veggie-burger + 12px;
+    margin-bottom: $gs-baseline * 2;
+
+    @include mq(mobileMedium) {
+        margin-right: $gs-gutter / 2;
+    }
+
+    @include mq(mobileLandscape) {
+        margin-right: $gs-gutter;
+    }
+
+    @include mq(desktop) {
+        margin-top: 5px;
+        margin-bottom: $gs-baseline + ($gs-baseline / 2);
+        position: relative;
+        z-index: $zindex-main-menu + 1;
+    }
+
+    body:not(.has-page-skin) & {
+        @include mq(wide) {
+            margin-right: 96px;
+        }
+    }
+
+    .header-top-nav--slim & {
+        position: absolute;
+        margin: 0;
+        right: $veggie-burger;
+        top: $gs-baseline / 4;
+        z-index: $zindex-main-menu;
+
+        body:not(.has-page-skin) & {
+            @include mq(mobileLandscape) {
+                margin-right: 0;
+                right: $veggie-burger + ($gs-gutter / 2);
+            }
+
+            @include mq(desktop) {
+                right: $gs-gutter;
+            }
+        }
+    }
+
+    .header-top-nav--slim.header-top-nav--open & {
+        @include mq(desktop) {
+            z-index: $zindex-main-menu + 2;
+        }
+    }
+}
+
+.inline-the-guardian-roundel__svg {
+    height: $veggie-burger;
+    width: $veggie-burger;
+
+    & path:nth-child(1) {
+        fill: $brightness-100;
+    }
+
+    & path:nth-child(2) {
+        fill: $brand-main;
+    }
+}
+
+.inline-the-guardian-logo__svg {
+    display: block;
+    height: 44px;
+    width: 135px;
+
+    @include mq(mobileMedium) {
+        height: 56px;
+        width: 175px;
+    }
+
+    @include mq(tablet) {
+        height: 72px;
+        width: 224px;
+    }
+
+    @include mq(desktop) {
+        height: 95px;
+        width: 295px;
+    }
+
+    path {
+        fill: $brightness-100;
+    }
+}
+
+.inline-guardian-best-website-logo {
+    display: block;
+    height: auto;
+    width: 146px;
+
+    @include mq(mobileMedium) {
+        width: 195px;
+    }
+
+    @include mq(tablet) {
+        width: 224px;
+    }
+
+    @include mq(desktop) {
+        width: 295px;
+    }
+}
+
+.header-top-nav--slim {
+    height: $pillar-height + $gs-baseline / 2;
+}

--- a/static/src/stylesheets/layout/nav/_header-top-nav.scss
+++ b/static/src/stylesheets/layout/nav/_header-top-nav.scss
@@ -40,7 +40,18 @@ from scrolling */
             justify-content: end;
         }
 
-        .top-bar__item {
+        a.top-bar__item {
+            &:hover {
+                text-decoration: underline;
+            }
+
+            &.yellow {
+                color: $highlight-main;
+                &:hover {
+                    color: $brightness-100;
+                }
+            }
+
             @include mq($until: desktop) {
                 padding: 3px 10px;
             }

--- a/static/src/stylesheets/layout/nav/_header-top-nav.scss
+++ b/static/src/stylesheets/layout/nav/_header-top-nav.scss
@@ -29,6 +29,44 @@ from scrolling */
             width: gs-span(12) + ($gs-gutter * 2);
         }
     }
+
+    .header-top-nav__top-bar {
+        display: flex;
+        justify-content: start;
+        font-weight: bold;
+        padding-right: 96px;
+
+        @include mq($from: desktop) {
+            justify-content: end;
+        }
+
+        .top-bar__item {
+            @include mq($until: desktop) {
+                padding: 3px 10px;
+            }
+        }
+    }
+
+    .header-top-nav__item {
+        position: relative;
+        margin-right: 0;
+
+        .header-top-nav__item--separator {
+            border-left: 1px solid $brand-pastel;
+            position: absolute;
+            left: 0;
+            top: 0;
+            height: $gs-baseline * 2;
+        }
+
+        svg {
+            fill: currentColor;
+            float: left;
+            height: 18px;
+            width: 18px;
+            margin: -1px 4px 0 0;
+        }
+    }
 }
 
 .header-top-nav__full-width {

--- a/static/src/stylesheets/layout/nav/_menu.scss
+++ b/static/src/stylesheets/layout/nav/_menu.scss
@@ -51,12 +51,14 @@
             margin-right: -50vw;
         }
 
-        .new-header--slim & {
+        .new-header--slim &,
+        .header-top-nav--slim & {
             top: $pillar-height;
         }
     }
 
-    .new-header--open & {
+    .new-header--open &
+    .header-top-nav--open & {
         @include mq($until: desktop) {
             @include menu-animation(0%);
         }
@@ -89,7 +91,8 @@
         box-sizing: border-box;
         padding: 0 $gs-gutter;
 
-        .new-header--slim & {
+        .new-header--slim &,
+        .header-top-nav--slim & {
             border-color: transparent;
         }
     }
@@ -107,7 +110,8 @@
     width: 0;
     z-index: $zindex-main-menu - 1;
 
-    .new-header--open & {
+    .new-header--open &,
+    .header-top-nav--open & {
         opacity: 1;
         width: 100%;
     }

--- a/static/src/stylesheets/layout/nav/_menu.scss
+++ b/static/src/stylesheets/layout/nav/_menu.scss
@@ -18,6 +18,7 @@
         overflow: auto;
         padding-top: $gs-baseline / 2;
         position: fixed;
+        z-index: $zindex-main-menu + 2;
         right: 0;
         transition: transform .2s cubic-bezier(.23, 1, .32, 1);
         will-change: transform;
@@ -57,7 +58,7 @@
         }
     }
 
-    .new-header--open &
+    .new-header--open &,
     .header-top-nav--open & {
         @include mq($until: desktop) {
             @include menu-animation(0%);

--- a/static/src/stylesheets/layout/nav/_pillar-link.scss
+++ b/static/src/stylesheets/layout/nav/_pillar-link.scss
@@ -36,7 +36,8 @@
         padding-right: $gs-gutter;
         padding-left: $pillar-padding;
 
-        .new-header--slim & {
+        .new-header--slim &,
+        .header-top-nav--slim & {
             height: $pillar-height + ($gs-baseline / 2);
             padding-top: $gs-baseline - 1px;
         }
@@ -75,7 +76,8 @@
         @include mq(desktop) {
             bottom: .6em;
 
-            .new-header--open & {
+            .new-header--open &,
+            .header-top-nav--open & {
                 bottom: 0;
             }
         }
@@ -100,7 +102,8 @@
         }
     }
 
-    .new-header--open & {
+    .new-header--open &,
+    .header-top-nav--open & {
         @include mq(desktop) {
             &:hover,
             &:focus {
@@ -136,11 +139,13 @@
         transform: translateY(0) rotate(45deg);
     }
 
-    .new-header--open .pillar-link--dropdown & {
+    .new-header--open .pillar-link--dropdown &,
+    .header-top-nav--open .pillar-link--dropdown & {
         transform: translateY(1px) rotate(-135deg);
     }
 
-    .new-header--open .pillar-link--dropdown:hover & {
+    .new-header--open .pillar-link--dropdown:hover & ,
+    .header-top-nav--open .pillar-link--dropdown:hover & {
         transform: translateY(-2px) rotate(-135deg);
     }
 }

--- a/static/src/stylesheets/layout/nav/_pillars.scss
+++ b/static/src/stylesheets/layout/nav/_pillars.scss
@@ -4,7 +4,7 @@
     padding: 0 0 0 ($gs-gutter / 2);
 
     .new-header:not(.new-header--slim) &,
-    .header-top-nav:not(.header-top-nav--slim) {
+    .header-top-nav:not(.header-top-nav--slim) & {
         &:after {
             content: '';
             border: 1px solid $brand-pastel;

--- a/static/src/stylesheets/layout/nav/_pillars.scss
+++ b/static/src/stylesheets/layout/nav/_pillars.scss
@@ -3,7 +3,8 @@
     margin: 0;
     padding: 0 0 0 ($gs-gutter / 2);
 
-    .new-header:not(.new-header--slim) & {
+    .new-header:not(.new-header--slim) &,
+    .header-top-nav:not(.header-top-nav--slim) {
         &:after {
             content: '';
             border: 1px solid $brand-pastel;
@@ -34,12 +35,14 @@
     }
 
     @include mq(desktop) {
-        .new-header--open & {
+        .new-header--open &,
+        .header-top-nav--open {
             z-index: $zindex-main-menu;
         }
     }
 
-    .new-header--slim & {
+    .new-header--slim &,
+    .header-top-nav--slim & {
         @include mq($until: tablet) {
             display: none;
         }

--- a/static/src/stylesheets/layout/nav/_top-bar.scss
+++ b/static/src/stylesheets/layout/nav/_top-bar.scss
@@ -75,7 +75,8 @@
     position: relative;
     z-index: $zindex-ads;
 
-    .new-header--open & {
+    .new-header--open &,
+    .header-top-nav--open & {
         // Needs to sit below the menu, and the veggie burger
         z-index: $zindex-ads;
     }

--- a/static/src/stylesheets/layout/nav/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/nav/_veggie-burger.scss
@@ -12,8 +12,9 @@
     z-index: $zindex-main-menu - 1;
 
     // menu is open
-    .new-header--open & {
-        z-index: $zindex-main-menu + 1;
+    .new-header--open &,
+    .header-top-nav--open & {
+        z-index: $zindex-main-menu + 2;
     }
 
     // Don't show menu on opera mini: https://wp-mix.com/css-target-opera/
@@ -51,7 +52,8 @@
     }
 
     // transform burger into cross
-    .new-header--open & {
+    .new-header--open &,
+    .header-top-nav--open & {
         background-color: transparent;
 
         &:before {


### PR DESCRIPTION
## What does this change?

Adds the new Header Top Nav based on a Header redesign. In order to have a smooth transition between DCR and Frontend, this is kept behind a feature switch named `header-top-nav`.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes – https://github.com/guardian/dotcom-rendering/pull/6420

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![beforeM][] | ![afterM][] |

[before]: https://user-images.githubusercontent.com/76776/201294305-0c6761c3-d6e8-48d2-96e2-2a47586e7f22.png
[after]: https://user-images.githubusercontent.com/76776/201316032-6dde9b9a-9e69-4d09-a28c-ed9458661513.png

[beforeM]: https://user-images.githubusercontent.com/76776/201327555-77f2a9ba-657c-4b8c-84c6-85ae07ee8ac6.png
[afterM]: https://user-images.githubusercontent.com/76776/201327512-b000c15c-404a-4ad8-ad10-8c0c3916cb8e.png

## What is the value of this and can you measure success?

It is urgently needed since we release the new single front door call to action!

## Checklist

### Does this affect other platforms?

- [X] AMP – Sort of, mainly updating the CTA (call to actions) in https://github.com/guardian/dotcom-rendering/pull/6407
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)