### PR TITLE
Update container IDs for custom 'today in focus' containera

### DIFF
--- a/common/app/conf/audio/FlagshipFrontContainer.scala
+++ b/common/app/conf/audio/FlagshipFrontContainer.scala
@@ -4,8 +4,11 @@ import conf.switches.Switches.FlagshipFrontContainerSwitch
 
 object FlagshipFrontContainer extends FlagshipContainer {
   override val containerIds = Seq(
-    "75ef80cd-2f3d-40d6-abf6-2021f88ece8e", //PROD
-    "c57a70c8-a00a-4a15-93a2-035b9221622b", //CODE
+    "75ef80cd-2f3d-40d6-abf6-2021f88ece8e", //PROD - OLD
+    "c57a70c8-a00a-4a15-93a2-035b9221622b", //CODE - OLD
+    // New as of 17/11/2022
+    "5546dab9-da59-4e35-81dd-843fef1fd373", // PROD - UK
+    "b0ebe405-db49-4a1d-9a5c-9d59c963cf99", // PROD - INT & Video & US
   )
 
   override val switch = FlagshipFrontContainerSwitch


### PR DESCRIPTION
## What does this change?

Update the container IDs with the new ones provided by central production

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) - DCR implementations doesn't exist yet

