### PR TITLE
Revert to last deployed

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,7 +13,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeNetworkFront,
       DCRJavascriptBundle,
       BillboardsInMerchSlots,
-      HeaderTopBarSearchCapi,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -82,13 +81,4 @@ object BillboardsInMerchSlots
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
       sellByDate = LocalDate.of(2023, 2, 1),
       participationGroup = Perc0E,
-    )
-
-object HeaderTopBarSearchCapi
-    extends Experiment(
-      name = "header-top-bar-search-capi",
-      description = "Adds CAPI search to the top nav",
-      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2023, 2, 1),
-      participationGroup = Perc1B,
     )

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -27,33 +27,33 @@ object FooterLinks {
 
   val ukListOne = List(
     FooterLink("About us", "/about", "uk : footer : about us"),
-    help("uk"),
+    FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
     complaintsAndCorrections,
     secureDrop,
     workForUs("uk"),
     privacyPolicy,
     cookiePolicy,
     termsAndConditions,
-    FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
+    help("uk"),
   )
 
   val usListOne = List(
     FooterLink("About us", "/info/about-guardian-us", "us : footer : about us"),
-    help("us"),
+    FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
     complaintsAndCorrections,
     secureDrop,
     workForUs("us"),
     privacyPolicy,
     cookiePolicy,
     termsAndConditions,
-    FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
+    help("us"),
   )
 
   val auListOne = List(
     FooterLink("About us", "/info/about-guardian-australia", "au : footer : about us"),
     FooterLink("Information", "/info", "au : footer : information"),
     complaintsAndCorrections,
-    help("au"),
+    FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
     secureDrop,
     FooterLink(
       "Vacancies",
@@ -62,18 +62,18 @@ object FooterLinks {
     ),
     privacyPolicy,
     termsAndConditions,
-    FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
+    help("au"),
   )
 
   val intListOne = List(
-    help("international"),
+    FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
     complaintsAndCorrections,
     secureDrop,
     workForUs("international"),
     privacyPolicy,
     cookiePolicy,
     termsAndConditions,
-    FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
+    help("international"),
   )
 
   // Footer column two

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -15,11 +15,6 @@ object FrontChecks {
   val SUPPORTED_COLLECTIONS: Set[String] =
     Set(
       /*
-    "fixed/thrasher",
-      pending https://github.com/guardian/dotcom-rendering/issues/5134
-       */
-
-      /*
     "dynamic/slow-mpu",
       pending https://github.com/guardian/dotcom-rendering/issues/5926
        */

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -57,7 +57,6 @@ object FrontChecks {
       "fixed/medium/fast-XI",
       "fixed/large/slow-XIV",
       "nav/list",
-      "nav/media-list",
       "news/most-popular",
     )
 


### PR DESCRIPTION
## What does this change?

Reverts deploys from the last two days as they have not actually gone live due to:

https://github.com/guardian/riff-raff/pull/947

This gets `main` into a (known) safe state for the weekend. The Dotcom team will need to redeploy these PRs next week.