### PR TITLE
Bump `@guardian/commercial-core@^4.25.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^7.4.0",
-		"@guardian/commercial-core": "4.24.0",
+		"@guardian/commercial-core": "^4.25.0",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/libs": "^7.1.4",
 		"@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
@@ -9,6 +9,9 @@ const buildPageTargeting = buildPageTargeting_ as jest.MockedFunction<
 jest.mock('../../../../lib/geolocation', () => ({
 	getCountryCode: jest.fn(),
 }));
+jest.mock('../experiments/ab', () => ({
+	getSynchronousParticipations: jest.fn(),
+}));
 jest.mock('@guardian/commercial-core', () => ({
 	buildPageTargeting: jest.fn(),
 }));

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -3,6 +3,7 @@ import { buildPageTargeting } from '@guardian/commercial-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
+import { getSynchronousParticipations } from 'common/modules/experiments/ab';
 import { removeFalseyValues } from '../../../commercial/modules/header-bidding/utils';
 import { commercialFeatures } from './commercial-features';
 
@@ -44,8 +45,9 @@ const getPageTargeting = (consentState: ConsentState): PageTargeting => {
 	const { page } = window.guardian.config;
 
 	const pageTargeting = buildPageTargeting({
-		consentState,
 		adFree: commercialFeatures.adFree,
+		clientSideParticipations: getSynchronousParticipations(),
+		consentState,
 	});
 
 	// third-parties wish to access our page targeting, before the googletag script is loaded.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,10 +2089,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.4.0.tgz#cccd1e39156a12ca4304bfb4f6113d41521af753"
   integrity sha512-r3+yM/qh45g1gI/FCD1ooCwOntcHnemcjo/E+phgYLvXGGDG82l6AzdMVyC8c4ZGfeFu2EnUPhHALUMyaT/qdg==
 
-"@guardian/commercial-core@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.24.0.tgz#4812d2a97f8b888092a4170624a0871742d83128"
-  integrity sha512-6ql4W6y0bx0GehSn7jNEkcn8DAoq3b/R9sfOCtbI952rouSaoKtIZcxKPK9PA9vSkWqkXF3hm9r/Ci2AKo+7gA==
+"@guardian/commercial-core@^4.25.0":
+  version "4.25.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.25.0.tgz#cbc1ab2aaff456a3dc20836b1520a4a29b3a75ec"
+  integrity sha512-EDFSiCtTAlXdu/WK8dCp+BO5TLIYeyZ4QGkYv2lNXJ7y2U3zFkyTipPHq2Ld9iOSyy2+TtcF3OPnXS4j1pJ7vA==
 
 "@guardian/consent-management-platform@^10.11.1":
   version "10.11.1"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/commercial-core@^4.25.0`

This reverts the change to derive ab test participations (aka client side participations) in commercial-core as DCR does not currently provide them in localstorage.

Instead we pass participations to `buildPageTargeting` from Frontend and DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (only used in https://github.com/guardian/atoms-rendering/pull/492)

### Tested

- [ ] Locally
- [ ] On CODE (WIP)
