### PR TITLE
Core web vitals from own lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@guardian/braze-components": "^7.4.0",
 		"@guardian/commercial-core": "^4.25.0",
 		"@guardian/consent-management-platform": "^10.11.1",
+		"@guardian/core-web-vitals": "^1.0.0",
 		"@guardian/libs": "^7.1.4",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "^4.0.3",

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,8 +1,8 @@
 import {
 	bypassCoreWebVitalsSampling,
-	getCookie,
 	initCoreWebVitals,
-} from '@guardian/libs';
+} from '@guardian/core-web-vitals';
+import { getCookie } from '@guardian/libs';
 import { shouldCaptureMetrics } from './shouldCaptureMetrics';
 
 const coreVitals = (): void => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,6 +2101,11 @@
   dependencies:
     "@guardian/libs" "^7.1.4"
 
+"@guardian/core-web-vitals@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-1.0.0.tgz#f5624eabbf7123f8a764c00674e640a10a80e2da"
+  integrity sha512-3WTUK6FmZpVUQGoc+hlAcuYx8yVKdYfpcP7HWkBmy1yaWV5yJ81HBxxoACwUeMrZrKLMlCMriPTC9CLhPgGGUQ==
+
 "@guardian/eslint-config-typescript@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config-typescript/-/eslint-config-typescript-0.7.0.tgz#9b675639377bd71bc42f33741ea3bbbf20525c4a"


### PR DESCRIPTION
## What does this change?

Use [`@guardian/core-web-vitals`](https://github.com/guardian/csnx/releases/tag/%40guardian%2Fcore-web-vitals%401.0.0) directly. This package has been taken out of `@guardian/libs` as it has a peer dependency on Google’s web-vitals.

This will be required for [`@guardian/libs` v10](https://github.com/guardian/csnx/releases/tag/%40guardian%2Flibs%4010.0.0)

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/6542