### PR TITLE
feat: add fixed/thrasher comment to FaciaPicker

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -15,6 +15,11 @@ object FrontChecks {
   val SUPPORTED_COLLECTIONS: Set[String] =
     Set(
       /*
+    "fixed/thrasher",
+      pending https://github.com/guardian/dotcom-rendering/issues/5134
+       */
+
+      /*
     "dynamic/slow-mpu",
       pending https://github.com/guardian/dotcom-rendering/issues/5926
        */


### PR DESCRIPTION
## What does this change?
Adds a note about supporting `fixed/thrasher` to `FaciaPicker` tracking at: https://github.com/guardian/dotcom-rendering/issues/5134