### PR TITLE
Refactor newspaper icon

### DIFF
--- a/static/src/inline-svgs/icon/newspaper.svg
+++ b/static/src/inline-svgs/icon/newspaper.svg
@@ -1,4 +1,7 @@
-<svg width="19" height="19" viewBox="0 0 19 19">
-	<circle cx="9.59" cy="9.93" r="9"/>
-	<path fill-rule="evenodd" clip-rule="evenodd" d="M14.20 14.72L13.67 15.27H6.02L5.47 14.72V4.91L6.02 4.36H12.03L14.20 6.54V14.72ZM13.11 7.63H6.56V8.45H13.11V7.63ZM13.11 9.27H6.56V10.09H13.11V9.27ZM10.38 10.91H6.56V11.72H10.38V10.91Z" fill="#052962"/>
+<svg width="18" height="18" viewBox="-4 -4 32 32" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12,-4 a15,15 0,0,0 0,32 15,15 0,0,0 0,-32
+    M20 21L19 21H5L4 21V3L5 2H16L20 6V21Z
+    M18 8H6V9.5H18V8Z
+    M18 11H6V12.5H18V11Z
+    M13 14H6V15.5H13V14Z" />
 </svg>


### PR DESCRIPTION
## What does this change?

Instead of several layers of colour, this contains a single path that has the newspaper cut out.
Looks just ever so slightly sharper and works on any background.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes [(please indicate your plans for DCR Implementation)](https://github.com/guardian/dotcom-rendering/pull/6439)

### Tested

- [X] Locally
- [ ] On CODE (optional)