### PR TITLE
Add 'Accessible version' to accessible crossword title

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -91,7 +91,11 @@ class CrosswordPageController(val contentApiClient: ContentApiClient, val contro
           RevalidatableResult.Ok(
             CrosswordHtmlPage.html(
               AccessibleCrosswordPage(
-                CrosswordContent.make(CrosswordData.fromCrossword(crossword, content), content),
+                CrosswordContent.make(
+                  CrosswordData
+                    .fromCrossword(crossword.copy(name = s"Accessible version of ${crossword.name}"), content),
+                  content,
+                ),
                 AccessibleCrosswordRows(crossword),
               ),
             ),


### PR DESCRIPTION
The title and h1 tags for Accessible Crosswords didn't differentiate them from the default crossword. This change differentiates them in a way that screen reader-users can detect. See [issue #5067](https://github.com/guardian/dotcom-rendering/issues/5067) from the DAC audit.

Co-authored-by: Max Duval <max.duval@theguardian.com>

## What does this change?

Creates a 'copy' of the crossword before it's transformed into CrosswordData, modifying the `name` to add `Accessible version of` to the beginning.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| <img width="899" alt="image" src="https://user-images.githubusercontent.com/37048459/204558809-e4e1922b-01a2-40dc-9a77-e770de1fe66e.png"> | <img width="881" alt="image" src="https://user-images.githubusercontent.com/37048459/204558997-fd1a1a60-1fe3-4429-b370-8de5c0d747df.png"> |
-->

## What is the value of this and can you measure success?

Improve accessibility.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
