### PR TITLE
Ad labels refactor

### DIFF
--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -25,8 +25,5 @@
     }
     aria-hidden="true"
     >
-    @if(name == "top-above-nav") {
-        <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-    }
     @placeholderContent
 </div>

--- a/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.spec.ts
@@ -5,7 +5,6 @@ jest.mock('../../../common/modules/commercial/commercial-features', () => ({
 }));
 
 const adSelector = '.js-ad-slot';
-const labelSelector = '.ad-slot__label';
 
 const adverts: Record<string, string> = {
 	withLabel: `
@@ -42,69 +41,62 @@ describe('Rendering advert labels', () => {
 		document.body.innerHTML = '';
 	});
 
+	//To test the new style of ad label, we need to be able to use the window.getComputedStyle(element, pseudoSelector)
+	//function, but the pseudo selector capability isn't currently supported by JSDOM. So for now we can't access
+	//pseudo elements in the DOM while testing, which means we can't test for ad label rendering.
+	//However, we can at least make sure that 'data-label-show' is correctly assigned for each test case.
+
 	it('Can add a label', async () => {
 		createAd(adverts['withLabel']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector);
-			expect(label).not.toBeNull();
-		});
-	});
-
-	it('The label has a message', async () => {
-		createAd(adverts['withLabel']);
-		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector) as Element;
-			expect(label.textContent).toBe('Advertisement');
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeTruthy();
 		});
 	});
 
 	it('Will not add a label if it has an attribute data-label="false"', async () => {
 		createAd(adverts['labelDisabled']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector);
-			expect(label).toBeNull();
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label if the adSlot already has one', async () => {
 		createAd(adverts['alreadyLabelled']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelectorAll(labelSelector);
-			expect(label.length).toBe(1);
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label to frame ads', async () => {
 		createAd(adverts['frame']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector);
-			expect(label).toBeNull();
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
 		createAd(adverts['uh']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector);
-			expect(label).toBeNull();
-		});
-	});
-
-	it('When the ad is top above nav and the label is toggleable, make the label visible', async () => {
-		createAd(adverts['topAboveNavToggleLabel']);
-		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const adSlotLabel = getAd().querySelector(labelSelector);
-			expect(adSlotLabel).not.toBeNull();
-			const label = document.querySelector(labelSelector) as HTMLElement;
-			expect(label.classList.contains('visible')).toBe(true);
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
 		});
 	});
 
 	it('When the ad is top above nav and the label is NOT toggleable, render the label dynamically', async () => {
 		createAd(adverts['topAboveNav']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector) as HTMLElement;
-			expect(label.textContent).toEqual('Advertisement');
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeTruthy();
 		});
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.spec.ts
@@ -49,8 +49,7 @@ describe('Rendering advert labels', () => {
 	it('Can add a label', async () => {
 		createAd(adverts['withLabel']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeTruthy();
 		});
 	});
@@ -58,8 +57,7 @@ describe('Rendering advert labels', () => {
 	it('Will not add a label if it has an attribute data-label="false"', async () => {
 		createAd(adverts['labelDisabled']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
 		});
 	});
@@ -67,8 +65,7 @@ describe('Rendering advert labels', () => {
 	it('Will not add a label if the adSlot already has one', async () => {
 		createAd(adverts['alreadyLabelled']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
 		});
 	});
@@ -76,8 +73,7 @@ describe('Rendering advert labels', () => {
 	it('Will not add a label to frame ads', async () => {
 		createAd(adverts['frame']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
 		});
 	});
@@ -85,8 +81,7 @@ describe('Rendering advert labels', () => {
 	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
 		createAd(adverts['uh']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
 		});
 	});
@@ -94,8 +89,7 @@ describe('Rendering advert labels', () => {
 	it('When the ad is top above nav and the label is NOT toggleable, render the label dynamically', async () => {
 		createAd(adverts['topAboveNav']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeTruthy();
 		});
 	});

--- a/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.ts
@@ -1,8 +1,14 @@
+/* eslint-disable @typescript-eslint/no-misused-promises
+-- Fastdom measure and mutate signatures are Promise<void>
+-- Nested fastdom measure-mutate promises throw the error:
+-- "Promise returned in function argument where a void return was expected"
+*/
+
 import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
 import { shouldRenderLabel } from '../dfp/render-advert-label';
 
-const createAdCloseDiv = (): HTMLElement => {
+export const createAdCloseDiv = (): HTMLElement => {
 	const closeDiv: HTMLElement = document.createElement('button');
 	closeDiv.className = 'ad-slot__close-button';
 	closeDiv.innerHTML = crossIcon.markup;
@@ -15,12 +21,19 @@ const createAdCloseDiv = (): HTMLElement => {
 	return closeDiv;
 };
 
-const createAdLabel = (): HTMLElement => {
-	const adLabel = document.createElement('div');
-	adLabel.className = 'ad-slot__label';
-	adLabel.innerHTML = 'Advertisement';
-	adLabel.appendChild(createAdCloseDiv());
-	return adLabel;
+export const renderConsentlessAdvertLabel = (
+	adSlotNode: HTMLElement,
+): Promise<Promise<void>> => {
+	return fastdom.measure(() => {
+		if (shouldRenderLabel(adSlotNode)) {
+			return fastdom.mutate(() => {
+				//when the time comes to use a different ad label for consentless, we can update
+				//the attribute name that we set below and add a css selector accordingly
+				adSlotNode.setAttribute('data-label-show', 'true');
+			});
+		}
+		return Promise.resolve();
+	});
 };
 
 // TODO: flesh out this function once we have a better idea of what we want it to look like
@@ -34,63 +47,3 @@ const createAdLabel = (): HTMLElement => {
 // 	consentlessLabelInfo.innerHTML = `Opt Out: Why am I seeing this?`;
 // 	adLabelNode.appendChild(consentlessLabelInfo);
 // };
-
-/**
- *  **Dynamic labels:**
- *  Advert labels are historically inserted dynamically as a child of the advert slot node.
- *  This causes a cumulative layout shift (CLS) as content below is pushed down. This is
- *  particularly noticeable when ads are refreshed as the advert slot contents are deleted.
- *
- *  **Toggled labels:**
- *  To prevent CLS the label inserted on the server with its visibility initially hidden.
- *  Its visibility and width is toggled once the ad and its width is known.
- *  Currently only for dfp-ad--top-above-nav.
- * @param {HTMLElement} adSlotNode
- */
-export const renderConsentlessAdvertLabel = (
-	adSlotNode: HTMLElement,
-): Promise<Promise<void>> => {
-	let renderDynamic = true;
-	const shouldRender = shouldRenderLabel(adSlotNode);
-
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises -- fastdom miss-typed
-	return fastdom.measure(async () => {
-		if (adSlotNode.id === 'dfp-ad--top-above-nav') {
-			const labelToggle = document.querySelector<HTMLElement>(
-				'.ad-slot__label.ad-slot__label--toggle',
-			);
-			// const adLabelNode =
-			// adSlotNode.querySelector<HTMLElement>('.ad-slot__label');
-
-			// if (adLabelNode) {
-			// insertConsentlessLabelInfo(adLabelNode);
-			// }
-
-			if (labelToggle) {
-				// found a toggled label so don't render dynamically
-				renderDynamic = false;
-				if (shouldRender) {
-					await fastdom.mutate(() => {
-						labelToggle.classList.remove('hidden');
-						labelToggle.classList.add('visible');
-					});
-				} else {
-					// some ads should not have a label
-					// for example fabric ads can have an embedded label
-					// so don't display and remove from layout
-					await fastdom.mutate(() => {
-						labelToggle.style.display = 'none';
-					});
-				}
-			}
-		}
-
-		if (renderDynamic && shouldRender) {
-			const adLabelNode = createAdLabel();
-			await fastdom.mutate(() => {
-				adSlotNode.prepend(adLabelNode);
-				// insertConsentlessLabelInfo(adLabelNode);
-			});
-		}
-	});
-};

--- a/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.ts
@@ -26,10 +26,14 @@ export const renderConsentlessAdvertLabel = (
 ): Promise<Promise<void>> => {
 	return fastdom.measure(() => {
 		if (shouldRenderLabel(adSlotNode)) {
+			//Assigning the ad label text like this allows us to conditionally add extra text to it
+			//eg. for the ad test labelling for google ads
+			const adLabelContent = `Advertisement`;
 			return fastdom.mutate(() => {
 				//when the time comes to use a different ad label for consentless, we can update
 				//the attribute name that we set below and add a css selector accordingly
 				adSlotNode.setAttribute('data-label-show', 'true');
+				adSlotNode.setAttribute('ad-label-text', adLabelContent);
 			});
 		}
 		return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.ts
@@ -1,5 +1,27 @@
+import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
-import { createAdLabel, shouldRenderLabel } from '../dfp/render-advert-label';
+import { shouldRenderLabel } from '../dfp/render-advert-label';
+
+const createAdCloseDiv = (): HTMLElement => {
+	const closeDiv: HTMLElement = document.createElement('button');
+	closeDiv.className = 'ad-slot__close-button';
+	closeDiv.innerHTML = crossIcon.markup;
+	closeDiv.onclick = () => {
+		const container: HTMLElement | null = closeDiv.closest(
+			'.mobilesticky-container',
+		);
+		if (container) container.remove();
+	};
+	return closeDiv;
+};
+
+const createAdLabel = (): HTMLElement => {
+	const adLabel = document.createElement('div');
+	adLabel.className = 'ad-slot__label';
+	adLabel.innerHTML = 'Advertisement';
+	adLabel.appendChild(createAdCloseDiv());
+	return adLabel;
+};
 
 // TODO: flesh out this function once we have a better idea of what we want it to look like
 // const insertConsentlessLabelInfo = (adLabelNode: HTMLElement): void => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
@@ -9,7 +9,7 @@ const labelSelector = '.ad-slot__label';
 
 const adverts: Record<string, string> = {
 	withLabel: `
-        <div class="js-ad-slot"></div>`,
+        <div class="js-ad-slot" data-label-show="true"></div>`,
 	labelDisabled: `
         <div class="js-ad-slot" data-label="false"></div>`,
 	alreadyLabelled: `
@@ -45,8 +45,11 @@ describe('Rendering advert labels', () => {
 	it('Can add a label', async () => {
 		createAd(adverts['withLabel']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector);
-			expect(label).not.toBeNull();
+			const ad = getAd().querySelector('.js-ad-slot');
+			const labelStyles = ad && getComputedStyle(ad, '::before');
+			if (labelStyles) {
+				expect(labelStyles.content).toBe('Advertisement');
+			}
 		});
 	});
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
@@ -49,8 +49,7 @@ describe('Rendering advert labels', () => {
 	it('Can add a label', async () => {
 		createAd(adverts['withLabel']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeTruthy();
 		});
 	});
@@ -58,8 +57,7 @@ describe('Rendering advert labels', () => {
 	it('Will not add a label if it has an attribute data-label="false"', async () => {
 		createAd(adverts['labelDisabled']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
 		});
 	});
@@ -67,8 +65,7 @@ describe('Rendering advert labels', () => {
 	it('Will not add a label if the adSlot already has one', async () => {
 		createAd(adverts['alreadyLabelled']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
 		});
 	});
@@ -76,8 +73,7 @@ describe('Rendering advert labels', () => {
 	it('Will not add a label to frame ads', async () => {
 		createAd(adverts['frame']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
 		});
 	});
@@ -85,8 +81,7 @@ describe('Rendering advert labels', () => {
 	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
 		createAd(adverts['uh']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
 		});
 	});
@@ -94,8 +89,7 @@ describe('Rendering advert labels', () => {
 	it('When the ad is top above nav and the label is NOT toggleable, render the label dynamically', async () => {
 		createAd(adverts['topAboveNav']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const adElement = getAd();
-			const dataLabelShow = adElement.getAttribute('data-label-show');
+			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeTruthy();
 		});
 	});

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
@@ -5,7 +5,6 @@ jest.mock('../../../common/modules/commercial/commercial-features', () => ({
 }));
 
 const adSelector = '.js-ad-slot';
-const labelSelector = '.ad-slot__label';
 
 const adverts: Record<string, string> = {
 	withLabel: `
@@ -89,16 +88,6 @@ describe('Rendering advert labels', () => {
 			const adElement = getAd();
 			const dataLabelShow = adElement.getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
-		});
-	});
-
-	it('When the ad is top above nav and the label is toggleable, make the label visible', async () => {
-		createAd(adverts['topAboveNavToggleLabel']);
-		return renderAdvertLabel(getAd()).then(() => {
-			const adSlotLabel = getAd().querySelector(labelSelector);
-			expect(adSlotLabel).not.toBeNull();
-			const label = document.querySelector(labelSelector) as HTMLElement;
-			expect(label.classList.contains('visible')).toBe(true);
 		});
 	});
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
@@ -9,7 +9,7 @@ const labelSelector = '.ad-slot__label';
 
 const adverts: Record<string, string> = {
 	withLabel: `
-        <div class="js-ad-slot" data-label-show="true"></div>`,
+        <div class="js-ad-slot"></div>`,
 	labelDisabled: `
         <div class="js-ad-slot" data-label="false"></div>`,
 	alreadyLabelled: `
@@ -42,54 +42,53 @@ describe('Rendering advert labels', () => {
 		document.body.innerHTML = '';
 	});
 
+	//To test the new style of ad label, we need to be able to use the window.getComputedStyle(element, pseudoSelector)
+	//function, but the pseudo selector capability isn't currently supported by JSDOM. So for now we can't access
+	//pseudo elements in the DOM while testing, which means we can't test for ad label rendering.
+	//However, we can at least make sure that 'data-label-show' is correctly assigned for each test case.
+
 	it('Can add a label', async () => {
 		createAd(adverts['withLabel']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const ad = getAd().querySelector('.js-ad-slot');
-			const labelStyles = ad && getComputedStyle(ad, '::before');
-			if (labelStyles) {
-				expect(labelStyles.content).toBe('Advertisement');
-			}
-		});
-	});
-
-	it('The label has a message', async () => {
-		createAd(adverts['withLabel']);
-		return renderAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector) as Element;
-			expect(label.textContent).toBe('Advertisement');
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeTruthy();
 		});
 	});
 
 	it('Will not add a label if it has an attribute data-label="false"', async () => {
 		createAd(adverts['labelDisabled']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector);
-			expect(label).toBeNull();
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label if the adSlot already has one', async () => {
 		createAd(adverts['alreadyLabelled']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelectorAll(labelSelector);
-			expect(label.length).toBe(1);
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label to frame ads', async () => {
 		createAd(adverts['frame']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector);
-			expect(label).toBeNull();
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
 		createAd(adverts['uh']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector);
-			expect(label).toBeNull();
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
 		});
 	});
 
@@ -106,8 +105,9 @@ describe('Rendering advert labels', () => {
 	it('When the ad is top above nav and the label is NOT toggleable, render the label dynamically', async () => {
 		createAd(adverts['topAboveNav']);
 		return renderAdvertLabel(getAd()).then(() => {
-			const label = getAd().querySelector(labelSelector) as HTMLElement;
-			expect(label.textContent).toEqual('Advertisement');
+			const adElement = getAd();
+			const dataLabelShow = adElement.getAttribute('data-label-show');
+			expect(dataLabelShow).toBeTruthy();
 		});
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -9,7 +9,8 @@ import fastdom from '../../../../lib/fastdom-promise';
 
 const shouldRenderLabel = (adSlotNode: HTMLElement): boolean =>
 	!(
-		adSlotNode.classList.contains('ad-slot--fluid') ||
+		(adSlotNode.classList.contains('ad-slot--fluid') &&
+			!adSlotNode.classList.contains('ad-slot--interscroller')) ||
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
@@ -48,9 +49,7 @@ const createAdTestLabel = (): string => {
 	let adTestLabel = '';
 
 	const shouldRender = shouldRenderAdTestLabel();
-	console.log(shouldRender);
 	const val = getCookie({ name: 'adtest', shouldMemoize: true });
-	console.log(val);
 
 	if (shouldRender && val) {
 		adTestLabel += ` [?adtest=${val}] `;
@@ -72,6 +71,8 @@ const createAdTestLabel = (): string => {
  */
 const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 	return fastdom.measure(() => {
+		console.log(adSlotNode);
+		console.log(adSlotNode.classList.contains('ad-slot--interscroller'));
 		if (shouldRenderLabel(adSlotNode)) {
 			const adLabelContent = `Advertisement${createAdTestLabel()}`;
 			return fastdom.mutate(() => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -80,19 +80,6 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 	});
 };
 
-const renderInterscrollerAdLabel = (adSlotNode: HTMLElement): Promise<void> =>
-	fastdom.measure(() => {
-		const adSlotLabel: HTMLElement = document.createElement('div');
-		adSlotLabel.classList.add('ad-slot__label');
-		adSlotLabel.style.cssText = `
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;`;
-		adSlotLabel.innerHTML = 'Advertisement';
-		adSlotNode.appendChild(adSlotLabel);
-	});
-
 const renderStickyScrollForMoreLabel = (
 	adSlotNode: HTMLElement,
 ): Promise<void> =>
@@ -113,7 +100,6 @@ const renderStickyScrollForMoreLabel = (
 
 export {
 	renderAdvertLabel,
-	renderInterscrollerAdLabel,
 	renderStickyScrollForMoreLabel,
 	shouldRenderLabel,
 	createAdCloseDiv,

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -4,7 +4,6 @@
 -- "Promise returned in function argument where a void return was expected"
 */
 import { getCookie } from '@guardian/libs';
-import type { String } from 'lodash';
 import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -25,15 +25,21 @@ const shouldRenderLabel = (adSlotNode: HTMLElement): boolean =>
 	);
 
 const createAdCloseDiv = (): HTMLElement => {
-	const closeDiv: HTMLElement = document.createElement('button');
-	closeDiv.className = 'ad-slot__close-button';
-	closeDiv.innerHTML = crossIcon.markup;
-	closeDiv.onclick = () => {
-		const container: HTMLElement | null = closeDiv.closest(
+	const buttonDiv: HTMLElement = document.createElement('button');
+	buttonDiv.className = 'ad-slot__close-button';
+	buttonDiv.innerHTML = crossIcon.markup;
+	buttonDiv.onclick = () => {
+		const container: HTMLElement | null = buttonDiv.closest(
 			'.mobilesticky-container',
 		);
 		if (container) container.remove();
 	};
+
+	const closeDiv: HTMLElement = document.createElement('div');
+	closeDiv.style.cssText =
+		'position: relative;padding: 0 0.5rem;text-align: left;box-sizing: border-box;';
+	closeDiv.appendChild(buttonDiv);
+
 	return closeDiv;
 };
 
@@ -88,12 +94,10 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
 				adSlotNode.setAttribute('ad-label-text', adLabelContent);
-				const closeButtonDiv: HTMLElement =
-					document.createElement('div');
-				closeButtonDiv.style.cssText =
-					'position: relative;padding: 0 0.5rem;text-align: left;box-sizing: border-box;';
-				closeButtonDiv.appendChild(createAdCloseDiv());
-				adSlotNode.insertBefore(closeButtonDiv, adSlotNode.firstChild);
+				adSlotNode.insertBefore(
+					createAdCloseDiv(),
+					adSlotNode.firstChild,
+				);
 				if (shouldRenderAdTestLabel()) {
 					adSlotNode.insertBefore(
 						createAdTestCookieRemovalLink(),

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -57,6 +57,27 @@ const createAdTestLabel = (): string => {
 	return adTestLabel;
 };
 
+const createAdTestCookieRemovalLink = (): HTMLElement => {
+	const shouldRender = shouldRenderAdTestLabel();
+	const val = getCookie({ name: 'adtest', shouldMemoize: true });
+
+	const adTestCookieRemovalLink = document.createElement('div');
+	adTestCookieRemovalLink.style.cssText =
+		'position: relative;padding: 0 0.5rem;text-align: left;box-sizing: border-box;';
+
+	if (shouldRender && val) {
+		const url = new URL(window.location.href);
+		url.searchParams.set('adtest', 'clear');
+		const clearLink = document.createElement('a');
+		clearLink.className = 'ad-slot__adtest-cookie-clear-link';
+		clearLink.href = url.href;
+		clearLink.innerHTML = 'clear';
+		adTestCookieRemovalLink.appendChild(clearLink);
+	}
+
+	return adTestCookieRemovalLink;
+};
+
 /**
  * @param {HTMLElement} adSlotNode
  */
@@ -73,6 +94,12 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 					'position: relative;padding: 0 0.5rem;text-align: left;box-sizing: border-box;';
 				closeButtonDiv.appendChild(createAdCloseDiv());
 				adSlotNode.insertBefore(closeButtonDiv, adSlotNode.firstChild);
+				if (shouldRenderAdTestLabel()) {
+					adSlotNode.insertBefore(
+						createAdTestCookieRemovalLink(),
+						adSlotNode.firstChild,
+					);
+				}
 			});
 		}
 		return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -57,7 +57,6 @@ const createAdTestLabel = (): string => {
 
 	if (shouldRender && val) {
 		adTestLabel += ` [?adtest=${val}] `;
-		//the functionality to clear the adtest cookie will be reimplemented in a future ticket
 	}
 
 	return adTestLabel;

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -43,9 +43,7 @@ const shouldRenderAdTestLabel = (): boolean =>
 		shouldMemoize: true,
 	});
 // If `adtest` cookie is set, display its value in the ad label
-// Furthermore, provide a link to clear the cookie
 const createAdTestLabel = (): string => {
-	//const adTestLabel = document.createElement('span');
 	let adTestLabel = '';
 
 	const shouldRender = shouldRenderAdTestLabel();
@@ -53,14 +51,7 @@ const createAdTestLabel = (): string => {
 
 	if (shouldRender && val) {
 		adTestLabel += ` [?adtest=${val}] `;
-
-		//const url = new URL(window.location.href);
-		//url.searchParams.set('adtest', 'clear');
-
-		//const clearLink = document.createElement('a');
-		//clearLink.href = url.href;
-		//clearLink.innerHTML = 'clear';
-		//adTestLabel.appendChild(clearLink);
+		//the functionality to clear the adtest cookie will be reimplemented in a future ticket
 	}
 
 	return adTestLabel;

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -3,7 +3,7 @@
 -- Nested fastdom measure-mutate promises throw the error:
 -- "Promise returned in function argument where a void return was expected"
 */
-import { getCookie } from '@guardian/libs';
+//import { getCookie } from '@guardian/libs';
 import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
 
@@ -13,7 +13,6 @@ const shouldRenderLabel = (adSlotNode: HTMLElement): boolean =>
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
-		adSlotNode.classList.contains('ad-slot--fluid') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
 		adSlotNode.getAttribute('data-label') === 'false' ||

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -76,6 +76,12 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
 				adSlotNode.setAttribute('ad-label-text', adLabelContent);
+				const closeButtonDiv: HTMLElement =
+					document.createElement('div');
+				closeButtonDiv.style.cssText =
+					'position: relative;padding: 0 0.5rem;text-align: left;box-sizing: border-box;';
+				closeButtonDiv.appendChild(createAdCloseDiv());
+				adSlotNode.insertBefore(closeButtonDiv, adSlotNode.firstChild);
 			});
 		}
 		return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -13,6 +13,7 @@ const shouldRenderLabel = (adSlotNode: HTMLElement): boolean =>
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
+		adSlotNode.classList.contains('ad-slot--fluid') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
 		adSlotNode.getAttribute('data-label') === 'false' ||

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -71,8 +71,6 @@ const createAdTestLabel = (): string => {
  */
 const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 	return fastdom.measure(() => {
-		console.log(adSlotNode);
-		console.log(adSlotNode.classList.contains('ad-slot--interscroller'));
 		if (shouldRenderLabel(adSlotNode)) {
 			const adLabelContent = `Advertisement${createAdTestLabel()}`;
 			return fastdom.mutate(() => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -3,7 +3,8 @@
 -- Nested fastdom measure-mutate promises throw the error:
 -- "Promise returned in function argument where a void return was expected"
 */
-//import { getCookie } from '@guardian/libs';
+import { getCookie } from '@guardian/libs';
+import type { String } from 'lodash';
 import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
 
@@ -36,35 +37,36 @@ const createAdCloseDiv = (): HTMLElement => {
 	return closeDiv;
 };
 
-/*const shouldRenderAdTestLabel = (): boolean =>
+const shouldRenderAdTestLabel = (): boolean =>
 	!!getCookie({
 		name: 'adtestInLabels',
 		shouldMemoize: true,
 	});
-*/
 // If `adtest` cookie is set, display its value in the ad label
 // Furthermore, provide a link to clear the cookie
-/*const createAdTestLabel = (): HTMLElement => {
-	const adTestLabel = document.createElement('span');
+const createAdTestLabel = (): string => {
+	//const adTestLabel = document.createElement('span');
+	let adTestLabel = '';
 
 	const shouldRender = shouldRenderAdTestLabel();
+	console.log(shouldRender);
 	const val = getCookie({ name: 'adtest', shouldMemoize: true });
+	console.log(val);
 
 	if (shouldRender && val) {
-		adTestLabel.innerHTML += ` [?adtest=${val}] `;
+		adTestLabel += ` [?adtest=${val}] `;
 
-		const url = new URL(window.location.href);
-		url.searchParams.set('adtest', 'clear');
+		//const url = new URL(window.location.href);
+		//url.searchParams.set('adtest', 'clear');
 
-		const clearLink = document.createElement('a');
-		clearLink.href = url.href;
-		clearLink.innerHTML = 'clear';
-		adTestLabel.appendChild(clearLink);
+		//const clearLink = document.createElement('a');
+		//clearLink.href = url.href;
+		//clearLink.innerHTML = 'clear';
+		//adTestLabel.appendChild(clearLink);
 	}
 
 	return adTestLabel;
 };
-*/
 
 /**
  * @param {HTMLElement} adSlotNode
@@ -72,8 +74,10 @@ const createAdCloseDiv = (): HTMLElement => {
 const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 	return fastdom.measure(() => {
 		if (shouldRenderLabel(adSlotNode)) {
+			const adLabelContent = `Advertisement${createAdTestLabel()}`;
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
+				adSlotNode.setAttribute('ad-label-text', adLabelContent);
 			});
 		}
 		return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -36,15 +36,15 @@ const createAdCloseDiv = (): HTMLElement => {
 	return closeDiv;
 };
 
-const shouldRenderAdTestLabel = (): boolean =>
+/*const shouldRenderAdTestLabel = (): boolean =>
 	!!getCookie({
 		name: 'adtestInLabels',
 		shouldMemoize: true,
 	});
-
+*/
 // If `adtest` cookie is set, display its value in the ad label
 // Furthermore, provide a link to clear the cookie
-const createAdTestLabel = (): HTMLElement => {
+/*const createAdTestLabel = (): HTMLElement => {
 	const adTestLabel = document.createElement('span');
 
 	const shouldRender = shouldRenderAdTestLabel();
@@ -64,59 +64,16 @@ const createAdTestLabel = (): HTMLElement => {
 
 	return adTestLabel;
 };
-
-const createAdLabel = (): HTMLElement => {
-	const adLabel = document.createElement('div');
-	adLabel.className = 'ad-slot__label';
-	adLabel.innerHTML = 'Advertisement';
-	adLabel.appendChild(createAdTestLabel());
-	adLabel.appendChild(createAdCloseDiv());
-	return adLabel;
-};
+*/
 
 /**
- *  **Dynamic labels:**
- *  Advert labels are historically inserted dynamically as a child of the advert slot node.
- *  This causes a cumulative layout shift (CLS) as content below is pushed down. This is
- *  particularly noticeable when ads are refreshed as the advert slot contents are deleted.
- *
- *  **Toggled labels:**
- *  To prevent CLS the label inserted on the server with its visibility initially hidden.
- *  Its visibility and width is toggled once the ad and its width is known.
- *  Currently only for dfp-ad--top-above-nav.
  * @param {HTMLElement} adSlotNode
  */
 const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
-	let renderDynamic = true;
-	const shouldRender = shouldRenderLabel(adSlotNode);
-
 	return fastdom.measure(() => {
-		if (adSlotNode.id === 'dfp-ad--top-above-nav') {
-			const labelToggle = document.querySelector<HTMLElement>(
-				'.ad-slot__label.ad-slot__label--toggle',
-			);
-			if (labelToggle) {
-				// found a toggled label so don't render dynamically
-				renderDynamic = false;
-				if (shouldRender) {
-					void fastdom.mutate(() => {
-						labelToggle.classList.remove('hidden');
-						labelToggle.classList.add('visible');
-					});
-				} else {
-					// some ads should not have a label
-					// for example fabric ads can have an embedded label
-					// so don't display and remove from layout
-					return fastdom.mutate(() => {
-						labelToggle.style.display = 'none';
-					});
-				}
-			}
-		}
-
-		if (renderDynamic && shouldRender) {
+		if (shouldRenderLabel(adSlotNode)) {
 			return fastdom.mutate(() => {
-				adSlotNode.prepend(createAdLabel());
+				adSlotNode.setAttribute('data-label-show', 'true');
 			});
 		}
 		return Promise.resolve();
@@ -160,5 +117,4 @@ export {
 	renderStickyScrollForMoreLabel,
 	shouldRenderLabel,
 	createAdCloseDiv,
-	createAdLabel,
 };

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.ts
@@ -199,7 +199,7 @@ const setupBackground = async (
 				adSlot.style.position = 'relative';
 			}
 
-			void renderAdvertLabel(backgroundParent);
+			void renderAdvertLabel(adSlot);
 			void renderStickyScrollForMoreLabel(backgroundParent);
 
 			isDCR && renderBottomLine(background, backgroundParent);

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.ts
@@ -2,7 +2,7 @@ import type { RegisterListener } from '@guardian/commercial-core';
 import { isObject } from '@guardian/libs';
 import fastdom from '../../../../lib/fastdom-promise';
 import {
-	renderInterscrollerAdLabel,
+	renderAdvertLabel,
 	renderStickyScrollForMoreLabel,
 } from '../dfp/render-advert-label';
 
@@ -199,7 +199,7 @@ const setupBackground = async (
 				adSlot.style.position = 'relative';
 			}
 
-			void renderInterscrollerAdLabel(adSlot);
+			void renderAdvertLabel(backgroundParent);
 			void renderStickyScrollForMoreLabel(backgroundParent);
 
 			isDCR && renderBottomLine(background, backgroundParent);

--- a/static/src/javascripts/projects/commercial/modules/remove-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/remove-slots.spec.js
@@ -1,7 +1,6 @@
 import { removeSlots, removeDisabledSlots } from './remove-slots';
 
 const adSlotSelector = '.js-ad-slot';
-const toggledAdLabelSelector = '.ad-slot__label--toggle';
 
 describe('Remove ad slots and labels', () => {
 	afterEach(() => {
@@ -9,57 +8,33 @@ describe('Remove ad slots and labels', () => {
 			document.body.innerHTML = '';
 		}
 	});
-	test('Remove all ad slots and toggled labels', () => {
+	test('Remove all ad slots', () => {
 		if (document.body) {
 			document.body.innerHTML = `
                 <div>
-                    <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-                    <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-                    <div class="ad-slot__label">Advertisement</div>
                     <div class="js-ad-slot"></div>
                     <div class="js-ad-slot"></div>
                 </div>
             `;
 		}
 		expect(document.querySelectorAll(adSlotSelector).length).toEqual(2);
-		expect(
-			document.querySelectorAll(toggledAdLabelSelector).length,
-		).toEqual(2);
 		return removeSlots().then(() => {
 			expect(document.querySelectorAll(adSlotSelector).length).toEqual(0);
-			expect(
-				document.querySelectorAll(toggledAdLabelSelector).length,
-			).toEqual(0);
-			expect(document.querySelectorAll('.ad-slot__label').length).toEqual(
-				1,
-			);
 		});
 	});
 
-	test('Remove all disabled (ie display: none) ad slots and toggled labels', () => {
+	test('Remove all disabled (ie display: none) ad slots', () => {
 		if (document.body) {
 			document.body.innerHTML = `
                 <div>
-                    <div style="display: none" class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-                    <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-                    <div class="ad-slot__label">Advertisement</div>
                     <div style="display: none" class="js-ad-slot"></div>
                     <div class="js-ad-slot"></div>
                 </div>
             `;
 		}
 		expect(document.querySelectorAll(adSlotSelector).length).toEqual(2);
-		expect(
-			document.querySelectorAll(toggledAdLabelSelector).length,
-		).toEqual(2);
 		return removeDisabledSlots().then(() => {
 			expect(document.querySelectorAll(adSlotSelector).length).toEqual(1);
-			expect(
-				document.querySelectorAll(toggledAdLabelSelector).length,
-			).toEqual(1);
-			expect(document.querySelectorAll('.ad-slot__label').length).toEqual(
-				2,
-			);
 		});
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/remove-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/remove-slots.ts
@@ -4,11 +4,7 @@ import { dfpEnv } from './dfp/dfp-env';
 
 // Remove ad slots
 // Remove toggled ad labels that sit outside of the ad slot
-const selectors: string[] = [
-	dfpEnv.adSlotSelector,
-	'.ad-slot__label--toggle',
-	'.top-banner-ad-container',
-];
+const selectors: string[] = [dfpEnv.adSlotSelector, '.top-banner-ad-container'];
 
 const selectNodes = () =>
 	selectors.reduce(

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -600,7 +600,7 @@
 
 .ad-slot[data-label-show='true']:not(.ad-slot--dark):not(.ad-slot--interscroller)::before {
     @include font-size(12, 20);
-    content: 'Advertisement';
+    content: attr(ad-label-text);
     display: block;
     visibility: visible;
     position: relative;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -90,12 +90,6 @@
 .ad-slot--top-banner-ad {
     text-align: center;
 
-    .ad-slot__label {
-        @include mq(wide) {
-            margin: 0;
-        }
-    }
-
     .has-page-skin & {
         @include mq(wide) {
             text-align: center;
@@ -268,7 +262,7 @@
     @include mq(tablet) {
         padding-bottom: $gs-baseline*2;
 
-        & > div:not(.ad-slot__label) {
+        & > div {
             width: 300px;
             margin-left: auto;
             margin-right: auto;
@@ -277,11 +271,6 @@
 }
 .ad-slot--liveblog-inline {
     background-color: $brightness-93;
-
-    .ad-slot__label {
-        color: $brightness-46;
-        border-top-color: $brightness-86;
-    }
 }
 .ad-slot--mpu-banner-ad {
     display: none;
@@ -448,12 +437,6 @@
     }
 }
 
-.ad-slot--gc {
-    .ad-slot__label {
-        display: none;
-    }
-}
-
 .ad-slot--fabric-v1 {
     min-height: 250px;
 }
@@ -478,10 +461,6 @@
     width: auto;
     margin-left: 0;
     padding: 0;
-
-    .ad-slot__label {
-        display: none;
-    }
 }
 
 .ad-slot--fluid250 {
@@ -555,7 +534,7 @@
     text-align: center;
 }
 
-.ad-slot--mobile-sticky .ad-slot__label .ad-slot__close-button {
+.ad-slot--mobile-sticky .ad-slot__close-button {
     display: block;
 }
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -516,7 +516,7 @@
     display: none;
     position: absolute;
     right: 3px;
-    top: 3px;
+    top: -21px;
     padding: 0;
     border: 0;
     height: $mpu-ad-label-height - 3px;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -35,45 +35,6 @@
     }
 }
 
-.ad-slot__label {
-    @include font-size(12, 20);
-    position: relative;
-    height: $mpu-ad-label-height;
-    max-height: $mpu-ad-label-height;
-    background-color: $brightness-97;
-    padding: 0 ($gs-baseline/3)*2;
-    border-top: 1px solid $brightness-86;
-    color: $brightness-46;
-    text-align: left;
-    box-sizing: border-box;
-    font-family: $f-sans-serif-text;
-
-    .ad-slot--dark & {
-        color: $brightness-86;
-        border-top-color: $brightness-20;
-        background-color: transparent;
-    }
-
-    .ad-slot--sky & {
-        width: $mpu-skyscraper-width;
-    }
-
-    &--toggle {
-        margin: 0 auto;
-        @include mq($until: tablet) {
-            display: none;
-        }
-    }
-
-    &.visible {
-        visibility: initial;
-    }
-
-    &.hidden {
-        visibility: hidden;
-    }
-}
-
 /**
  * Banner ads
  */

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -637,7 +637,7 @@
     visibility: hidden;
 }
 
-.ad-slot[data-label-show='true']:not([data-label='false'])::before {
+.ad-slot[data-label-show='true']:not(.ad-slot--dark)::before {
     @include font-size(12, 20);
     content: 'Advertisement';
     display: block;
@@ -648,6 +648,22 @@
     padding: 0 ($gs-baseline/3)*2;
     border-top: 1px solid $brightness-86;
     color: $brightness-46;
+    text-align: left;
+    box-sizing: border-box;
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+}
+
+.ad-slot--dark[data-label-show='true']::before {
+    @include font-size(12, 20);
+    content: 'Advertisement';
+    display: block;
+    visibility: visible;
+    position: relative;
+    height: $mpu-ad-label-height;
+    background-color: transparent;
+    padding: 0 ($gs-baseline/3)*2;
+    border-top: 1px solid $brightness-20;
+    color: $brightness-86;
     text-align: left;
     box-sizing: border-box;
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -627,3 +627,14 @@
     left: 0px;
     right: 0px;
 }
+
+.ad-slot__adtest-cookie-clear-link {
+    @include font-size(12, 20);
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    text-align: left;
+    position: absolute;
+    right: 3px;
+    top: -22px;
+    padding: 0;
+    border: 0;
+}

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -629,3 +629,26 @@
     margin-bottom: 12px;
     position: relative;
 }
+
+.ad-slot:not[data-label-show='true']::before {
+    content: '';
+    display: block;
+    height: $mpu-ad-label-height;
+    visibility: hidden;
+}
+
+.ad-slot[data-label-show='true']:not([data-label='false'])::before {
+    @include font-size(12, 20);
+    content: 'Advertisement';
+    display: block;
+    visibility: visible;
+    position: relative;
+    height: $mpu-ad-label-height;
+    background-color: $brightness-97;
+    padding: 0 ($gs-baseline/3)*2;
+    border-top: 1px solid $brightness-86;
+    color: $brightness-46;
+    text-align: left;
+    box-sizing: border-box;
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+}

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -598,7 +598,7 @@
     visibility: hidden;
 }
 
-.ad-slot[data-label-show='true']:not(.ad-slot--dark)::before {
+.ad-slot[data-label-show='true']:not(.ad-slot--dark):not(.ad-slot--interscroller)::before {
     @include font-size(12, 20);
     content: 'Advertisement';
     display: block;
@@ -628,4 +628,23 @@
     text-align: left;
     box-sizing: border-box;
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+}
+
+.ad-slot--interscroller[data-label-show='true']::before {
+    content: 'Advertisement';
+    display: block;
+    visibility: visible;
+    height: $mpu-ad-label-height;
+    background-color: transparent;
+    padding: 0 ($gs-baseline/3)*2;
+    border: 0;
+    border-top: 1px solid $brightness-20;
+    color: $brightness-86;
+    text-align: left;
+    box-sizing: border-box;
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    right: 0px;
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -595,7 +595,7 @@
 
 .ad-slot--dark[data-label-show='true']::before {
     @include font-size(12, 20);
-    content: 'Advertisement';
+    content: attr(ad-label-text);
     display: block;
     visibility: visible;
     position: relative;

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -127,9 +127,6 @@
         }
 
         .gallery__divider,
-        .ad-slot--dark .ad-slot__label {
-            border-top-color: $brightness-93;
-        }
 
         .gallery__meta-container::before,
         .gallery::before {

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -4,8 +4,8 @@
  ],
  "../lib/detect-adblock.ts": [],
  "../lib/detect-breakpoint.ts": [
-  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/detect-viewport.ts"
  ],
  "../lib/detect-google-proxy.ts": [],
@@ -162,7 +162,7 @@
  "../projects/commercial/modules/dfp/Advert.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/fastdom-promise.ts",
   "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
   "../projects/commercial/modules/dfp/define-slot.ts"
@@ -186,7 +186,7 @@
  ],
  "../projects/commercial/modules/dfp/define-slot.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/url.ts",
   "../projects/common/modules/commercial/lib/googletag-ad-size.ts",
@@ -345,7 +345,7 @@
   "../projects/common/modules/commercial/geo-utils.ts"
  ],
  "../projects/commercial/modules/dfp/refresh-on-resize.ts": [
-  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/detect-breakpoint.ts",
   "../lib/mediator.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
@@ -490,7 +490,7 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/detect-breakpoint.ts",
   "../lib/fastdom-promise.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts"
@@ -541,7 +541,7 @@
  ],
  "../projects/commercial/modules/sticky-inlines.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/fastdom-promise.ts"
  ],
  "../projects/commercial/modules/third-party-tags.ts": [


### PR DESCRIPTION
## What does this change?
Uses new rendering logic for the ad labels. Instead of creating divs, we use CSS pseudo :before elements to add ad labels. This moves some of our rendering logic to the stylesheets, and helps to remove some code complexity needed to handle different edge cases.

The adtest labelling functionality has also been recreated, using CSS attributes to allow us to update the label content.

DCR PR: https://github.com/guardian/dotcom-rendering/pull/6628

### Tested

- [X] Locally
- [X] On CODE (optional)
