### PR TITLE
fix: ensure plaindark terms and privacy wording has sufficient contrast

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -442,6 +442,24 @@
     .email-sub__message__headline {
         color: #ffffff;
     }
+
+    .email-sub__form-wrapper .newsletters-terms {
+        color: #ffffff;
+        a {
+            color: #ffffff;
+        }
+
+        &[data-privacy-visible='true'] {
+            .newsletters-privacy-notice {
+                display: inline;
+            }
+
+            color: #ffffff;
+            a {
+                color: #ffffff;
+            }
+        }
+    }
 }
 
 // PLAIN-TONE MODS


### PR DESCRIPTION
## What does this change?

A bug was raised where the terms and privacy wording under the email embed on the documentaries front was the same colour as the background - so it's impossible to see.

This specifies that the colour of this text (for plaindark) should always be white.

This is not a long term fix as it looks like `plaindark` is technically deprecated

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before1][] | ![after][] |
| ![before2][] | ![after][] |

[before1]: https://user-images.githubusercontent.com/43961396/201998587-f0b1cb2e-7bed-400b-a4d4-78b9ce9250ca.png
[before2]: https://user-images.githubusercontent.com/43961396/201998600-1a5754fe-6192-4c36-9193-2e3c4a769fea.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
