### PR TITLE
Remove `/most-read/society.json` healthcheck from onwards

### DIFF
--- a/onward/app/controllers/HealthCheck.scala
+++ b/onward/app/controllers/HealthCheck.scala
@@ -10,5 +10,4 @@ class HealthCheck(wsClient: WSClient, val controllerComponents: ControllerCompon
     executionContext: ExecutionContext,
 ) extends AllGoodCachedHealthCheck(
       NeverExpiresSingleHealthCheck("/top-stories.json"),
-      NeverExpiresSingleHealthCheck("/most-read/society.json"),
     )(wsClient, executionContext)


### PR DESCRIPTION
Co-authored-by: Marjan Kalanaki <marjan.kalanaki@guardian.co.uk>
Co-authored-by: James Gorrie <james.gorrie@guardian.co.uk>

## What does this change?
It removes `/most-read/society.json` healthcheck from onwards, because if CAPI returns empty `mostViewed`, [the endpoint returns 404](https://github.com/guardian/frontend/blob/main/onward/app/controllers/MostPopularController.scala#L73) and healthcheck fails while 404 is a valid response. 

<img width="678" alt="image" src="https://user-images.githubusercontent.com/19683595/204596034-7e26b817-f660-41c9-91de-2009b59c1a9c.png">

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
