### PR TITLE
Refactor filter placeholder matches

### DIFF
--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -164,7 +164,7 @@ class CompetitionAgent(
       comp.copy(matches = updatedMatches)
     }
 
-  def isPlaceholderMatch(footballMatch: FootballMatch): Boolean = {
+  private def isPlaceholderMatch(footballMatch: FootballMatch): Boolean = {
     val placeholderIndicator = Set("Winner", "Runner-up", "Wnr Gp", "R-Up Gp", "Loser")
     placeholderIndicator.exists(indicator => footballMatch.homeTeam.name.contains(indicator))
   }

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -156,12 +156,12 @@ class CompetitionAgent(
 
       val allMatches = (newMatches ++ comp.matches).sorted(MatchStatusOrdering).distinctBy(_.id).sortByDate
 
-      val updatedMatches = allMatches.filter(footballMatch =>
-        (!isPlaceholderMatch(footballMatch)) ||
-          (isPlaceholderMatch(footballMatch) && !nonPlaceHolderMatchWithSameDateExists(allMatches, footballMatch)),
+      comp.copy(matches =
+        allMatches.filterNot(footballMatch =>
+          isPlaceholderMatch(footballMatch) &&
+            nonPlaceHolderMatchWithSameDateExists(allMatches, footballMatch),
+        ),
       )
-
-      comp.copy(matches = updatedMatches)
     }
 
   private def isPlaceholderMatch(footballMatch: FootballMatch): Boolean = {

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -7,11 +7,10 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Span}
-import test.FootballTestData.{competitions, fixture}
+import test.FootballTestData.fixture
 
 import java.time.{Clock, LocalDate, ZonedDateTime}
 import java.time.ZoneId
-import scala.concurrent.Future
 import scala.concurrent.duration._
 
 @DoNotDiscover class CompetitionAgentTest
@@ -112,32 +111,12 @@ import scala.concurrent.duration._
     eventually(comps.competitions(0).leagueTable(0).team.id should be("23"))
   }
 
-  it should "recognise placeholder games" in {
-    val comps = testCompetitionsService(
-      Competition(
-        "700",
-        "/football/world-cup-2022",
-        "World Cup 2022",
-        "World Cup 2022",
-        "Internationals",
-        showInTeamsList = true,
-        tableDividers = List(2),
-      ),
-    )
-
-    val competitionAgent = comps.competitionAgents.head
-    val date = ZonedDateTime.of(2022, 12, 3, 15, 0, 0, 0, ZoneId.of("Europe/London"))
-
-    assert(competitionAgent.isPlaceholderMatch(fixture("Winner Group A", "Runner-Up Group B", date)) === true)
-    assert(competitionAgent.isPlaceholderMatch(fixture("England", "France", date)) === false)
-    assert(competitionAgent.isPlaceholderMatch(fixture("Wnr Gp F/R-Up Gp E", "Wnr Gp H/R-Up Gp G", date)) === true)
-    assert(competitionAgent.isPlaceholderMatch(fixture("Winner Q/F 3", "Winner Q/F 4", date)) === true)
-    assert(competitionAgent.isPlaceholderMatch(fixture("Loser SF1", "Loser SF2", date)) === true)
-  }
-
   it should "not contain matches with known opponents as placeholders" in {
-    val date = ZonedDateTime.of(2022, 12, 9, 15, 0, 0, 0, ZoneId.of("Europe/London"))
-    val placeHolderMatch = fixture("Wnr Gp E/R-Up Gp F", "Wnr Gp G/R-Up Gp H", date)
+    val date1 = ZonedDateTime.of(2022, 12, 9, 15, 0, 0, 0, ZoneId.of("Europe/London"))
+    val date2 = ZonedDateTime.of(2022, 12, 10, 15, 0, 0, 0, ZoneId.of("Europe/London"))
+    val placeHolderMatches = Seq(
+      fixture("Wnr Gp E/R-Up Gp F", "Wnr Gp G/R-Up Gp H", date1),
+      fixture("Winner Q/F 3", "Winner Q/F 4", date2))
 
     val comps = testCompetitionsService(
       Competition(
@@ -148,20 +127,24 @@ import scala.concurrent.duration._
         "Internationals",
         showInTeamsList = true,
         tableDividers = List(2),
-        matches = Seq(placeHolderMatch),
+        matches = placeHolderMatches,
       ),
     )
 
     val competitionAgent = comps.competitionAgents.head
 
-    assert(competitionAgent.competition.matches.length === 1)
-    assert(competitionAgent.competition.matches.head === placeHolderMatch)
+    assert(competitionAgent.competition.matches.length === 2)
+    assert(competitionAgent.competition.matches.contains(placeHolderMatches.head))
+    assert(competitionAgent.competition.matches.contains(placeHolderMatches(1)))
 
-    val matchWithKnownOpponents = fixture("Brazil", "Croatia", date)
-    Await.result(competitionAgent.addMatches(Seq(matchWithKnownOpponents)), 2.second)
+    val matchesWithKnownOpponents = Seq(
+      fixture("Brazil", "Croatia", date1),
+      fixture("Spain", "Portugal", date2))
+    Await.result(competitionAgent.addMatches(matchesWithKnownOpponents), 2.second)
 
-    assert(competitionAgent.competition.matches.length === 1)
-    assert(competitionAgent.competition.matches.head === matchWithKnownOpponents)
+    assert(competitionAgent.competition.matches.length === 2)
+    assert(competitionAgent.competition.matches.contains(matchesWithKnownOpponents.head))
+    assert(competitionAgent.competition.matches.contains(matchesWithKnownOpponents(1)))
   }
 
   it should "still contain placeholder matches with unknown opponents" in {

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -114,9 +114,8 @@ import scala.concurrent.duration._
   it should "not contain matches with known opponents as placeholders" in {
     val date1 = ZonedDateTime.of(2022, 12, 9, 15, 0, 0, 0, ZoneId.of("Europe/London"))
     val date2 = ZonedDateTime.of(2022, 12, 10, 15, 0, 0, 0, ZoneId.of("Europe/London"))
-    val placeHolderMatches = Seq(
-      fixture("Wnr Gp E/R-Up Gp F", "Wnr Gp G/R-Up Gp H", date1),
-      fixture("Winner Q/F 3", "Winner Q/F 4", date2))
+    val placeHolderMatches =
+      Seq(fixture("Wnr Gp E/R-Up Gp F", "Wnr Gp G/R-Up Gp H", date1), fixture("Winner Q/F 3", "Winner Q/F 4", date2))
 
     val comps = testCompetitionsService(
       Competition(
@@ -137,9 +136,7 @@ import scala.concurrent.duration._
     assert(competitionAgent.competition.matches.contains(placeHolderMatches.head))
     assert(competitionAgent.competition.matches.contains(placeHolderMatches(1)))
 
-    val matchesWithKnownOpponents = Seq(
-      fixture("Brazil", "Croatia", date1),
-      fixture("Spain", "Portugal", date2))
+    val matchesWithKnownOpponents = Seq(fixture("Brazil", "Croatia", date1), fixture("Spain", "Portugal", date2))
     Await.result(competitionAgent.addMatches(matchesWithKnownOpponents), 2.second)
 
     assert(competitionAgent.competition.matches.length === 2)


### PR DESCRIPTION
## What does this change?
Refactors [this one](https://github.com/guardian/frontend/pull/25734) as per reviewers' suggestions.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
