### PR TITLE
Most viewed data in fronts data model

### DIFF
--- a/common/app/feed/MostViewed.scala
+++ b/common/app/feed/MostViewed.scala
@@ -11,12 +11,12 @@ import java.net.URL
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-sealed trait Country {
+sealed trait EditionalisedCountry {
   val code: String
   val edition: Edition
 }
-object Country {
-  def fromHeaderString(header: RichRequestHeader): Country =
+object EditionalisedCountry {
+  def fromHeaderString(header: RichRequestHeader): EditionalisedCountry =
     header.countryCode.toLowerCase match {
       case "gb" => GB
       case "us" => US
@@ -28,35 +28,35 @@ object Country {
       case _    => ROW
     }
 }
-case object GB extends Country {
+case object GB extends EditionalisedCountry {
   val code = "gb"
   val edition = editions.Uk
 }
-case object US extends Country {
+case object US extends EditionalisedCountry {
   val code = "us"
   val edition = editions.Us
 }
-case object AU extends Country {
+case object AU extends EditionalisedCountry {
   val code = "au"
   val edition = editions.Au
 }
-case object CA extends Country {
+case object CA extends EditionalisedCountry {
   val code = "ca"
   val edition = editions.Us
 }
-case object IN extends Country {
+case object IN extends EditionalisedCountry {
   val code = "in"
   val edition = Edition.defaultEdition
 }
-case object NG extends Country {
+case object NG extends EditionalisedCountry {
   val code = "ng"
   val edition = Edition.defaultEdition
 }
-case object NZ extends Country {
+case object NZ extends EditionalisedCountry {
   val code = "nz"
   val edition = editions.Au
 }
-case object ROW extends Country {
+case object ROW extends EditionalisedCountry {
   val code = "row"
   val edition = Edition.defaultEdition
 }

--- a/facia/app/agents/MostViewedAgent.scala
+++ b/facia/app/agents/MostViewedAgent.scala
@@ -4,7 +4,7 @@ import conf.Configuration
 import contentapi.ContentApiClient
 import com.gu.contentapi.client.model.v1.Content
 import common._
-import feed.{AU, CA, GB, US, NG, NZ, IN, ROW, Country, MostViewed}
+import feed.{AU, CA, GB, US, NG, NZ, IN, ROW, EditionalisedCountry, MostViewed}
 import services.OphanApi
 import model.RelatedContentItem
 import play.api.libs.json._
@@ -15,12 +15,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MostViewedAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, wsClient: WSClient) extends GuLogging {
 
-  private val mostViewedBox = Box[Map[Country, Seq[RelatedContentItem]]](Map.empty)
+  private val mostViewedBox = Box[Map[EditionalisedCountry, Seq[RelatedContentItem]]](Map.empty)
   private val mostCommentedCardBox = Box[Option[Content]](None)
   private val mostSharedCardBox = Box[Option[Content]](None)
 
-  // todo: better typing for country codes
-  def mostViewed(country: Country): Seq[RelatedContentItem] = mostViewedBox().getOrElse(country, Nil)
+  def mostViewed(country: EditionalisedCountry): Seq[RelatedContentItem] = mostViewedBox().getOrElse(country, Nil)
   def mostCommented = mostCommentedCardBox.get()
   def mostShared = mostSharedCardBox.get()
 
@@ -93,8 +92,8 @@ class MostViewedAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, ws
   )
 
   private def refresh(
-      country: Country,
-  )(implicit ec: ExecutionContext): Future[Map[Country, Seq[RelatedContentItem]]] = {
+      country: EditionalisedCountry,
+  )(implicit ec: ExecutionContext): Future[Map[EditionalisedCountry, Seq[RelatedContentItem]]] = {
     val ophanMostViewed = ophanApi.getMostRead(hours = 3, count = 10, country = country.code.toLowerCase)
     MostViewed.relatedContentItems(ophanMostViewed, country.edition)(contentApiClient).flatMap { items =>
       val validItems = items.flatten

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -227,6 +227,10 @@ trait FaciaController
               RevalidatableResult(Ok(body).as("text/xml; charset=utf-8"), body)
             } else if (request.isJson) {
               if (request.forceDCR) {
+                log.info(
+                  s"Front Geo Request: ${EditionalisedCountry.fromHeaderString(request)} ${request.headers.toSimpleMap
+                    .getOrElse("X-GU-GeoLocation", "country:row")}",
+                )
                 JsonComponent.fromWritable(
                   DotcomFrontsRenderingDataModel(
                     page = faciaPage,

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -27,7 +27,7 @@ import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
 import experiments.{ActiveExperiments, EuropeNetworkFront}
-import feed.Country
+import feed.EditionalisedCountry
 import play.api.http.ContentTypes.JSON
 import services.dotcomrendering.{FaciaPicker, RemoteRender}
 import services.fronts.{FrontJsonFapi, FrontJsonFapiLive}
@@ -213,7 +213,7 @@ trait FaciaController
             ws = ws,
             page = faciaPage,
             pageType = pageType,
-            mostViewed = mostViewedAgent.mostViewed(Country.fromHeaderString(request)),
+            mostViewed = mostViewedAgent.mostViewed(EditionalisedCountry.fromHeaderString(request)),
             mostCommented = mostViewedAgent.mostCommented,
             mostShared = mostViewedAgent.mostShared,
           )(request),
@@ -232,7 +232,7 @@ trait FaciaController
                     page = faciaPage,
                     request = request,
                     pageType = PageType(faciaPage, request, context),
-                    mostViewed = mostViewedAgent.mostViewed(Country.fromHeaderString(request)),
+                    mostViewed = mostViewedAgent.mostViewed(EditionalisedCountry.fromHeaderString(request)),
                     mostCommented = mostViewedAgent.mostCommented,
                     mostShared = mostViewedAgent.mostShared,
                   ),


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
