### PR TITLE
Upgrade to Scala 2.13.10

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -22,7 +22,7 @@ object ProjectSettings {
     scalacOptions ++= Seq(
       "-unchecked",
       "-deprecation",
-      "-target:jvm-1.8",
+      "-release:11",
       "-Xcheckinit",
       "-encoding",
       "utf8",
@@ -32,7 +32,7 @@ object ProjectSettings {
     Compile / packageDoc / publishArtifact := false,
     Compile / doc / sources := Seq.empty,
     Compile / doc := target.map(_ / "none").value,
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.10",
     initialize := {
       val _ = initialize.value
       assert(


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/25548

## What does this change?
* Upgrades to Scala 2.13.10
* Also changes sbt compiler option `-target` to `-release` as the former got deprecated with https://github.com/scala/scala/pull/9982

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
