### PR TITLE
Removed aria-hidden on content__dateline

### DIFF
--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -21,6 +21,7 @@
         <time datetime='@GuDateTimeFormatOld(date, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@date.getMillis" class="content__dateline-lm js-lm u-h"
         @optItemProp.map { itemProp => itemprop="@itemProp" }
+        aria-hidden="true"
         >
             @label @GuDateTimeFormatOld(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormatNew.formatTimeForDisplay(date, request)</span>
         </time>

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -4,7 +4,7 @@
 
 @(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, firstPublicationDate: Option[DateTime], isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 
-<p class="@if(!isMinute){content__dateline}@if(isMinute){content__dateline--minute-article}" aria-hidden="true">
+<p class="@if(!isMinute){content__dateline}@if(isMinute){content__dateline--minute-article}">
     <time itemprop="datePublished" datetime='@GuDateTimeFormatOld(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@webPublicationDate.getMillis" class="content__dateline-wpd js-wpd">
         @if(isMinute) {


### PR DESCRIPTION
Co-authored-by: Daniel Clifton <daniel.clifton@guardian.co.uk>
Co-authored-by: Ashleigh Carr <ashcorr20@gmail.com>

## What does this change?

Resolves [issue 5062](https://github.com/guardian/dotcom-rendering/issues/5062), making information with
the date relating to podcasts or galleries more accessible.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots



Before (content__dateline element has aria_hidden="true")
![image](https://user-images.githubusercontent.com/102960844/201955357-fae5650a-52d7-4173-bf3e-9f05e96e9bc8.png)

After (content__dateline doesn't have aria_hidden="true" anymore)

![image](https://user-images.githubusercontent.com/102960844/201955965-8342a866-e103-4bf8-8a9e-37abdd934e68.png)



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->


