### PR TITLE
IntegrateIma AB test fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,12 +1,12 @@
 import type { ABTest } from '@guardian/ab-core';
 import { getUrlVars } from 'lib/url';
 import { isInABTestSynchronous } from '../experiments/ab';
-import { integrateIMA } from '../experiments/tests/integrate-ima';
+import { integrateIma } from '../experiments/tests/integrate-ima';
 import { removePrebidA9Canada } from '../experiments/tests/removePrebidA9Canada';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
-	integrateIMA,
+	integrateIma,
 	removePrebidA9Canada,
 ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,7 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
-import { integrateIMA } from './tests/integrate-ima';
+import { integrateIma } from './tests/integrate-ima';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { removePrebidA9Canada } from './tests/removePrebidA9Canada';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -25,7 +25,7 @@ export const concurrentTests: readonly ABTest[] = [
 	remoteRRHeaderLinksTest,
 	deeplyReadArticleFooterTest,
 	consentlessAds,
-	integrateIMA,
+	integrateIma,
 	signInGateMandatoryLongTestControlAunz,
 	signInGateMandatoryLongTestControlEu,
 	signInGateMandatoryLongTestControlNa,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -1,8 +1,8 @@
 import type { ABTest } from '@guardian/ab-core';
 import { noop } from '../../../../../lib/noop';
 
-export const integrateIMA: ABTest = {
-	id: 'IntegrateIMA',
+export const integrateIma: ABTest = {
+	id: 'IntegrateIma',
 	start: '2022-07-14',
 	expiry: '2022-12-30',
 	author: 'Zeke Hunter-Green',


### PR DESCRIPTION
## What does this change?

Fixes the casing for the `IntegrateIma` test.

For the switch to work the test name should be 🐫 case

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6559

### Tested

- [ ] Locally
- [x] On CODE (optional)

