### PR TITLE
Increase YouTube IMA integration AB test to 5%

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,10 +1,12 @@
 import type { ABTest } from '@guardian/ab-core';
 import { getUrlVars } from 'lib/url';
 import { isInABTestSynchronous } from '../experiments/ab';
+import { integrateIMA } from '../experiments/tests/integrate-ima';
 import { removePrebidA9Canada } from '../experiments/tests/removePrebidA9Canada';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
+	integrateIMA,
 	removePrebidA9Canada,
 ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -8,8 +8,8 @@ export const integrateIMA: ABTest = {
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',
-	audience: 0,
-	audienceOffset: 0,
+	audience: 5 / 100,
+	audienceOffset: 30 / 100,
 	audienceCriteria: 'Opt in',
 	successMeasure:
 		'IMA integration works as expected without adversely affecting pages with videos',


### PR DESCRIPTION
## What does this change?

Increase YouTube IMA integration ab test to 5%

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6540

