### PR TITLE
Give world cup priority in tables, dropdown and fixtures

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -27,6 +27,7 @@ class LeagueTableController(
 
   // Competitions must be added to this list to show up at /football/tables
   val tableOrder: Seq[String] = Seq(
+    "World Cup 2022",
     "Premier League",
     "Bundesliga",
     "Serie A",
@@ -35,7 +36,6 @@ class LeagueTableController(
     "Women's Super League",
     "Champions League",
     "Women's Champions League",
-    "World Cup 2022",
     "Europa League",
     "Carabao Cup",
     "International friendlies",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -124,6 +124,16 @@ object Competitions {
 object CompetitionsProvider {
   val allCompetitions: Seq[Competition] = Seq(
     Competition(
+      "700",
+      "/football/world-cup-2022",
+      "World Cup 2022",
+      "World Cup 2022",
+      "Internationals",
+      showInTeamsList = true,
+      tableDividers = List(2),
+      startDate = Some(LocalDate.of(2022, 11, 1)),
+    ),
+    Competition(
       "423",
       "/football/women-s-euro-2022",
       "Women's Euro 2022",
@@ -187,16 +197,6 @@ object CompetitionsProvider {
       "Champions League",
       "European",
       tableDividers = List(2, 6, 21),
-    ),
-    Competition(
-      "700",
-      "/football/world-cup-2022",
-      "World Cup 2022",
-      "World Cup 2022",
-      "Internationals",
-      showInTeamsList = true,
-      tableDividers = List(2),
-      startDate = Some(LocalDate.of(2022, 11, 1)),
     ),
     Competition(
       "750",

--- a/sport/app/football/views/fragments/leagueSelector.scala.html
+++ b/sport/app/football/views/fragments/leagueSelector.scala.html
@@ -18,10 +18,10 @@
     <label for="football-leagues" class="football-leagues__label">Choose league: </label>
     <select class="football-leagues__list" name="competitionUrl" id="football-leagues">
         <option value="/football/@pageType">All @pageType</option>
+        @renderOpts("Internationals")
         @renderOpts("English")
         @renderOpts("European")
         @renderOpts("Scottish")
-        @renderOpts("Internationals")
         @renderOpts("Rest of world")
     </select>
 </form>


### PR DESCRIPTION
## What does this change?

Responds to a request by Gabriel Smith:

"Sports desk have asked that the World Cup be given primacy at the top of the Tables page (including the drop down menu, but also to have the group and then knock out tables appear at the top), and the Live Scores and Fixtures pages, although I'm fairly sure the matches already appear at the top on their respective days. "

This edits the relevant files to: 
- move the WC to the top of the tables page
- move the International competitions to the top of the drop-down menu. Due to the fact that the WC and Nations League appear under the same section, they've both been moved up - not sure if this is desired though?
- move the WC to the top of live scores/fixtures pages 


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before    | After        |
|-------------|------------|
| ![Tables before][] | ![Tables after][] |
| ![Fixtures before][] | ![Fixtures after][] |

[Tables before]: https://user-images.githubusercontent.com/102960844/201970684-afc74d71-c952-4d16-869f-42e0140befd0.png

[Tables after]: https://user-images.githubusercontent.com/102960844/201973251-b5497136-e13c-4800-b0d2-0e3dd652f914.png

[Fixtures before]: https://user-images.githubusercontent.com/102960844/201973896-63b1aa35-af62-4d6a-86b8-272451bae43d.png

[Fixtures after]: https://user-images.githubusercontent.com/102960844/201973949-7f48e27b-47bf-46f8-a4e1-1fa3981a1584.png

Not sure how to test that the matches do appear at the top of live score pages without one actually being live, but WC matches should come up at the top of the list, as implied by the DOM: 
![image](https://user-images.githubusercontent.com/102960844/201975391-99838ebf-2b78-4105-ac1e-5eb3723d24f2.png)



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
