### PR TITLE
Remove Relevant Yield cookie sync

### DIFF
--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -12,12 +12,6 @@
 			width="0"
 			sandbox="allow-scripts allow-same-origin"
 		></iframe>
-		<iframe
-			src="https://guardian-cdn.relevant-digital.com/static/tags/6214c1072d89bdff800f25f2_cookiesync.html?endpoint=relevant&max_sync_count=5"
-			height="0"
-			width="0"
-			sandbox="allow-scripts allow-same-origin"
-		></iframe>
 	</body>
 	<script>
 		const iframes = Array.from(document.getElementsByTagName('iframe'));


### PR DESCRIPTION
## What does this change?

Removes the Relevant Yield cookie sync iframe that we serve onto AMP.

Note that this `amp-iframe.html` file is itself fetched by a 1x1 tracking iframe on AMP.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We shouldn't be cookie syncing with a third party we no longer use.

### Tested

- [ ] Locally
- [ ] On CODE (optional)
