### PR TITLE
Bump `commercial-core` to `5.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^8.1.1",
-		"@guardian/commercial-core": "^4.25.0",
+		"@guardian/commercial-core": "^5.0.1",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^1.0.0",
 		"@guardian/libs": "^7.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,10 +2171,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.1.tgz#7b265a7d2a2163df70238823e881950a6d43598d"
   integrity sha512-4izZBDS9HXgEmf9hLBs0X3JdtgrdnGuFRCGhyJFodUPU+ZFXo2H4rOQlTBBsUhr5PurEZBDVU+9y6ZCe74ZWcg==
 
-"@guardian/commercial-core@^4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.25.0.tgz#cbc1ab2aaff456a3dc20836b1520a4a29b3a75ec"
-  integrity sha512-EDFSiCtTAlXdu/WK8dCp+BO5TLIYeyZ4QGkYv2lNXJ7y2U3zFkyTipPHq2Ld9iOSyy2+TtcF3OPnXS4j1pJ7vA==
+"@guardian/commercial-core@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.0.1.tgz#728221b054944a6cd38ca2dfa347cd435e286f9f"
+  integrity sha512-dxjJWOIpSUnjjuBFRWL6xLg0SZiUi8l8eO5GrISjNiTxv4FAjYG0/9qk9brJlgRtqwO0Aq2HC1Y8CHLYG54kNg==
+  dependencies:
+    type-fest "2.12.2"
 
 "@guardian/consent-management-platform@^10.11.1":
   version "10.11.1"
@@ -14407,6 +14409,11 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
+  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
## What does this change?

Bumps commercial-core to bring in this change: 

https://github.com/guardian/commercial-core/pull/734

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
