### PR TITLE
feat: Support `nav/media-list` in FaciaPicker

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -57,6 +57,7 @@ object FrontChecks {
       "fixed/medium/fast-XI",
       "fixed/large/slow-XIV",
       "nav/list",
+      "nav/media-list",
       "news/most-popular",
     )
 


### PR DESCRIPTION
## What does this change?

Adds `nav/media-list` to FaciaPicker's supported containers

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes guardian/dotcom-rendering#6194 
