### PR TITLE
Provide dropdown matchday option in football fronts tool 

### DIFF
--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -50,35 +50,35 @@ class FrontsController(
     }
 
   def matchDay(competitionId: String): Action[AnyContent] =
-  Action.async { implicit request =>
-    val foResult =
-      if ("all" == competitionId) {
-        val snapFields = SnapFields(
-          SNAP_TYPE,
-          SNAP_CSS,
-          s"$host/football/live.json",
-          s"${Configuration.site.host}/football/live",
-          "Live matches",
-          "Today's matches",
-        )
-        FutureOpt.fromFuture(previewFrontsComponent(snapFields))
-      } else {
-        for {
-          season <- getCompetition(competitionId)
-          competitionName = PA.competitionName(season)
-          snapFields = SnapFields(
+    Action.async { implicit request =>
+      val foResult =
+        if ("all" == competitionId) {
+          val snapFields = SnapFields(
             SNAP_TYPE,
             SNAP_CSS,
-            s"$host/football/$competitionId/live.json",
+            s"$host/football/live.json",
             s"${Configuration.site.host}/football/live",
-            s"$competitionName results",
-            s"View today's live $competitionName matches",
+            "Live matches",
+            "Today's matches",
           )
-          previewContent <- FutureOpt.fromFuture(previewFrontsComponent(snapFields))
-        } yield previewContent
-      }
-    foResult.getOrElse(NoCache(NotFound(views.html.football.error(s"Competition $competitionId not found"))))
-  }
+          FutureOpt.fromFuture(previewFrontsComponent(snapFields))
+        } else {
+          for {
+            season <- getCompetition(competitionId)
+            competitionName = PA.competitionName(season)
+            snapFields = SnapFields(
+              SNAP_TYPE,
+              SNAP_CSS,
+              s"$host/football/$competitionId/live.json",
+              s"${Configuration.site.host}/football/live",
+              s"$competitionName results",
+              s"View today's live $competitionName matches",
+            )
+            previewContent <- FutureOpt.fromFuture(previewFrontsComponent(snapFields))
+          } yield previewContent
+        }
+      foResult.getOrElse(NoCache(NotFound(views.html.football.error(s"Competition $competitionId not found"))))
+    }
 
   def resultsRedirect: Action[AnyContent] =
     Action { implicit request =>

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -42,18 +42,43 @@ class FrontsController(
       }
     }
 
-  def matchDay: Action[AnyContent] =
-    Action.async { implicit request =>
-      val snapFields = SnapFields(
-        SNAP_TYPE,
-        SNAP_CSS,
-        s"$host/football/live.json",
-        s"${Configuration.site.host}/football/live",
-        "Live matches",
-        "Today's matches",
-      )
-      previewFrontsComponent(snapFields)
+  def matchDayRedirect: Action[AnyContent] =
+    Action { implicit request =>
+      val submission = request.body.asFormUrlEncoded.get
+      val competitionId = submission("competition").head
+      Cached(60)(WithoutRevalidationResult(SeeOther(s"/admin/football/fronts/live/$competitionId")))
     }
+
+  def matchDay(competitionId: String): Action[AnyContent] =
+  Action.async { implicit request =>
+    val foResult =
+      if ("all" == competitionId) {
+        val snapFields = SnapFields(
+          SNAP_TYPE,
+          SNAP_CSS,
+          s"$host/football/live.json",
+          s"${Configuration.site.host}/football/live",
+          "Live matches",
+          "Today's matches",
+        )
+        FutureOpt.fromFuture(previewFrontsComponent(snapFields))
+      } else {
+        for {
+          season <- getCompetition(competitionId)
+          competitionName = PA.competitionName(season)
+          snapFields = SnapFields(
+            SNAP_TYPE,
+            SNAP_CSS,
+            s"$host/football/$competitionId/live.json",
+            s"${Configuration.site.host}/football/live",
+            s"$competitionName results",
+            s"View today's live $competitionName matches",
+          )
+          previewContent <- FutureOpt.fromFuture(previewFrontsComponent(snapFields))
+        } yield previewContent
+      }
+    foResult.getOrElse(NoCache(NotFound(views.html.football.error(s"Competition $competitionId not found"))))
+  }
 
   def resultsRedirect: Action[AnyContent] =
     Action { implicit request =>

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -71,7 +71,7 @@ class FrontsController(
               SNAP_CSS,
               s"$host/football/$competitionId/live.json",
               s"${Configuration.site.host}/football/live",
-              s"$competitionName results",
+              s"$competitionName matches",
               s"View today's live $competitionName matches",
             )
             previewContent <- FutureOpt.fromFuture(previewFrontsComponent(snapFields))

--- a/admin/app/views/football/fronts/index.scala.html
+++ b/admin/app/views/football/fronts/index.scala.html
@@ -1,3 +1,4 @@
+
 @(competitions: List[pa.Season], teams: List[pa.Team])(implicit context: model.ApplicationContext, request: RequestHeader)
 
 @views.html.football.main("Fronts components") {
@@ -13,9 +14,15 @@
     <div class="row">
         <div class="col-sm-12">
             <p>
-                <a href="/admin/football/fronts/live" class="btn btn-success">Today's matches</a>
+                <a href="/admin/football/fronts/live/all" class="btn btn-success">All today's matches</a>
             </p>
         </div>
+    </div>
+    <div class="col-sm-12">
+        <form class="form-inline" role="form" action="/admin/football/fronts/live/redirect" method="post">
+            @views.html.football.fragments.chooseLeague("competition", competitions)
+            <button type="submit" class="btn btn-success">Competition matches</button>
+        </form>
     </div>
     <div class="row">
         <div class="col-sm-12">

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -141,7 +141,8 @@ GET         /admin/football/tables/league/:competitionId                        
 GET         /admin/football/tables/league/:competitionId/:focus                                     controllers.admin.TablesController.leagueTableFragment(competitionId: String, focus: String)
 GET         /admin/football/tables/league/:competitionId/:team1Id/:team2Id                          controllers.admin.TablesController.leagueTable2Teams(competitionId: String, team1Id: String, team2Id: String)
 GET         /admin/football/fronts                                                                  controllers.admin.FrontsController.index
-GET         /admin/football/fronts/live                                                             controllers.admin.FrontsController.matchDay
+POST        /admin/football/fronts/live/redirect                                                    controllers.admin.FrontsController.matchDayRedirect
+GET         /admin/football/fronts/live/:competition                                                controllers.admin.FrontsController.matchDay(competition: String)
 POST        /admin/football/fronts/results/redirect                                                 controllers.admin.FrontsController.resultsRedirect
 GET         /admin/football/fronts/results/:competition                                             controllers.admin.FrontsController.results(competition: String)
 POST        /admin/football/fronts/fixtures/redirect                                                controllers.admin.FrontsController.fixturesRedirect


### PR DESCRIPTION
## What does this change?

Aligns with results and fixtures

Somewhat overdue PR to respond to this request: 

From: 'James Dart' via Core Central Production <[core.central.production@guardian.co.uk](mailto:core.central.production@guardian.co.uk)>
Date: Tue, 22 Nov 2022 at 09:44
Subject: live scores embed
To: central.production <[central.production@theguardian.com](mailto:central.production@theguardian.com)>, Core Central Production <[core.central.production@guardian.co.uk](mailto:core.central.production@guardian.co.uk)>


Morning. I was just wondering if there was any way for someone to look at our live football data embeds, please. 

https://frontend.gutools.co.uk/admin/football/fronts

On the 'matchday' element, which enables us to drag over live scores, it also retains non-World Cup games. So, if I drag this over now, it also shows the big League Two action tonight on there too (which isn't going to work in the World Cup containers on main fronts). Is there a way to get a bespoke dropdown, like the other sections, so I could select purely World Cup, please? As a workaround, I've dragged over the World Cup fixtures, but obviously that only works as a schedule rather than updating to live status as the live scores matchday one does.

Thanks
James

--
James Dart

Sport Editor (digital)

Guardian News & Media

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
