### PR TITLE
add HeaderTopBarSearchCapi switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeNetworkFront,
       DCRJavascriptBundle,
       BillboardsInMerchSlots,
+      HeaderTopBarSearchCapi,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -81,4 +82,13 @@ object BillboardsInMerchSlots
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
       sellByDate = LocalDate.of(2023, 2, 1),
       participationGroup = Perc0E,
+    )
+
+object HeaderTopBarSearchCapi
+    extends Experiment(
+      name = "header-top-bar-search-capi",
+      description = "Adds CAPI search to the top nav",
+      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
+      sellByDate = LocalDate.of(2023, 2, 1),
+      participationGroup = Perc1B,
     )


### PR DESCRIPTION
## What does this change?
Add a switch for https://github.com/guardian/dotcom-rendering/pull/6629

