### PR TITLE
Filter out placeholder matches in agent when the opponents are known

### DIFF
--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -156,9 +156,10 @@ class CompetitionAgent(
 
       val allMatches = (newMatches ++ comp.matches).sorted(MatchStatusOrdering).distinctBy(_.id).sortByDate
 
-      val updatedMatches = allMatches.filter(
-        footballMatch => (!isPlaceholderMatch(footballMatch)) ||
-          (isPlaceholderMatch(footballMatch) && !nonPlaceHolderMatchWithSameDateExists(allMatches, footballMatch)))
+      val updatedMatches = allMatches.filter(footballMatch =>
+        (!isPlaceholderMatch(footballMatch)) ||
+          (isPlaceholderMatch(footballMatch) && !nonPlaceHolderMatchWithSameDateExists(allMatches, footballMatch)),
+      )
 
       comp.copy(matches = updatedMatches)
     }
@@ -168,8 +169,13 @@ class CompetitionAgent(
     placeholderIndicator.exists(indicator => footballMatch.homeTeam.name.contains(indicator))
   }
 
-  def nonPlaceHolderMatchWithSameDateExists(allMatches: Seq[FootballMatch], placeHolderMatch: FootballMatch): Boolean = {
-    allMatches.exists(footballMatch => footballMatch.date == placeHolderMatch.date && !isPlaceholderMatch(footballMatch))
+  def nonPlaceHolderMatchWithSameDateExists(
+      allMatches: Seq[FootballMatch],
+      placeHolderMatch: FootballMatch,
+  ): Boolean = {
+    allMatches.exists(footballMatch =>
+      footballMatch.date == placeHolderMatch.date && !isPlaceholderMatch(footballMatch),
+    )
   }
 
   def refresh(clock: Clock)(implicit executionContext: ExecutionContext): Unit = {

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -169,7 +169,7 @@ class CompetitionAgent(
     placeholderIndicator.exists(indicator => footballMatch.homeTeam.name.contains(indicator))
   }
 
-  def nonPlaceHolderMatchWithSameDateExists(
+  private def nonPlaceHolderMatchWithSameDateExists(
       allMatches: Seq[FootballMatch],
       placeHolderMatch: FootballMatch,
   ): Boolean = {

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -154,8 +154,26 @@ class CompetitionAgent(
         }
       }
 
+      val allMatches = (newMatches ++ comp.matches).sorted(MatchStatusOrdering).distinctBy(_.id).sortByDate
+
       //it is important that newMatches are at the start of the list here
-      comp.copy(matches = (newMatches ++ comp.matches).sorted(MatchStatusOrdering).distinctBy(_.id).sortByDate)
+      comp.copy(matches = allMatches.filter(footballMatch => {
+        if (isPlaceholderMatch(footballMatch)) {
+          allMatches.find(_.date == footballMatch.date) match {
+            case Some(_) => false
+            case None    => true
+          }
+        } else {
+          true
+        }
+      }))
+    }
+
+  def isPlaceholderMatch(footballMatch: FootballMatch): Boolean =
+    footballMatch.homeTeam.name match {
+      case s"Winner Group ${_}"    => true
+      case s"Runner-up Group ${_}" => true
+      case _                       => false
     }
 
   def refresh(clock: Clock)(implicit executionContext: ExecutionContext): Unit = {

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -169,12 +169,10 @@ class CompetitionAgent(
       }))
     }
 
-  def isPlaceholderMatch(footballMatch: FootballMatch): Boolean =
-    footballMatch.homeTeam.name match {
-      case s"Winner Group ${_}"    => true
-      case s"Runner-up Group ${_}" => true
-      case _                       => false
-    }
+  def isPlaceholderMatch(footballMatch: FootballMatch): Boolean = {
+    val placeholderIndicator = Set("Winner", "Runner-up", "Wnr Gp", "R-Up Gp", "Loser")
+    placeholderIndicator.exists(indicator => footballMatch.homeTeam.name.contains(indicator))
+  }
 
   def refresh(clock: Clock)(implicit executionContext: ExecutionContext): Unit = {
     refreshFixtures()

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -156,22 +156,20 @@ class CompetitionAgent(
 
       val allMatches = (newMatches ++ comp.matches).sorted(MatchStatusOrdering).distinctBy(_.id).sortByDate
 
-      //it is important that newMatches are at the start of the list here
-      comp.copy(matches = allMatches.filter(footballMatch => {
-        if (isPlaceholderMatch(footballMatch)) {
-          allMatches.find(_.date == footballMatch.date) match {
-            case Some(_) => false
-            case None    => true
-          }
-        } else {
-          true
-        }
-      }))
+      val updatedMatches = allMatches.filter(
+        footballMatch => (!isPlaceholderMatch(footballMatch)) ||
+          (isPlaceholderMatch(footballMatch) && !nonPlaceHolderMatchWithSameDateExists(allMatches, footballMatch)))
+
+      comp.copy(matches = updatedMatches)
     }
 
   def isPlaceholderMatch(footballMatch: FootballMatch): Boolean = {
     val placeholderIndicator = Set("Winner", "Runner-up", "Wnr Gp", "R-Up Gp", "Loser")
     placeholderIndicator.exists(indicator => footballMatch.homeTeam.name.contains(indicator))
+  }
+
+  def nonPlaceHolderMatchWithSameDateExists(allMatches: Seq[FootballMatch], placeHolderMatch: FootballMatch): Boolean = {
+    allMatches.exists(footballMatch => footballMatch.date == placeHolderMatch.date && !isPlaceholderMatch(footballMatch))
   }
 
   def refresh(clock: Clock)(implicit executionContext: ExecutionContext): Unit = {

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -1,5 +1,5 @@
 package test
-
+import scala.concurrent.Await
 import feed.CompetitionsService
 import model.Competition
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
@@ -7,10 +7,12 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Span}
-import test.FootballTestData.fixture
+import test.FootballTestData.{competitions, fixture}
 
 import java.time.{Clock, LocalDate, ZonedDateTime}
 import java.time.ZoneId
+import scala.concurrent.Future
+import scala.concurrent.duration._
 
 @DoNotDiscover class CompetitionAgentTest
     extends AnyFlatSpec
@@ -136,5 +138,64 @@ import java.time.ZoneId
       fixture("Winner Q/F 3", "Winner Q/F 4", date)) === true)
     assert(competitionAgent.isPlaceholderMatch(
       fixture("Loser SF1", "Loser SF2", date)) === true)
+  }
+
+  it should "not contain matches with known opponents as placeholders" in {
+    val date = ZonedDateTime.of(2022, 12, 9, 15, 0, 0, 0, ZoneId.of("Europe/London"))
+    val placeHolderMatch = fixture("Wnr Gp E/R-Up Gp F", "Wnr Gp G/R-Up Gp H", date)
+
+    val comps = testCompetitionsService(
+      Competition(
+        "700",
+        "/football/world-cup-2022",
+        "World Cup 2022",
+        "World Cup 2022",
+        "Internationals",
+        showInTeamsList = true,
+        tableDividers = List(2),
+        matches = Seq(placeHolderMatch)
+      ),
+    )
+
+    val competitionAgent = comps.competitionAgents.head
+
+    assert(competitionAgent.competition.matches.length === 1)
+    assert(competitionAgent.competition.matches.head === placeHolderMatch)
+
+    val matchWithKnownOpponents = fixture("Brazil", "Croatia", date)
+    Await.result(competitionAgent.addMatches(Seq(matchWithKnownOpponents)), 2.second)
+
+    assert(competitionAgent.competition.matches.length === 1)
+    assert(competitionAgent.competition.matches.head === matchWithKnownOpponents)
+  }
+
+
+  it should "still contain placeholder matches with unknown opponents" in {
+    val firstGameDate = ZonedDateTime.of(2022, 12, 10, 15, 0, 0, 0, ZoneId.of("Europe/London"))
+    val secondGameDate = ZonedDateTime.of(2022, 12, 10, 19, 0, 0, 0, ZoneId.of("Europe/London"))
+
+    val firstPlaceHolderMatch = fixture("Winner Group F/Runner-Up Group E", "Winner Group H/Runner-Up Group G", firstGameDate)
+    val secondPlaceHolderMatch = fixture("Winner Group B/Runner-Up Group A", "Winner Group D/Runner-Up Group C", secondGameDate)
+    val matchWithKnownOpponents = fixture("England", "France", secondGameDate)
+
+    val comps = testCompetitionsService(
+      Competition(
+        "700",
+        "/football/world-cup-2022",
+        "World Cup 2022",
+        "World Cup 2022",
+        "Internationals",
+        showInTeamsList = true,
+        tableDividers = List(2),
+        matches = Seq(firstPlaceHolderMatch, secondPlaceHolderMatch)))
+
+    val competitionAgent = comps.competitionAgents.head
+
+    Await.result(competitionAgent.addMatches(Seq(matchWithKnownOpponents)), 2.second)
+
+    assert(competitionAgent.competition.matches.length === 2)
+    assert(competitionAgent.competition.matches.contains(firstPlaceHolderMatch))
+    assert(competitionAgent.competition.matches.contains(matchWithKnownOpponents))
+
   }
 }

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -128,16 +128,11 @@ import scala.concurrent.duration._
     val competitionAgent = comps.competitionAgents.head
     val date = ZonedDateTime.of(2022, 12, 3, 15, 0, 0, 0, ZoneId.of("Europe/London"))
 
-    assert(competitionAgent.isPlaceholderMatch(
-      fixture("Winner Group A", "Runner-Up Group B", date)) === true)
-    assert(competitionAgent.isPlaceholderMatch(
-      fixture("England", "France", date)) === false)
-    assert(competitionAgent.isPlaceholderMatch(
-      fixture("Wnr Gp F/R-Up Gp E", "Wnr Gp H/R-Up Gp G", date)) === true)
-    assert(competitionAgent.isPlaceholderMatch(
-      fixture("Winner Q/F 3", "Winner Q/F 4", date)) === true)
-    assert(competitionAgent.isPlaceholderMatch(
-      fixture("Loser SF1", "Loser SF2", date)) === true)
+    assert(competitionAgent.isPlaceholderMatch(fixture("Winner Group A", "Runner-Up Group B", date)) === true)
+    assert(competitionAgent.isPlaceholderMatch(fixture("England", "France", date)) === false)
+    assert(competitionAgent.isPlaceholderMatch(fixture("Wnr Gp F/R-Up Gp E", "Wnr Gp H/R-Up Gp G", date)) === true)
+    assert(competitionAgent.isPlaceholderMatch(fixture("Winner Q/F 3", "Winner Q/F 4", date)) === true)
+    assert(competitionAgent.isPlaceholderMatch(fixture("Loser SF1", "Loser SF2", date)) === true)
   }
 
   it should "not contain matches with known opponents as placeholders" in {
@@ -153,7 +148,7 @@ import scala.concurrent.duration._
         "Internationals",
         showInTeamsList = true,
         tableDividers = List(2),
-        matches = Seq(placeHolderMatch)
+        matches = Seq(placeHolderMatch),
       ),
     )
 
@@ -169,13 +164,14 @@ import scala.concurrent.duration._
     assert(competitionAgent.competition.matches.head === matchWithKnownOpponents)
   }
 
-
   it should "still contain placeholder matches with unknown opponents" in {
     val firstGameDate = ZonedDateTime.of(2022, 12, 10, 15, 0, 0, 0, ZoneId.of("Europe/London"))
     val secondGameDate = ZonedDateTime.of(2022, 12, 10, 19, 0, 0, 0, ZoneId.of("Europe/London"))
 
-    val firstPlaceHolderMatch = fixture("Winner Group F/Runner-Up Group E", "Winner Group H/Runner-Up Group G", firstGameDate)
-    val secondPlaceHolderMatch = fixture("Winner Group B/Runner-Up Group A", "Winner Group D/Runner-Up Group C", secondGameDate)
+    val firstPlaceHolderMatch =
+      fixture("Winner Group F/Runner-Up Group E", "Winner Group H/Runner-Up Group G", firstGameDate)
+    val secondPlaceHolderMatch =
+      fixture("Winner Group B/Runner-Up Group A", "Winner Group D/Runner-Up Group C", secondGameDate)
     val matchWithKnownOpponents = fixture("England", "France", secondGameDate)
 
     val comps = testCompetitionsService(
@@ -187,7 +183,9 @@ import scala.concurrent.duration._
         "Internationals",
         showInTeamsList = true,
         tableDividers = List(2),
-        matches = Seq(firstPlaceHolderMatch, secondPlaceHolderMatch)))
+        matches = Seq(firstPlaceHolderMatch, secondPlaceHolderMatch),
+      ),
+    )
 
     val competitionAgent = comps.competitionAgents.head
 

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Span}
+import test.FootballTestData.fixture
 
 import java.time.{Clock, LocalDate, ZonedDateTime}
 import java.time.ZoneId
@@ -109,4 +110,31 @@ import java.time.ZoneId
     eventually(comps.competitions(0).leagueTable(0).team.id should be("23"))
   }
 
+  it should "recognise placeholder games" in {
+    val comps = testCompetitionsService(
+      Competition(
+        "700",
+        "/football/world-cup-2022",
+        "World Cup 2022",
+        "World Cup 2022",
+        "Internationals",
+        showInTeamsList = true,
+        tableDividers = List(2),
+      ),
+    )
+
+    val competitionAgent = comps.competitionAgents.head
+    val date = ZonedDateTime.of(2022, 12, 3, 15, 0, 0, 0, ZoneId.of("Europe/London"))
+
+    assert(competitionAgent.isPlaceholderMatch(
+      fixture("Winner Group A", "Runner-Up Group B", date)) === true)
+    assert(competitionAgent.isPlaceholderMatch(
+      fixture("England", "France", date)) === false)
+    assert(competitionAgent.isPlaceholderMatch(
+      fixture("Wnr Gp F/R-Up Gp E", "Wnr Gp H/R-Up Gp G", date)) === true)
+    assert(competitionAgent.isPlaceholderMatch(
+      fixture("Winner Q/F 3", "Winner Q/F 4", date)) === true)
+    assert(competitionAgent.isPlaceholderMatch(
+      fixture("Loser SF1", "Loser SF2", date)) === true)
+  }
 }


### PR DESCRIPTION
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

Fixes: https://github.com/guardian/frontend/issues/25736

## Background
The competition agent fetches all the matches when the sport app starts. This PR is fixing a problem that occurs when we have the following scenario:

1. Sport app starts and fetches all matches from PA API. Some of these matches are placeholders because the opponents are unknown at this point of time.
2. Games are played and the opponents are now known
3. PA creates new match instead of updating the existing one
4. If sport app doesn't get redeployed so that the agent can fetch the games from scratch, we see the following issue

![Image_20221201_161923](https://user-images.githubusercontent.com/19683595/205671733-377c8929-d20e-4709-91ca-a98ecc819691.jpeg)

## What does this change?
* Filters out placeholder matches when the opponents are known 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
