### PR TITLE
add Content-Security-Policy header to preview

### DIFF
--- a/preview/app/http/PreviewFilters.scala
+++ b/preview/app/http/PreviewFilters.scala
@@ -24,7 +24,7 @@ class PreviewFilters(
     httpConfiguration,
   )
 
-  val filters = previewAuthFilter :: new NoCacheFilter :: Filters.common
+  val filters = previewAuthFilter :: new NoCacheFilter :: new ContentSecurityPolicyFilter :: Filters.common
 }
 
 // OBVIOUSLY this is only for the preview server
@@ -32,4 +32,16 @@ class PreviewFilters(
 class NoCacheFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] =
     nextFilter(request).map(_.withHeaders("Cache-Control" -> "no-cache"))
+}
+
+// This should be kept up to date with the prod configured in VCL (fastly-edge-cache repo).
+// We don't have fastly or a cache in front of `preview.gutools.co.uk` as it provisioned in CloudFormation in the `platform` repo (private):
+// https://github.com/guardian/platform/blob/main/provisioning/cloudformation/frontend.yaml#L824
+class ContentSecurityPolicyFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
+  override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] =
+    nextFilter(request).map(
+      _.withHeaders(
+        "Content-Security-Policy" -> "default-src https:; script-src https: 'unsafe-inline' 'unsafe-eval' blob: 'unsafe-inline'; frame-src https: data:; style-src https: 'unsafe-inline'; img-src https: data: blob:; media-src https: data: blob:; font-src https: data:; connect-src https: wss: blob:; child-src https: blob:; object-src 'none'; base-uri https://*.gracenote.com",
+      ),
+    )
 }


### PR DESCRIPTION
## What does this change?
Replicates the Content-Security-Policy header on preview to replicate prod.

This is so people using `preview` will pick up on errors or issues regarding this at the preview stage, rather than launching something broken to `PROD`.

## Screenshots
![Screenshot 2022-11-29 at 15 02 05](https://user-images.githubusercontent.com/31692/204564443-2fbb580b-b422-4d0c-a94f-2dfa254e0208.png)
