### PR TITLE
Add outstream to inline2+ on liveblogs on desktop

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,7 +67,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "liveblog-desktop-outstream",
+    "ab-liveblog-desktop-outstream",
     "Test the impact of enabling outstream on inline2+ on liveblogs on desktop",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -64,4 +64,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2023, 1, 31)),
     exposeClientSide = true,
   )
+
+    Switch(
+    ABTests,
+    "liveblog-desktop-outstream",
+    "Test the impact of enabling outstream on inline2+ on liveblogs on desktop",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 1, 31)),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -65,7 +65,7 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
-    Switch(
+  Switch(
     ABTests,
     "liveblog-desktop-outstream",
     "Test the impact of enabling outstream on inline2+ on liveblogs on desktop",

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -1,4 +1,6 @@
 import { adSizes, createAdSlot } from '@guardian/commercial-core';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { liveblogDesktopOutstream } from 'common/modules/experiments/tests/liveblog-desktop-outstream';
 import { getCurrentBreakpoint } from 'lib/detect-breakpoint';
 import { getUrlVars } from 'lib/url';
 import fastdom from '../../../lib/fastdom-promise';
@@ -114,16 +116,22 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 			}
 		})
 		.then(() => {
-			addSlot(ad, false, {
-				phablet: [
-					adSizes.outstreamDesktop,
-					adSizes.outstreamGoogleDesktop,
-				],
-				desktop: [
-					adSizes.outstreamDesktop,
-					adSizes.outstreamGoogleDesktop,
-				],
-			});
+			addSlot(
+				ad,
+				false,
+				isInVariantSynchronous(liveblogDesktopOutstream, 'variant')
+					? {
+							phablet: [
+								adSizes.outstreamDesktop,
+								adSizes.outstreamGoogleDesktop,
+							],
+							desktop: [
+								adSizes.outstreamDesktop,
+								adSizes.outstreamGoogleDesktop,
+							],
+					  }
+					: {},
+			);
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -120,7 +120,8 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 				ad,
 				false,
 				isInVariantSynchronous(liveblogDesktopOutstream, 'variant')
-					? {
+					? {}
+					: {
 							phablet: [
 								adSizes.outstreamDesktop,
 								adSizes.outstreamGoogleDesktop,
@@ -129,8 +130,7 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 								adSizes.outstreamDesktop,
 								adSizes.outstreamGoogleDesktop,
 							],
-					  }
-					: {},
+					  },
 			);
 		});
 };

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -1,4 +1,4 @@
-import { createAdSlot } from '@guardian/commercial-core';
+import { adSizes, createAdSlot } from '@guardian/commercial-core';
 import { getCurrentBreakpoint } from 'lib/detect-breakpoint';
 import { getUrlVars } from 'lib/url';
 import fastdom from '../../../lib/fastdom-promise';
@@ -114,7 +114,16 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 			}
 		})
 		.then(() => {
-			addSlot(ad, false);
+			addSlot(ad, false, {
+				phablet: [
+					adSizes.outstreamDesktop,
+					adSizes.outstreamGoogleDesktop,
+				],
+				desktop: [
+					adSizes.outstreamDesktop,
+					adSizes.outstreamGoogleDesktop,
+				],
+			});
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -119,9 +119,8 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 			addSlot(
 				ad,
 				false,
-				isInVariantSynchronous(liveblogDesktopOutstream, 'variant')
-					? {}
-					: {
+				!isInVariantSynchronous(liveblogDesktopOutstream, 'control')
+					? {
 							phablet: [
 								adSizes.outstreamDesktop,
 								adSizes.outstreamGoogleDesktop,
@@ -130,7 +129,8 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 								adSizes.outstreamDesktop,
 								adSizes.outstreamGoogleDesktop,
 							],
-					  },
+					  }
+					: {},
 			);
 		});
 };

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { integrateIma } from './tests/integrate-ima';
+import { liveblogDesktopOutstream } from './tests/liveblog-desktop-outstream';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { removePrebidA9Canada } from './tests/removePrebidA9Canada';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -17,4 +18,5 @@ export const concurrentTests: readonly ABTest[] = [
 	consentlessAds,
 	integrateIma,
 	removePrebidA9Canada,
+	liveblogDesktopOutstream,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { noop } from '../../../../../lib/noop';
+import { bypassMetricsSampling } from '../utils';
 
 export const liveblogDesktopOutstream: ABTest = {
 	id: 'LiveblogDesktopOutstream',
@@ -8,13 +9,13 @@ export const liveblogDesktopOutstream: ABTest = {
 	author: 'Jake Lee Kennedy',
 	description:
 		'Test the impact of enabling outstream on inline2+ on liveblogs on desktop',
-	audience: 95 / 100,
+	audience: 5 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Opt in',
 	successMeasure: 'No significant impact to CWV',
 	canRun: () => true,
 	variants: [
 		{ id: 'control', test: () => noop },
-		{ id: 'variant', test: () => noop },
+		{ id: 'variant', test: () => bypassMetricsSampling },
 	],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts
@@ -1,5 +1,4 @@
 import type { ABTest } from '@guardian/ab-core';
-import { noop } from '../../../../../lib/noop';
 import { bypassMetricsSampling } from '../utils';
 
 export const liveblogDesktopOutstream: ABTest = {
@@ -15,7 +14,7 @@ export const liveblogDesktopOutstream: ABTest = {
 	successMeasure: 'No significant impact to CWV',
 	canRun: () => true,
 	variants: [
-		{ id: 'control', test: () => noop },
+		{ id: 'control', test: () => bypassMetricsSampling },
 		{ id: 'variant', test: () => bypassMetricsSampling },
 	],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts
@@ -1,0 +1,20 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const liveblogDesktopOutstream: ABTest = {
+	id: 'IntegrateIma',
+	start: '2022-12-02',
+	expiry: '2023-01-31',
+	author: 'Jake Lee Kennedy',
+	description:
+		'Test the impact of enabling outstream on inline2+ on liveblogs on desktop',
+	audience: 95 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in',
+	successMeasure: 'No significant impact to CWV',
+	canRun: () => true,
+	variants: [
+		{ id: 'control', test: () => noop },
+		{ id: 'variant', test: () => noop },
+	],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts
@@ -2,7 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { noop } from '../../../../../lib/noop';
 
 export const liveblogDesktopOutstream: ABTest = {
-	id: 'IntegrateIma',
+	id: 'LiveblogDesktopOutstream',
 	start: '2022-12-02',
 	expiry: '2023-01-31',
 	author: 'Jake Lee Kennedy',

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -1,698 +1,605 @@
 {
- "../../../../../Prebid.js/build/dist/prebid.js": [],
- "../lib/$$.ts": [
-  "../../../../node_modules/csstype/index.d.ts"
- ],
- "../lib/detect-adblock.ts": [],
- "../lib/detect-breakpoint.ts": [
-  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
-  "../lib/detect-viewport.ts"
- ],
- "../lib/detect-google-proxy.ts": [],
- "../lib/detect-pushstate.ts": [],
- "../lib/detect-viewport.ts": [],
- "../lib/events.ts": [],
- "../lib/fastdom-promise.ts": [
-  "../../../../node_modules/fastdom/extensions/fastdom-promised.d.ts",
-  "../../../../node_modules/fastdom/fastdom.d.ts"
- ],
- "../lib/fetch-json.ts": [],
- "../lib/geolocation.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/report-error.ts"
- ],
- "../lib/manage-ad-free-cookie.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../projects/common/modules/commercial/lib/cookie.ts"
- ],
- "../lib/mediator.ts": [
-  "../../../../node_modules/wolfy87-eventemitter/EventEmitter.d.ts"
- ],
- "../lib/noop.ts": [],
- "../lib/partition.ts": [],
- "../lib/raven.ts": [
-  "../../../../node_modules/raven-js/typescript/raven.d.ts",
-  "../../../../node_modules/raven-js/typescript/raven.d.ts",
-  "../lib/detect-adblock.ts"
- ],
- "../lib/report-error.ts": [
-  "../lib/raven.ts"
- ],
- "../lib/robust.ts": [
-  "../lib/report-error.ts"
- ],
- "../lib/time-utils.ts": [],
- "../lib/url.ts": [
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/detect-pushstate.ts"
- ],
- "../projects/commercial/adblock-ask.ts": [
-  "../lib/fastdom-promise.ts",
-  "../projects/common/modules/commercial/contributions-utilities.ts",
-  "../projects/common/modules/commercial/support-utilities.ts",
-  "../projects/common/modules/commercial/user-features.ts"
- ],
- "../projects/commercial/am-i-used.ts": [],
- "../projects/commercial/modules/ad-free-slot-remove.ts": [
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../projects/commercial/modules/remove-slots.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts"
- ],
- "../projects/commercial/modules/article-aside-adverts.ts": [
-  "../lib/$$.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/mediator.ts"
- ],
- "../projects/commercial/modules/article-body-adverts.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/mediator.ts",
-  "../lib/url.ts",
-  "../projects/commercial/modules/carrot-traffic-driver.ts",
-  "../projects/commercial/modules/dfp/add-slot.ts",
-  "../projects/commercial/modules/dfp/wait-for-advert.ts",
-  "../projects/commercial/modules/sticky-inlines.ts",
-  "../projects/common/modules/article/space-filler.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/spacefinder-debug-tools.ts",
-  "../projects/common/modules/spacefinder.ts"
- ],
- "../projects/commercial/modules/carrot-traffic-driver.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/url.ts",
-  "../projects/commercial/modules/dfp/add-slot.ts",
-  "../projects/common/modules/article/space-filler.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/spacefinder.ts"
- ],
- "../projects/commercial/modules/comment-adverts.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/mediator.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/add-slot.ts",
-  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/comscore.ts": [
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/consentless/define-slot.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/fastdom/fastdom.d.ts",
-  "../projects/commercial/modules/consentless/render-advert-label.ts"
- ],
- "../projects/commercial/modules/consentless/dynamic/article-inline.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/url.ts",
-  "../projects/commercial/modules/consentless/define-slot.ts",
-  "../projects/commercial/modules/sticky-inlines.ts",
-  "../projects/common/modules/article/space-filler.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/spacefinder-debug-tools.ts",
-  "../projects/common/modules/spacefinder.ts"
- ],
- "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/url.ts",
-  "../projects/commercial/modules/consentless/define-slot.ts",
-  "../projects/common/modules/article/space-filler.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/spacefinder.ts"
- ],
- "../projects/commercial/modules/consentless/init-fixed-slots.ts": [
-  "../projects/commercial/modules/consentless/define-slot.ts"
- ],
- "../projects/commercial/modules/consentless/prepare-ootag.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/consentless/render-advert-label.ts": [
-  "../lib/fastdom-promise.ts",
-  "../projects/commercial/modules/dfp/render-advert-label.ts"
- ],
- "../projects/commercial/modules/creatives/page-skin.ts": [
-  "../../../../node_modules/fastdom/fastdom.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/mediator.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/dfp/Advert.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
-  "../projects/commercial/modules/dfp/define-slot.ts"
- ],
- "../projects/commercial/modules/dfp/add-slot.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/report-error.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/create-advert.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/dfp/lazy-load.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts",
-  "../projects/commercial/modules/dfp/queue-advert.ts"
- ],
- "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
- "../projects/commercial/modules/dfp/create-advert.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/report-error.ts",
-  "../projects/commercial/modules/dfp/Advert.ts"
- ],
- "../projects/commercial/modules/dfp/define-slot.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/url.ts",
-  "../projects/common/modules/commercial/lib/googletag-ad-size.ts",
-  "../types/ias.d.ts"
- ],
- "../projects/commercial/modules/dfp/dfp-env-globals.ts": [],
- "../projects/commercial/modules/dfp/dfp-env.ts": [
-  "../lib/url.ts",
-  "../projects/commercial/modules/dfp/Advert.ts"
- ],
- "../projects/commercial/modules/dfp/display-ads.ts": [
-  "../projects/commercial/modules/creatives/page-skin.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts"
- ],
- "../projects/commercial/modules/dfp/display-lazy-ads.ts": [
-  "../lib/partition.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/dfp/lazy-load.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts"
- ],
- "../projects/commercial/modules/dfp/empty-advert.ts": [
-  "../../../../node_modules/fastdom/fastdom.d.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "../projects/commercial/modules/dfp/fill-advert-slots.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/create-advert.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/dfp/display-ads.ts",
-  "../projects/commercial/modules/dfp/display-lazy-ads.ts",
-  "../projects/commercial/modules/dfp/prepare-prebid.ts",
-  "../projects/commercial/modules/dfp/queue-advert.ts",
-  "../projects/commercial/modules/remove-slots.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/dfp/get-ad-iframe.ts": [],
- "../projects/commercial/modules/dfp/get-advert-by-id.ts": [
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "../projects/commercial/modules/dfp/lazy-load.ts": [
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts"
- ],
- "../projects/commercial/modules/dfp/load-advert.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/header-bidding/a9/a9.ts",
-  "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts"
- ],
- "../projects/commercial/modules/dfp/non-refreshable-line-items.ts": [
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/report-error.ts"
- ],
- "../projects/commercial/modules/dfp/on-slot-load.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../projects/commercial/modules/dfp/get-advert-by-id.ts"
- ],
- "../projects/commercial/modules/dfp/on-slot-render.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/report-error.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/dfp/empty-advert.ts",
-  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/render-advert.ts",
-  "../projects/commercial/modules/dfp/should-refresh.ts"
- ],
- "../projects/commercial/modules/dfp/on-slot-viewable.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/url.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/lazy-load.ts",
-  "../projects/commercial/modules/dfp/non-refreshable-line-items.ts",
-  "../projects/commercial/modules/dfp/should-refresh.ts"
- ],
- "../projects/commercial/modules/dfp/prepare-a9.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/detect-google-proxy.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/header-bidding/a9/a9.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/commercial/geo-utils.ts"
- ],
- "../projects/commercial/modules/dfp/prepare-googletag.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/raven.ts",
-  "../lib/report-error.ts",
-  "../projects/commercial/modules/dfp/fill-advert-slots.ts",
-  "../projects/commercial/modules/dfp/on-slot-load.ts",
-  "../projects/commercial/modules/dfp/on-slot-render.ts",
-  "../projects/commercial/modules/dfp/on-slot-viewable.ts",
-  "../projects/commercial/modules/dfp/refresh-on-resize.ts",
-  "../projects/commercial/modules/messenger/background.ts",
-  "../projects/commercial/modules/messenger/click.ts",
-  "../projects/commercial/modules/messenger/disable-refresh.ts",
-  "../projects/commercial/modules/messenger/get-page-targeting.ts",
-  "../projects/commercial/modules/messenger/get-page-url.ts",
-  "../projects/commercial/modules/messenger/get-stylesheet.ts",
-  "../projects/commercial/modules/messenger/measure-ad-load.ts",
-  "../projects/commercial/modules/messenger/passback.ts",
-  "../projects/commercial/modules/messenger/resize.ts",
-  "../projects/commercial/modules/messenger/scroll.ts",
-  "../projects/commercial/modules/messenger/type.ts",
-  "../projects/commercial/modules/messenger/viewport.ts",
-  "../projects/commercial/modules/remove-slots.ts",
-  "../projects/common/modules/commercial/build-page-targeting.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/dfp/prepare-permutive.ts": [
-  "../lib/report-error.ts"
- ],
- "../projects/commercial/modules/dfp/prepare-prebid.ts": [
-  "../../../../../Prebid.js/build/dist/prebid.js",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/detect-google-proxy.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/commercial/geo-utils.ts"
- ],
- "../projects/commercial/modules/dfp/queue-advert.ts": [
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "../projects/commercial/modules/dfp/redplanet.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/commercial/geo-utils.ts"
- ],
- "../projects/commercial/modules/dfp/refresh-on-resize.ts": [
-  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/mediator.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts"
- ],
- "../projects/commercial/modules/dfp/render-advert-label.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/fastdom-promise.ts"
- ],
- "../projects/commercial/modules/dfp/render-advert.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/$$.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/report-error.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/get-ad-iframe.ts",
-  "../projects/commercial/modules/dfp/render-advert-label.ts"
- ],
- "../projects/commercial/modules/dfp/should-refresh.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../projects/commercial/modules/dfp/Advert.ts"
- ],
- "../projects/commercial/modules/dfp/wait-for-advert.ts": [
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/get-advert-by-id.ts"
- ],
- "../projects/commercial/modules/header-bidding/a9/a9.ts": [
-  "../lib/noop.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/header-bidding/slot-config.ts"
- ],
- "../projects/commercial/modules/header-bidding/prebid/appnexus.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/build-page-targeting.ts",
-  "../projects/common/modules/commercial/geo-utils.ts"
- ],
- "../projects/commercial/modules/header-bidding/prebid/bid-config.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/url.ts",
-  "../projects/commercial/modules/header-bidding/prebid/appnexus.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/build-page-targeting.ts",
-  "../projects/common/modules/commercial/geo-utils.ts"
- ],
- "../projects/commercial/modules/header-bidding/prebid/prebid.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/esm/constants/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
-  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/header-bidding/prebid/bid-config.ts",
-  "../projects/commercial/modules/header-bidding/prebid/price-config.ts",
-  "../projects/commercial/modules/header-bidding/slot-config.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/build-page-targeting.ts"
- ],
- "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
- ],
- "../projects/commercial/modules/header-bidding/slot-config.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts"
- ],
- "../projects/commercial/modules/header-bidding/utils.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/url.ts",
-  "../projects/common/modules/commercial/geo-utils.ts"
- ],
- "../projects/commercial/modules/high-merch.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/ipsos-mori.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/commercial/modules/liveblog-adverts.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/fastdom-promise.ts",
-  "../lib/url.ts",
-  "../projects/commercial/modules/dfp/add-slot.ts",
-  "../projects/common/modules/article/space-filler.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/spacefinder.ts"
- ],
- "../projects/commercial/modules/manage-ad-free-cookie-on-consent-change.ts": [
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/manage-ad-free-cookie.ts",
-  "../projects/commercial/modules/remove-slots.ts"
- ],
- "../projects/commercial/modules/messenger/background.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../projects/commercial/modules/dfp/render-advert-label.ts"
- ],
- "../projects/commercial/modules/messenger/click.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../projects/common/modules/analytics/google.ts"
- ],
- "../projects/commercial/modules/messenger/disable-refresh.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "../projects/commercial/modules/messenger/get-page-targeting.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
- ],
- "../projects/commercial/modules/messenger/get-page-url.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
- ],
- "../projects/commercial/modules/messenger/get-stylesheet.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/commercial/modules/messenger/measure-ad-load.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/commercial/modules/messenger/passback.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../lib/fastdom-promise.ts",
-  "../projects/commercial/modules/dfp/dfp-env-globals.ts"
- ],
- "../projects/commercial/modules/messenger/resize.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/fastdom-promise.ts"
- ],
- "../projects/commercial/modules/messenger/scroll.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/detect-viewport.ts",
-  "../lib/events.ts",
-  "../lib/fastdom-promise.ts"
- ],
- "../projects/commercial/modules/messenger/type.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/fastdom-promise.ts"
- ],
- "../projects/commercial/modules/messenger/viewport.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/detect-viewport.ts",
-  "../lib/fastdom-promise.ts"
- ],
- "../projects/commercial/modules/mobile-sticky.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../projects/commercial/modules/dfp/add-slot.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts"
- ],
- "../projects/commercial/modules/paid-containers.ts": [
-  "../../../../node_modules/fastdom/fastdom.d.ts",
-  "../lib/$$.ts"
- ],
- "../projects/commercial/modules/remove-slots.ts": [
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "../projects/commercial/modules/set-adtest-cookie.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/url.ts"
- ],
- "../projects/commercial/modules/set-adtest-in-labels-cookie.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/url.ts"
- ],
- "../projects/commercial/modules/sticky-inlines.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
-  "../lib/fastdom-promise.ts"
- ],
- "../projects/commercial/modules/third-party-tags.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../projects/commercial/modules/third-party-tags/imr-worldwide-legacy.ts",
-  "../projects/commercial/modules/third-party-tags/imr-worldwide.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/commercial/modules/third-party-tags/imr-worldwide-legacy.ts": [
-  "../projects/common/modules/commercial/geo-utils.ts"
- ],
- "../projects/commercial/modules/third-party-tags/imr-worldwide.ts": [
-  "../projects/common/modules/commercial/geo-utils.ts"
- ],
- "../projects/commercial/modules/track-gpc-signal.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/commercial/modules/track-labs-container.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/commercial/modules/track-scroll-depth.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/common/modules/analytics/google.ts": [
-  "../../../../node_modules/web-vitals/dist/modules/index.d.ts",
-  "../lib/mediator.ts"
- ],
- "../projects/common/modules/analytics/mvt-cookie.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/common/modules/article/space-filler.ts": [
-  "../lib/raven.ts",
-  "../projects/common/modules/spacefinder.ts"
- ],
- "../projects/common/modules/async-call-merger.ts": [],
- "../projects/common/modules/commercial/build-page-targeting.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/commercial-features.ts"
- ],
- "../projects/common/modules/commercial/commercial-features.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/detect-breakpoint.ts",
-  "../projects/common/modules/commercial/user-features.ts",
-  "../projects/common/modules/user-prefs.ts"
- ],
- "../projects/common/modules/commercial/contributions-utilities.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/common/modules/commercial/geo-utils.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/geolocation.ts"
- ],
- "../projects/common/modules/commercial/lib/cookie.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../projects/common/modules/commercial/lib/googletag-ad-size.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
- ],
- "../projects/common/modules/commercial/support-utilities.ts": [
-  "../lib/geolocation.ts"
- ],
- "../projects/common/modules/commercial/user-features.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@guardian/support-dotcom-components/dist/dotcom/src/types.d.ts",
-  "../lib/fetch-json.ts",
-  "../lib/manage-ad-free-cookie.ts",
-  "../lib/noop.ts",
-  "../lib/time-utils.ts",
-  "../projects/common/modules/commercial/lib/cookie.ts",
-  "../types/dates.ts",
-  "../types/membership.ts"
- ],
- "../projects/common/modules/spacefinder-debug-tools.ts": [
-  "../projects/common/modules/spacefinder.ts"
- ],
- "../projects/common/modules/spacefinder.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/fastdom-promise.ts",
-  "../projects/commercial/am-i-used.ts",
-  "../projects/common/modules/spacefinder-debug-tools.ts"
- ],
- "../projects/common/modules/user-prefs.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../types/dates.ts": [],
- "../types/ias.d.ts": [],
- "../types/membership.ts": [
-  "../types/dates.ts"
- ],
- "commercial.consentless.ts": [
-  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
-  "../lib/manage-ad-free-cookie.ts",
-  "../projects/commercial/modules/consentless/dynamic/article-inline.ts",
-  "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts",
-  "../projects/commercial/modules/consentless/init-fixed-slots.ts",
-  "../projects/commercial/modules/consentless/prepare-ootag.ts",
-  "../projects/commercial/modules/set-adtest-cookie.ts",
-  "../projects/commercial/modules/set-adtest-in-labels-cookie.ts"
- ],
- "standalone.commercial.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/report-error.ts",
-  "../lib/robust.ts",
-  "../projects/commercial/adblock-ask.ts",
-  "../projects/commercial/modules/ad-free-slot-remove.ts",
-  "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts",
-  "../projects/commercial/modules/article-aside-adverts.ts",
-  "../projects/commercial/modules/article-body-adverts.ts",
-  "../projects/commercial/modules/comment-adverts.ts",
-  "../projects/commercial/modules/comscore.ts",
-  "../projects/commercial/modules/dfp/dfp-env-globals.ts",
-  "../projects/commercial/modules/dfp/prepare-a9.ts",
-  "../projects/commercial/modules/dfp/prepare-googletag.ts",
-  "../projects/commercial/modules/dfp/prepare-permutive.ts",
-  "../projects/commercial/modules/dfp/prepare-prebid.ts",
-  "../projects/commercial/modules/dfp/redplanet.ts",
-  "../projects/commercial/modules/high-merch.ts",
-  "../projects/commercial/modules/ipsos-mori.ts",
-  "../projects/commercial/modules/liveblog-adverts.ts",
-  "../projects/commercial/modules/manage-ad-free-cookie-on-consent-change.ts",
-  "../projects/commercial/modules/mobile-sticky.ts",
-  "../projects/commercial/modules/paid-containers.ts",
-  "../projects/commercial/modules/remove-slots.ts",
-  "../projects/commercial/modules/set-adtest-cookie.ts",
-  "../projects/commercial/modules/set-adtest-in-labels-cookie.ts",
-  "../projects/commercial/modules/third-party-tags.ts",
-  "../projects/commercial/modules/track-gpc-signal.ts",
-  "../projects/commercial/modules/track-labs-container.ts",
-  "../projects/commercial/modules/track-scroll-depth.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/commercial/user-features.ts",
-  "commercial.consentless.ts",
-  "types.ts"
- ],
- "types.ts": []
+ "bootstraps/commercial.consentless.ts": [
+  "lib/manage-ad-free-cookie.ts",
+  "projects/commercial/modules/consentless/dynamic/article-inline.ts",
+  "projects/commercial/modules/consentless/dynamic/liveblog-inline.ts",
+  "projects/commercial/modules/consentless/init-fixed-slots.ts",
+  "projects/commercial/modules/consentless/prepare-ootag.ts",
+  "projects/commercial/modules/set-adtest-cookie.ts",
+  "projects/commercial/modules/set-adtest-in-labels-cookie.ts"
+ ],
+ "bootstraps/standalone.commercial.ts": [
+  "bootstraps/commercial.consentless.ts",
+  "bootstraps/types.ts",
+  "lib/report-error.ts",
+  "lib/robust.ts",
+  "projects/commercial/adblock-ask.ts",
+  "projects/commercial/modules/ad-free-slot-remove.ts",
+  "projects/commercial/modules/ad-verification/prepare-ad-verification.ts",
+  "projects/commercial/modules/article-aside-adverts.ts",
+  "projects/commercial/modules/article-body-adverts.ts",
+  "projects/commercial/modules/comment-adverts.ts",
+  "projects/commercial/modules/comscore.ts",
+  "projects/commercial/modules/dfp/dfp-env-globals.ts",
+  "projects/commercial/modules/dfp/prepare-a9.ts",
+  "projects/commercial/modules/dfp/prepare-googletag.ts",
+  "projects/commercial/modules/dfp/prepare-permutive.ts",
+  "projects/commercial/modules/dfp/prepare-prebid.ts",
+  "projects/commercial/modules/dfp/redplanet.ts",
+  "projects/commercial/modules/high-merch.ts",
+  "projects/commercial/modules/ipsos-mori.ts",
+  "projects/commercial/modules/liveblog-adverts.ts",
+  "projects/commercial/modules/manage-ad-free-cookie-on-consent-change.ts",
+  "projects/commercial/modules/mobile-sticky.ts",
+  "projects/commercial/modules/paid-containers.ts",
+  "projects/commercial/modules/remove-slots.ts",
+  "projects/commercial/modules/set-adtest-cookie.ts",
+  "projects/commercial/modules/set-adtest-in-labels-cookie.ts",
+  "projects/commercial/modules/third-party-tags.ts",
+  "projects/commercial/modules/track-gpc-signal.ts",
+  "projects/commercial/modules/track-labs-container.ts",
+  "projects/commercial/modules/track-scroll-depth.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/commercial/user-features.ts",
+  "projects/common/modules/experiments/ab.ts",
+  "projects/common/modules/experiments/tests/consentlessAds.ts"
+ ],
+ "bootstraps/types.ts": [],
+ "lib/$$.ts": [],
+ "lib/detect-adblock.ts": [],
+ "lib/detect-breakpoint.ts": [
+  "lib/detect-viewport.ts"
+ ],
+ "lib/detect-google-proxy.ts": [],
+ "lib/detect-pushstate.ts": [],
+ "lib/detect-viewport.ts": [],
+ "lib/events.ts": [],
+ "lib/fastdom-promise.ts": [],
+ "lib/fetch-json.ts": [],
+ "lib/geolocation.ts": [
+  "lib/report-error.ts"
+ ],
+ "lib/manage-ad-free-cookie.ts": [
+  "projects/common/modules/commercial/lib/cookie.ts"
+ ],
+ "lib/mediator.ts": [],
+ "lib/noop.ts": [],
+ "lib/partition.ts": [],
+ "lib/raven.ts": [
+  "lib/detect-adblock.ts"
+ ],
+ "lib/report-error.ts": [
+  "lib/raven.ts"
+ ],
+ "lib/robust.ts": [
+  "lib/report-error.ts"
+ ],
+ "lib/time-utils.ts": [],
+ "lib/url.ts": [
+  "lib/detect-pushstate.ts"
+ ],
+ "projects/commercial/adblock-ask.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/common/modules/commercial/contributions-utilities.ts",
+  "projects/common/modules/commercial/support-utilities.ts",
+  "projects/common/modules/commercial/user-features.ts"
+ ],
+ "projects/commercial/am-i-used.ts": [],
+ "projects/commercial/modules/ad-free-slot-remove.ts": [
+  "projects/commercial/modules/remove-slots.ts",
+  "projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
+  "projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "projects/commercial/modules/dfp/load-advert.ts",
+  "projects/commercial/modules/header-bidding/utils.ts"
+ ],
+ "projects/commercial/modules/article-aside-adverts.ts": [
+  "lib/$$.ts",
+  "lib/fastdom-promise.ts",
+  "lib/mediator.ts"
+ ],
+ "projects/commercial/modules/article-body-adverts.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/fastdom-promise.ts",
+  "lib/mediator.ts",
+  "lib/url.ts",
+  "projects/commercial/modules/carrot-traffic-driver.ts",
+  "projects/commercial/modules/dfp/add-slot.ts",
+  "projects/commercial/modules/dfp/wait-for-advert.ts",
+  "projects/commercial/modules/sticky-inlines.ts",
+  "projects/common/modules/article/space-filler.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/spacefinder-debug-tools.ts",
+  "projects/common/modules/spacefinder.ts"
+ ],
+ "projects/commercial/modules/carrot-traffic-driver.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/fastdom-promise.ts",
+  "lib/url.ts",
+  "projects/commercial/modules/dfp/add-slot.ts",
+  "projects/common/modules/article/space-filler.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/spacefinder.ts"
+ ],
+ "projects/commercial/modules/comment-adverts.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/fastdom-promise.ts",
+  "lib/mediator.ts",
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/add-slot.ts",
+  "projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "projects/commercial/modules/dfp/load-advert.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/identity/api.ts"
+ ],
+ "projects/commercial/modules/comscore.ts": [
+  "projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "projects/commercial/modules/consentless/define-slot.ts": [
+  "projects/commercial/modules/consentless/render-advert-label.ts"
+ ],
+ "projects/commercial/modules/consentless/dynamic/article-inline.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/fastdom-promise.ts",
+  "lib/url.ts",
+  "projects/commercial/modules/consentless/define-slot.ts",
+  "projects/commercial/modules/sticky-inlines.ts",
+  "projects/common/modules/article/space-filler.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/spacefinder-debug-tools.ts",
+  "projects/common/modules/spacefinder.ts"
+ ],
+ "projects/commercial/modules/consentless/dynamic/liveblog-inline.ts": [
+  "lib/fastdom-promise.ts",
+  "lib/url.ts",
+  "projects/commercial/modules/consentless/define-slot.ts",
+  "projects/common/modules/article/space-filler.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/spacefinder.ts"
+ ],
+ "projects/commercial/modules/consentless/init-fixed-slots.ts": [
+  "projects/commercial/modules/consentless/define-slot.ts"
+ ],
+ "projects/commercial/modules/consentless/prepare-ootag.ts": [
+  "projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "projects/commercial/modules/consentless/render-advert-label.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/commercial/modules/dfp/render-advert-label.ts"
+ ],
+ "projects/commercial/modules/creatives/page-skin.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/mediator.ts",
+  "projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "projects/commercial/modules/dfp/Advert.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
+  "projects/commercial/modules/dfp/define-slot.ts"
+ ],
+ "projects/commercial/modules/dfp/add-slot.ts": [
+  "lib/report-error.ts",
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/create-advert.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/dfp/lazy-load.ts",
+  "projects/commercial/modules/dfp/load-advert.ts",
+  "projects/commercial/modules/dfp/queue-advert.ts"
+ ],
+ "projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
+ "projects/commercial/modules/dfp/create-advert.ts": [
+  "lib/report-error.ts",
+  "projects/commercial/modules/dfp/Advert.ts"
+ ],
+ "projects/commercial/modules/dfp/define-slot.ts": [
+  "lib/url.ts",
+  "projects/common/modules/commercial/lib/googletag-ad-size.ts",
+  "types/ias.d.ts"
+ ],
+ "projects/commercial/modules/dfp/dfp-env-globals.ts": [],
+ "projects/commercial/modules/dfp/dfp-env.ts": [
+  "lib/url.ts",
+  "projects/commercial/modules/dfp/Advert.ts"
+ ],
+ "projects/commercial/modules/dfp/display-ads.ts": [
+  "projects/commercial/modules/creatives/page-skin.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/dfp/load-advert.ts"
+ ],
+ "projects/commercial/modules/dfp/display-lazy-ads.ts": [
+  "lib/partition.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/dfp/lazy-load.ts",
+  "projects/commercial/modules/dfp/load-advert.ts"
+ ],
+ "projects/commercial/modules/dfp/empty-advert.ts": [
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "projects/commercial/modules/dfp/fill-advert-slots.ts": [
+  "lib/detect-breakpoint.ts",
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/create-advert.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/dfp/display-ads.ts",
+  "projects/commercial/modules/dfp/display-lazy-ads.ts",
+  "projects/commercial/modules/dfp/prepare-prebid.ts",
+  "projects/commercial/modules/dfp/queue-advert.ts",
+  "projects/commercial/modules/remove-slots.ts",
+  "projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "projects/commercial/modules/dfp/get-ad-iframe.ts": [],
+ "projects/commercial/modules/dfp/get-advert-by-id.ts": [
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "projects/commercial/modules/dfp/lazy-load.ts": [
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "projects/commercial/modules/dfp/load-advert.ts"
+ ],
+ "projects/commercial/modules/dfp/load-advert.ts": [
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/header-bidding/a9/a9.ts",
+  "projects/commercial/modules/header-bidding/prebid/prebid.ts",
+  "projects/commercial/modules/header-bidding/utils.ts"
+ ],
+ "projects/commercial/modules/dfp/non-refreshable-line-items.ts": [
+  "lib/report-error.ts"
+ ],
+ "projects/commercial/modules/dfp/on-slot-load.ts": [
+  "projects/commercial/modules/dfp/get-advert-by-id.ts"
+ ],
+ "projects/commercial/modules/dfp/on-slot-render.ts": [
+  "lib/report-error.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/dfp/empty-advert.ts",
+  "projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "projects/commercial/modules/dfp/render-advert.ts",
+  "projects/commercial/modules/dfp/should-refresh.ts"
+ ],
+ "projects/commercial/modules/dfp/on-slot-viewable.ts": [
+  "lib/fastdom-promise.ts",
+  "lib/url.ts",
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "projects/commercial/modules/dfp/lazy-load.ts",
+  "projects/commercial/modules/dfp/non-refreshable-line-items.ts",
+  "projects/commercial/modules/dfp/should-refresh.ts"
+ ],
+ "projects/commercial/modules/dfp/prepare-a9.ts": [
+  "lib/detect-google-proxy.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/header-bidding/a9/a9.ts",
+  "projects/commercial/modules/header-bidding/utils.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/commercial/geo-utils.ts",
+  "projects/common/modules/experiments/ab.ts",
+  "projects/common/modules/experiments/tests/removePrebidA9Canada.ts"
+ ],
+ "projects/commercial/modules/dfp/prepare-googletag.ts": [
+  "lib/raven.ts",
+  "lib/report-error.ts",
+  "projects/commercial/modules/dfp/fill-advert-slots.ts",
+  "projects/commercial/modules/dfp/on-slot-load.ts",
+  "projects/commercial/modules/dfp/on-slot-render.ts",
+  "projects/commercial/modules/dfp/on-slot-viewable.ts",
+  "projects/commercial/modules/dfp/refresh-on-resize.ts",
+  "projects/commercial/modules/messenger/background.ts",
+  "projects/commercial/modules/messenger/click.ts",
+  "projects/commercial/modules/messenger/disable-refresh.ts",
+  "projects/commercial/modules/messenger/get-page-targeting.ts",
+  "projects/commercial/modules/messenger/get-page-url.ts",
+  "projects/commercial/modules/messenger/get-stylesheet.ts",
+  "projects/commercial/modules/messenger/measure-ad-load.ts",
+  "projects/commercial/modules/messenger/passback.ts",
+  "projects/commercial/modules/messenger/resize.ts",
+  "projects/commercial/modules/messenger/scroll.ts",
+  "projects/commercial/modules/messenger/type.ts",
+  "projects/commercial/modules/messenger/viewport.ts",
+  "projects/commercial/modules/remove-slots.ts",
+  "projects/common/modules/commercial/build-page-targeting.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/identity/api.ts"
+ ],
+ "projects/commercial/modules/dfp/prepare-permutive.ts": [
+  "lib/report-error.ts"
+ ],
+ "projects/commercial/modules/dfp/prepare-prebid.ts": [
+  "lib/detect-google-proxy.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/header-bidding/prebid/prebid.ts",
+  "projects/commercial/modules/header-bidding/utils.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/commercial/geo-utils.ts",
+  "projects/common/modules/experiments/ab.ts",
+  "projects/common/modules/experiments/tests/removePrebidA9Canada.ts"
+ ],
+ "projects/commercial/modules/dfp/queue-advert.ts": [
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "projects/commercial/modules/dfp/redplanet.ts": [
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "projects/commercial/modules/dfp/refresh-on-resize.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/mediator.ts",
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/dfp/load-advert.ts"
+ ],
+ "projects/commercial/modules/dfp/render-advert-label.ts": [
+  "lib/fastdom-promise.ts"
+ ],
+ "projects/commercial/modules/dfp/render-advert.ts": [
+  "lib/$$.ts",
+  "lib/fastdom-promise.ts",
+  "lib/report-error.ts",
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/get-ad-iframe.ts",
+  "projects/commercial/modules/dfp/render-advert-label.ts"
+ ],
+ "projects/commercial/modules/dfp/should-refresh.ts": [
+  "projects/commercial/modules/dfp/Advert.ts"
+ ],
+ "projects/commercial/modules/dfp/wait-for-advert.ts": [
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/get-advert-by-id.ts"
+ ],
+ "projects/commercial/modules/header-bidding/a9/a9.ts": [
+  "lib/noop.ts",
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/header-bidding/slot-config.ts"
+ ],
+ "projects/commercial/modules/header-bidding/prebid/appnexus.ts": [
+  "projects/commercial/modules/header-bidding/utils.ts",
+  "projects/common/modules/commercial/build-page-targeting.ts",
+  "projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "projects/commercial/modules/header-bidding/prebid/bid-config.ts": [
+  "lib/url.ts",
+  "projects/commercial/modules/header-bidding/prebid/appnexus.ts",
+  "projects/commercial/modules/header-bidding/utils.ts",
+  "projects/common/modules/commercial/build-page-targeting.ts",
+  "projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "projects/commercial/modules/header-bidding/prebid/prebid.ts": [
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts",
+  "projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "projects/commercial/modules/header-bidding/prebid/bid-config.ts",
+  "projects/commercial/modules/header-bidding/prebid/price-config.ts",
+  "projects/commercial/modules/header-bidding/slot-config.ts",
+  "projects/commercial/modules/header-bidding/utils.ts",
+  "projects/common/modules/commercial/build-page-targeting.ts"
+ ],
+ "projects/commercial/modules/header-bidding/prebid/price-config.ts": [],
+ "projects/commercial/modules/header-bidding/slot-config.ts": [
+  "projects/commercial/modules/dfp/Advert.ts",
+  "projects/commercial/modules/header-bidding/utils.ts"
+ ],
+ "projects/commercial/modules/header-bidding/utils.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/url.ts",
+  "projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "projects/commercial/modules/high-merch.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "projects/commercial/modules/ipsos-mori.ts": [],
+ "projects/commercial/modules/liveblog-adverts.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/fastdom-promise.ts",
+  "lib/url.ts",
+  "projects/commercial/modules/dfp/add-slot.ts",
+  "projects/common/modules/article/space-filler.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/experiments/ab.ts",
+  "projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts",
+  "projects/common/modules/spacefinder.ts"
+ ],
+ "projects/commercial/modules/manage-ad-free-cookie-on-consent-change.ts": [
+  "lib/manage-ad-free-cookie.ts",
+  "projects/commercial/modules/remove-slots.ts"
+ ],
+ "projects/commercial/modules/messenger/background.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/commercial/modules/dfp/render-advert-label.ts"
+ ],
+ "projects/commercial/modules/messenger/click.ts": [
+  "projects/common/modules/analytics/google.ts"
+ ],
+ "projects/commercial/modules/messenger/disable-refresh.ts": [
+  "projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "projects/commercial/modules/messenger/get-page-targeting.ts": [],
+ "projects/commercial/modules/messenger/get-page-url.ts": [],
+ "projects/commercial/modules/messenger/get-stylesheet.ts": [],
+ "projects/commercial/modules/messenger/measure-ad-load.ts": [],
+ "projects/commercial/modules/messenger/passback.ts": [
+  "lib/detect-breakpoint.ts",
+  "lib/fastdom-promise.ts",
+  "projects/commercial/modules/dfp/dfp-env-globals.ts"
+ ],
+ "projects/commercial/modules/messenger/resize.ts": [
+  "lib/fastdom-promise.ts"
+ ],
+ "projects/commercial/modules/messenger/scroll.ts": [
+  "lib/detect-viewport.ts",
+  "lib/events.ts",
+  "lib/fastdom-promise.ts"
+ ],
+ "projects/commercial/modules/messenger/type.ts": [
+  "lib/fastdom-promise.ts"
+ ],
+ "projects/commercial/modules/messenger/viewport.ts": [
+  "lib/detect-viewport.ts",
+  "lib/fastdom-promise.ts"
+ ],
+ "projects/commercial/modules/mobile-sticky.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/commercial/modules/dfp/add-slot.ts",
+  "projects/commercial/modules/header-bidding/utils.ts"
+ ],
+ "projects/commercial/modules/paid-containers.ts": [
+  "lib/$$.ts"
+ ],
+ "projects/commercial/modules/remove-slots.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "projects/commercial/modules/set-adtest-cookie.ts": [
+  "lib/url.ts"
+ ],
+ "projects/commercial/modules/set-adtest-in-labels-cookie.ts": [
+  "lib/url.ts"
+ ],
+ "projects/commercial/modules/sticky-inlines.ts": [
+  "lib/fastdom-promise.ts"
+ ],
+ "projects/commercial/modules/third-party-tags.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/commercial/modules/third-party-tags/imr-worldwide-legacy.ts",
+  "projects/commercial/modules/third-party-tags/imr-worldwide.ts",
+  "projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "projects/commercial/modules/third-party-tags/imr-worldwide-legacy.ts": [
+  "projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "projects/commercial/modules/third-party-tags/imr-worldwide.ts": [
+  "projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "projects/commercial/modules/track-gpc-signal.ts": [],
+ "projects/commercial/modules/track-labs-container.ts": [],
+ "projects/commercial/modules/track-scroll-depth.ts": [],
+ "projects/common/modules/analytics/google.ts": [
+  "lib/mediator.ts"
+ ],
+ "projects/common/modules/analytics/mvt-cookie.ts": [],
+ "projects/common/modules/article/space-filler.ts": [
+  "lib/raven.ts",
+  "projects/common/modules/spacefinder.ts"
+ ],
+ "projects/common/modules/async-call-merger.ts": [],
+ "projects/common/modules/commercial/build-page-targeting.ts": [
+  "projects/commercial/modules/header-bidding/utils.ts",
+  "projects/common/modules/commercial/commercial-features.ts",
+  "projects/common/modules/experiments/ab.ts"
+ ],
+ "projects/common/modules/commercial/commercial-features.ts": [
+  "lib/detect-breakpoint.ts",
+  "projects/common/modules/commercial/user-features.ts",
+  "projects/common/modules/identity/api.ts",
+  "projects/common/modules/user-prefs.ts"
+ ],
+ "projects/common/modules/commercial/contributions-utilities.ts": [],
+ "projects/common/modules/commercial/geo-utils.ts": [
+  "lib/geolocation.ts"
+ ],
+ "projects/common/modules/commercial/lib/cookie.ts": [],
+ "projects/common/modules/commercial/lib/googletag-ad-size.ts": [],
+ "projects/common/modules/commercial/support-utilities.ts": [
+  "lib/geolocation.ts"
+ ],
+ "projects/common/modules/commercial/user-features.ts": [
+  "lib/fetch-json.ts",
+  "lib/manage-ad-free-cookie.ts",
+  "lib/noop.ts",
+  "lib/time-utils.ts",
+  "projects/common/modules/commercial/lib/cookie.ts",
+  "projects/common/modules/identity/api.ts",
+  "types/dates.ts",
+  "types/membership.ts"
+ ],
+ "projects/common/modules/experiments/ab-constants.ts": [],
+ "projects/common/modules/experiments/ab-core.ts": [
+  "lib/time-utils.ts",
+  "projects/common/modules/analytics/mvt-cookie.ts",
+  "projects/common/modules/experiments/ab-constants.ts",
+  "projects/common/modules/experiments/ab-local-storage.ts",
+  "projects/common/modules/experiments/ab-url.ts",
+  "projects/common/modules/experiments/ab-utils.ts",
+  "projects/common/modules/experiments/automatLog.ts"
+ ],
+ "projects/common/modules/experiments/ab-local-storage.ts": [
+  "projects/common/modules/experiments/ab-constants.ts",
+  "projects/common/modules/experiments/ab-utils.ts"
+ ],
+ "projects/common/modules/experiments/ab-ophan.ts": [
+  "lib/noop.ts",
+  "lib/report-error.ts"
+ ],
+ "projects/common/modules/experiments/ab-tests.ts": [
+  "projects/common/modules/experiments/tests/consentlessAds.ts",
+  "projects/common/modules/experiments/tests/deeply-read-article-footer.js",
+  "projects/common/modules/experiments/tests/integrate-ima.ts",
+  "projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts",
+  "projects/common/modules/experiments/tests/remote-header-test.js",
+  "projects/common/modules/experiments/tests/removePrebidA9Canada.ts",
+  "projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
+  "projects/common/modules/experiments/tests/sign-in-gate-main-variant.js"
+ ],
+ "projects/common/modules/experiments/ab-url.ts": [
+  "projects/common/modules/experiments/ab-utils.ts"
+ ],
+ "projects/common/modules/experiments/ab-utils.ts": [
+  "projects/common/modules/experiments/ab-constants.ts"
+ ],
+ "projects/common/modules/experiments/ab.ts": [
+  "projects/common/modules/experiments/ab-core.ts",
+  "projects/common/modules/experiments/ab-local-storage.ts",
+  "projects/common/modules/experiments/ab-ophan.ts",
+  "projects/common/modules/experiments/ab-tests.ts",
+  "projects/common/modules/experiments/ab-url.ts",
+  "projects/common/modules/experiments/ab-utils.ts"
+ ],
+ "projects/common/modules/experiments/automatLog.ts": [],
+ "projects/common/modules/experiments/tests/consentlessAds.ts": [
+  "lib/noop.ts"
+ ],
+ "projects/common/modules/experiments/tests/deeply-read-article-footer.js": [],
+ "projects/common/modules/experiments/tests/integrate-ima.ts": [
+  "lib/noop.ts"
+ ],
+ "projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts": [
+  "lib/noop.ts"
+ ],
+ "projects/common/modules/experiments/tests/remote-header-test.js": [],
+ "projects/common/modules/experiments/tests/removePrebidA9Canada.ts": [
+  "lib/noop.ts",
+  "projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
+ "projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
+ "projects/common/modules/identity/api.ts": [
+  "lib/fetch-json.ts",
+  "lib/mediator.ts",
+  "lib/url.ts",
+  "projects/common/modules/async-call-merger.ts",
+  "projects/common/modules/identity/auth-component-event-params.js"
+ ],
+ "projects/common/modules/identity/auth-component-event-params.js": [
+  "lib/url.ts"
+ ],
+ "projects/common/modules/spacefinder-debug-tools.ts": [
+  "projects/common/modules/spacefinder.ts"
+ ],
+ "projects/common/modules/spacefinder.ts": [
+  "lib/fastdom-promise.ts",
+  "projects/commercial/am-i-used.ts",
+  "projects/common/modules/spacefinder-debug-tools.ts"
+ ],
+ "projects/common/modules/user-prefs.ts": [],
+ "types/dates.ts": [],
+ "types/ias.d.ts": [],
+ "types/membership.ts": [
+  "types/dates.ts"
+ ]
 }

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -1,605 +1,696 @@
 {
- "bootstraps/commercial.consentless.ts": [
-  "lib/manage-ad-free-cookie.ts",
-  "projects/commercial/modules/consentless/dynamic/article-inline.ts",
-  "projects/commercial/modules/consentless/dynamic/liveblog-inline.ts",
-  "projects/commercial/modules/consentless/init-fixed-slots.ts",
-  "projects/commercial/modules/consentless/prepare-ootag.ts",
-  "projects/commercial/modules/set-adtest-cookie.ts",
-  "projects/commercial/modules/set-adtest-in-labels-cookie.ts"
- ],
- "bootstraps/standalone.commercial.ts": [
-  "bootstraps/commercial.consentless.ts",
-  "bootstraps/types.ts",
-  "lib/report-error.ts",
-  "lib/robust.ts",
-  "projects/commercial/adblock-ask.ts",
-  "projects/commercial/modules/ad-free-slot-remove.ts",
-  "projects/commercial/modules/ad-verification/prepare-ad-verification.ts",
-  "projects/commercial/modules/article-aside-adverts.ts",
-  "projects/commercial/modules/article-body-adverts.ts",
-  "projects/commercial/modules/comment-adverts.ts",
-  "projects/commercial/modules/comscore.ts",
-  "projects/commercial/modules/dfp/dfp-env-globals.ts",
-  "projects/commercial/modules/dfp/prepare-a9.ts",
-  "projects/commercial/modules/dfp/prepare-googletag.ts",
-  "projects/commercial/modules/dfp/prepare-permutive.ts",
-  "projects/commercial/modules/dfp/prepare-prebid.ts",
-  "projects/commercial/modules/dfp/redplanet.ts",
-  "projects/commercial/modules/high-merch.ts",
-  "projects/commercial/modules/ipsos-mori.ts",
-  "projects/commercial/modules/liveblog-adverts.ts",
-  "projects/commercial/modules/manage-ad-free-cookie-on-consent-change.ts",
-  "projects/commercial/modules/mobile-sticky.ts",
-  "projects/commercial/modules/paid-containers.ts",
-  "projects/commercial/modules/remove-slots.ts",
-  "projects/commercial/modules/set-adtest-cookie.ts",
-  "projects/commercial/modules/set-adtest-in-labels-cookie.ts",
-  "projects/commercial/modules/third-party-tags.ts",
-  "projects/commercial/modules/track-gpc-signal.ts",
-  "projects/commercial/modules/track-labs-container.ts",
-  "projects/commercial/modules/track-scroll-depth.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/commercial/user-features.ts",
-  "projects/common/modules/experiments/ab.ts",
-  "projects/common/modules/experiments/tests/consentlessAds.ts"
- ],
- "bootstraps/types.ts": [],
- "lib/$$.ts": [],
- "lib/detect-adblock.ts": [],
- "lib/detect-breakpoint.ts": [
-  "lib/detect-viewport.ts"
- ],
- "lib/detect-google-proxy.ts": [],
- "lib/detect-pushstate.ts": [],
- "lib/detect-viewport.ts": [],
- "lib/events.ts": [],
- "lib/fastdom-promise.ts": [],
- "lib/fetch-json.ts": [],
- "lib/geolocation.ts": [
-  "lib/report-error.ts"
- ],
- "lib/manage-ad-free-cookie.ts": [
-  "projects/common/modules/commercial/lib/cookie.ts"
- ],
- "lib/mediator.ts": [],
- "lib/noop.ts": [],
- "lib/partition.ts": [],
- "lib/raven.ts": [
-  "lib/detect-adblock.ts"
- ],
- "lib/report-error.ts": [
-  "lib/raven.ts"
- ],
- "lib/robust.ts": [
-  "lib/report-error.ts"
- ],
- "lib/time-utils.ts": [],
- "lib/url.ts": [
-  "lib/detect-pushstate.ts"
- ],
- "projects/commercial/adblock-ask.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/common/modules/commercial/contributions-utilities.ts",
-  "projects/common/modules/commercial/support-utilities.ts",
-  "projects/common/modules/commercial/user-features.ts"
- ],
- "projects/commercial/am-i-used.ts": [],
- "projects/commercial/modules/ad-free-slot-remove.ts": [
-  "projects/commercial/modules/remove-slots.ts",
-  "projects/common/modules/commercial/commercial-features.ts"
- ],
- "projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
-  "projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "projects/commercial/modules/dfp/load-advert.ts",
-  "projects/commercial/modules/header-bidding/utils.ts"
- ],
- "projects/commercial/modules/article-aside-adverts.ts": [
-  "lib/$$.ts",
-  "lib/fastdom-promise.ts",
-  "lib/mediator.ts"
- ],
- "projects/commercial/modules/article-body-adverts.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/fastdom-promise.ts",
-  "lib/mediator.ts",
-  "lib/url.ts",
-  "projects/commercial/modules/carrot-traffic-driver.ts",
-  "projects/commercial/modules/dfp/add-slot.ts",
-  "projects/commercial/modules/dfp/wait-for-advert.ts",
-  "projects/commercial/modules/sticky-inlines.ts",
-  "projects/common/modules/article/space-filler.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/spacefinder-debug-tools.ts",
-  "projects/common/modules/spacefinder.ts"
- ],
- "projects/commercial/modules/carrot-traffic-driver.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/fastdom-promise.ts",
-  "lib/url.ts",
-  "projects/commercial/modules/dfp/add-slot.ts",
-  "projects/common/modules/article/space-filler.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/spacefinder.ts"
- ],
- "projects/commercial/modules/comment-adverts.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/fastdom-promise.ts",
-  "lib/mediator.ts",
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/add-slot.ts",
-  "projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "projects/commercial/modules/dfp/load-advert.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/identity/api.ts"
- ],
- "projects/commercial/modules/comscore.ts": [
-  "projects/common/modules/commercial/commercial-features.ts"
- ],
- "projects/commercial/modules/consentless/define-slot.ts": [
-  "projects/commercial/modules/consentless/render-advert-label.ts"
- ],
- "projects/commercial/modules/consentless/dynamic/article-inline.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/fastdom-promise.ts",
-  "lib/url.ts",
-  "projects/commercial/modules/consentless/define-slot.ts",
-  "projects/commercial/modules/sticky-inlines.ts",
-  "projects/common/modules/article/space-filler.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/spacefinder-debug-tools.ts",
-  "projects/common/modules/spacefinder.ts"
- ],
- "projects/commercial/modules/consentless/dynamic/liveblog-inline.ts": [
-  "lib/fastdom-promise.ts",
-  "lib/url.ts",
-  "projects/commercial/modules/consentless/define-slot.ts",
-  "projects/common/modules/article/space-filler.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/spacefinder.ts"
- ],
- "projects/commercial/modules/consentless/init-fixed-slots.ts": [
-  "projects/commercial/modules/consentless/define-slot.ts"
- ],
- "projects/commercial/modules/consentless/prepare-ootag.ts": [
-  "projects/common/modules/commercial/commercial-features.ts"
- ],
- "projects/commercial/modules/consentless/render-advert-label.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/commercial/modules/dfp/render-advert-label.ts"
- ],
- "projects/commercial/modules/creatives/page-skin.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/mediator.ts",
-  "projects/common/modules/commercial/commercial-features.ts"
- ],
- "projects/commercial/modules/dfp/Advert.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
-  "projects/commercial/modules/dfp/define-slot.ts"
- ],
- "projects/commercial/modules/dfp/add-slot.ts": [
-  "lib/report-error.ts",
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/create-advert.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/dfp/lazy-load.ts",
-  "projects/commercial/modules/dfp/load-advert.ts",
-  "projects/commercial/modules/dfp/queue-advert.ts"
- ],
- "projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
- "projects/commercial/modules/dfp/create-advert.ts": [
-  "lib/report-error.ts",
-  "projects/commercial/modules/dfp/Advert.ts"
- ],
- "projects/commercial/modules/dfp/define-slot.ts": [
-  "lib/url.ts",
-  "projects/common/modules/commercial/lib/googletag-ad-size.ts",
-  "types/ias.d.ts"
- ],
- "projects/commercial/modules/dfp/dfp-env-globals.ts": [],
- "projects/commercial/modules/dfp/dfp-env.ts": [
-  "lib/url.ts",
-  "projects/commercial/modules/dfp/Advert.ts"
- ],
- "projects/commercial/modules/dfp/display-ads.ts": [
-  "projects/commercial/modules/creatives/page-skin.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/dfp/load-advert.ts"
- ],
- "projects/commercial/modules/dfp/display-lazy-ads.ts": [
-  "lib/partition.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/dfp/lazy-load.ts",
-  "projects/commercial/modules/dfp/load-advert.ts"
- ],
- "projects/commercial/modules/dfp/empty-advert.ts": [
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "projects/commercial/modules/dfp/fill-advert-slots.ts": [
-  "lib/detect-breakpoint.ts",
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/create-advert.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/dfp/display-ads.ts",
-  "projects/commercial/modules/dfp/display-lazy-ads.ts",
-  "projects/commercial/modules/dfp/prepare-prebid.ts",
-  "projects/commercial/modules/dfp/queue-advert.ts",
-  "projects/commercial/modules/remove-slots.ts",
-  "projects/common/modules/commercial/commercial-features.ts"
- ],
- "projects/commercial/modules/dfp/get-ad-iframe.ts": [],
- "projects/commercial/modules/dfp/get-advert-by-id.ts": [
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "projects/commercial/modules/dfp/lazy-load.ts": [
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "projects/commercial/modules/dfp/load-advert.ts"
- ],
- "projects/commercial/modules/dfp/load-advert.ts": [
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/header-bidding/a9/a9.ts",
-  "projects/commercial/modules/header-bidding/prebid/prebid.ts",
-  "projects/commercial/modules/header-bidding/utils.ts"
- ],
- "projects/commercial/modules/dfp/non-refreshable-line-items.ts": [
-  "lib/report-error.ts"
- ],
- "projects/commercial/modules/dfp/on-slot-load.ts": [
-  "projects/commercial/modules/dfp/get-advert-by-id.ts"
- ],
- "projects/commercial/modules/dfp/on-slot-render.ts": [
-  "lib/report-error.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/dfp/empty-advert.ts",
-  "projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "projects/commercial/modules/dfp/render-advert.ts",
-  "projects/commercial/modules/dfp/should-refresh.ts"
- ],
- "projects/commercial/modules/dfp/on-slot-viewable.ts": [
-  "lib/fastdom-promise.ts",
-  "lib/url.ts",
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "projects/commercial/modules/dfp/lazy-load.ts",
-  "projects/commercial/modules/dfp/non-refreshable-line-items.ts",
-  "projects/commercial/modules/dfp/should-refresh.ts"
- ],
- "projects/commercial/modules/dfp/prepare-a9.ts": [
-  "lib/detect-google-proxy.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/header-bidding/a9/a9.ts",
-  "projects/commercial/modules/header-bidding/utils.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/commercial/geo-utils.ts",
-  "projects/common/modules/experiments/ab.ts",
-  "projects/common/modules/experiments/tests/removePrebidA9Canada.ts"
- ],
- "projects/commercial/modules/dfp/prepare-googletag.ts": [
-  "lib/raven.ts",
-  "lib/report-error.ts",
-  "projects/commercial/modules/dfp/fill-advert-slots.ts",
-  "projects/commercial/modules/dfp/on-slot-load.ts",
-  "projects/commercial/modules/dfp/on-slot-render.ts",
-  "projects/commercial/modules/dfp/on-slot-viewable.ts",
-  "projects/commercial/modules/dfp/refresh-on-resize.ts",
-  "projects/commercial/modules/messenger/background.ts",
-  "projects/commercial/modules/messenger/click.ts",
-  "projects/commercial/modules/messenger/disable-refresh.ts",
-  "projects/commercial/modules/messenger/get-page-targeting.ts",
-  "projects/commercial/modules/messenger/get-page-url.ts",
-  "projects/commercial/modules/messenger/get-stylesheet.ts",
-  "projects/commercial/modules/messenger/measure-ad-load.ts",
-  "projects/commercial/modules/messenger/passback.ts",
-  "projects/commercial/modules/messenger/resize.ts",
-  "projects/commercial/modules/messenger/scroll.ts",
-  "projects/commercial/modules/messenger/type.ts",
-  "projects/commercial/modules/messenger/viewport.ts",
-  "projects/commercial/modules/remove-slots.ts",
-  "projects/common/modules/commercial/build-page-targeting.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/identity/api.ts"
- ],
- "projects/commercial/modules/dfp/prepare-permutive.ts": [
-  "lib/report-error.ts"
- ],
- "projects/commercial/modules/dfp/prepare-prebid.ts": [
-  "lib/detect-google-proxy.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/header-bidding/prebid/prebid.ts",
-  "projects/commercial/modules/header-bidding/utils.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/commercial/geo-utils.ts",
-  "projects/common/modules/experiments/ab.ts",
-  "projects/common/modules/experiments/tests/removePrebidA9Canada.ts"
- ],
- "projects/commercial/modules/dfp/queue-advert.ts": [
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "projects/commercial/modules/dfp/redplanet.ts": [
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/commercial/geo-utils.ts"
- ],
- "projects/commercial/modules/dfp/refresh-on-resize.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/mediator.ts",
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/dfp/load-advert.ts"
- ],
- "projects/commercial/modules/dfp/render-advert-label.ts": [
-  "lib/fastdom-promise.ts"
- ],
- "projects/commercial/modules/dfp/render-advert.ts": [
-  "lib/$$.ts",
-  "lib/fastdom-promise.ts",
-  "lib/report-error.ts",
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/get-ad-iframe.ts",
-  "projects/commercial/modules/dfp/render-advert-label.ts"
- ],
- "projects/commercial/modules/dfp/should-refresh.ts": [
-  "projects/commercial/modules/dfp/Advert.ts"
- ],
- "projects/commercial/modules/dfp/wait-for-advert.ts": [
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/get-advert-by-id.ts"
- ],
- "projects/commercial/modules/header-bidding/a9/a9.ts": [
-  "lib/noop.ts",
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/header-bidding/slot-config.ts"
- ],
- "projects/commercial/modules/header-bidding/prebid/appnexus.ts": [
-  "projects/commercial/modules/header-bidding/utils.ts",
-  "projects/common/modules/commercial/build-page-targeting.ts",
-  "projects/common/modules/commercial/geo-utils.ts"
- ],
- "projects/commercial/modules/header-bidding/prebid/bid-config.ts": [
-  "lib/url.ts",
-  "projects/commercial/modules/header-bidding/prebid/appnexus.ts",
-  "projects/commercial/modules/header-bidding/utils.ts",
-  "projects/common/modules/commercial/build-page-targeting.ts",
-  "projects/common/modules/commercial/geo-utils.ts"
- ],
- "projects/commercial/modules/header-bidding/prebid/prebid.ts": [
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts",
-  "projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "projects/commercial/modules/header-bidding/prebid/bid-config.ts",
-  "projects/commercial/modules/header-bidding/prebid/price-config.ts",
-  "projects/commercial/modules/header-bidding/slot-config.ts",
-  "projects/commercial/modules/header-bidding/utils.ts",
-  "projects/common/modules/commercial/build-page-targeting.ts"
- ],
- "projects/commercial/modules/header-bidding/prebid/price-config.ts": [],
- "projects/commercial/modules/header-bidding/slot-config.ts": [
-  "projects/commercial/modules/dfp/Advert.ts",
-  "projects/commercial/modules/header-bidding/utils.ts"
- ],
- "projects/commercial/modules/header-bidding/utils.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/url.ts",
-  "projects/common/modules/commercial/geo-utils.ts"
- ],
- "projects/commercial/modules/high-merch.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/common/modules/commercial/commercial-features.ts"
- ],
- "projects/commercial/modules/ipsos-mori.ts": [],
- "projects/commercial/modules/liveblog-adverts.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/fastdom-promise.ts",
-  "lib/url.ts",
-  "projects/commercial/modules/dfp/add-slot.ts",
-  "projects/common/modules/article/space-filler.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/experiments/ab.ts",
-  "projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts",
-  "projects/common/modules/spacefinder.ts"
- ],
- "projects/commercial/modules/manage-ad-free-cookie-on-consent-change.ts": [
-  "lib/manage-ad-free-cookie.ts",
-  "projects/commercial/modules/remove-slots.ts"
- ],
- "projects/commercial/modules/messenger/background.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/commercial/modules/dfp/render-advert-label.ts"
- ],
- "projects/commercial/modules/messenger/click.ts": [
-  "projects/common/modules/analytics/google.ts"
- ],
- "projects/commercial/modules/messenger/disable-refresh.ts": [
-  "projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "projects/commercial/modules/messenger/get-page-targeting.ts": [],
- "projects/commercial/modules/messenger/get-page-url.ts": [],
- "projects/commercial/modules/messenger/get-stylesheet.ts": [],
- "projects/commercial/modules/messenger/measure-ad-load.ts": [],
- "projects/commercial/modules/messenger/passback.ts": [
-  "lib/detect-breakpoint.ts",
-  "lib/fastdom-promise.ts",
-  "projects/commercial/modules/dfp/dfp-env-globals.ts"
- ],
- "projects/commercial/modules/messenger/resize.ts": [
-  "lib/fastdom-promise.ts"
- ],
- "projects/commercial/modules/messenger/scroll.ts": [
-  "lib/detect-viewport.ts",
-  "lib/events.ts",
-  "lib/fastdom-promise.ts"
- ],
- "projects/commercial/modules/messenger/type.ts": [
-  "lib/fastdom-promise.ts"
- ],
- "projects/commercial/modules/messenger/viewport.ts": [
-  "lib/detect-viewport.ts",
-  "lib/fastdom-promise.ts"
- ],
- "projects/commercial/modules/mobile-sticky.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/commercial/modules/dfp/add-slot.ts",
-  "projects/commercial/modules/header-bidding/utils.ts"
- ],
- "projects/commercial/modules/paid-containers.ts": [
-  "lib/$$.ts"
- ],
- "projects/commercial/modules/remove-slots.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/commercial/modules/dfp/dfp-env.ts"
- ],
- "projects/commercial/modules/set-adtest-cookie.ts": [
-  "lib/url.ts"
- ],
- "projects/commercial/modules/set-adtest-in-labels-cookie.ts": [
-  "lib/url.ts"
- ],
- "projects/commercial/modules/sticky-inlines.ts": [
-  "lib/fastdom-promise.ts"
- ],
- "projects/commercial/modules/third-party-tags.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/commercial/modules/third-party-tags/imr-worldwide-legacy.ts",
-  "projects/commercial/modules/third-party-tags/imr-worldwide.ts",
-  "projects/common/modules/commercial/commercial-features.ts"
- ],
- "projects/commercial/modules/third-party-tags/imr-worldwide-legacy.ts": [
-  "projects/common/modules/commercial/geo-utils.ts"
- ],
- "projects/commercial/modules/third-party-tags/imr-worldwide.ts": [
-  "projects/common/modules/commercial/geo-utils.ts"
- ],
- "projects/commercial/modules/track-gpc-signal.ts": [],
- "projects/commercial/modules/track-labs-container.ts": [],
- "projects/commercial/modules/track-scroll-depth.ts": [],
- "projects/common/modules/analytics/google.ts": [
-  "lib/mediator.ts"
- ],
- "projects/common/modules/analytics/mvt-cookie.ts": [],
- "projects/common/modules/article/space-filler.ts": [
-  "lib/raven.ts",
-  "projects/common/modules/spacefinder.ts"
- ],
- "projects/common/modules/async-call-merger.ts": [],
- "projects/common/modules/commercial/build-page-targeting.ts": [
-  "projects/commercial/modules/header-bidding/utils.ts",
-  "projects/common/modules/commercial/commercial-features.ts",
-  "projects/common/modules/experiments/ab.ts"
- ],
- "projects/common/modules/commercial/commercial-features.ts": [
-  "lib/detect-breakpoint.ts",
-  "projects/common/modules/commercial/user-features.ts",
-  "projects/common/modules/identity/api.ts",
-  "projects/common/modules/user-prefs.ts"
- ],
- "projects/common/modules/commercial/contributions-utilities.ts": [],
- "projects/common/modules/commercial/geo-utils.ts": [
-  "lib/geolocation.ts"
- ],
- "projects/common/modules/commercial/lib/cookie.ts": [],
- "projects/common/modules/commercial/lib/googletag-ad-size.ts": [],
- "projects/common/modules/commercial/support-utilities.ts": [
-  "lib/geolocation.ts"
- ],
- "projects/common/modules/commercial/user-features.ts": [
-  "lib/fetch-json.ts",
-  "lib/manage-ad-free-cookie.ts",
-  "lib/noop.ts",
-  "lib/time-utils.ts",
-  "projects/common/modules/commercial/lib/cookie.ts",
-  "projects/common/modules/identity/api.ts",
-  "types/dates.ts",
-  "types/membership.ts"
- ],
- "projects/common/modules/experiments/ab-constants.ts": [],
- "projects/common/modules/experiments/ab-core.ts": [
-  "lib/time-utils.ts",
-  "projects/common/modules/analytics/mvt-cookie.ts",
-  "projects/common/modules/experiments/ab-constants.ts",
-  "projects/common/modules/experiments/ab-local-storage.ts",
-  "projects/common/modules/experiments/ab-url.ts",
-  "projects/common/modules/experiments/ab-utils.ts",
-  "projects/common/modules/experiments/automatLog.ts"
- ],
- "projects/common/modules/experiments/ab-local-storage.ts": [
-  "projects/common/modules/experiments/ab-constants.ts",
-  "projects/common/modules/experiments/ab-utils.ts"
- ],
- "projects/common/modules/experiments/ab-ophan.ts": [
-  "lib/noop.ts",
-  "lib/report-error.ts"
- ],
- "projects/common/modules/experiments/ab-tests.ts": [
-  "projects/common/modules/experiments/tests/consentlessAds.ts",
-  "projects/common/modules/experiments/tests/deeply-read-article-footer.js",
-  "projects/common/modules/experiments/tests/integrate-ima.ts",
-  "projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts",
-  "projects/common/modules/experiments/tests/remote-header-test.js",
-  "projects/common/modules/experiments/tests/removePrebidA9Canada.ts",
-  "projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
-  "projects/common/modules/experiments/tests/sign-in-gate-main-variant.js"
- ],
- "projects/common/modules/experiments/ab-url.ts": [
-  "projects/common/modules/experiments/ab-utils.ts"
- ],
- "projects/common/modules/experiments/ab-utils.ts": [
-  "projects/common/modules/experiments/ab-constants.ts"
- ],
- "projects/common/modules/experiments/ab.ts": [
-  "projects/common/modules/experiments/ab-core.ts",
-  "projects/common/modules/experiments/ab-local-storage.ts",
-  "projects/common/modules/experiments/ab-ophan.ts",
-  "projects/common/modules/experiments/ab-tests.ts",
-  "projects/common/modules/experiments/ab-url.ts",
-  "projects/common/modules/experiments/ab-utils.ts"
- ],
- "projects/common/modules/experiments/automatLog.ts": [],
- "projects/common/modules/experiments/tests/consentlessAds.ts": [
-  "lib/noop.ts"
- ],
- "projects/common/modules/experiments/tests/deeply-read-article-footer.js": [],
- "projects/common/modules/experiments/tests/integrate-ima.ts": [
-  "lib/noop.ts"
- ],
- "projects/common/modules/experiments/tests/liveblog-desktop-outstream.ts": [
-  "lib/noop.ts"
- ],
- "projects/common/modules/experiments/tests/remote-header-test.js": [],
- "projects/common/modules/experiments/tests/removePrebidA9Canada.ts": [
-  "lib/noop.ts",
-  "projects/common/modules/commercial/geo-utils.ts"
- ],
- "projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
- "projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
- "projects/common/modules/identity/api.ts": [
-  "lib/fetch-json.ts",
-  "lib/mediator.ts",
-  "lib/url.ts",
-  "projects/common/modules/async-call-merger.ts",
-  "projects/common/modules/identity/auth-component-event-params.js"
- ],
- "projects/common/modules/identity/auth-component-event-params.js": [
-  "lib/url.ts"
- ],
- "projects/common/modules/spacefinder-debug-tools.ts": [
-  "projects/common/modules/spacefinder.ts"
- ],
- "projects/common/modules/spacefinder.ts": [
-  "lib/fastdom-promise.ts",
-  "projects/commercial/am-i-used.ts",
-  "projects/common/modules/spacefinder-debug-tools.ts"
- ],
- "projects/common/modules/user-prefs.ts": [],
- "types/dates.ts": [],
- "types/ias.d.ts": [],
- "types/membership.ts": [
-  "types/dates.ts"
- ]
+ "../lib/$$.ts": [
+  "../../../../node_modules/csstype/index.d.ts"
+ ],
+ "../lib/detect-adblock.ts": [],
+ "../lib/detect-breakpoint.ts": [
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../lib/detect-viewport.ts"
+ ],
+ "../lib/detect-google-proxy.ts": [],
+ "../lib/detect-pushstate.ts": [],
+ "../lib/detect-viewport.ts": [],
+ "../lib/events.ts": [],
+ "../lib/fastdom-promise.ts": [
+  "../../../../node_modules/fastdom/extensions/fastdom-promised.d.ts",
+  "../../../../node_modules/fastdom/fastdom.d.ts"
+ ],
+ "../lib/fetch-json.ts": [],
+ "../lib/geolocation.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/report-error.ts"
+ ],
+ "../lib/manage-ad-free-cookie.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/common/modules/commercial/lib/cookie.ts"
+ ],
+ "../lib/mediator.ts": [
+  "../../../../node_modules/wolfy87-eventemitter/EventEmitter.d.ts"
+ ],
+ "../lib/noop.ts": [],
+ "../lib/partition.ts": [],
+ "../lib/raven.ts": [
+  "../../../../node_modules/raven-js/typescript/raven.d.ts",
+  "../../../../node_modules/raven-js/typescript/raven.d.ts",
+  "../lib/detect-adblock.ts"
+ ],
+ "../lib/report-error.ts": [
+  "../lib/raven.ts"
+ ],
+ "../lib/robust.ts": [
+  "../lib/report-error.ts"
+ ],
+ "../lib/time-utils.ts": [],
+ "../lib/url.ts": [
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/detect-pushstate.ts"
+ ],
+ "../projects/commercial/adblock-ask.ts": [
+  "../lib/fastdom-promise.ts",
+  "../projects/common/modules/commercial/contributions-utilities.ts",
+  "../projects/common/modules/commercial/support-utilities.ts",
+  "../projects/common/modules/commercial/user-features.ts"
+ ],
+ "../projects/commercial/am-i-used.ts": [],
+ "../projects/commercial/modules/ad-free-slot-remove.ts": [
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../projects/commercial/modules/remove-slots.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "../projects/commercial/modules/dfp/load-advert.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts"
+ ],
+ "../projects/commercial/modules/article-aside-adverts.ts": [
+  "../lib/$$.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/mediator.ts"
+ ],
+ "../projects/commercial/modules/article-body-adverts.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/mediator.ts",
+  "../lib/url.ts",
+  "../projects/commercial/modules/carrot-traffic-driver.ts",
+  "../projects/commercial/modules/dfp/add-slot.ts",
+  "../projects/commercial/modules/dfp/wait-for-advert.ts",
+  "../projects/commercial/modules/sticky-inlines.ts",
+  "../projects/common/modules/article/space-filler.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder-debug-tools.ts",
+  "../projects/common/modules/spacefinder.ts"
+ ],
+ "../projects/commercial/modules/carrot-traffic-driver.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/url.ts",
+  "../projects/commercial/modules/dfp/add-slot.ts",
+  "../projects/common/modules/article/space-filler.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder.ts"
+ ],
+ "../projects/commercial/modules/comment-adverts.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/mediator.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/add-slot.ts",
+  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "../projects/commercial/modules/dfp/load-advert.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/comscore.ts": [
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/consentless/define-slot.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/fastdom/fastdom.d.ts",
+  "../projects/commercial/modules/consentless/render-advert-label.ts"
+ ],
+ "../projects/commercial/modules/consentless/dynamic/article-inline.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/url.ts",
+  "../projects/commercial/modules/consentless/define-slot.ts",
+  "../projects/commercial/modules/sticky-inlines.ts",
+  "../projects/common/modules/article/space-filler.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder-debug-tools.ts",
+  "../projects/common/modules/spacefinder.ts"
+ ],
+ "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/url.ts",
+  "../projects/commercial/modules/consentless/define-slot.ts",
+  "../projects/common/modules/article/space-filler.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder.ts"
+ ],
+ "../projects/commercial/modules/consentless/init-fixed-slots.ts": [
+  "../projects/commercial/modules/consentless/define-slot.ts"
+ ],
+ "../projects/commercial/modules/consentless/prepare-ootag.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/consentless/render-advert-label.ts": [
+  "../lib/fastdom-promise.ts",
+  "../projects/commercial/modules/dfp/render-advert-label.ts"
+ ],
+ "../projects/commercial/modules/creatives/page-skin.ts": [
+  "../../../../node_modules/fastdom/fastdom.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/mediator.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/dfp/Advert.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
+  "../projects/commercial/modules/dfp/define-slot.ts"
+ ],
+ "../projects/commercial/modules/dfp/add-slot.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/report-error.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/create-advert.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/lazy-load.ts",
+  "../projects/commercial/modules/dfp/load-advert.ts",
+  "../projects/commercial/modules/dfp/queue-advert.ts"
+ ],
+ "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
+ "../projects/commercial/modules/dfp/create-advert.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/report-error.ts",
+  "../projects/commercial/modules/dfp/Advert.ts"
+ ],
+ "../projects/commercial/modules/dfp/define-slot.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/url.ts",
+  "../projects/common/modules/commercial/lib/googletag-ad-size.ts",
+  "../types/ias.d.ts"
+ ],
+ "../projects/commercial/modules/dfp/dfp-env-globals.ts": [],
+ "../projects/commercial/modules/dfp/dfp-env.ts": [
+  "../lib/url.ts",
+  "../projects/commercial/modules/dfp/Advert.ts"
+ ],
+ "../projects/commercial/modules/dfp/display-ads.ts": [
+  "../projects/commercial/modules/creatives/page-skin.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/load-advert.ts"
+ ],
+ "../projects/commercial/modules/dfp/display-lazy-ads.ts": [
+  "../lib/partition.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/lazy-load.ts",
+  "../projects/commercial/modules/dfp/load-advert.ts"
+ ],
+ "../projects/commercial/modules/dfp/empty-advert.ts": [
+  "../../../../node_modules/fastdom/fastdom.d.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "../projects/commercial/modules/dfp/fill-advert-slots.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/create-advert.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/display-ads.ts",
+  "../projects/commercial/modules/dfp/display-lazy-ads.ts",
+  "../projects/commercial/modules/dfp/prepare-prebid.ts",
+  "../projects/commercial/modules/dfp/queue-advert.ts",
+  "../projects/commercial/modules/remove-slots.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/dfp/get-ad-iframe.ts": [],
+ "../projects/commercial/modules/dfp/get-advert-by-id.ts": [
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "../projects/commercial/modules/dfp/lazy-load.ts": [
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "../projects/commercial/modules/dfp/load-advert.ts"
+ ],
+ "../projects/commercial/modules/dfp/load-advert.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/header-bidding/a9/a9.ts",
+  "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts"
+ ],
+ "../projects/commercial/modules/dfp/non-refreshable-line-items.ts": [
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/report-error.ts"
+ ],
+ "../projects/commercial/modules/dfp/on-slot-load.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../projects/commercial/modules/dfp/get-advert-by-id.ts"
+ ],
+ "../projects/commercial/modules/dfp/on-slot-render.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/report-error.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/empty-advert.ts",
+  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "../projects/commercial/modules/dfp/render-advert.ts",
+  "../projects/commercial/modules/dfp/should-refresh.ts"
+ ],
+ "../projects/commercial/modules/dfp/on-slot-viewable.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/url.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "../projects/commercial/modules/dfp/lazy-load.ts",
+  "../projects/commercial/modules/dfp/non-refreshable-line-items.ts",
+  "../projects/commercial/modules/dfp/should-refresh.ts"
+ ],
+ "../projects/commercial/modules/dfp/prepare-a9.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/detect-google-proxy.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/header-bidding/a9/a9.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "../projects/commercial/modules/dfp/prepare-googletag.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/raven.ts",
+  "../lib/report-error.ts",
+  "../projects/commercial/modules/dfp/fill-advert-slots.ts",
+  "../projects/commercial/modules/dfp/on-slot-load.ts",
+  "../projects/commercial/modules/dfp/on-slot-render.ts",
+  "../projects/commercial/modules/dfp/on-slot-viewable.ts",
+  "../projects/commercial/modules/dfp/refresh-on-resize.ts",
+  "../projects/commercial/modules/messenger/background.ts",
+  "../projects/commercial/modules/messenger/click.ts",
+  "../projects/commercial/modules/messenger/disable-refresh.ts",
+  "../projects/commercial/modules/messenger/get-page-targeting.ts",
+  "../projects/commercial/modules/messenger/get-page-url.ts",
+  "../projects/commercial/modules/messenger/get-stylesheet.ts",
+  "../projects/commercial/modules/messenger/measure-ad-load.ts",
+  "../projects/commercial/modules/messenger/passback.ts",
+  "../projects/commercial/modules/messenger/resize.ts",
+  "../projects/commercial/modules/messenger/scroll.ts",
+  "../projects/commercial/modules/messenger/type.ts",
+  "../projects/commercial/modules/messenger/viewport.ts",
+  "../projects/commercial/modules/remove-slots.ts",
+  "../projects/common/modules/commercial/build-page-targeting.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/dfp/prepare-permutive.ts": [
+  "../lib/report-error.ts"
+ ],
+ "../projects/commercial/modules/dfp/prepare-prebid.ts": [
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/detect-google-proxy.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "../projects/commercial/modules/dfp/queue-advert.ts": [
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "../projects/commercial/modules/dfp/redplanet.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "../projects/commercial/modules/dfp/refresh-on-resize.ts": [
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/mediator.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/load-advert.ts"
+ ],
+ "../projects/commercial/modules/dfp/render-advert-label.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/fastdom-promise.ts"
+ ],
+ "../projects/commercial/modules/dfp/render-advert.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/$$.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/report-error.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/get-ad-iframe.ts",
+  "../projects/commercial/modules/dfp/render-advert-label.ts"
+ ],
+ "../projects/commercial/modules/dfp/should-refresh.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../projects/commercial/modules/dfp/Advert.ts"
+ ],
+ "../projects/commercial/modules/dfp/wait-for-advert.ts": [
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/get-advert-by-id.ts"
+ ],
+ "../projects/commercial/modules/header-bidding/a9/a9.ts": [
+  "../lib/noop.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/header-bidding/slot-config.ts"
+ ],
+ "../projects/commercial/modules/header-bidding/prebid/appnexus.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts",
+  "../projects/common/modules/commercial/build-page-targeting.ts",
+  "../projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "../projects/commercial/modules/header-bidding/prebid/bid-config.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/url.ts",
+  "../projects/commercial/modules/header-bidding/prebid/appnexus.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts",
+  "../projects/common/modules/commercial/build-page-targeting.ts",
+  "../projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "../projects/commercial/modules/header-bidding/prebid/prebid.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/esm/constants/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/get-advert-by-id.ts",
+  "../projects/commercial/modules/header-bidding/prebid/bid-config.ts",
+  "../projects/commercial/modules/header-bidding/prebid/price-config.ts",
+  "../projects/commercial/modules/header-bidding/slot-config.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts",
+  "../projects/common/modules/commercial/build-page-targeting.ts"
+ ],
+ "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
+ ],
+ "../projects/commercial/modules/header-bidding/slot-config.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts"
+ ],
+ "../projects/commercial/modules/header-bidding/utils.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/url.ts",
+  "../projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "../projects/commercial/modules/high-merch.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/ipsos-mori.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/commercial/modules/liveblog-adverts.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/fastdom-promise.ts",
+  "../lib/url.ts",
+  "../projects/commercial/modules/dfp/add-slot.ts",
+  "../projects/common/modules/article/space-filler.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder.ts"
+ ],
+ "../projects/commercial/modules/manage-ad-free-cookie-on-consent-change.ts": [
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/manage-ad-free-cookie.ts",
+  "../projects/commercial/modules/remove-slots.ts"
+ ],
+ "../projects/commercial/modules/messenger/background.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../projects/commercial/modules/dfp/render-advert-label.ts"
+ ],
+ "../projects/commercial/modules/messenger/click.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/common/modules/analytics/google.ts"
+ ],
+ "../projects/commercial/modules/messenger/disable-refresh.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "../projects/commercial/modules/messenger/get-page-targeting.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
+ ],
+ "../projects/commercial/modules/messenger/get-page-url.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
+ ],
+ "../projects/commercial/modules/messenger/get-stylesheet.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/commercial/modules/messenger/measure-ad-load.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/commercial/modules/messenger/passback.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../lib/fastdom-promise.ts",
+  "../projects/commercial/modules/dfp/dfp-env-globals.ts"
+ ],
+ "../projects/commercial/modules/messenger/resize.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/fastdom-promise.ts"
+ ],
+ "../projects/commercial/modules/messenger/scroll.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect-viewport.ts",
+  "../lib/events.ts",
+  "../lib/fastdom-promise.ts"
+ ],
+ "../projects/commercial/modules/messenger/type.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/fastdom-promise.ts"
+ ],
+ "../projects/commercial/modules/messenger/viewport.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect-viewport.ts",
+  "../lib/fastdom-promise.ts"
+ ],
+ "../projects/commercial/modules/mobile-sticky.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../projects/commercial/modules/dfp/add-slot.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts"
+ ],
+ "../projects/commercial/modules/paid-containers.ts": [
+  "../../../../node_modules/fastdom/fastdom.d.ts",
+  "../lib/$$.ts"
+ ],
+ "../projects/commercial/modules/remove-slots.ts": [
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../projects/commercial/modules/dfp/dfp-env.ts"
+ ],
+ "../projects/commercial/modules/set-adtest-cookie.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/url.ts"
+ ],
+ "../projects/commercial/modules/set-adtest-in-labels-cookie.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/url.ts"
+ ],
+ "../projects/commercial/modules/sticky-inlines.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../lib/fastdom-promise.ts"
+ ],
+ "../projects/commercial/modules/third-party-tags.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../projects/commercial/modules/third-party-tags/imr-worldwide-legacy.ts",
+  "../projects/commercial/modules/third-party-tags/imr-worldwide.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/commercial/modules/third-party-tags/imr-worldwide-legacy.ts": [
+  "../projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "../projects/commercial/modules/third-party-tags/imr-worldwide.ts": [
+  "../projects/common/modules/commercial/geo-utils.ts"
+ ],
+ "../projects/commercial/modules/track-gpc-signal.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/commercial/modules/track-labs-container.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/commercial/modules/track-scroll-depth.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/common/modules/analytics/google.ts": [
+  "../../../../node_modules/web-vitals/dist/modules/index.d.ts",
+  "../lib/mediator.ts"
+ ],
+ "../projects/common/modules/analytics/mvt-cookie.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/common/modules/article/space-filler.ts": [
+  "../lib/raven.ts",
+  "../projects/common/modules/spacefinder.ts"
+ ],
+ "../projects/common/modules/async-call-merger.ts": [],
+ "../projects/common/modules/commercial/build-page-targeting.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../projects/commercial/modules/header-bidding/utils.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
+ "../projects/common/modules/commercial/commercial-features.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/detect-breakpoint.ts",
+  "../projects/common/modules/commercial/user-features.ts",
+  "../projects/common/modules/user-prefs.ts"
+ ],
+ "../projects/common/modules/commercial/contributions-utilities.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/common/modules/commercial/geo-utils.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/geolocation.ts"
+ ],
+ "../projects/common/modules/commercial/lib/cookie.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/common/modules/commercial/lib/googletag-ad-size.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
+ ],
+ "../projects/common/modules/commercial/support-utilities.ts": [
+  "../lib/geolocation.ts"
+ ],
+ "../projects/common/modules/commercial/user-features.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/support-dotcom-components/dist/dotcom/src/types.d.ts",
+  "../lib/fetch-json.ts",
+  "../lib/manage-ad-free-cookie.ts",
+  "../lib/noop.ts",
+  "../lib/time-utils.ts",
+  "../projects/common/modules/commercial/lib/cookie.ts",
+  "../types/dates.ts",
+  "../types/membership.ts"
+ ],
+ "../projects/common/modules/spacefinder-debug-tools.ts": [
+  "../projects/common/modules/spacefinder.ts"
+ ],
+ "../projects/common/modules/spacefinder.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/fastdom-promise.ts",
+  "../projects/commercial/am-i-used.ts",
+  "../projects/common/modules/spacefinder-debug-tools.ts"
+ ],
+ "../projects/common/modules/user-prefs.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../types/dates.ts": [],
+ "../types/ias.d.ts": [],
+ "../types/membership.ts": [
+  "../types/dates.ts"
+ ],
+ "commercial.consentless.ts": [
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../lib/manage-ad-free-cookie.ts",
+  "../projects/commercial/modules/consentless/dynamic/article-inline.ts",
+  "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts",
+  "../projects/commercial/modules/consentless/init-fixed-slots.ts",
+  "../projects/commercial/modules/consentless/prepare-ootag.ts",
+  "../projects/commercial/modules/set-adtest-cookie.ts",
+  "../projects/commercial/modules/set-adtest-in-labels-cookie.ts"
+ ],
+ "standalone.commercial.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/report-error.ts",
+  "../lib/robust.ts",
+  "../projects/commercial/adblock-ask.ts",
+  "../projects/commercial/modules/ad-free-slot-remove.ts",
+  "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts",
+  "../projects/commercial/modules/article-aside-adverts.ts",
+  "../projects/commercial/modules/article-body-adverts.ts",
+  "../projects/commercial/modules/comment-adverts.ts",
+  "../projects/commercial/modules/comscore.ts",
+  "../projects/commercial/modules/dfp/dfp-env-globals.ts",
+  "../projects/commercial/modules/dfp/prepare-a9.ts",
+  "../projects/commercial/modules/dfp/prepare-googletag.ts",
+  "../projects/commercial/modules/dfp/prepare-permutive.ts",
+  "../projects/commercial/modules/dfp/prepare-prebid.ts",
+  "../projects/commercial/modules/dfp/redplanet.ts",
+  "../projects/commercial/modules/high-merch.ts",
+  "../projects/commercial/modules/ipsos-mori.ts",
+  "../projects/commercial/modules/liveblog-adverts.ts",
+  "../projects/commercial/modules/manage-ad-free-cookie-on-consent-change.ts",
+  "../projects/commercial/modules/mobile-sticky.ts",
+  "../projects/commercial/modules/paid-containers.ts",
+  "../projects/commercial/modules/remove-slots.ts",
+  "../projects/commercial/modules/set-adtest-cookie.ts",
+  "../projects/commercial/modules/set-adtest-in-labels-cookie.ts",
+  "../projects/commercial/modules/third-party-tags.ts",
+  "../projects/commercial/modules/track-gpc-signal.ts",
+  "../projects/commercial/modules/track-labs-container.ts",
+  "../projects/commercial/modules/track-scroll-depth.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/commercial/user-features.ts",
+  "commercial.consentless.ts",
+  "types.ts"
+ ],
+ "types.ts": []
 }


### PR DESCRIPTION
## What does this change?
Add desktop outstream (670x350) to inline2+ slots on liveblogs

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [x] Yes (https://github.com/guardian/dotcom-rendering/pull/6660)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
