### PR TITLE
Proposal: Dynamically import the consentless scripts

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.consentless.ts
+++ b/static/src/javascripts/bootstraps/commercial.consentless.ts
@@ -1,0 +1,38 @@
+import { onConsent } from '@guardian/consent-management-platform';
+import { initArticleInline } from 'commercial/modules/consentless/dynamic/article-inline';
+import { initLiveblogInline } from 'commercial/modules/consentless/dynamic/liveblog-inline';
+import { initFixedSlots } from 'commercial/modules/consentless/init-fixed-slots';
+import { initConsentless } from 'commercial/modules/consentless/prepare-ootag';
+import {
+	AdFreeCookieReasons,
+	maybeUnsetAdFreeCookie,
+} from 'lib/manage-ad-free-cookie';
+import { init as setAdTestCookie } from '../projects/commercial/modules/set-adtest-cookie';
+import { init as setAdTestInLabelsCookie } from '../projects/commercial/modules/set-adtest-in-labels-cookie';
+
+const bootConsentless = async (): Promise<void> => {
+	/*  In the consented ad stack, we set the ad free cookie for users who
+		don't consent to targeted ads in order to hide empty ads slots.
+		We remove the cookie here so that we can show Opt Out ads.
+		TODO: Stop setting ad free cookie for users who opt out when
+		consentless ads are rolled out to all users.
+ 	*/
+	maybeUnsetAdFreeCookie(AdFreeCookieReasons.ConsentOptOut);
+
+	const consentState = await onConsent();
+
+	await Promise.all([
+		setAdTestCookie(),
+		setAdTestInLabelsCookie(),
+		initConsentless(consentState),
+		initFixedSlots(),
+		initArticleInline(),
+		initLiveblogInline(),
+	]);
+
+	// Since we're in single-request mode
+	// Call this once all ad slots are present on the page
+	window.ootag.makeRequests();
+};
+
+export { bootConsentless };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -647,11 +647,19 @@
  "../types/membership.ts": [
   "../types/dates.ts"
  ],
+ "commercial.consentless.ts": [
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../lib/manage-ad-free-cookie.ts",
+  "../projects/commercial/modules/consentless/dynamic/article-inline.ts",
+  "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts",
+  "../projects/commercial/modules/consentless/init-fixed-slots.ts",
+  "../projects/commercial/modules/consentless/prepare-ootag.ts",
+  "../projects/commercial/modules/set-adtest-cookie.ts",
+  "../projects/commercial/modules/set-adtest-in-labels-cookie.ts"
+ ],
  "standalone.commercial.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/manage-ad-free-cookie.ts",
   "../lib/report-error.ts",
   "../lib/robust.ts",
   "../projects/commercial/adblock-ask.ts",
@@ -661,10 +669,6 @@
   "../projects/commercial/modules/article-body-adverts.ts",
   "../projects/commercial/modules/comment-adverts.ts",
   "../projects/commercial/modules/comscore.ts",
-  "../projects/commercial/modules/consentless/dynamic/article-inline.ts",
-  "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts",
-  "../projects/commercial/modules/consentless/init-fixed-slots.ts",
-  "../projects/commercial/modules/consentless/prepare-ootag.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/dfp/prepare-a9.ts",
   "../projects/commercial/modules/dfp/prepare-googletag.ts",
@@ -686,6 +690,7 @@
   "../projects/commercial/modules/track-scroll-depth.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/commercial/user-features.ts",
+  "commercial.consentless.ts",
   "types.ts"
  ],
  "types.ts": []


### PR DESCRIPTION
## What does this change?

This PR introduces a dynamic import of the `bootConsentless` function in `standalone.commercial.ts`. To do this, we split this function out into its own file so that we can import it via a path.

This dynamic import will instruct Webpack to produce a separate JavaScript bundle`graun.consentless.commercial.js` that is fetched once a browser is determined as participating in the consentless AB test variant.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We currently have the consentless experience behind a 0% test. This means that only people who opt into the test (developers, AdOps, etc) will receive a consentless advertising experience. By dynamically importing the code that handles this, we defer the fetching and parsing until we're sure the user is in the variant. This should be a small performance gain for consented browsers.

**Note that this separate bundle is currently only `23.09kb` stat size and `2.45kb` when gzipped.** So it's definitely not a big performance win.

This can be revisited once we're ready to decide how we'll perform code-splitting / AB testing when we want to roll out the test to a greater percentage of our browsers.

### Tested

- [x] Locally
- [ ] On CODE (optional)