### PR TITLE
Spike: billboard adverts in merchandising slots

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -84,4 +84,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2022, 12, 30)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-billboards-in-merch",
+    "Test the commercial impact of showing billboard adverts in merchandising slots",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 1, 30)),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,7 +12,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       TableOfContents,
       EuropeNetworkFront,
       DCRJavascriptBundle,
-      BillboardsInMerchSlots,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -72,13 +71,4 @@ object EuropeNetworkFront
       owners = Seq(Owner.withGithub("rowannekabalan")),
       sellByDate = LocalDate.of(2023, 3, 1),
       participationGroup = Perc0D,
-    )
-
-object BillboardsInMerchSlots
-    extends Experiment(
-      name = "billboards-in-merch-slots",
-      description = "Test commercial impact of serving billboard sized ads in merchandising slots",
-      owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
-      sellByDate = LocalDate.of(2023, 2, 1),
-      participationGroup = Perc0E,
     )

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { billboardsInMerch } from './tests/billboards-in-merch';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { integrateIma } from './tests/integrate-ima';
@@ -21,4 +22,5 @@ export const concurrentTests: readonly ABTest[] = [
 	removePrebidA9Canada,
 	liveblogDesktopOutstream,
 	teadsCookieless,
+	billboardsInMerch,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/billboards-in-merch.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/billboards-in-merch.ts
@@ -1,0 +1,23 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const billboardsInMerch: ABTest = {
+	id: 'BillboardsInMerch',
+	author: '@commercial-dev',
+	start: '2022-12-07',
+	expiry: '2023-02-31',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in only',
+	successMeasure:
+		'Test the commercial impact of showing billboard adverts in merchandising slots',
+	description:
+		'Show billboard adverts in merchandising slots to browsers in the variant',
+	variants: [
+		// TODO Bypass metrics sampling once we increase audience size
+		{ id: 'control', test: noop },
+		// TODO Bypass metrics sampling once we increase audience size
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -215,6 +215,7 @@
  ],
  "../projects/commercial/modules/dfp/fill-advert-slots.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/detect-breakpoint.ts",
   "../projects/commercial/modules/dfp/Advert.ts",


### PR DESCRIPTION
## What does this change?

This PR adds the billboard (`970x250`) size to the merchandising units on pages of the website (they're included in almost all content types).

Currently this behaviour is gated behind a zero-percent client-side AB test. Hence, we determine participation in the variant client-side and add the additional size when we execute the `fill-advert-slots` module. Whilst we're here, we pull this logic out into a `decideAdditionalSizes` function.

**Note users not in the test or the control will not get the new billboard sizing.**

Some further styling and attribute changes are required in DCR- See https://github.com/guardian/dotcom-rendering/pull/6720.

> **Note**
> This is a spike for work we may want to pursue more thoroughly in the future. 
> 
> As such, it comes with some caveats:
> - The new logic is gated by a 0% AB test, so won't be exposed to any browsers that haven't opted in.
> - There's no guarantees of the behaviour of Frontend-rendered merchandising units. That can come later.
> - Some CSS might be off and need fixing in the variant group.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - https://github.com/guardian/dotcom-rendering/pull/6720

## Screenshots

`merchandising-high` and `merchandising` slots.

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/8000415/206233309-95181da8-658e-4e56-937e-2f2be0285fa3.png
[before2]: https://user-images.githubusercontent.com/8000415/206233356-1ad6f151-211c-40d0-9298-f8c25f2d2997.png
[after]: https://user-images.githubusercontent.com/8000415/206232735-f0c304d9-e592-4926-8f19-27e4d1526b82.png
[after2]: https://user-images.githubusercontent.com/8000415/206232837-08a87779-2f8e-4c3c-85a5-b7e374bcf3fd.png

## What is the value of this and can you measure success?

This is a spike into displaying billboard (that's `970x250` sized display ads) into the merchandising units on the site. These units typically contain fluid-sized commercial templates that display in-house promotions and marketing. Allowing billboards would present an opportunity to further monetise these slots via Google's OMP and our own direct campaigns.

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
