### PR TITLE
Fix commercial e2e consent test

### DIFF
--- a/cypress/e2e/consent.cy.ts
+++ b/cypress/e2e/consent.cy.ts
@@ -136,8 +136,11 @@ describe('tcfv2 consent', () => {
 
 		cy.get(`[data-name="top-above-nav"]`).should('not.exist');
 
-		// Check the banner still shows support message
-		cy.get('[name="ReaderRevenueLinks"]')
+		// Check the header still shows support message
+		cy.get('[name="SupportTheG"]')
+			.should('have.attr', 'data-gu-ready', 'true', {
+				timeout: 30000,
+			})
 			.find('h2')
 			.should('contain', 'Support the Guardian');
 	});


### PR DESCRIPTION
## What does this change?

Fix commercial e2e `consent.cy` test

The underlying dom structure of the support message had changed causing the test to fail.

Regardless I decided to switch the assert to the support header `[name="SupportTheG"]` rather than the footer `[name="ReaderRevenueLinks"]`. The footer `ReaderRevenueLinks` is a deferUntil="visible" island which has issues with visibility and scrolling.

### Tested

- [x] Locally
- [ ] On CODE (optional)
