### PR TITLE
Add Alex Ware to alumni section of humans.txt

### DIFF
--- a/facia/public/humans.txt
+++ b/facia/public/humans.txt
@@ -433,3 +433,8 @@ From: London, UK
 
 Developer: Divya Bhatt
 From: Woodley, UK
+
+Developer: Alex Ware
+Twitter: @MostFoolhardy
+From: Truro, UK
+Location: Bristol, UK


### PR DESCRIPTION
## What does this change?
Adds an honorary ex-guardian developer to humans.txt - see https://github.com/AWare for his contributions!

See https://www.theguardian.com/humans.txt for the full list