### PR TITLE
Make knockout games time timezone specific

### DIFF
--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -29,10 +29,10 @@
             @if(fm.isFixture){
                 <div class="football-match__date">
                     <span class="football-match__kickoff">@fm.date.format(DateTimeFormatter.ofPattern("HH:mm ").withZone(Edition(request).timezoneId))</span>
-                    @fm.date.format(DateTimeFormatter.ofPattern("E dd MMMM"))
+                    @fm.date.withZoneSameInstant(Edition(request).timezoneId).toLocalDate.format(DateTimeFormatter.ofPattern("E dd MMMM"))
                 </div>
-
             }
+
             @fm.comments.map { comments =>
                 <div class="football-match__comments">@comments.reverse.dropWhile(_ == '.').reverse</div>
             }

--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -1,5 +1,8 @@
 @import java.time.format.DateTimeFormatter
-@(fm: pa.FootballMatch, round: pa.Round, competition: model.Competition)
+@import common.Edition
+@import java.time.LocalTime
+@import java.time.ZonedDateTime
+@(fm: pa.FootballMatch, round: pa.Round, competition: model.Competition)(implicit request: RequestHeader)
 
 @import implicits.Football._
 @import conf.Configuration
@@ -25,9 +28,10 @@
             }
             @if(fm.isFixture){
                 <div class="football-match__date">
-                    <span class="football-match__kickoff">@fm.date.format(DateTimeFormatter.ofPattern("HH:mm"))</span>
+                    <span class="football-match__kickoff">@fm.date.format(DateTimeFormatter.ofPattern("HH:mm ").withZone(Edition(request).timezoneId))</span>
                     @fm.date.format(DateTimeFormatter.ofPattern("E dd MMMM"))
                 </div>
+
             }
             @fm.comments.map { comments =>
                 <div class="football-match__comments">@comments.reverse.dropWhile(_ == '.').reverse</div>

--- a/sport/app/football/views/wallchart/knockoutSpider.scala.html
+++ b/sport/app/football/views/wallchart/knockoutSpider.scala.html
@@ -1,3 +1,7 @@
+@import java.time.format.DateTimeFormatter
+@import java.time.ZonedDateTime
+@import common.Edition
+@import java.time.LocalTime
 @(competition: model.Competition, knockoutStage: _root_.football.model.KnockoutSpider)(implicit request: RequestHeader)
 
 @football.views.html.wallchart.knockoutList(competition, knockoutStage, true)
@@ -63,5 +67,5 @@
         }
     </div>
 
-    <div class="football-knockout-chart__timezone">All matches are in UK time</div>
+    <div class="football-knockout-chart__timezone">All matches are in <span class="football-matches__timezone">@DateTimeFormatter.ofPattern("z").format(ZonedDateTime.of(knockoutStage.matches.head.date.toLocalDate, LocalTime.of(0, 0), Edition(request).timezoneId))</span> time</div>
 </div>


### PR DESCRIPTION
## What does this change?
It is making the knockout games time timezone specific.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

|     | Before | After |
|-----|--------|-------|
| UK  | <img width="1243" alt="image" src="https://user-images.githubusercontent.com/19683595/202478393-c83c037e-c4fc-4b0b-b954-5879a6233858.png"> |<img width="1226" alt="image" src="https://user-images.githubusercontent.com/19683595/202493293-895eddbd-c5ca-42cf-9f0e-ea1a45f1c745.png">|
| AUS | <img width="1230" alt="image" src="https://user-images.githubusercontent.com/19683595/202478200-731b9d74-18ea-4c85-b2c8-a0623d5c54bb.png"> |<img width="1236" alt="image" src="https://user-images.githubusercontent.com/19683595/202493099-92f00b5f-f92a-46e0-80c4-ec802e00c0a2.png">|

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
