### PR TITLE
Fixes for teads cookieless tag AB test and increase to 1%

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -564,7 +564,7 @@ trait PrebidSwitches {
   val teadsCookieless: Switch = Switch(
     group = Commercial,
     name = "teads-cookieless",
-    description = "Enable Teads cookieless tag",
+    description = "Enable the Teads cookieless tag on articles and liveblogs",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,

--- a/static/src/javascripts/projects/commercial/modules/teads-cookieless.ts
+++ b/static/src/javascripts/projects/commercial/modules/teads-cookieless.ts
@@ -3,7 +3,7 @@ import {
 	onConsent,
 	onConsentChange,
 } from '@guardian/consent-management-platform';
-import { loadScript, setCookie } from '@guardian/libs';
+import { getCookie, loadScript } from '@guardian/libs';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { teadsCookieless as teadsCookielessTest } from 'common/modules/experiments/tests/teads-cookieless';
 
@@ -39,9 +39,15 @@ const initTeadsCookieless = async (): Promise<void> => {
 
 onConsentChange((consentState) => {
 	const hasConsent = getConsentFor('teads', consentState);
-
-	if (!hasConsent) {
-		setCookie({ name: '_tfpvi', value: '' });
+	const teadsCookie = getCookie({ name: '_tfpvi' });
+	if (!hasConsent && teadsCookie) {
+		/*
+		Teads sets a cookie called _tfpvi, which is used to track users across sites.
+		We need to delete this cookie if the user has not consented to Teads.
+		We can't use the @guardian/libs setCookie function here, because it normalizes
+		the domain to theguardian.com but the cookie is set on www.theguardian.com
+		*/
+		document.cookie = '_tfpvi=;path=/';
 	}
 });
 

--- a/static/src/javascripts/projects/commercial/modules/teads-cookieless.ts
+++ b/static/src/javascripts/projects/commercial/modules/teads-cookieless.ts
@@ -12,10 +12,14 @@ const initTeadsCookieless = async (): Promise<void> => {
 
 	const hasConsent = getConsentFor('teads', consentState);
 
+	// Teads only runs on these content types, so lets not give them any more data than necessary
+	const allowedContentTypes = ['Article', 'LiveBlog'];
+
 	if (
 		hasConsent &&
 		window.guardian.config.switches.teadsCookieless &&
-		isInVariantSynchronous(teadsCookielessTest, 'variant')
+		isInVariantSynchronous(teadsCookielessTest, 'variant') &&
+		allowedContentTypes.includes(window.guardian.config.page.contentType)
 	) {
 		window.teads_analytics = window.teads_analytics ?? {};
 		window.teads_analytics.analytics_tag_id = 'PUB_2167';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
@@ -7,7 +7,7 @@ export const teadsCookieless: ABTest = {
 	expiry: '2023-12-31',
 	author: 'Jake Lee Kennedy',
 	description: 'Test the impact of enabling the Teads cookieless tag',
-	audience: 1 / 100,
+	audience: 0,
 	audienceOffset: 5 / 100,
 	audienceCriteria: 'Opt in',
 	successMeasure: 'No significant impact to UX',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
@@ -4,7 +4,7 @@ import { bypassMetricsSampling } from '../utils';
 export const teadsCookieless: ABTest = {
 	id: 'TeadsCookieless',
 	start: '2022-12-07',
-	expiry: '2023-12-31',
+	expiry: '2022-12-31',
 	author: 'Jake Lee Kennedy',
 	description: 'Test the impact of enabling the Teads cookieless tag',
 	audience: 1 / 100,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/teads-cookieless.ts
@@ -7,7 +7,7 @@ export const teadsCookieless: ABTest = {
 	expiry: '2023-12-31',
 	author: 'Jake Lee Kennedy',
 	description: 'Test the impact of enabling the Teads cookieless tag',
-	audience: 0,
+	audience: 1 / 100,
 	audienceOffset: 5 / 100,
 	audienceCriteria: 'Opt in',
 	successMeasure: 'No significant impact to UX',


### PR DESCRIPTION
## What does this change?

- fix cookie deletion when consent is denied
- restrict cookie/tracking to article and liveblog pages
- increase AB test to 1%

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (test needs increasing to 1%)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
