### PR TITLE
Add `SpecialReportAlt` card styles

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -139,6 +139,13 @@ $labs-main:              #69d1ca;
 // Special report ==============================================================
 $special-report-dark:    #3f464a;
 
+// Special report alt ==========================================================
+$special-report-alt-dark:         #2b2b2a;
+$special-report-alt-main:         #b9300a;
+$special-report-alt-bright:       #ff663d;
+$special-report-alt-pastel:       #ebe6e1;
+$special-report-alt-faded:        #f5f0eb;
+
 
 // Social icons ================================================================
 $social-facebook:        #3067a3;

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -197,7 +197,7 @@ $pillars: (
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--type-immersive.fc-item--has-boosted-title:not(.fc-item--pillar-special-report) .fc-item__standfirst {
+    &.fc-item--type-immersive.fc-item--has-boosted-title:not(.fc-item--pillar-special-report):not(.fc-item--pillar-special-report-alt) .fc-item__standfirst {
         color: $brightness-7;
     }
 
@@ -288,7 +288,7 @@ $pillars: (
         background-color: map-get($palette, kicker);
     }
 
-    &.fc-item--type-comment:not(.fc-item--pillar-special-report) {
+    &.fc-item--type-comment:not(.fc-item--pillar-special-report):not(.fc-item--pillar-special-report-alt) {
 
         background-color: $opinion-faded;
 
@@ -355,7 +355,6 @@ $pillars: (
         .fc-item__content {
             background-color: $special-report-dark;
         }
-
         &:hover {
             .fc-item__content {
                 background-color: darken($special-report-dark, 5%);
@@ -395,5 +394,104 @@ $pillars: (
 
     .fc-sublink__title {
         color: #ffffff;
+    }
+}
+
+
+.fc-item--pillar-special-report-alt,
+.fc-item--pillar-special-report-alt.fc-item--type-feature {
+    &.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile {
+        .fc-item__content {
+            background-color: $special-report-alt-faded;
+        }
+
+        &:hover {
+            .fc-item__content {
+                background-color: $special-report-alt-faded;
+            }
+        }
+    }
+
+    background-color: $special-report-alt-faded !important;
+
+    .fc-item__container.u-faux-block-link--hover {
+        background-color: $special-report-alt-faded !important;
+
+        .fc-item__timestamp,
+        .fc-trail__count--commentcount {
+            background-color: $special-report-alt-dark !important;
+        }
+    }
+
+    &.fc-item--type-media,
+    &.fc-item--type-interview {
+        .inline-video-icon,
+        .inline-volume-high,
+        .inline-camera {
+            svg {
+                fill:  $special-report-alt-faded;
+            }
+
+            &::after {
+                background-color:  $special-report-alt-faded;
+            }
+        }
+    }
+
+    .fc-item__container {
+        &:before {
+            background-color: $special-report-alt-dark !important;
+        }
+    }
+
+    .fc-item__title {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-item__kicker {
+        color: $special-report-alt-dark;
+    }
+
+    fc-item__headline {
+        color: $special-report-alt-dark;
+    }
+
+    &.fc-item--type-comment {
+
+        .fc-item__byline {
+            display: inline;
+            color: $special-report-alt-dark !important;
+        }
+
+        .fc-item__kicker {
+            color: $special-report-alt-dark !important;
+
+        }
+
+        .inline-icon {
+            fill: $special-report-alt-dark !important;
+        }
+    }
+
+    &.fc-item--type-media {
+        background-color: $special-report-alt-faded;
+
+        .youtube-media-atom__play-button.vjs-control-text {
+            .inline-play svg {
+                fill: $special-report-alt-faded;
+            }
+        }
+    }
+
+    .fc-item__container.u-faux-block-link--hover {
+        background-color: darken($special-report-alt-faded, 2%);
+    }
+
+    .fc-sublink__kicker {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-sublink__title {
+        color: $special-report-alt-dark;
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -82,6 +82,20 @@ $pillars: (
         cutoutBackground: $highlight-main,
         invertedKicker: $highlight-main,
         liveColour: #ffffff
+    ),
+    special-report-alt: (
+        cardBackground: $special-report-alt-faded,
+        lines: $special-report-alt-dark,
+        kicker: $brightness-7,
+        headline: $special-report-alt-dark,
+        featureHeadline: $special-report-alt-dark,
+        byline: $special-report-alt-dark,
+        commentCount: $special-report-alt-dark,
+        headlineIcon: $special-report-alt-dark,
+        metaText: $special-report-alt-dark,
+        cutoutBackground: $special-report-alt-dark,
+        invertedKicker: $brightness-7,
+        liveColour: $special-report-alt-faded
     )
 );
 

--- a/static/src/stylesheets/module/facia-garnett/_sublinks.scss
+++ b/static/src/stylesheets/module/facia-garnett/_sublinks.scss
@@ -42,6 +42,36 @@
     }
 }
 
+.fc-sublink__title.fc-sublink--pillar-special-report-alt {
+    @include fs-headline(1);
+    color: $brightness-7;
+    margin: 0;
+    padding: 0;
+    font-weight: 400;
+
+    &:before {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        content: '';
+        width: $gs-gutter * 6 + 2px;
+        border-top: 1px solid rgba(60, 60, 60, .3);
+
+        @include mq($from: tablet) {
+            width: $gs-column-width * 2;
+        }
+    }
+
+    .fc-sublink__kicker {
+        float: left;
+        margin-right: .2em;
+        font-weight: 700;
+    }
+}
+
+
+
 @mixin fc-sublinks--horizontal {
     .fc-sublinks {
         display: flex;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -284,3 +284,47 @@
         @include colours(map-get($pillars, opinion));
     }
 }
+
+.fc-item--pillar-special-report-alt {
+    .fc-item__container > .fc-item__meta {
+        @include multiline(3, rgba(60, 60, 60, .3));
+
+        display: flex;
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        height: 16px;
+
+        svg {
+            fill: #2b2b2a;
+        }
+
+        .fc-trail__count,
+        .fc-item__timestamp {
+            position: absolute;
+            padding-top: 2px;
+            padding-right: $gs-gutter * .25;
+            padding-left: $gs-gutter * .25;
+            bottom: 0;
+            top: 0;
+            z-index: 1;
+            line-height: 10px;
+        }
+
+        .fc-trail__count {
+            right: 0;
+
+            .inline-icon {
+                margin-top: 0;
+            }
+        }
+
+        .fc-item__timestamp {
+            left: 0;
+
+            .inline-icon {
+                margin-top: -1px;
+            }
+        }
+    }
+}

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
@@ -94,3 +94,85 @@
         color: #ffffff;
     }
 }
+
+.fc-item--type-media.fc-item--pillar-special-report-alt {
+
+    .fc-item__video-duration {
+        //ensures the alingment of the timestamp
+        display: inline-block;
+        transform: translateY(-8px);
+    }
+
+    .fc-item__content {
+        justify-content: space-between;
+    }
+
+    .fc-item__standfirst {
+        flex: 0 1 auto;
+    }
+
+    .fc-item__headline {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-item__standfirst {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-sublink__link {
+        color: $special-report-alt-dark;
+    }
+
+    .fc-item__meta-wrapper {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding-top: $gs-baseline / 2;
+        padding-bottom: $gs-baseline / 2;
+
+    }
+
+    .fc-item__footer-meta-wrapper {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+    }
+
+    .fc-item__media-meta,
+    .fc-item__meta {
+        flex: 0 0 auto;
+    }
+
+    .fc-item__media-meta,
+    .fc-item__meta {
+        @include fs-textSans(1);
+        font-weight: 600;
+    }
+
+    .fc-item__media-meta {
+        margin-bottom: -#{$gs-baseline / 2};
+
+        .inline-icon__svg {
+            width: 14px;
+            height: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: 6px;
+            display: block;
+        }
+    }
+
+    .fc-trail__count--commentcount {
+        color: $special-report-alt-dark;
+
+        svg {
+            fill: $special-report-alt-dark;
+        }
+    }
+
+    .fc-sublink__link {
+        color: $special-report-alt-dark;
+    }
+}


### PR DESCRIPTION
## What does this change?
Adds SpecialReportAlt card styles. These styles will be applied when a container has no palette and the cards are of type SpecialReportAlt.

Re-introduces changes of [this PR](https://github.com/guardian/frontend/pull/25602) which was reverted by [this](https://github.com/guardian/frontend/pull/25687).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)
https://github.com/guardian/dotcom-rendering/pull/6314

## Screenshots

### Standard type
![image](https://user-images.githubusercontent.com/19683595/200864448-f95eede5-74e0-4b65-9b23-2e15e367618c.png)


### Comment type
![image](https://user-images.githubusercontent.com/19683595/200850298-b0b4a3e9-4563-4826-bb1a-cac2d17e55df.png)

### With media type
![image](https://user-images.githubusercontent.com/19683595/200865122-3b0bd03f-0204-4ccc-b1fe-c8df87ea771e.png)

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
