### PR TITLE
Add new `exclusion` ad slot to all pages

### DIFF
--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -14,7 +14,8 @@
     @fragments.commercial.standardAd(
         "exclusion",
         Seq.empty[String],
-        Map()
+        Map(),
+        showLabel=false
     )
     @fragments.commercial.standardAd(
         "top-above-nav",

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -3,6 +3,19 @@
 @import views.support.Commercial.topAboveNavSlot
 
 <div class="@topAboveNavSlot.cssClasses(page.metadata)">
+    <!--
+        This is a special type of ad which, when filled, blocks
+        all other ads on the page. This allows us to run "exclusion
+        campaigns" against certain breaking news pages. Exclusion
+        ads are used for consentless advertising only. They are
+        ignored by GAM, which has a different mechanism to achieve
+        the same thing.
+    -->
+    @fragments.commercial.standardAd(
+        "exclusion",
+        Seq.empty[String],
+        Map()
+    )
     @fragments.commercial.standardAd(
         "top-above-nav",
         topAboveNavSlot.slotCssClasses,

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -1,5 +1,4 @@
 {
- "../../../../../Prebid.js/build/dist/prebid.js": [],
  "../lib/$$.ts": [
   "../../../../node_modules/csstype/index.d.ts"
  ],
@@ -322,11 +321,11 @@
   "../lib/report-error.ts"
  ],
  "../projects/commercial/modules/dfp/prepare-prebid.ts": [
-  "../../../../../Prebid.js/build/dist/prebid.js",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../../../../node_modules/prebid.js/build/dist/prebid.js",
   "../lib/detect-google-proxy.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/header-bidding/prebid/prebid.ts",


### PR DESCRIPTION
## What does this change?

Adds a new `exclusion` ad slot to the header of the page, just before `top-above-nav`.

See the equivalent change in DCR for more information: https://github.com/guardian/dotcom-rendering/pull/6656

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6656

## Screenshots

The DOM ends up looking like this:

![Screenshot 2022-12-02 at 14 57 17](https://user-images.githubusercontent.com/7423751/205322013-db932fb6-7049-47c2-9ddc-d839cc1b216e.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
