### PR TITLE
handle callout element type

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -157,7 +157,7 @@ object CalloutExtraction {
       formFields1 <- (campaign \ "fields" \ "formFields").asOpt[JsArray]
     } yield {
       val formFields2 = formFields1.value
-        .flatMap(formFieldItemToCalloutFormField(_))
+        .flatMap(formFieldItemToCalloutFormField)
         .toList
       CalloutBlockElement(
         id,
@@ -189,7 +189,7 @@ object CalloutExtraction {
       formFields1 <- (campaign \ "fields" \ "formFields").asOpt[JsArray]
     } yield {
       val formFields2 = formFields1.value
-        .flatMap(formFieldItemToCalloutFormField(_))
+        .flatMap(formFieldItemToCalloutFormField)
         .toList
 
       CalloutBlockElementV2(

--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -356,8 +356,6 @@ object CalloutExtraction {
       campaign <- extractCampaignByCampaignId(callout.campaignId, cpgs)
       element <- campaignJsObjectToCalloutBlockElementV2(campaign, callout.isNonCollapsible, calloutsUrl)
     } yield {
-      println("element: ")
-      println(element)
       element
     }
   }

--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -1,5 +1,6 @@
 package model.dotcomrendering.pageElements
 
+import com.gu.contentapi.client.model.v1.CalloutElementFields
 import org.jsoup.Jsoup
 import play.api.libs.json._
 
@@ -62,6 +63,11 @@ object CalloutExtraction {
       .filter(c => (c \ "fields" \ "tagName").asOpt[String].getOrElse("") == tagName)
       .map(_.asInstanceOf[JsObject])
       .headOption
+  }
+
+  private def extractCampaignByCampaignId(campaignId: Option[String], campaigns: JsValue): Option[JsObject] = {
+    val campaigns2 = campaigns.asInstanceOf[JsArray].value
+    campaigns2.filter(c => (c \ "id").asOpt[String] == campaignId).map(_.asInstanceOf[JsObject]).headOption
   }
 
   private def formFieldItemToCalloutFormFieldBase(item: JsValue): Option[CalloutFormFieldBase] = {
@@ -163,6 +169,41 @@ object CalloutExtraction {
         description,
         tagName,
         formFields2,
+      )
+    }
+  }
+
+  private def campaignJsObjectToCalloutBlockElementV2(
+      campaign: JsObject,
+      isNonCollapsible: Option[Boolean],
+      calloutsUrl: Option[String],
+  ): Option[CalloutBlockElementV2] = {
+    for {
+      id <- (campaign \ "id").asOpt[String]
+      activeFrom <- (campaign \ "activeFrom").asOpt[Long]
+      displayOnSensitive <- (campaign \ "displayOnSensitive").asOpt[Boolean]
+      formId <- (campaign \ "fields" \ "formId").asOpt[Int]
+      title <- (campaign \ "fields" \ "callout").asOpt[String]
+      description <- (campaign \ "fields" \ "description").asOpt[String]
+      tagName <- (campaign \ "fields" \ "tagName").asOpt[String]
+      formFields1 <- (campaign \ "fields" \ "formFields").asOpt[JsArray]
+    } yield {
+      val formFields2 = formFields1.value
+        .flatMap(formFieldItemToCalloutFormField(_))
+        .toList
+
+      CalloutBlockElementV2(
+        id,
+        calloutsUrl,
+        activeFrom,
+        (campaign \ "activeUntil").asOpt[Long],
+        displayOnSensitive,
+        formId,
+        title,
+        description,
+        tagName,
+        formFields2,
+        isNonCollapsible.getOrElse(false),
       )
     }
   }
@@ -301,6 +342,22 @@ object CalloutExtraction {
       campaign <- extractCampaignPerTagName(cpgs, name)
       element <- campaignJsObjectToCalloutBlockElement(campaign, calloutsUrl)
     } yield {
+      element
+    }
+  }
+
+  def extractCalloutByCampaignId(
+      callout: CalloutElementFields,
+      campaigns: Option[JsValue],
+      calloutsUrl: Option[String],
+  ): Option[CalloutBlockElementV2] = {
+    for {
+      cpgs <- campaigns
+      campaign <- extractCampaignByCampaignId(callout.campaignId, cpgs)
+      element <- campaignJsObjectToCalloutBlockElementV2(campaign, callout.isNonCollapsible, calloutsUrl)
+    } yield {
+      println("element: ")
+      println(element)
       element
     }
   }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1053,8 +1053,8 @@ object PageElement {
       // 2. EmbedBlockElement
       // 3. CalloutBlockElement
 
-      case Callout => {
-        val res = element.calloutTypeData
+      case Callout =>
+        element.calloutTypeData
           .map { callout =>
             CalloutExtraction.extractCalloutByCampaignId(
               callout,
@@ -1064,9 +1064,6 @@ object PageElement {
           }
           .flatten
           .toList
-        println(res)
-        res
-      }
 
       case Contentatom =>
         (extractAtom match {

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -148,7 +148,7 @@ case class CalloutBlockElementV2(
     id: String,
     calloutsUrl: Option[String],
     activeFrom: Long,
-    activeTo: Option[Long],
+    activeUntil: Option[Long],
     displayOnSensitive: Boolean,
     formId: Int,
     title: String,
@@ -1054,7 +1054,6 @@ object PageElement {
       // 3. CalloutBlockElement
 
       case Callout => {
-        println("I'm a callout element")
         val res = element.calloutTypeData
           .map { callout =>
             CalloutExtraction.extractCalloutByCampaignId(

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -51,6 +51,7 @@ case class InstagramBlockElement(html: Option[String]) extends BlockElement
 case class VineBlockElement(html: Option[String]) extends BlockElement
 case class MapBlockElement(html: Option[String]) extends BlockElement
 case class UnknownBlockElement(html: Option[String]) extends BlockElement
+case class UnsupportedBlockElement(html: Option[String]) extends BlockElement
 case class InteractiveBlockElement(html: Option[String], scriptUrl: Option[String] = None) extends BlockElement
 
 case class MembershipBlockElement(
@@ -176,6 +177,7 @@ object BlockElement {
       case Form            => Some(FormBlockElement(None))
 
       case EnumUnknownElementType(f) => Some(UnknownBlockElement(None))
+      case Callout                   => Some(UnsupportedBlockElement(None))
 
     }
   }
@@ -226,6 +228,7 @@ object BlockElement {
   implicit val MembershipBlockElementWrites: Writes[MembershipBlockElement] = Json.writes[MembershipBlockElement]
   implicit val FormBlockElementWrites: Writes[FormBlockElement] = Json.writes[FormBlockElement]
   implicit val UnknownBlockElementWrites: Writes[UnknownBlockElement] = Json.writes[UnknownBlockElement]
+  implicit val UnsupportedBlockElementWrites: Writes[UnsupportedBlockElement] = Json.writes[UnsupportedBlockElement]
 
   implicit val SponsorshipWrites: Writes[Sponsorship] = new Writes[Sponsorship] {
     def writes(sponsorship: Sponsorship): JsObject =

--- a/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
@@ -1,7 +1,9 @@
 package model.dotcomrendering.pageElements
 
+import com.gu.contentapi.client.model.v1.CalloutElementFields
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsArray, JsValue, Json}
 
 class CalloutExtractionTest extends AnyFlatSpec with Matchers {
   "CalloutExtraction isCallout" should "return true when data-callout-tagname attribute exists in html and has value" in {
@@ -18,4 +20,167 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
     val result = CalloutExtraction.isCallout("<div some-data='someValue'>some stuff</div>")
     result should equal(false)
   }
+
+  "extractCampaignByCampaignId" should "return successfully given the callout campaign exist in the campaign list" in {
+    val capiCallout = CalloutElementFields(Some("b06a08e0-ca5f-410c-a28b-95e7d7ca37b7"), Some(false))
+
+    val result = CalloutExtraction.extractCalloutByCampaignId(
+      capiCallout,
+      existingCampaigns,
+      Some("http://test.com"),
+    )
+
+    result.isDefined should be(true)
+    result.map { callout =>
+      callout should equal(expectedCalloutBlockElementV2)
+    }
+  }
+
+  it should "return None given the relevant callout campaign doesn't exist in the campaign list" in {
+    val capiCallout = CalloutElementFields(Some("some-random-id"), Some(false))
+
+    val result = CalloutExtraction.extractCalloutByCampaignId(
+      capiCallout,
+      existingCampaigns,
+      Some("http://test.com"),
+    )
+
+    result.isDefined should be(false)
+  }
+
+  def existingCampaigns: Option[JsValue] = {
+
+    Some(
+      Json.parse(
+        """
+  [
+    {
+      "id": "b06a08e0-ca5f-410c-a28b-95e7d7ca37b7",
+      "name": "CALLOUT: Coronavirus",
+      "rules": [
+
+      ],
+      "priority": 0,
+      "activeFrom": 1579651200000,
+      "displayOnSensitive": false,
+      "fields": {
+        "formId": 3730905,
+        "callout": "Share your stories",
+        "_type": "callout",
+        "description": "<p>If you have been affected</p>",
+        "formFields": [
+          {
+            "name": "share_your_experiences_here",
+            "description": "Please include as much detail as possible",
+            "hide_label": "0",
+            "label": "Share your experiences here",
+            "id": "87320974",
+            "type": "textarea",
+            "required": "1"
+          },
+          {
+            "text_size": 50,
+            "name": "name",
+            "description": "You do not need to use your full name",
+            "hide_label": "0",
+            "label": "Name",
+            "id": "87320975",
+            "type": "text",
+            "required": "1"
+          },
+          {
+            "name": "can_we_publish_your_response",
+            "options": [
+              {
+                "label": "Yes, entirely",
+                "value": "Yes, entirely"
+              },
+              {
+                "label": "Yes, but please keep me anonymous",
+                "value": "Yes, but please keep me anonymous"
+              }
+            ],
+            "hide_label": "0",
+            "label": "Can we publish your response?",
+            "id": "87320977",
+            "type": "radio",
+            "required": "1"
+          }
+        ],
+        "tagName": "callout-coronavirus"
+      }
+    }
+  ]
+       """,
+      ),
+    )
+
+  }
+
+  def expectedCalloutBlockElementV2 = {
+    CalloutBlockElementV2(
+      "b06a08e0-ca5f-410c-a28b-95e7d7ca37b7",
+      Some("http://test.com"),
+      1579651200000L,
+      None,
+      false,
+      3730905,
+      "Share your stories",
+      "<p>If you have been affected</p>",
+      "callout-coronavirus",
+      expectedRadioFields,
+      false,
+    )
+  }
+
+  def expectedRadioOptions =
+    JsArray.apply(
+      Seq(
+        Json.parse("""
+        {
+                  "label": "Yes, entirely",
+                  "value": "Yes, entirely"
+                }
+        """),
+        Json.parse("""
+        {
+                  "label": "Yes, but please keep me anonymous",
+                  "value": "Yes, but please keep me anonymous"
+                }
+        """),
+      ),
+    )
+
+  def expectedRadioFields: List[CalloutFormField] =
+    List(
+      CalloutFormFieldBase(
+        "87320974",
+        "textarea",
+        "share_your_experiences_here",
+        Some("Please include as much detail as possible"),
+        true,
+        false,
+        "Share your experiences here",
+      ),
+      CalloutFormFieldBase(
+        "87320975",
+        "text",
+        "name",
+        Some("You do not need to use your full name"),
+        true,
+        false,
+        "Name",
+      ),
+      CalloutFormFieldRadio(
+        "87320977",
+        "radio",
+        "can_we_publish_your_response",
+        None,
+        true,
+        false,
+        "Can we publish your response?",
+        expectedRadioOptions,
+      ),
+    )
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.0.5"
+  val capiVersion = "19.1.0"
   val faciaVersion = "4.0.4"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?
This PR is adding support for a new CAPI element type `callout` by adding a new page element `CalloutBlockElementV2`.

- Updates capiVersion to `19.1.0`
- Adds case for `callout` capi element
- Adds new PageElement `CalloutBlockElementV2`
- Adds `extractCalloutByCampaignId` method 
- Adds `UnsupportedBlockElementWrites` block element in liveblog/BlockElement.scala to cover for capi `callout` block element (callout can currently only be used for body element in composer)

Note: The DCR handling of `CalloutBlockElementV2`  https://github.com/guardian/dotcom-rendering/pull/6539

IMPORTANT: This PR can only be merged after https://github.com/guardian/dotcom-rendering/pull/6539

## Screenshots
![image](https://user-images.githubusercontent.com/15894063/204271861-4c766521-f47b-4c4d-bb1a-5d4e0276fc28.png)

![image](https://user-images.githubusercontent.com/15894063/204271964-a3d1c0f7-458b-4f26-ae46-111184985e38.png)


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
