### PR TITLE
Setup empty test for billboards in merchandising slots

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,6 +12,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       TableOfContents,
       EuropeNetworkFront,
       DCRJavascriptBundle,
+      BillboardsInMerchSlots,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -71,4 +72,13 @@ object EuropeNetworkFront
       owners = Seq(Owner.withGithub("rowannekabalan")),
       sellByDate = LocalDate.of(2023, 3, 1),
       participationGroup = Perc0D,
+    )
+
+object BillboardsInMerchSlots
+    extends Experiment(
+      name = "billboards-in-merch-slots",
+      description = "Test commercial impact of serving billboard sized ads in merchandising slots",
+      owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
+      sellByDate = LocalDate.of(2023, 2, 1),
+      participationGroup = Perc0E,
     )


### PR DESCRIPTION
## What does this change?

Introduce a server-side test for including 970x250 billboard sized adverts in merchandising slots. This will just be a zero-percent test for now.

This is just the empty test: the next step will be to render different slots based on participation in DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Introduce the test into PROD early to avoid having to mess around with headers locally. ~This way I can switch it on and use it against local DCR/Commercial straight-away.~ EDIT: This will probably still require messing with headers actually!

### Tested

- [X] Locally
- [ ] On CODE (optional)