### PR TITLE
Update header top nav items hover styling

### DIFF
--- a/static/src/stylesheets/layout/nav/_edition-picker-toggle.scss
+++ b/static/src/stylesheets/layout/nav/_edition-picker-toggle.scss
@@ -5,6 +5,6 @@
 }
 
 button.edition-picker-toggle-button:hover {
-    color: #fff;
+    color: #ffffff;
     text-decoration: underline;
 }

--- a/static/src/stylesheets/layout/nav/_edition-picker-toggle.scss
+++ b/static/src/stylesheets/layout/nav/_edition-picker-toggle.scss
@@ -3,3 +3,8 @@
     background: none;
     text-align: left;
 }
+
+button.edition-picker-toggle-button:hover {
+    color: #fff;
+    text-decoration: underline;
+}

--- a/static/src/stylesheets/layout/nav/_my-account.scss
+++ b/static/src/stylesheets/layout/nav/_my-account.scss
@@ -16,7 +16,7 @@
 }
 
 button.my-account-toggle-button:hover {
-    color: #fff;
+    color: #ffffff;
     text-decoration: underline;
 }
 

--- a/static/src/stylesheets/layout/nav/_my-account.scss
+++ b/static/src/stylesheets/layout/nav/_my-account.scss
@@ -15,6 +15,11 @@
     }
 }
 
+button.my-account-toggle-button:hover {
+    color: #fff;
+    text-decoration: underline;
+}
+
 .my-account--icon {
     svg {
         height: 18px;


### PR DESCRIPTION
## What does this change?
This updates the the hover styling for the 'edition picker' and 'my account' nav items.

## Does this change need to be reproduced in dotcom-rendering ?
This change has already been made on dotcom rendering in https://github.com/guardian/dotcom-rendering/pull/6420
- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
| Before      | After      |
|-------------|------------|
| <img width="703" alt="Screenshot 2022-12-13 at 16 49 31" src="https://user-images.githubusercontent.com/44685872/207394913-043a2884-e86b-48b2-a519-3141219b960b.png"> | <img width="703" alt="Screenshot 2022-12-13 at 16 47 59" src="https://user-images.githubusercontent.com/44685872/207394904-b3b08d6d-462f-4a62-ae50-312e119ec7a5.png"> |
| <img width="703" alt="Screenshot 2022-12-13 at 16 49 37" src="https://user-images.githubusercontent.com/44685872/207394916-2e98e2bd-0281-4196-bfd4-45519eb5c83c.png"> | <img width="703" alt="Screenshot 2022-12-13 at 16 50 14" src="https://user-images.githubusercontent.com/44685872/207394918-91460131-6c94-4a48-ba1d-419ca0da6758.png"> |
