### PR TITLE
Keep Series & Blog tag `/latest` redirects out of Google Search

### DIFF
--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -49,7 +49,7 @@ class LatestIndexController(contentApiClient: ContentApiClient, val controllerCo
         Redirect(url, queryString)
 
       case Some(latest) =>
-        Found(latest.metadata.url)
+        Found(latest.metadata.url).withHeaders("X-Robots-Tag" -> "noindex")
 
       case None =>
         NotFound

--- a/applications/test/LatestIndexControllerTest.scala
+++ b/applications/test/LatestIndexControllerTest.scala
@@ -21,10 +21,22 @@ import play.api.test.Helpers._
   lazy val latestIndexController =
     new LatestIndexController(testContentApiClient, play.api.test.Helpers.stubControllerComponents())
 
+  private val seriesTagPath = "football/series/thefiver"
+
   it should "redirect to latest for a series" in {
-    val result = latestIndexController.latest("football/series/thefiver")(TestRequest())
+    val result = latestIndexController.latest(seriesTagPath)(TestRequest())
     status(result) should be(Found)
     header("Location", result).head should include("/football/20")
+  }
+
+  it should "redirect while indicating that the redirecting url should not appear in Google Search results" in {
+    val result = latestIndexController.latest(seriesTagPath)(TestRequest())
+    // We've noticed /latest paths appearing in Google Search results - probably as a result of using /latest in
+    // standfirsts etc. Inadvertently this gives these redirect urls search-rank authority. It's possible that as a
+    // result /latest may be cannibalising the search authority of liveblogs that take series tags (due to the
+    // association of latest liveblog with the redirect).
+    // https://developers.google.com/search/docs/crawling-indexing/block-indexing
+    header("X-Robots-Tag", result).head should include("noindex")
   }
 
   it should "redirect to latest email for a blog" in {


### PR DESCRIPTION
The `/latest` endpoints (for blog & series tags) were introduced in April 2014 with PR  https://github.com/guardian/frontend/pull/3895. For example:

https://www.theguardian.com/world/series/coronavirus-live/latest

...will redirect you to the latest article in the https://www.theguardian.com/world/series/coronavirus-live series.

However, we've noticed that some **`/latest` urls are showing up in Google Search, and that isn't a good thing** - from email conversation with Peter Martin, Tom Johnson, Dave Earley, etc (Audience Development heads), there is concern that the `/latest` version of the url may be stealing page rank from the actual liveblogs they redirect to. We don't want to split pagerank between the liveblog and the `/latest` endpoint!

We can [tell Google to not index](https://developers.google.com/search/docs/crawling-indexing/block-indexing) these `/latest` urls. We have to use a `X-Robots-Tag` HTTP response header, rather than a meta tag, as a redirect - like `/latest` - has no html body you can put tags in.

### Running locally

```
$ ./sbt applications/run

$ curl -I http://localhost:9000/world/series/coronavirus-live/latest
HTTP/1.1 302 Found
Location: /world/live/2022/feb/25/covid-live-news-coronavirus-mask-wearing-vaccines-hong-kong
X-Robots-Tag: noindex
Surrogate-Key: 4f5222014ddbd39d722f271979573a2d
X-Gu-Backend-App: applications
Date: Thu, 08 Dec 2022 17:17:00 GMT
Content-Length: 0
```
### Other examples of using `noindex` to keep urls out of Google Search

https://github.com/guardian/ophan/pull/5016 recently used `noindex` to address https://github.com/guardian/ophan/issues/4986 and keep https://dashboard.ophan.co.uk/ out of Google Search results.