### PR TITLE
Remove references to legacy ad label toggling

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.spec.ts
@@ -11,22 +11,12 @@ const adverts: Record<string, string> = {
         <div class="js-ad-slot"></div>`,
 	labelDisabled: `
         <div class="js-ad-slot" data-label="false"></div>`,
-	alreadyLabelled: `
-        <div class="js-ad-slot">
-            <div class="ad-slot__label">Advertisement</div>
-        </div>`,
 	frame: `
         <div class="js-ad-slot ad-slot--frame"></div>`,
 	uh: `
         <div class="js-ad-slot u-h"></div>`,
 	topAboveNav: `
         <div class="js-ad-slot" id="dfp-ad--top-above-nav"></div>`,
-	topAboveNavToggleLabel: `
-        <div>
-            <div class="js-ad-slot" id="dfp-ad--top-above-nav">
-				<div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-			</div>
-        </div>`,
 };
 
 const createAd = (html: string) => {
@@ -56,14 +46,6 @@ describe('Rendering advert labels', () => {
 
 	it('Will not add a label if it has an attribute data-label="false"', async () => {
 		createAd(adverts['labelDisabled']);
-		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const dataLabelShow = getAd().getAttribute('data-label-show');
-			expect(dataLabelShow).toBeFalsy();
-		});
-	});
-
-	it('Will not add a label if the adSlot already has one', async () => {
-		createAd(adverts['alreadyLabelled']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
 			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
@@ -11,22 +11,12 @@ const adverts: Record<string, string> = {
         <div class="js-ad-slot"></div>`,
 	labelDisabled: `
         <div class="js-ad-slot" data-label="false"></div>`,
-	alreadyLabelled: `
-        <div class="js-ad-slot">
-            <div class="ad-slot__label">Advertisement</div>
-        </div>`,
 	frame: `
         <div class="js-ad-slot ad-slot--frame"></div>`,
 	uh: `
         <div class="js-ad-slot u-h"></div>`,
 	topAboveNav: `
         <div class="js-ad-slot" id="dfp-ad--top-above-nav"></div>`,
-	topAboveNavToggleLabel: `
-        <div>
-            <div class="js-ad-slot" id="dfp-ad--top-above-nav">
-				<div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-			</div>
-        </div>`,
 };
 
 const createAd = (html: string) => {
@@ -56,14 +46,6 @@ describe('Rendering advert labels', () => {
 
 	it('Will not add a label if it has an attribute data-label="false"', async () => {
 		createAd(adverts['labelDisabled']);
-		return renderAdvertLabel(getAd()).then(() => {
-			const dataLabelShow = getAd().getAttribute('data-label-show');
-			expect(dataLabelShow).toBeFalsy();
-		});
-	});
-
-	it('Will not add a label if the adSlot already has one', async () => {
-		createAd(adverts['alreadyLabelled']);
 		return renderAdvertLabel(getAd()).then(() => {
 			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -16,12 +16,7 @@ const shouldRenderLabel = (adSlotNode: HTMLElement): boolean =>
 		adSlotNode.classList.contains('u-h') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
-		adSlotNode.getAttribute('data-label') === 'false' ||
-		// Don't render an ad slot label if there's one already present in the slot
-		// It's fine for a hidden toggled label to be present
-		adSlotNode.querySelectorAll(
-			'.ad-slot__label:not(.ad-slot__label--toggle.hidden)',
-		).length
+		adSlotNode.getAttribute('data-label') === 'false'
 	);
 
 const createAdCloseDiv = (): HTMLElement => {


### PR DESCRIPTION
## What does this change?

Removes all remaining references to the `ad-slot__label--toggle` class, which was replaced in #25727

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Ad label toggling was introduced in #23613 to reduce layout shift related to add labels. It was refactored to use a CSS-based solution in #25727. As a result, the `ad-slot__label--toggle` class is no longer needed.

As a handy side-effect, a [high-volume issue](https://sentry.io/organizations/the-guardian/issues/3525255940/?project=35463&query=is%3Aunresolved+feature%3Acommercial+querySelectorAll&referrer=issue-stream&statsPeriod=14d) will no longer be sent to Sentry. This was related to the `:not()` selector being unavailable in Chrome < v88.

