### PR TITLE
Extend sign in gate AB test switch expiry

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -11,7 +11,7 @@ trait ABTestSwitches {
     "Control audience for the sign in gate to 9% audience. Will never see the sign in gate.",
     owners = Seq(Owner.withGithub("coldlink")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 12, 1)),
+    sellByDate = Some(LocalDate.of(2025, 12, 1)),
     exposeClientSide = true,
   )
 
@@ -21,7 +21,7 @@ trait ABTestSwitches {
     "Show sign in gate to 90% of users on 3rd article view, variant/full audience",
     owners = Seq(Owner.withGithub("coldlink")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 12, 1)),
+    sellByDate = Some(LocalDate.of(2025, 12, 1)),
     exposeClientSide = true,
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
@@ -4,7 +4,7 @@
 export const signInGateMainControl = {
 	id: 'SignInGateMainControl',
 	start: '2020-05-20',
-	expiry: '2022-12-01',
+	expiry: '2025-12-01',
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Control Audience.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -4,7 +4,7 @@
 export const signInGateMainVariant = {
 	id: 'SignInGateMainVariant',
 	start: '2020-05-20',
-	expiry: '2022-12-01',
+	expiry: '2025-12-01',
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',


### PR DESCRIPTION
## What does this change?

Extends the expiry date for the main sign in gate AB test by two years.  

