### PR TITLE
Editionalise match date for football fixtures

### DIFF
--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -58,9 +58,11 @@ trait MatchesList extends Football with RichList {
     }
   }
   def matchesGroupedByDate(implicit request: RequestHeader) = {
-    relevantMatches.segmentBy(key = _._1.date.withZoneSameInstant(Edition(request).timezoneId).toLocalDate)
+    relevantMatches.segmentBy(key = _._1.date.withZoneSameInstant(Edition(request).timezoneId))
   }
-  def matchesGroupedByDateAndCompetition(implicit request: RequestHeader): Seq[(LocalDate, List[(Competition, List[FootballMatch])])] =
+  def matchesGroupedByDateAndCompetition(implicit
+      request: RequestHeader,
+  ): Seq[(ZonedDateTime, List[(Competition, List[FootballMatch])])] =
     matchesGroupedByDate.map {
       case (d, ms) =>
         val competitionsWithMatches = ms

--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -58,11 +58,11 @@ trait MatchesList extends Football with RichList {
     }
   }
   def matchesGroupedByDate(implicit request: RequestHeader) = {
-    relevantMatches.segmentBy(key = _._1.date.withZoneSameInstant(Edition(request).timezoneId))
+    relevantMatches.segmentBy(key = _._1.date.withZoneSameInstant(Edition(request).timezoneId).toLocalDate)
   }
   def matchesGroupedByDateAndCompetition(implicit
       request: RequestHeader,
-  ): Seq[(ZonedDateTime, List[(Competition, List[FootballMatch])])] =
+  ): Seq[(LocalDate, List[(Competition, List[FootballMatch])])] =
     matchesGroupedByDate.map {
       case (d, ms) =>
         val competitionsWithMatches = ms

--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -1,11 +1,13 @@
 package football.model
 
 import com.madgag.scala.collection.decorators.MapDecorator
+import common.Edition
 import football.collections.RichList
 import football.datetime.DateHelpers
 import implicits.Football
 import model.Competition
 import pa.{FootballMatch, Round}
+import play.api.mvc.RequestHeader
 
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZonedDateTime}
@@ -55,8 +57,10 @@ trait MatchesList extends Football with RichList {
         eligibleDates.contains(fMatch.date.toLocalDate)
     }
   }
-  lazy val matchesGroupedByDate = relevantMatches.segmentBy(key = _._1.date.toLocalDate)
-  def matchesGroupedByDateAndCompetition: Seq[(LocalDate, List[(Competition, List[FootballMatch])])] =
+  def matchesGroupedByDate(implicit request: RequestHeader) = {
+    relevantMatches.segmentBy(key = _._1.date.withZoneSameInstant(Edition(request).timezoneId).toLocalDate)
+  }
+  def matchesGroupedByDateAndCompetition(implicit request: RequestHeader): Seq[(LocalDate, List[(Competition, List[FootballMatch])])] =
     matchesGroupedByDate.map {
       case (d, ms) =>
         val competitionsWithMatches = ms

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -5,9 +5,10 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.RowInfo
 
+@import java.time.ZonedDateTime
 @(matchesList: MatchesList, customLink: Option[(String, String)] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@footballMatchDay(date: LocalDate, competitionMatches: List[(Competition, List[FootballMatch])], dateRow: RowInfo) = {
+@footballMatchDay(date: ZonedDateTime, competitionMatches: List[(Competition, List[FootballMatch])], dateRow: RowInfo) = {
     <div class="football-matches__day">
     @{competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
         football.views.html.matchList.matchesList(

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -8,7 +8,7 @@
 @import java.time.ZonedDateTime
 @(matchesList: MatchesList, customLink: Option[(String, String)] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@footballMatchDay(date: ZonedDateTime, competitionMatches: List[(Competition, List[FootballMatch])], dateRow: RowInfo) = {
+@footballMatchDay(date: LocalDate, competitionMatches: List[(Competition, List[FootballMatch])], dateRow: RowInfo) = {
     <div class="football-matches__day">
     @{competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
         football.views.html.matchList.matchesList(

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -1,9 +1,12 @@
 @import java.time.format.DateTimeFormatter
+@import java.time.ZonedDateTime
 @import football.model.GuTeamCodes
 @import common.Edition
+@import java.time.LocalTime
+
 @(matchesList: List[pa.FootballMatch],
     competition: model.Competition,
-    date: java.time.ZonedDateTime,
+    date: java.time.LocalDate,
     responsiveFont: Boolean = false,
     matchType: String = "",
     linkToCompetition: Boolean = false,
@@ -92,7 +95,7 @@
         }
         <span class="football-matches__date">
             @date.format(DateTimeFormatter.ofPattern("E d MMMM "))
-            <span class="football-matches__timezone">(@date.format(DateTimeFormatter.ofPattern("z")))</span>
+            <span class="football-matches__timezone">(@DateTimeFormatter.ofPattern("z").format(ZonedDateTime.of(date, LocalTime.of(0, 0), Edition(request).timezoneId)))</span>
         </span>
 
     </caption>

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -1,8 +1,9 @@
 @import java.time.format.DateTimeFormatter
 @import football.model.GuTeamCodes
+@import common.Edition
 @(matchesList: List[pa.FootballMatch],
     competition: model.Competition,
-    date: java.time.LocalDate,
+    date: java.time.ZonedDateTime,
     responsiveFont: Boolean = false,
     matchType: String = "",
     linkToCompetition: Boolean = false,
@@ -39,9 +40,8 @@
                 ))">
                 <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub">
                     @if(theMatch.isFixture){
-                        <time datetime="@theMatch.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ"))" data-timestamp="@theMatch.date.toInstant.toEpochMilli"
-                        class="js-locale-timestamp">
-                            @theMatch.date.format(DateTimeFormatter.ofPattern("HH:mm"))</time>
+                        <time datetime="@theMatch.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZone(Edition(request).timezoneId))" data-timestamp="@theMatch.date.toInstant.toEpochMilli">
+                            @theMatch.date.format(DateTimeFormatter.ofPattern("HH:mm ").withZone(Edition(request).timezoneId))</time>
                     }else{
                         @MatchStatus(theMatch.matchStatus)
                     }
@@ -90,7 +90,11 @@
                 <span class="football-matches__heading">@text</span>
             }
         }
-        <span class="football-matches__date">@date.format(DateTimeFormatter.ofPattern("E d MMMM"))</span>
+        <span class="football-matches__date">
+            @date.format(DateTimeFormatter.ofPattern("E d MMMM "))
+            <span class="football-matches__timezone">(@date.format(DateTimeFormatter.ofPattern("z")))</span>
+        </span>
+
     </caption>
     @if(linkToCompetition && link == None){
         <tfoot class="table__caption table__caption--bottom" >

--- a/sport/test/football/model/FixturesListTest.scala
+++ b/sport/test/football/model/FixturesListTest.scala
@@ -7,6 +7,7 @@ import model.Competition
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import test.ConfiguredTestSuite
+import play.api.test.FakeRequest
 
 import java.time.format.DateTimeFormatter
 
@@ -32,7 +33,8 @@ import java.time.format.DateTimeFormatter
       }
 
       "should group matches correctly by date" in {
-        fixtures.matchesGroupedByDateAndCompetition.map(_._1) should equal(
+        val request = FakeRequest()
+        fixtures.matchesGroupedByDateAndCompetition(request).map(_._1) should equal(
           List(today, today.plusDays(1), today.plusDays(3)),
         )
       }

--- a/sport/test/football/model/MatchDayListTest.scala
+++ b/sport/test/football/model/MatchDayListTest.scala
@@ -5,6 +5,7 @@ import implicits.Football
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import test.ConfiguredTestSuite
+import play.api.test.FakeRequest
 
 @DoNotDiscover class MatchDayListTest
     extends AnyFreeSpec
@@ -23,12 +24,16 @@ import test.ConfiguredTestSuite
       }
 
       "should group matches correctly by date" in {
-        matches.matchesGroupedByDateAndCompetition.map(_._1) should equal(List(today))
+        val request = FakeRequest()
+        matches.matchesGroupedByDateAndCompetition(request).map(_._1) should equal(List(today))
       }
 
       "should subgroup matches correctly league, with the leagues ordered correctly" in {
-        val (_, competitionMatches1) = matches.matchesGroupedByDateAndCompetition(0)
-        competitionMatches1.map { case (comp, fMatches) => comp.id } should equal(List("500", "100"))
+        val request = FakeRequest()
+        val (_, competitionMatches1) = matches.matchesGroupedByDateAndCompetition(request)(0)
+        competitionMatches1.map { case (comp, fMatches) => comp.id } should equal(
+          List("500", "100"),
+        )
       }
 
       "should show all matches happening today" in {

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -75,7 +75,7 @@ $brand-pastel:           #506991;
 // Neutrals ====================================================================
 $brightness-7:           #121212;
 $brightness-20:          #333333;
-$brightness-46:          #767676;
+$brightness-46:          #707070;
 $brightness-60:          #999999;
 $brightness-86:          #dcdcdc;
 $brightness-93:          #ededed;

--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -287,6 +287,12 @@
         float: none;
     }
 
+    .football-matches__timezone {
+        color: $brightness-46;
+        font-weight: normal;
+        font-size: 12px;
+    }
+
     .football-matches {
         .table__caption--top {
             border-top: 1px solid darken($brightness-97, 4%);


### PR DESCRIPTION
## What does this change?

Fixes: https://github.com/guardian/frontend/issues/25670

The 'days' were wrong when the time was localised in Australia, and we'd see issues like two matches listed for 'Sat 26 Nov' where was was at 9pm, and another was at 3am the next day (so the 27th).

By editionalising the timezone at the grouping stages, matches are now grouped by their date in the timezone of their edition.

We've also switched from using the client-side 'local' time for the time elements, and now use the editionalised time here too, as inconsistencies between the two could break the layout

> After talking to @HarryFischer, we changed brightness-46 from #767676 to 707070 for accessibility reasons

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/201952327-8f5368ef-9b96-4065-b539-f68c1f4e2a39.png
[after]: https://user-images.githubusercontent.com/9575458/202163409-80570c96-c312-4f26-9844-e0012c2e1f6f.png


## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
