### PR TITLE
Create 0% AB test for inserting server side ad slots on liveblogs

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeNetworkFront,
       DCRJavascriptBundle,
       HeaderTopBarSearchCapi,
+      ServerSideLiveblogInlineAds,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -81,4 +82,14 @@ object HeaderTopBarSearchCapi
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 2, 1),
       participationGroup = Perc1B,
+    )
+
+object ServerSideLiveblogInlineAds
+    extends Experiment(
+      name = "server-side-liveblog-inline-ads",
+      description =
+        "Test whether we can load liveblog inline ads server-side without negative effects on user experience or revenue",
+      owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
+      sellByDate = LocalDate.of(2023, 2, 1),
+      participationGroup = Perc0E,
     )

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.spec.ts
@@ -82,9 +82,11 @@ describe('Liveblog Dynamic Adverts', () => {
 		if (block1 === null || block2 === null) {
 			throw Error();
 		}
+
 		spaceFillerStub.mockImplementationOnce(
 			createFillSpaceMock([block1, block2]),
 		);
+
 		return init().then(() => {
 			expect(
 				document.querySelector('.x1')?.nextElementSibling
@@ -98,5 +100,41 @@ describe('Liveblog Dynamic Adverts', () => {
 				document.querySelector('.js-liveblog-body')?.children.length,
 			).toBe(14);
 		});
+	});
+
+	it('should NOT insert ad slots if in the server-side ad slot test variant', () => {
+		document.body.innerHTML = `
+			<div class="js-liveblog-body">
+				<div class="block x1"></div>
+				<div class="block x2"></div>
+				<div class="ad-slot--inline1"></div>
+				<div class="block x3"></div>
+				<div class="block x4"></div>
+				<div class="block x5"></div>
+				<div class="block x6"></div>
+				<div class="block x7"></div>
+				<div class="block x8"></div>
+				<div class="block x9"></div>
+				<div class="block x10"></div>
+				<div class="block x11"></div>
+				<div class="block x12"></div>
+			</div>';
+			`;
+
+		console.log('document.body.innerHTML', document.body.innerHTML);
+
+		const block1 = document.querySelector<HTMLElement>('.x1');
+		const block2 = document.querySelector<HTMLElement>('.x12');
+		if (block1 === null || block2 === null) {
+			throw Error();
+		}
+
+		spaceFillerStub.mockImplementationOnce(
+			createFillSpaceMock([block1, block2]),
+		);
+
+		expect(() => {
+			void init();
+		}).toThrow();
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.spec.ts
@@ -55,7 +55,7 @@ describe('Liveblog Dynamic Adverts', () => {
 				<div class="block x11"></div>
 				<div class="block x12"></div>
 			</div>';
-			`;
+		`;
 	});
 
 	afterEach(() => {
@@ -102,26 +102,10 @@ describe('Liveblog Dynamic Adverts', () => {
 		});
 	});
 
-	it('should NOT insert ad slots if in the server-side ad slot test variant', () => {
-		document.body.innerHTML = `
-			<div class="js-liveblog-body">
-				<div class="block x1"></div>
-				<div class="block x2"></div>
-				<div class="ad-slot--inline1"></div>
-				<div class="block x3"></div>
-				<div class="block x4"></div>
-				<div class="block x5"></div>
-				<div class="block x6"></div>
-				<div class="block x7"></div>
-				<div class="block x8"></div>
-				<div class="block x9"></div>
-				<div class="block x10"></div>
-				<div class="block x11"></div>
-				<div class="block x12"></div>
-			</div>';
-			`;
-
-		console.log('document.body.innerHTML', document.body.innerHTML);
+	it('should insert ad slots if in the server-side ad slot test CONTROL group', async () => {
+		window.guardian.config.tests = window.guardian.config.tests ?? {};
+		window.guardian.config.tests.serverSideLiveblogInlineAdsControl =
+			'control';
 
 		const block1 = document.querySelector<HTMLElement>('.x1');
 		const block2 = document.querySelector<HTMLElement>('.x12');
@@ -133,8 +117,32 @@ describe('Liveblog Dynamic Adverts', () => {
 			createFillSpaceMock([block1, block2]),
 		);
 
-		expect(() => {
-			void init();
-		}).toThrow();
+		await init().then(() => {
+			expect(
+				document.querySelector('.js-liveblog-body')?.children.length,
+			).toBe(14);
+		});
+	});
+
+	it('should NOT insert ad slots if in the server-side ad slot test VARIANT group', async () => {
+		window.guardian.config.tests = window.guardian.config.tests ?? {};
+		window.guardian.config.tests.serverSideLiveblogInlineAdsVariant =
+			'variant';
+
+		const block1 = document.querySelector<HTMLElement>('.x1');
+		const block2 = document.querySelector<HTMLElement>('.x12');
+		if (block1 === null || block2 === null) {
+			throw Error();
+		}
+
+		spaceFillerStub.mockImplementationOnce(
+			createFillSpaceMock([block1, block2]),
+		);
+
+		await init().then(() => {
+			expect(
+				document.querySelector('.js-liveblog-body')?.children.length,
+			).toBe(12);
+		});
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -183,25 +183,24 @@ export const init = (): Promise<void> => {
 		return Promise.resolve();
 	}
 
+	const isServerSideAdsMode =
+		window.guardian.config.tests?.serverSideLiveblogInlineAdsVariant ===
+		'variant';
+	if (isServerSideAdsMode) {
+		log(
+			'commercial',
+			'Server side inline ads mode. No client-side inline ad slots inserted',
+		);
+		return Promise.resolve();
+	}
+
 	return fastdom
 		.measure(() => {
-			const isServerSideAdsMode =
-				document.querySelector('.ad-slot--inline1') !== null;
-			if (isServerSideAdsMode) {
-				throw Error;
-			}
-
 			WINDOWHEIGHT = getWindowHeight();
 			return WINDOWHEIGHT;
 		})
 		.then(getSpaceFillerRules)
-		.then(fill)
-		.catch(() => {
-			log(
-				'commercial',
-				'Server side inline ads mode. No client-side inline ad slots inserted',
-			);
-		});
+		.then(fill);
 };
 
 export const _ = { getSlotName };

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -1,4 +1,5 @@
 import { adSizes, createAdSlot } from '@guardian/commercial-core';
+import { log } from '@guardian/libs';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { liveblogDesktopOutstream } from 'common/modules/experiments/tests/liveblog-desktop-outstream';
 import { getCurrentBreakpoint } from 'lib/detect-breakpoint';
@@ -184,11 +185,23 @@ export const init = (): Promise<void> => {
 
 	return fastdom
 		.measure(() => {
+			const isServerSideAdsMode =
+				document.querySelector('.ad-slot--inline1') !== null;
+			if (isServerSideAdsMode) {
+				throw Error;
+			}
+
 			WINDOWHEIGHT = getWindowHeight();
 			return WINDOWHEIGHT;
 		})
 		.then(getSpaceFillerRules)
-		.then(fill);
+		.then(fill)
+		.catch(() => {
+			log(
+				'commercial',
+				'Server side inline ads mode. No client-side inline ad slots inserted',
+			);
+		});
 };
 
 export const _ = { getSlotName };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -443,6 +443,7 @@
  ],
  "../projects/commercial/modules/liveblog-adverts.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/detect-breakpoint.ts",
   "../lib/fastdom-promise.ts",
   "../lib/url.ts",


### PR DESCRIPTION
## What does this change?

- Creates a 0% AB test for inserting server side ad slots on liveblog pages
- Does not load client side ads 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] [Yes](https://github.com/guardian/dotcom-rendering/pull/6574)

<!-- Please use the following table template to make image comparison easier to parse:

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

If successful, inserting ad slots on liveblog pages server-side means we do not have to run client-side code to insert ad slots.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
