### PR TITLE
Update facia-scala-client from 4.0.3 to 4.0.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
   val capiVersion = "19.0.5"
-  val faciaVersion = "4.0.3"
+  val faciaVersion = "4.0.4"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

## What does this change?

Updates facia-scala-client to fix a bug for item backfill queries which start with 'search'

facia-scala-client PR: https://github.com/guardian/facia-scala-client/pull/282

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
