### PR TITLE
Consume CardStyle SpecialReportAlt and SpecialReportAltTheme

### DIFF
--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -12,20 +12,18 @@ object CardStylePicker {
   def apply(content: CapiContent): CardStyle = {
     val tags = content.tags.map(_.id).toSeq
     extractCampaigns(tags) match {
-      case Nil => CardStyle(content, TrailMetaData.empty)
-      case campaign :: _ =>
-        if (campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
-      case _ => SpecialReport
+      case Nil                                                                         => CardStyle(content, TrailMetaData.empty)
+      case campaign :: Nil if campaign.id.toString.toLowerCase() == "specialreportalt" => SpecialReportAlt
+      case _                                                                           => SpecialReport
     }
   }
 
   def apply(content: FaciaContent): CardStyle = {
     val tags = FaciaContentUtils.tags(content).map(_.id)
     extractCampaigns(tags) match {
-      case Nil => FaciaContentUtils.cardStyle(content)
-      case campaign :: _ =>
-        if (campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
-      case _ => SpecialReport
+      case Nil                                                                         => FaciaContentUtils.cardStyle(content)
+      case campaign :: Nil if campaign.id.toString.toLowerCase() == "specialreportalt" => SpecialReportAlt
+      case _                                                                           => SpecialReport
     }
   }
 

--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport}
+import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport, SpecialReportAlt}
 import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 import com.gu.targeting.client.{Campaign, ReportFields}
 import com.gu.contentapi.client.model.v1.{Content => CapiContent}
@@ -9,11 +9,13 @@ import commercial.targeting.CampaignAgent
 
 object CardStylePicker {
 
-  def apply(content: CapiContent, trailMetaData: MetaDataCommonFields): CardStyle = {
+  def apply(content: CapiContent): CardStyle = {
     val tags = content.tags.map(_.id).toSeq
     extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
-      case _   => SpecialReport
+      case campaign :: _ =>
+        if (campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
+      case _ => SpecialReport
     }
   }
 
@@ -21,7 +23,9 @@ object CardStylePicker {
     val tags = FaciaContentUtils.tags(content).map(_.id)
     extractCampaigns(tags) match {
       case Nil => FaciaContentUtils.cardStyle(content)
-      case _   => SpecialReport
+      case campaign :: _ =>
+        if (campaign.id.toString.toLowerCase() == "specialreportalt") SpecialReportAlt else SpecialReport
+      case _ => SpecialReport
     }
   }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -416,7 +416,7 @@ object Content {
     val apifields = apiContent.fields
     val references: Map[String, String] =
       apiContent.references.map(ref => (ref.`type`, Reference.split(ref.id)._2)).toMap
-    val cardStyle: fapiutils.CardStyle = CardStylePicker(apiContent, TrailMetaData.empty)
+    val cardStyle: fapiutils.CardStyle = CardStylePicker(apiContent)
 
     Content(
       trail = trail,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -280,14 +280,15 @@ object ContentFormat {
 
   def parseTheme(s: String): Theme =
     s match {
-      case "NewsPillar"         => NewsPillar
-      case "OpinionPillar"      => OpinionPillar
-      case "SportPillar"        => SportPillar
-      case "CulturePillar"      => CulturePillar
-      case "LifestylePillar"    => LifestylePillar
-      case "SpecialReportTheme" => SpecialReportTheme
-      case "Labs"               => Labs
-      case _                    => NewsPillar
+      case "NewsPillar"            => NewsPillar
+      case "OpinionPillar"         => OpinionPillar
+      case "SportPillar"           => SportPillar
+      case "CulturePillar"         => CulturePillar
+      case "LifestylePillar"       => LifestylePillar
+      case "SpecialReportTheme"    => SpecialReportTheme
+      case "SpecialReportAltTheme" => SpecialReportAltTheme
+      case "Labs"                  => Labs
+      case _                       => NewsPillar
     }
 
   def parseDisplay(s: String): Display =

--- a/common/app/services/FaciaContentConvert.scala
+++ b/common/app/services/FaciaContentConvert.scala
@@ -13,7 +13,7 @@ object FaciaContentConvert {
   def contentToFaciaContent(content: Content): PressedContent = {
     val frontendContent = model.Content(content)
     val trailMetaData = TrailMetaData.empty
-    val cardStyle = CardStylePicker(content, trailMetaData)
+    val cardStyle = CardStylePicker(content)
     val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData, cardStyle)
 
     val curated = fapi.CuratedContent(

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -14,8 +14,7 @@ import com.gu.facia.client.models.{
 }
 import layout._
 import layout.slices._
-import model.pressed.{Audio, Gallery, SpecialReport, Video}
-import slices.{Dynamic, DynamicSlowMPU}
+import model.pressed.{Audio, Gallery, SpecialReport, SpecialReportAlt, Video}
 import play.api.mvc.RequestHeader
 import model.Pillar.RichPillar
 import model.ContentDesignType.RichContentDesignType
@@ -47,6 +46,7 @@ object GetClasses {
         ("fc-item--pillar-" + item.pillar.nameOrDefault, true),
         ("fc-item--type-" + item.designType.nameOrDefault, true),
         ("fc-item--pillar-special-report", item.cardStyle == SpecialReport),
+        ("fc-item--pillar-special-report-alt", item.cardStyle == SpecialReportAlt),
         ("fc-item--paid-content", item.branding.exists(_.isPaid)),
         ("fc-item--has-cutout", item.cutOut.isDefined),
         ("fc-item--has-no-image", !item.hasImage),
@@ -77,6 +77,7 @@ object GetClasses {
         (sublinkMediaTypeClass(sublink).getOrElse(""), true),
         ("fc-sublink--pillar-" + sublink.pillar.nameOrDefault, true),
         ("fc-sublink--type-" + sublink.designType.nameOrDefault, true),
+        ("fc-sublink--pillar-special-report-alt", sublink.cardStyle == SpecialReportAlt),
       ),
     )
 


### PR DESCRIPTION
## What does this change?
Extracted from: https://github.com/guardian/frontend/pull/25602

* Makes it possible for frontend to consume `SpecialReportAlt` `CardStyle` and `SpecialReportAltTheme`
* facia-press can decide when `CardStyle` is `SpecialReportAlt`
* Adds special-report-alt classes for cards

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
https://github.com/guardian/dotcom-rendering/pull/6313
https://github.com/guardian/dotcom-rendering/pull/6314

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
