### PR TITLE
Add Teads Cookieless tag AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -74,4 +74,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2023, 1, 31)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-teads-cookieless",
+    "Test UX impact of cookieless Teads",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 12, 30)),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -560,4 +560,14 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val teadsCookieless: Switch = Switch(
+    group = Commercial,
+    name = "teads-cookieless",
+    description = "Enable Teads cookieless tag",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -14,6 +14,7 @@
 
 import { EventTimer } from '@guardian/commercial-core';
 import { log } from '@guardian/libs';
+import { initTeadsCookieless } from 'commercial/modules/teads-cookieless';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { consentlessAds } from 'common/modules/experiments/tests/consentlessAds';
 import { reportError } from '../lib/report-error';
@@ -75,6 +76,7 @@ const commercialExtraModules: Modules = [
 	['cm-closeDisabledSlots', closeDisabledSlots],
 	['cm-comscore', initComscore],
 	['cm-ipsosmori', initIpsosMori],
+	['cm-teadsCookieless', initTeadsCookieless],
 	['cm-trackScrollDepth', initTrackScrollDepth],
 	['cm-trackLabsContainer', initTrackLabsContainer],
 	['cm-trackGpcSignal', initTrackGpcSignal],

--- a/static/src/javascripts/projects/commercial/modules/teads-cookieless.ts
+++ b/static/src/javascripts/projects/commercial/modules/teads-cookieless.ts
@@ -1,0 +1,44 @@
+import {
+	getConsentFor,
+	onConsent,
+	onConsentChange,
+} from '@guardian/consent-management-platform';
+import { loadScript, setCookie } from '@guardian/libs';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { teadsCookieless as teadsCookielessTest } from 'common/modules/experiments/tests/teads-cookieless';
+
+const initTeadsCookieless = async (): Promise<void> => {
+	const consentState = await onConsent();
+
+	const hasConsent = getConsentFor('teads', consentState);
+
+	if (
+		hasConsent &&
+		window.guardian.config.switches.teadsCookieless &&
+		isInVariantSynchronous(teadsCookielessTest, 'variant')
+	) {
+		window.teads_analytics = window.teads_analytics ?? {};
+		window.teads_analytics.analytics_tag_id = 'PUB_2167';
+		window.teads_analytics.share =
+			window.teads_analytics.share ??
+			function (...args) {
+				if (window.teads_analytics) {
+					(window.teads_analytics.shared_data =
+						window.teads_analytics.shared_data ?? []).push(...args);
+				}
+			};
+		await loadScript('https://a.teads.tv/analytics/tag.js', {
+			async: false,
+		});
+	}
+};
+
+onConsentChange((consentState) => {
+	const hasConsent = getConsentFor('teads', consentState);
+
+	if (!hasConsent) {
+		setCookie({ name: '_tfpvi', value: '' });
+	}
+});
+
+export { initTeadsCookieless };

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -7,6 +7,7 @@ import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { removePrebidA9Canada } from './tests/removePrebidA9Canada';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
+import { teadsCookieless } from './tests/teads-cookieless';
 
 // keep in sync with ab-tests in dotcom-rendering
 // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -19,4 +20,5 @@ export const concurrentTests: readonly ABTest[] = [
 	integrateIma,
 	removePrebidA9Canada,
 	liveblogDesktopOutstream,
+	teadsCookieless,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
@@ -7,7 +7,7 @@ export const teadsCookieless: ABTest = {
 	expiry: '2023-12-31',
 	author: 'Jake Lee Kennedy',
 	description: 'Test the impact of enabling the Teads cookieless tag',
-	audience: 1 / 100,
+	audience: 0,
 	audienceOffset: 5 / 100,
 	audienceCriteria: 'Opt in',
 	successMeasure: 'No significant impact to UX',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
@@ -1,0 +1,19 @@
+import type { ABTest } from '@guardian/ab-core';
+import { bypassMetricsSampling } from '../utils';
+
+export const teadsCookieless: ABTest = {
+	id: 'TeadsCookieless',
+	start: '2022-12-07',
+	expiry: '2023-12-31',
+	author: 'Jake Lee Kennedy',
+	description: 'Test the impact of enabling the Teads cookieless tag',
+	audience: 1 / 100,
+	audienceOffset: 5 / 100,
+	audienceCriteria: 'Opt in',
+	successMeasure: 'No significant impact to UX',
+	canRun: () => true,
+	variants: [
+		{ id: 'control', test: () => bypassMetricsSampling },
+		{ id: 'variant', test: () => bypassMetricsSampling },
+	],
+};

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -303,6 +303,12 @@ interface IasPET {
 	pubId?: string;
 }
 
+interface TeadsAnalytics {
+	analytics_tag_id?: string;
+	share?: () => void;
+	shared_data?: unknown[];
+}
+
 interface OptOutInitializeOptions {
 	publisher: number;
 	onlyNoConsent?: 0 | 1;
@@ -454,6 +460,7 @@ interface Window {
 	permutive?: Permutive;
 	_comscore?: ComscoreGlobals[];
 	__iasPET?: IasPET;
+	teads_analytics?: TeadsAnalytics;
 
 	// https://www.iab.com/wp-content/uploads/2014/08/SafeFrames_v1.1_final.pdf
 	$sf: SafeFrameAPI;

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -544,6 +544,10 @@
   "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/fastdom-promise.ts"
  ],
+ "../projects/commercial/modules/teads-cookieless.ts": [
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
  "../projects/commercial/modules/third-party-tags.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
@@ -684,6 +688,7 @@
   "../projects/commercial/modules/remove-slots.ts",
   "../projects/commercial/modules/set-adtest-cookie.ts",
   "../projects/commercial/modules/set-adtest-in-labels-cookie.ts",
+  "../projects/commercial/modules/teads-cookieless.ts",
   "../projects/commercial/modules/third-party-tags.ts",
   "../projects/commercial/modules/track-gpc-signal.ts",
   "../projects/commercial/modules/track-labs-container.ts",


### PR DESCRIPTION
## What does this change?
Adds Teads Cookieless tag 0% AB test, the tag is not working as expected, we need to share a link with Teads so that the can assist.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (https://github.com/guardian/dotcom-rendering/pull/6730)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
