### PR TITLE
Header notifications insert and impression tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^2.0.0",
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/braze-components": "^8.1.1",
+		"@guardian/braze-components": "^8.1.3",
 		"@guardian/commercial-core": "^5.1.1",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -257,19 +257,31 @@ const initPublicApi = () => {
 };
 
 const initialiseHeaderNotifications = (brazeCardsPromise) => {
+    const isValid = (card) => Boolean(
+        card.extras.target
+        && card.extras.message
+        && card.extras.ophanLabel
+    );
+
     brazeCardsPromise.then(brazeCards => {
         return brazeCards.getCardsForProfileBadge();
     }).then(cards => {
-        cards.filter((card) => {
-            return Boolean(card.extras.target && card.extras.message);
-        }).forEach((card) => {
-            const notification = {
-                target: card.extras.target,
-                message: card.extras.message,
-            };
-
-            bufferedNotificationListener.emit(notification);
+        const notifications = cards.filter((card) => isValid(card))
+            .map((card) => {
+                return {
+                    id: card.id,
+                    target: card.extras.target,
+                    message: card.extras.message,
+                    ophanLabel: card.extras.ophanLabel,
+                    logImpression: () => {
+                        card.logImpression();
+                    }
+                };
         })
+
+        if (notifications.length > 0) {
+            bufferedNotificationListener.emit(notifications);
+        }
     })
 };
 

--- a/static/src/javascripts/projects/common/modules/bufferedNotificationListener.spec.ts
+++ b/static/src/javascripts/projects/common/modules/bufferedNotificationListener.spec.ts
@@ -1,5 +1,8 @@
 import { bufferedNotificationListener } from './bufferedNotificationListener';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function -- no-op
+const noOp = () => {};
+
 describe('bufferedNotificationListener', () => {
 	afterEach(() => {
 		window.guardian.notificationEventHistory = [];
@@ -10,28 +13,38 @@ describe('bufferedNotificationListener', () => {
 			done();
 		});
 		bufferedNotificationListener.on(callback);
-		const notification = {
-			target: 'settings',
-			message: 'Your card has expired',
-		};
+		const notifications = [
+			{
+				id: '1234abcde',
+				target: 'settings',
+				message: 'Your card has expired',
+				ophanLabel: 'settings-label',
+				logImpression: noOp,
+			},
+		];
 
-		bufferedNotificationListener.emit(notification);
+		bufferedNotificationListener.emit(notifications);
 
 		expect(callback).toHaveBeenCalledTimes(1);
 		expect(callback).toHaveBeenLastCalledWith(
 			expect.objectContaining({
-				detail: notification,
+				detail: notifications,
 			}),
 		);
 	});
 
 	describe('when an event listener is registered after an event', () => {
 		it('replays missed events', (done) => {
-			const notification = {
-				target: 'settings',
-				message: 'Your card has expired',
-			};
-			bufferedNotificationListener.emit(notification);
+			const notifications = [
+				{
+					id: '1234abcde',
+					target: 'settings',
+					message: 'Your card has expired',
+					ophanLabel: 'settings-label',
+					logImpression: noOp,
+				},
+			];
+			bufferedNotificationListener.emit(notifications);
 			const callback = jest.fn(() => {
 				done();
 			});
@@ -41,7 +54,7 @@ describe('bufferedNotificationListener', () => {
 			expect(callback).toHaveBeenCalledTimes(1);
 			expect(callback).toHaveBeenLastCalledWith(
 				expect.objectContaining({
-					detail: notification,
+					detail: notifications,
 				}),
 			);
 		});

--- a/static/src/javascripts/projects/common/modules/bufferedNotificationListener.ts
+++ b/static/src/javascripts/projects/common/modules/bufferedNotificationListener.ts
@@ -10,7 +10,9 @@ const eventName = 'my_account_notification';
  * object.
  */
 const bufferedNotificationListener = {
-	on: (callback: (event: CustomEvent<NotificationEvent>) => void): void => {
+	on: (
+		callback: (event: CustomEvent<HeaderNotification[]>) => void,
+	): void => {
 		// See https://github.com/microsoft/TypeScript/issues/28357 for why we have to cast here
 		document.addEventListener(eventName, callback as EventListener);
 
@@ -20,7 +22,7 @@ const bufferedNotificationListener = {
 			});
 		}
 	},
-	emit: (payload: NotificationEvent): void => {
+	emit: (payload: HeaderNotification[]): void => {
 		const event = new CustomEvent(eventName, {
 			detail: payload,
 		});

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.ts
@@ -38,9 +38,11 @@ const buildOphanComponentWithNotifications = (
 ) => {
 	if (notifications.length > 0) {
 		return {
-			componentType: NOTIFICATION_COMPONENT_TYPE,
-			id: target,
-			labels: notifications.map((n) => n.ophanLabel),
+			component: {
+				componentType: NOTIFICATION_COMPONENT_TYPE,
+				id: target,
+				labels: notifications.map((n) => n.ophanLabel),
+			},
 		};
 	}
 

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.ts
@@ -26,6 +26,27 @@ const updateCommentLink = (commentItems: Element[]): void => {
 	}
 };
 
+const trackFirstImpression = (el: HTMLElement): void => {
+	let hasBeenSeen = false;
+
+	if ('IntersectionObserver' in window) {
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting) {
+					if (!hasBeenSeen) {
+						hasBeenSeen = true;
+						// Track impression
+					}
+				}
+			},
+			{
+				threshold: 1.0,
+			},
+		);
+		observer.observe(el);
+	}
+};
+
 const groupNotificationsByTarget = (
 	notifications: NotificationEvent[],
 ): Record<string, string[]> => {
@@ -40,7 +61,7 @@ const groupNotificationsByTarget = (
 	return notificationsMap;
 };
 
-const showNotifications = (notifications: NotificationEvent[]): void => {
+const addNotifications = (notifications: NotificationEvent[]): void => {
 	void fastdom
 		.measure(() => ({
 			badge: document.querySelector(
@@ -78,6 +99,7 @@ const showNotifications = (notifications: NotificationEvent[]): void => {
 									'dropdown-menu__notification',
 								);
 								messageEl.innerText = message;
+								trackFirstImpression(messageEl);
 								return messageEl;
 							});
 							const notificationsContainerEl =
@@ -85,9 +107,7 @@ const showNotifications = (notifications: NotificationEvent[]): void => {
 									'.js-user-account-menu-notifications-container',
 								);
 							if (notificationsContainerEl) {
-								notificationsContainerEl.replaceChildren(
-									...messageEls,
-								);
+								notificationsContainerEl.append(...messageEls);
 							}
 						}
 					},
@@ -136,8 +156,8 @@ const showMyAccountIfNecessary = (): void => {
 					let notifications: NotificationEvent[] = [];
 
 					bufferedNotificationListener.on((event) => {
-						notifications = [...notifications, event.detail];
-						showNotifications(notifications);
+						notifications = [event.detail];
+						addNotifications(notifications);
 					});
 				});
 		});

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.ts
@@ -1,7 +1,10 @@
 import { getUserFromCookie, isUserLoggedIn } from 'common/modules/identity/api';
 import fastdom from 'lib/fastdom-promise';
 import { bufferedNotificationListener } from '../bufferedNotificationListener';
-import { submitInsertEvent } from '../commercial/acquisitions-ophan';
+import {
+	submitInsertEvent,
+	submitViewEvent,
+} from '../commercial/acquisitions-ophan';
 
 const NOTIFICATION_COMPONENT_TYPE = 'RETENTION_HEADER';
 
@@ -58,7 +61,7 @@ const trackNotificationsInsert = (
 };
 
 const setupTrackNotificationsView = (
-	el: HTMLElement,
+	el: Element,
 	target: string,
 	notifications: HeaderNotification[],
 ): void => {
@@ -77,8 +80,9 @@ const setupTrackNotificationsView = (
 								notifications,
 							);
 						if (ophanComponent) {
-							submitInsertEvent(ophanComponent);
+							submitViewEvent(ophanComponent);
 						}
+						notifications.forEach((n) => n.logImpression());
 					}
 				}
 			},

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.ts
@@ -48,7 +48,7 @@ const trackFirstImpression = (el: HTMLElement): void => {
 };
 
 const groupNotificationsByTarget = (
-	notifications: NotificationEvent[],
+	notifications: HeaderNotification[],
 ): Record<string, string[]> => {
 	const notificationsMap: Record<string, string[]> = {};
 	notifications.forEach(({ message, target }) => {
@@ -61,7 +61,7 @@ const groupNotificationsByTarget = (
 	return notificationsMap;
 };
 
-const addNotifications = (notifications: NotificationEvent[]): void => {
+const addNotifications = (notifications: HeaderNotification[]): void => {
 	void fastdom
 		.measure(() => ({
 			badge: document.querySelector(
@@ -153,10 +153,8 @@ const showMyAccountIfNecessary = (): void => {
 				.then(() => {
 					updateCommentLink(commentItems);
 
-					let notifications: NotificationEvent[] = [];
-
 					bufferedNotificationListener.on((event) => {
-						notifications = [event.detail];
+						const notifications = event.detail;
 						addNotifications(notifications);
 					});
 				});

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -420,9 +420,12 @@ interface Trac {
 	post: () => this;
 }
 
-interface NotificationEvent {
+interface HeaderNotification {
+	id: string;
 	target: string;
 	message: string;
+	ophanLabel: string;
+	logImpression: () => void;
 }
 interface Window {
 	// eslint-disable-next-line id-denylist -- this *is* the guardian object
@@ -439,7 +442,7 @@ interface Window {
 		commercial?: {
 			dfpEnv?: DfpEnv;
 		};
-		notificationEventHistory?: NotificationEvent[];
+		notificationEventHistory?: HeaderNotification[][];
 	};
 	ootag: {
 		queue: Array<() => void>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,10 +2166,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^8.1.1":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.1.tgz#7b265a7d2a2163df70238823e881950a6d43598d"
-  integrity sha512-4izZBDS9HXgEmf9hLBs0X3JdtgrdnGuFRCGhyJFodUPU+ZFXo2H4rOQlTBBsUhr5PurEZBDVU+9y6ZCe74ZWcg==
+"@guardian/braze-components@^8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.3.tgz#47adc4892716904a62afa62da66f31eae059d56b"
+  integrity sha512-Tol4O7A3ErmzgCd9YtkajJUfCps/1RCNXhtaUBwgT8u0OUPRmfk4jjD7cS3nok5gDTEUVemKwT2yysx1CxfWaw==
 
 "@guardian/commercial-core@^5.1.1":
   version "5.1.1"


### PR DESCRIPTION
## What does this change?

This PR adds logging of inserts (to Ophan) and impressions (Ophan and Braze) for header notifications. It includes a change to the way the notification events are emitted. They arrive from Braze as an array, but before we were emitting individually. We want to send a single event to Ophan for a menu item when it has notifications (rather than one per notification) so this supports that better.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) (Already done: guardian/dotcom-rendering#6626 and guardian/dotcom-rendering#6738)

## Screenshots

Here's the impression being sent to Ophan:

<img width="838" alt="Screenshot 2022-12-15 at 12 00 26" src="https://user-images.githubusercontent.com/379839/207858724-c9807252-8d1f-4ffd-967d-acf91285a1a4.png">

### Tested

- [x] Locally
- [x] On CODE (optional)