### PR TITLE
Add scalafmtCheckAll check to pre-push hook

### DIFF
--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -42,7 +42,7 @@ const confirmIfMain = execa
 const validate = () =>
     execa(
         './tools/task-runner/runner',
-        ['validate-head/index', 'validate/check-for-disallowed-strings'],
+        ['validate/scalafmt', 'validate-head/index', 'validate/check-for-disallowed-strings'],
         {
             stdio: 'inherit',
         }

--- a/tools/__tasks__/validate/scalafmt.js
+++ b/tools/__tasks__/validate/scalafmt.js
@@ -11,7 +11,7 @@ module.exports = {
     description: 'scalafmt check',
     task: [
         {
-            description: 'scalaFmtCheck',
+            description: 'scalafmtCheckAll',
             task: `./sbt scalafmtCheckAll ${config}`,
             onError: error,
         },

--- a/tools/__tasks__/validate/scalafmt.js
+++ b/tools/__tasks__/validate/scalafmt.js
@@ -1,0 +1,19 @@
+const chalk = require('chalk');
+const config = '--error';
+
+const error = ctx => {
+    ctx.messages.push(
+        `Run ${chalk.blue('./sbt scalafmt')} to format Scala files.`
+    );
+};
+
+module.exports = {
+    description: 'scalafmt check',
+    task: [
+        {
+            description: 'scalaFmtCheck',
+            task: `./sbt scalafmtCheckAll ${config}`,
+            onError: error,
+        },
+    ]
+}


### PR DESCRIPTION
## What does this change?

Adds a pre-push git hook that runs `./sbt scalafmtCheckAll` before allowing pushes to origin.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?

I have had builds fail in TeamCity because of the scalafmt check. Failing this late over something so trivial can prove quite a drag on productivity.

Also, it's a 10% day and I was curious to dig around in the CI for Frontend a bit to see how it's set up.

I'm imagining that this is a [Chesterton's fence](https://en.wiktionary.org/wiki/Chesterton%27s_fence), so I'm not inclined to merge this unless we can hear from someone who knows (or has a view on) why we don't have this check in pre-push already.