### PR TITLE
Correct width/height params in DocumentBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1334,8 +1334,8 @@ object PageElement {
           .map(d =>
             DocumentBlockElement(
               getEmbedUrl(d.html),
-              d.width,
               d.height,
+              d.width,
               d.title,
               d.isMandatory,
               containsThirdPartyTracking(element.tracking),

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1333,14 +1333,14 @@ object PageElement {
         element.documentTypeData
           .map(d =>
             DocumentBlockElement(
-              getEmbedUrl(d.html),
-              d.height,
-              d.width,
-              d.title,
-              d.isMandatory,
-              containsThirdPartyTracking(element.tracking),
-              d.source,
-              d.sourceDomain,
+              embedUrl = getEmbedUrl(d.html),
+              height = d.height,
+              width = d.width,
+              title = d.title,
+              isMandatory = d.isMandatory,
+              isThirdPartyTracking = containsThirdPartyTracking(element.tracking),
+              source = d.source,
+              sourceDomain = d.sourceDomain,
             ),
           )
           .toList


### PR DESCRIPTION
_co-authored-by: @andrew-nowak_ 

## What does this change?

Swaps the width and height params in the `DocumentBlockElement` to match the correct order for the case class. They're the wrong way round, which is causing some documents to look a bit odd.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

|Before (incorrect)|After (manually editing iframe props to be correct)|
|-|-|
|<img width="896" alt="Screenshot 2022-12-12 at 15 47 45" src="https://user-images.githubusercontent.com/7767575/207090176-ca29c7d4-366a-41dc-914b-7c2d702f6f67.png">|<img width="896" alt="Screenshot 2022-12-12 at 15 48 11" src="https://user-images.githubusercontent.com/7767575/207090202-f05108a9-17a8-4fb4-95ba-525971e97705.png">|

## What is the value of this and can you measure success?

Nicer looking documents, especially in portrait.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [x] Other (please specify)

I'm sure whichever consumers will be delighted to have the correct dimensions.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
