### PR TITLE
Add integrate-ima ab test control

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -15,9 +15,7 @@ export const integrateIma: ABTest = {
 		'IMA integration works as expected without adversely affecting pages with videos',
 	canRun: () => true,
 	variants: [
-		{
-			id: 'variant',
-			test: () => noop,
-		},
+		{ id: 'control', test: () => noop },
+		{ id: 'variant', test: () => noop },
 	],
 };


### PR DESCRIPTION
## What does this change?

Add a control variant to the integrate-ima test

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6586
