### PR TITLE
Add SpecialReportAltPalette

### DIFF
--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -10,6 +10,7 @@ import com.gu.facia.client.models.{
   Metadata,
   SombreAltPalette,
   SombrePalette,
+  SpecialReportAltPalette,
 }
 import layout._
 import layout.slices._
@@ -192,6 +193,7 @@ object GetClasses {
     BreakingPalette -> "fc-container--breaking-palette",
     EventPalette -> "fc-container--event-palette",
     EventAltPalette -> "fc-container--event-alt-palette",
+    SpecialReportAltPalette -> "fc-container--special-report-alt-palette",
   )
 
   private def primaryPaletteTag(metadata: Seq[Metadata]): Option[Metadata] = {


### PR DESCRIPTION
## What does this change?
Adds the class for `SpecialReportAltPalette`

CSS has been merged here: https://github.com/guardian/interactive-atom-container-colours/pull/4

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

PR has been merged: https://github.com/guardian/dotcom-rendering/pull/6335

Extracted from https://github.com/guardian/frontend/pull/25602