### PR TITLE
fix: hover state does not change colour

### DIFF
--- a/static/src/stylesheets/layout/nav/_header-top-nav.scss
+++ b/static/src/stylesheets/layout/nav/_header-top-nav.scss
@@ -42,13 +42,14 @@ from scrolling */
 
         a.top-bar__item {
             &:hover {
+                color: $brightness-100;
                 text-decoration: underline;
             }
 
             &.yellow {
                 color: $highlight-main;
                 &:hover {
-                    color: $brightness-100;
+                    color: $highlight-main;
                 }
             }
 


### PR DESCRIPTION
## What does this change?

Fix the hover state to keep the same colour and only add an underline.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)