### PR TITLE
change colors for the guardian documentaries thrashers form:

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -254,6 +254,18 @@
     }
 }
 
+.email-sub__form--thrasher-documentaries {
+    .email-sub__thrasher-embed-label {
+        color: $brightness-7;
+    }
+
+    .email-sub__thrasher-embed-button {
+        background-color: $brightness-7;
+        color: $brightness-100;
+        fill: $brightness-100;
+    }
+}
+
 .email-sub__form--thrasher-us-morning-newsletter,
 .email-sub__form--thrasher-morning-mail,
 .email-sub__form--thrasher-afternoon-update,


### PR DESCRIPTION
## What does this change?

Sets the custom colors for the guardian documentaries thrashers form:
- black label text
- black background and white color & svg fill for button 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots



[before]: https://example.com/before.png
<img width="1362" alt="Screenshot 2022-12-08 at 15 40 05" src="https://user-images.githubusercontent.com/30567854/206490678-2c988e61-7ac4-4aea-9184-b96e1f687884.png">


[after]: https://example.com/after.png
<img width="1362" alt="Screenshot 2022-12-08 at 15 42 07" src="https://user-images.githubusercontent.com/30567854/206490834-13cba1da-1b75-4fe1-a9c1-27e1ef3d677b.png">




### Tested

- [x] Locally
- [ ] On CODE (optional)


