### PR TITLE
Update to the comment above the exclusion slot...

### DIFF
--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -3,14 +3,14 @@
 @import views.support.Commercial.topAboveNavSlot
 
 <div class="@topAboveNavSlot.cssClasses(page.metadata)">
-    <!--
+    @{ /*
         This is a special type of ad which, when filled, blocks
         all other ads on the page. This allows us to run "exclusion
         campaigns" against certain breaking news pages. Exclusion
         ads are used for consentless advertising only. They are
         ignored by GAM, which has a different mechanism to achieve
         the same thing.
-    -->
+    */ }
     @fragments.commercial.standardAd(
         "exclusion",
         Seq.empty[String],


### PR DESCRIPTION
## What does this change?
Previously the comment in the code was expressed as a html comment `<!-- comment -->`, which meant it was sent over the wire and visible in the source of the page.

It's now a scala template comment `@{ /* comment */ }` and no longer sent to the page.

The DCR version isn't sent to the page: https://github.com/guardian/dotcom-rendering/pull/6656/files#diff-33f9877b463022dad5b2f83a3bd906c0e7600a627d76842e8fa9546fc1bc19ea

### Before
![Screenshot 2022-12-13 at 10 13 59](https://user-images.githubusercontent.com/768467/207290455-c4356614-b9f4-41cb-a2a6-ccd21f04f546.png)


### After
![Screenshot 2022-12-13 at 10 13 51](https://user-images.githubusercontent.com/768467/207290425-95338d81-b960-4c0a-bc01-2456478aec2e.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)
