### PR TITLE
feat(tables): put World Cup 2022 at the top

### DIFF
--- a/sport/app/football/controllers/CompetitionListController.scala
+++ b/sport/app/football/controllers/CompetitionListController.scala
@@ -18,10 +18,10 @@ class CompetitionListController(
   val page = new FootballPage("football/competitions", "football", "Leagues & competitions")
 
   val competitionList = List(
+    "Internationals",
     "English",
     "European",
     "Scottish",
-    "Internationals",
     "Rest of world",
   )
 

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -27,6 +27,7 @@ class LeagueTableController(
 
   // Competitions must be added to this list to show up at /football/tables
   val tableOrder: Seq[String] = Seq(
+    "World Cup 2022",
     "Premier League",
     "Bundesliga",
     "Serie A",

--- a/sport/app/football/views/fragments/leagueSelector.scala.html
+++ b/sport/app/football/views/fragments/leagueSelector.scala.html
@@ -18,10 +18,10 @@
     <label for="football-leagues" class="football-leagues__label">Choose league: </label>
     <select class="football-leagues__list" name="competitionUrl" id="football-leagues">
         <option value="/football/@pageType">All @pageType</option>
+        @renderOpts("Internationals")
         @renderOpts("English")
         @renderOpts("European")
         @renderOpts("Scottish")
-        @renderOpts("Internationals")
         @renderOpts("Rest of world")
     </select>
 </form>


### PR DESCRIPTION
## What does this change?

Put the Football World Cup 2022 at the top of our tables list. This request has come from the Sports desk.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before dropdown][] | ![after dropdown][] |


[before]: https://user-images.githubusercontent.com/76776/201979847-08aa9395-8c37-400b-95f5-58ab276d3728.png
[after]: https://user-images.githubusercontent.com/76776/201979772-e9fe59d1-dafa-43fe-b24f-e04adf998643.png

[before dropdown]: https://user-images.githubusercontent.com/76776/201980169-1e046706-2a97-48f9-b09e-f56695e64490.png
[after dropdown]: https://user-images.githubusercontent.com/76776/201980124-d0f2dd46-46de-4821-bf63-c66bf3ab40f7.png


## What is the value of this and can you measure success?

This is the event of the moment!

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
