### PR TITLE
Handle rendering multiple notifications

### DIFF
--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -81,7 +81,8 @@
                                 @(item.icon.map { icon =>
                                 views.html.fragments.inlineSvg(icon, "icon", isPresentation = true)
                                 })
-                                @item.label
+                                <div class="js-user-account-menu-label">@item.label</div>
+                                <div class="js-user-account-menu-notifications-container"></div>
                             </a>
                         </li>
                         }

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.ts
@@ -64,9 +64,13 @@ const showNotifications = (notifications: NotificationEvent[]): void => {
 						const menuItem = menu.querySelector(
 							`a[data-link-id=${target}]`,
 						);
-						if (menuItem?.textContent) {
-							const labelEl = document.createElement('div');
-							labelEl.innerText = menuItem.textContent.trim();
+						if (menuItem) {
+							const labelEl = menuItem.querySelector(
+								'.js-user-account-menu-label',
+							);
+							labelEl?.classList.add(
+								'top-bar__user-account-notification-badge',
+							);
 
 							const messageEls = messages.map((message) => {
 								const messageEl = document.createElement('div');
@@ -76,14 +80,15 @@ const showNotifications = (notifications: NotificationEvent[]): void => {
 								messageEl.innerText = message;
 								return messageEl;
 							});
-
-							menuItem.innerHTML = '';
-							labelEl.classList.add(
-								'top-bar__user-account-notification-badge',
-							);
-							[labelEl, ...messageEls].forEach((e) =>
-								menuItem.appendChild(e),
-							);
+							const notificationsContainerEl =
+								menuItem.querySelector(
+									'.js-user-account-menu-notifications-container',
+								);
+							if (notificationsContainerEl) {
+								notificationsContainerEl.replaceChildren(
+									...messageEls,
+								);
+							}
 						}
 					},
 				);


### PR DESCRIPTION
## What does this change?

I noticed that when multiple notifications arrive sequentially for a single target, the rendering doesn't quite work out how we want it it to. This fixes the issue by creating a notifications container element for each menu item which we always replace the contents of (rather than appending).

Note that this fix isn't urgent, this feature isn't enabled in prod yet (and we don't expect multiple notifications for a single user yet anyway).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

(The notification text is made up, and the same in both cases which we wouldn't expect to happen, but hopefully this illustrates the point).

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/379839/205342360-b1957982-d19a-450e-8eb6-dd26571d3a83.png
[after]: https://user-images.githubusercontent.com/379839/205342401-383b9fd4-2fb7-42d5-ae39-371667405275.png

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
