### PR TITLE
Add slot-level targeting to Opt Out

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -28,7 +28,8 @@ const defineSlot = (
 	) => {
 		log('commercial', `Filled consentless ${slotId}`);
 
-		if (width === 1 && height === 1) {
+		const isFluid = width === 1 && height === 1;
+		if (isFluid) {
 			slot.classList.add('ad-slot--fluid');
 		}
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -82,7 +82,11 @@ const insertAdAtPara = (
 			}
 		})
 		.then(() => {
-			defineSlot(adSlot, inlineId === 1 ? 'inline' : 'inline-right');
+			defineSlot(
+				adSlot,
+				name,
+				inlineId === 1 ? 'inline' : 'inline-right',
+			);
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/liveblog-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/liveblog-inline.ts
@@ -87,9 +87,9 @@ const getSpaceFillerRules = (
 const insertAdAtPara = (para: Node): Promise<void> => {
 	const container: HTMLElement = document.createElement('div');
 	container.className = `ad-slot-container`;
-
+	const name = `inline${AD_COUNTER + 1}`;
 	const adSlot = createAdSlot('inline', {
-		name: `inline${AD_COUNTER + 1}`,
+		name,
 		classes: 'liveblog-inline',
 	});
 
@@ -103,7 +103,7 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 			}
 		})
 		.then(() => {
-			defineSlot(adSlot, 'inline');
+			defineSlot(adSlot, name, 'inline');
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/init-fixed-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/init-fixed-slots.ts
@@ -10,11 +10,10 @@ const initFixedSlots = (): Promise<void> => {
 
 	// define slots
 	adverts.forEach((slotElement) => {
-		const slotName = slotElement.dataset.name?.includes('inline')
-			? 'inline'
-			: slotElement.dataset.name;
+		const slotName = slotElement.dataset.name;
+		const slotKind = slotName?.includes('inline') ? 'inline' : undefined;
 		if (slotName) {
-			defineSlot(slotElement, slotName);
+			defineSlot(slotElement, slotName, slotKind);
 		}
 	});
 

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -434,6 +434,11 @@ interface Window {
 		queue: Array<() => void>;
 		initializeOo: (o: OptOutInitializeOptions) => void;
 		addParameter: (key: string, value: string | string[]) => void;
+		addParameterForSlot: (
+			slotId: string,
+			key: string,
+			value: string | string[],
+		) => void;
 		defineSlot: (o: OptOutAdSlot) => void;
 		makeRequests: () => void;
 		refreshSlot: (slotId: string) => void;


### PR DESCRIPTION
## What does this change?

Add slot-level targeting to Opt Out advertising. We insert the targeting parameter just before we define each of the individual slots.

We match the slot targeting we send to GAM as closely as possible. Example targeting:
- For slot `dfp-ad--top-above-nav` we add `slot=top-above-nav`.
- For slot `dfp-ad--inline1` we add `slot=inline1`.
- For slot `dfp-ad--inline1-mobile` we add `slot=inline1`.

Note we now pass the slot name directly into the `defineSlot` function in order to supply it as the targeting value. We rename the value of type `'inline' | 'inline-right'` to `slotKind` to represent the _kind_ of slot it is. In a subsequent PR we'll remove this parameter in favour of computing Opt Out compatible names directly.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Excerpt of the request we make to Opt Out. Note the `customs` object associated with each slot contains the new targeting.

![Screenshot 2022-11-22 at 14 38 40](https://user-images.githubusercontent.com/8000415/203341914-17df2287-1ef5-43c7-8558-2f3c90beed19.png)

## What is the value of this and can you measure success?

Campaigns can be targeted to specific slots on our page.

### Tested

- [X] Locally
- [ ] On CODE (optional)
