### PR TITLE
Switched the help and contact us links in the footer

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -27,33 +27,33 @@ object FooterLinks {
 
   val ukListOne = List(
     FooterLink("About us", "/about", "uk : footer : about us"),
-    FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
+    help("uk"),
     complaintsAndCorrections,
     secureDrop,
     workForUs("uk"),
     privacyPolicy,
     cookiePolicy,
     termsAndConditions,
-    help("uk"),
+    FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
   )
 
   val usListOne = List(
     FooterLink("About us", "/info/about-guardian-us", "us : footer : about us"),
-    FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
+    help("us"),
     complaintsAndCorrections,
     secureDrop,
     workForUs("us"),
     privacyPolicy,
     cookiePolicy,
     termsAndConditions,
-    help("us"),
+    FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
   )
 
   val auListOne = List(
     FooterLink("About us", "/info/about-guardian-australia", "au : footer : about us"),
+    help("au"),
     FooterLink("Information", "/info", "au : footer : information"),
     complaintsAndCorrections,
-    FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
     secureDrop,
     FooterLink(
       "Vacancies",
@@ -62,18 +62,18 @@ object FooterLinks {
     ),
     privacyPolicy,
     termsAndConditions,
-    help("au"),
+    FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
   )
 
   val intListOne = List(
-    FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
+    help("international"),
     complaintsAndCorrections,
     secureDrop,
     workForUs("international"),
     privacyPolicy,
     cookiePolicy,
     termsAndConditions,
-    help("international"),
+    FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
   )
 
   // Footer column two

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -51,9 +51,9 @@ object FooterLinks {
 
   val auListOne = List(
     FooterLink("About us", "/info/about-guardian-australia", "au : footer : about us"),
-    help("au"),
     FooterLink("Information", "/info", "au : footer : information"),
     complaintsAndCorrections,
+    help("au"),
     secureDrop,
     FooterLink(
       "Vacancies",


### PR DESCRIPTION
## What does this change?

This switches the placement of the Help and Contact Us links in the footer of the website, on each edition, following a request from Jess King: 

"I work in the Customer Experience team and we're trying to improve our contact funnel...ideally we want people to visit the [help centre ](https://manage.theguardian.com/help-centre)before they contact us. 

I'm working on eventually phasing the [Contact Us](https://www.theguardian.com/help/contact-us#2c1862c7-92f2-4151-a0b7-6d6d12749a58) page out by migrating the relevant contact details to the help centre, it's a mammoth task in itself because there are so many stakeholders involved. As this could take a while I think, in the meantime, it would be good to switch 'Help' and 'Contact Us' in the footer, to replicate the funnel we want to create."

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before (UK, US, INT)      | After (UK, US, INT)      | Before (AU)     | After   (AU)   | 
|-------------|------------|-------------|------------|
| ![beforeUK][] | ![afterUK][] |![beforeAU][] | ![afterAU][] |


[beforeUK]: https://user-images.githubusercontent.com/102960844/206474618-5d2d6355-ecbd-4d16-b6ef-54e5085a2bc3.png
[afterUK]: https://user-images.githubusercontent.com/102960844/206475683-11ea8191-5715-4f08-8d4e-fbc43d1482e9.png

[beforeAU]: https://user-images.githubusercontent.com/102960844/206475038-1baecf73-aeba-43b3-9625-a3dfad638d59.png
[afterAU]: https://user-images.githubusercontent.com/102960844/206476924-5acdfab9-e474-483a-9982-fbf963ca0aa0.png


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
