### PR TITLE
Update artifact bucket config to use ssm lookup

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -46,8 +46,7 @@ deployments:
   frontend-static:
     type: aws-s3
     parameters:
-      bucketSsmKey: /account/services/dotcom-static
-      bucketSsmLookup: true
+      bucket: aws-frontend-static
       cacheControl: public, max-age=315360000
       prefixStack: false
       publicReadAcl: false

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,7 +10,7 @@ templates:
     type: autoscaling
     parameters:
       bucketSsmKey: /account/services/dotcom-artifact.bucket
-      bucketSsmLookup: true
+     
       warmupGrace: 60
     dependencies:
     - frontend-static

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -46,7 +46,8 @@ deployments:
   frontend-static:
     type: aws-s3
     parameters:
-      bucket: aws-frontend-static
+      bucketSsmKey: /account/services/dotcom-static
+      bucketSsmLookup: true
       cacheControl: public, max-age=315360000
       prefixStack: false
       publicReadAcl: false

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,8 @@ templates:
   frontend:
     type: autoscaling
     parameters:
-      bucket: aws-frontend-artifacts
+      bucketSsmKey: /account/services/dotcom-artifact.bucket
+      bucketSsmLookup: true
       warmupGrace: 60
     dependencies:
     - frontend-static


### PR DESCRIPTION
## What?

Replaces hard-coded bucket names with [the `bucketSsmLookup` functionality](https://github.com/guardian/riff-raff/pull/704) in RiffRaff.

## Why?

Avoiding hard-coded bucket names is consistent with current recommendations. Part of [DCR #6317](https://github.com/guardian/dotcom-rendering/issues/6317)

## Todo

- [x] Test this in CODE before merging.
- [x] Implement in DCR, too: https://github.com/guardian/dotcom-rendering/pull/6560


---
Co-authored-by: Ioanna Kokkini <ioannakok@users.noreply.github.com>