### PR TITLE
Fix and update commercial cypress CI

### DIFF
--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -53,7 +53,7 @@ jobs:
                   working-directory: ./dcr
 
             - name: Build DCR
-              run: make build-ci
+              run: make build
               working-directory: ./dcr/dotcom-rendering
 
             - name: Run Cypress

--- a/cypress/e2e/inline-slots.cy.ts
+++ b/cypress/e2e/inline-slots.cy.ts
@@ -40,7 +40,7 @@ describe('Slots and iframes load on article pages', () => {
 
 describe('Slots and iframes load on liveblog pages', () => {
 	beforeEach(() => {
-		cy.useConsentedSession();
+		cy.useConsentedSession('liveblog-consented-2');
 	});
 	liveBlogPages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {

--- a/cypress/e2e/inline-slots.cy.ts
+++ b/cypress/e2e/inline-slots.cy.ts
@@ -9,6 +9,10 @@ const liveBlogPages = liveblogs.filter(
 );
 
 describe('Slots and iframes load on article pages', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('article-consented');
+	});
+
 	pages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
@@ -19,8 +23,6 @@ describe('Slots and iframes load on article pages', () => {
 						mockIntersectionObserver(win, '.ad-slot--inline');
 					},
 				});
-
-				cy.allowAllConsent();
 
 				cy.get('.ad-slot--inline')
 					.should(
@@ -37,6 +39,9 @@ describe('Slots and iframes load on article pages', () => {
 });
 
 describe('Slots and iframes load on liveblog pages', () => {
+	beforeEach(() => {
+		cy.useConsentedSession();
+	});
 	liveBlogPages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
@@ -50,8 +55,6 @@ describe('Slots and iframes load on liveblog pages', () => {
 						);
 					},
 				});
-
-				cy.allowAllConsent();
 
 				cy.get('.ad-slot--liveblog-inline').should(
 					'have.length.at.least',

--- a/cypress/e2e/liveblog-live-update.cy.ts
+++ b/cypress/e2e/liveblog-live-update.cy.ts
@@ -5,6 +5,10 @@ import { mockIntersectionObserver } from '../lib/util';
 const pages = [...liveblogs];
 
 describe('Liveblog live updates', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('liveblog-live-update-consented');
+	});
+
 	pages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ads are inserted when liveblogs live update, breakpoint: ${breakpoint}`, () => {
@@ -15,8 +19,6 @@ describe('Liveblog live updates', () => {
 						mockIntersectionObserver(win, '#top-of-blog');
 					},
 				});
-
-				cy.allowAllConsent();
 
 				cy.get('#liveblog-body .ad-slot').its('length').as('adCount');
 

--- a/cypress/e2e/merchandising-high.cy.ts
+++ b/cypress/e2e/merchandising-high.cy.ts
@@ -3,6 +3,9 @@ import { articles, liveblogs } from '../fixtures/pages';
 import { mockIntersectionObserver } from '../lib/util';
 
 describe('merchandising-high slot on pages', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('merchandising-high-consented');
+	});
 	[...articles, ...liveblogs].forEach(({ path }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
@@ -16,8 +19,6 @@ describe('merchandising-high slot on pages', () => {
 						);
 					},
 				});
-
-				cy.allowAllConsent();
 
 				cy.get('#dfp-ad--merchandising-high')
 					.scrollIntoView({ duration: 200 })

--- a/cypress/e2e/merchandising.cy.ts
+++ b/cypress/e2e/merchandising.cy.ts
@@ -3,6 +3,9 @@ import { articles, liveblogs } from '../fixtures/pages';
 import { mockIntersectionObserver } from '../lib/util';
 
 describe('merchandising slot on pages', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('merchandising-consented');
+	});
 	[...articles, ...liveblogs].forEach(({ path }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
@@ -13,8 +16,6 @@ describe('merchandising slot on pages', () => {
 						mockIntersectionObserver(win, '#dfp-ad--merchandising');
 					},
 				});
-
-				cy.allowAllConsent();
 
 				cy.get('#dfp-ad--merchandising')
 					.scrollIntoView({ duration: 200 })

--- a/cypress/e2e/mostpop.cy.ts
+++ b/cypress/e2e/mostpop.cy.ts
@@ -3,6 +3,9 @@ import { articles, liveblogs } from '../fixtures/pages';
 import { mockIntersectionObserver } from '../lib/util';
 
 describe('mostpop slot on pages', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('mostpop-consented');
+	});
 	[...articles, ...liveblogs].forEach(({ path }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
@@ -13,8 +16,6 @@ describe('mostpop slot on pages', () => {
 						mockIntersectionObserver(win, '#dfp-ad--mostpop');
 					},
 				});
-
-				cy.allowAllConsent();
 
 				// Check that the mostpop ad slot is on the page
 				cy.get('#dfp-ad--mostpop').should('exist');

--- a/cypress/e2e/right-slot.cy.ts
+++ b/cypress/e2e/right-slot.cy.ts
@@ -2,14 +2,15 @@ import { breakpoints } from '@guardian/source-foundations';
 import { articles, liveblogs } from '../fixtures/pages';
 
 describe('right slot on pages', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('right-consented');
+	});
 	[...articles, ...liveblogs].forEach(({ path }) => {
 		it(`Test ${path} has correct slot and iframe`, () => {
 			// viewport width has to be >= 1300px in order for the right column to appear on liveblogs
 			cy.viewport(breakpoints['wide'], 1000);
 
 			cy.visit(path);
-
-			cy.allowAllConsent();
 
 			// Check that the right ad slot is on the page
 			cy.get('#dfp-ad--right').should('exist');

--- a/cypress/e2e/targeting.cy.ts
+++ b/cypress/e2e/targeting.cy.ts
@@ -4,11 +4,12 @@ import { bidderURLs, wins } from '../fixtures/prebid';
 const gamUrl = 'https://securepubads.g.doubleclick.net/gampad/ads?**';
 
 describe('GAM targeting', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('targeting-consented');
+	});
 	it(`checks that a request is made`, () => {
 		const { path } = articles[0];
 		cy.visit(path);
-
-		cy.allowAllConsent();
 
 		cy.intercept(gamUrl).as('gamRequest');
 
@@ -18,8 +19,6 @@ describe('GAM targeting', () => {
 	it(`checks the gdpr_consent param`, () => {
 		const { path } = articles[0];
 		cy.visit(path);
-
-		cy.allowAllConsent();
 
 		cy.intercept({ url: gamUrl }, function (req) {
 			const url = new URL(req.url);
@@ -38,8 +37,6 @@ describe('GAM targeting', () => {
 			throw new Error('No sensitive articles found to run test.');
 
 		cy.visit(sensitivePage.path);
-
-		cy.allowAllConsent();
 
 		cy.intercept({ url: gamUrl }, function (req) {
 			const url = new URL(req.url);
@@ -103,8 +100,6 @@ describe('Prebid targeting', () => {
 		url.searchParams.set('adrefresh', 'false');
 		url.searchParams.delete('adtest');
 		cy.visit(url.toString());
-
-		cy.allowAllConsent();
 
 		cy.getIframeBody('google_ads_iframe_')
 			.find('[data-cy="test-creative"]')

--- a/cypress/e2e/top-above-nav.cy.ts
+++ b/cypress/e2e/top-above-nav.cy.ts
@@ -1,11 +1,12 @@
 import { allPages } from '../fixtures/pages';
 
 describe('top-above-nav on pages', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('top-above-nav-consented');
+	});
 	allPages.forEach(({ path }) => {
 		it(`Test ${path} has top-above-nav slot and iframe`, () => {
 			cy.visit(path);
-
-			cy.allowAllConsent();
 
 			cy.window().then((window) => {
 				const { isImmersive } = window.guardian.config.page;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,4 +1,6 @@
 import { articles } from '../fixtures/pages';
+import { storage } from '@guardian/libs';
+
 // ***********************************************
 // For comprehensive examples of custom
 // commands please read more here:
@@ -71,6 +73,8 @@ Cypress.Commands.add('hydrate', () => {
 
 Cypress.Commands.add('useConsentedSession', (name: string) => {
 	cy.session(name, () => {
+		storage.local.set('gu.geo.override', 'GB');
+
 		cy.intercept('**/graun.vendors~Prebid.js.commercial.js').as(
 			'consentAll',
 		);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -76,6 +76,10 @@ Cypress.Commands.add('useConsentedSession', (name: string) => {
 		);
 
 		cy.visit(articles[0].path);
+		localStorage.setItem(
+			'gu.prefs.engagementBannerLastClosedAt',
+			`{"value":"${new Date().toISOString()}"}`,
+		);
 		cy.allowAllConsent();
 		cy.wait('@consentAll');
 	});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,3 +1,4 @@
+import { articles } from '../fixtures/pages';
 // ***********************************************
 // For comprehensive examples of custom
 // commands please read more here:
@@ -55,10 +56,10 @@ Cypress.Commands.add('hydrate', () => {
 		.each((el) => {
 			cy.log(`Scrolling to ${el.attr('name')}`);
 			cy.wrap(el)
-			.scrollIntoView({ duration: 1000, timeout: 30000 })
-			.should('have.attr', 'data-gu-ready', 'true', {
-				timeout: 30000,
-			});
+				.scrollIntoView({ duration: 1000, timeout: 30000 })
+				.should('have.attr', 'data-gu-ready', 'true', {
+					timeout: 30000,
+				});
 		})
 		.then(() => {
 			cy.scrollTo('top');
@@ -66,4 +67,16 @@ Cypress.Commands.add('hydrate', () => {
 			// eslint-disable-next-line cypress/no-unnecessary-waiting
 			cy.wait(5000);
 		});
+});
+
+Cypress.Commands.add('useConsentedSession', (name: string) => {
+	cy.session(name, () => {
+		cy.intercept('**/graun.vendors~Prebid.js.commercial.js').as(
+			'consentAll',
+		);
+
+		cy.visit(articles[0].path);
+		cy.allowAllConsent();
+		cy.wait('@consentAll');
+	});
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -32,6 +32,8 @@ declare global {
 			rejectAllConsent(): void;
 
 			hydrate(): Chainable<JQuery<HTMLElement>>;
+
+			useConsentedSession(name: string): void;
 		}
 
 		/**

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"cpy": "^7.3.0",
 		"cssstats": "^3.1.0",
 		"csstype": "^3.0.6",
-		"cypress": "^10.8.0",
+		"cypress": "^12.1.0",
 		"eslint": "^7.17.0",
 		"eslint-config-prettier": "^7.1.0",
 		"eslint-import-resolver-webpack": "^0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5735,10 +5735,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^10.8.0:
-  version "10.8.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.8.0.tgz#12a681f2642b6f13d636bab65d5b71abdb1497a5"
-  integrity sha512-QVse0dnLm018hgti2enKMVZR9qbIO488YGX06nH5j3Dg1isL38DwrBtyrax02CANU6y8F4EJUuyW6HJKw1jsFA==
+cypress@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.1.0.tgz#1fdaa631bc30df466dc9505154616f4cf69dbd4b"
+  integrity sha512-7fz8N84uhN1+ePNDsfQvoWEl4P3/VGKKmAg+bJQFY4onhA37Ys+6oBkGbNdwGeC7n2QqibNVPhk8x3YuQLwzfw==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## What does this change?
Utilizes `cy.session()` introduced recently to save the consent state between tests, required updating to Cypress 12

The consent banner now only needs to be clicked in the first test in each `.spec.ts` file 

The workflow was using `make build-ci` which started throwing 500 errors when running with `make start-ci`, DCR cypress tests are using `make build` switching to that solves the problem.

Summary of this PR:
- Fix broken DCR build in CI
- Updated to Cypress 12
- add sessions to tests

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
