### PR TITLE
Don't place carrot ads near newsletter blocks

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -94,4 +94,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2023, 1, 30)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-no-carrot-ads-near-newsletter-signup-blocks",
+    "Test the impact of preventing spacefinder from positioning carrot ads near newsletter signup blocks",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 2, 1)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
@@ -1,4 +1,6 @@
 import { createAdSlot } from '@guardian/commercial-core';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { noCarrotAdsNearNewsletterSignupBlocks } from 'common/modules/experiments/tests/no-carrot-ads-near-newsletter-signup-blocks';
 import { getCurrentTweakpoint } from 'lib/detect-breakpoint';
 import { getUrlVars } from 'lib/url';
 import fastdom from '../../../lib/fastdom-promise';
@@ -58,6 +60,19 @@ const wideRules: SpacefinderRules = {
 	},
 	fromBottom: true,
 };
+
+const avoidNewsletterSignupBlocks = !isInVariantSynchronous(
+	noCarrotAdsNearNewsletterSignupBlocks,
+	'control',
+);
+
+if (avoidNewsletterSignupBlocks && wideRules.selectors) {
+	// Don't place carrot ads near newsletter sign-up blocks
+	wideRules.selectors[' > figure[data-spacefinder-role="inline"]'] = {
+		minAbove: 400,
+		minBelow: 400,
+	};
+}
 
 // anything below leftCol (1140) : desktop, tablet, ..., mobile
 const desktopRules: SpacefinderRules = {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { integrateIma } from './tests/integrate-ima';
 import { liveblogDesktopOutstream } from './tests/liveblog-desktop-outstream';
+import { noCarrotAdsNearNewsletterSignupBlocks } from './tests/no-carrot-ads-near-newsletter-signup-blocks';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -21,4 +22,5 @@ export const concurrentTests: readonly ABTest[] = [
 	liveblogDesktopOutstream,
 	teadsCookieless,
 	billboardsInMerch,
+	noCarrotAdsNearNewsletterSignupBlocks,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/no-carrot-ads-near-newsletter-signup-blocks.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/no-carrot-ads-near-newsletter-signup-blocks.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { bypassMetricsSampling } from '../utils';
+
+export const noCarrotAdsNearNewsletterSignupBlocks: ABTest = {
+	id: 'NoCarrotAdsNearNewsletterSignupBlocks',
+	author: '@commercial-dev',
+	start: '2022-12-08',
+	expiry: '2023-02-01',
+	audience: 10 / 100,
+	audienceOffset: 35 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Making the change does not lead to a significant reduction in inline programmatic revenue per 1000 pageviews',
+	description:
+		'Test the impact of preventing spacefinder from positioning carrot ads near newsletter signup blocks',
+	variants: [
+		{ id: 'control', test: bypassMetricsSampling },
+		{ id: 'variant', test: bypassMetricsSampling },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

Prevents carrot ads being placed near newsletter signup blocks. 

Also introduces a 10% test `NoCarrotAdsNearNewsletterSignupBlocks` to measure the impact of this change.

![Screenshot 2022-12-08 at 16 48 58](https://user-images.githubusercontent.com/7423751/206513289-7f8bb5f5-d43f-4cf2-a125-250222c2eef4.png)

The change will be rolled out to everyone **not in the control group of the test** (that is, the variant of the test and non-participants). The table below summarises this behaviour:

|                 |                 **Behaviour**                 |
|:---------------:|:---------------------------------------------:|
|   **Control** (5% of audience)   |               no change ❌              |
|   **Variant** (5% of audience)  | don't place carrot ads near signup blocks  ✅ |
| **Not in test** (90% of audience) | don't place carrot ads near signup blocks ✅ |

The idea being: we're pretty sure we need to make this change from a UX perspective, but it still would be helpful to analyse the impact.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6728

## What is the value of this and can you measure success?

No more carrot ads colliding with newsletter signup blocks:

![Screen Shot 2022-10-20 at 1 32 16 pm](https://user-images.githubusercontent.com/7423751/206515660-e507c5d4-3571-4599-97b8-b9979a547469.png)

### Tested

- [x] Locally
- [x] On CODE - I couldn't get the AB test to work for some reason. Works fine locally. Can we deploy and test in production? 😅 