### PR TITLE
Spike: Apps rendering in frontend

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -12,7 +12,7 @@ import pages.{ArticleEmailHtmlPage, ArticleHtmlPage}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc._
-import renderers.DotcomRenderingService
+import renderers.{DotcomRenderingService, MobileApps}
 import services.{CAPILookup, NewsletterService}
 import services.dotcomrendering.{ArticlePicker, OnwardsPicker, PressedArticle, RemoteRender}
 import views.support._
@@ -52,6 +52,27 @@ class ArticleController(
       mapModel(path, ArticleBlocks) { (article, blocks) =>
         render(path, article, blocks)
       }
+    }
+  }
+
+  def renderMobileApps(path: String, edition: String): Action[AnyContent] = {
+    Action.async { implicit request =>
+      mapModel(path, ArticleBlocks) { (article, blocks) => {
+        val pageType: PageType = PageType(article, request, context)
+        val newsletter = newsletterService.getNewsletterForArticle(article)
+        remoteRenderer.getArticle(
+          ws,
+          article,
+          blocks,
+          pageType,
+          filterKeyEvents = false,
+          false,
+          newsletter = newsletter,
+          topicResult = None,
+          onwards = None,
+          platform = MobileApps,
+        )
+      }}
     }
   }
 

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -55,24 +55,26 @@ class ArticleController(
     }
   }
 
-  def renderMobileApps(path: String, edition: String): Action[AnyContent] = {
+  def renderMobileApps(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
-      mapModel(path, ArticleBlocks) { (article, blocks) => {
-        val pageType: PageType = PageType(article, request, context)
-        val newsletter = newsletterService.getNewsletterForArticle(article)
-        remoteRenderer.getArticle(
-          ws,
-          article,
-          blocks,
-          pageType,
-          filterKeyEvents = false,
-          false,
-          newsletter = newsletter,
-          topicResult = None,
-          onwards = None,
-          platform = MobileApps,
-        )
-      }}
+      mapModel(path, ArticleBlocks) { (article, blocks) =>
+        {
+          val pageType: PageType = PageType(article, request, context)
+          val newsletter = newsletterService.getNewsletterForArticle(article)
+          remoteRenderer.getArticle(
+            ws,
+            article,
+            blocks,
+            pageType,
+            filterKeyEvents = false,
+            false,
+            newsletter = newsletter,
+            topicResult = None,
+            onwards = None,
+            platform = MobileApps,
+          )
+        }
+      }
     }
   }
 

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -28,6 +28,9 @@ GET     /*path/email                controllers.ArticleController.renderEmail(pa
 GET     /*path/email/headline.txt   controllers.ArticleController.renderHeadline(path)
 GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
+# Apps Rendering
+GET     /*path/mobile-apps          controllers.ArticleController.renderMobileApps(path)
+
 
 # Newspaper pages paths
 # gallery format (?)
@@ -41,7 +44,4 @@ GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(pa
 GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
 GET     /*path                      controllers.ArticleController.renderArticle(path)
-
-# Apps Rendering
-GET        /mobile-apps/rendered/*path                controllers.ArticleController.renderMobileApps(path)
 

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -41,3 +41,7 @@ GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(pa
 GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
 GET     /*path                      controllers.ArticleController.renderArticle(path)
+
+# Apps Rendering
+GET        /mobile-apps/rendered/*path                controllers.ArticleController.renderMobileApps(path)
+

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -7,6 +7,7 @@ import model.{ApplicationContext, Cached, LiveBlogPage, PageWithStoryPackage, To
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
+import renderers.{Platform, Web}
 
 import scala.collection.mutable.{ArrayBuffer, Queue}
 import scala.concurrent.{ExecutionContext, Future}
@@ -29,6 +30,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
       mostPopular: Option[Seq[OnwardCollectionResponse]],
+      platform: Platform = Web,
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     requestedBlogs.enqueue(article)

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -66,6 +66,8 @@ trait Requests {
 
     lazy val isAmp: Boolean = r.getQueryString("amp").isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host)
 
+    lazy val isMobileApps: Boolean = r.path.endsWith("/mobile-apps")
+
     lazy val isEmail: Boolean = r.getQueryString("format").exists(_.contains("email")) || r.path.endsWith(
       EMAIL_SUFFIX,
     ) || isEmailJson || isEmailTxt
@@ -73,7 +75,7 @@ trait Requests {
     lazy val isHeadlineText: Boolean =
       r.getQueryString("format").contains("email-headline") || r.path.endsWith(HEADLINE_SUFFIX)
 
-    lazy val isModified = isJson || isRss || isEmail || isHeadlineText
+    lazy val isModified = isJson || isRss || isEmail || isMobileApps || isHeadlineText
 
     lazy val pathWithoutModifiers: String =
       if (isEmail) r.path.stripSuffix(EMAIL_SUFFIX)

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -41,6 +41,17 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import model.dotcomrendering.Trail
 
+sealed trait Platform {
+  val dcrPath: String
+}
+
+case object Web extends Platform {
+  val dcrPath = "/Article"
+}
+case object MobileApps extends Platform {
+  val dcrPath = "/apps/Article"
+}
+
 // Introduced as CAPI error handling elsewhere would smother these otherwise
 case class DCRLocalConnectException(message: String) extends ConnectException(message)
 case class DCRTimeoutException(message: String) extends TimeoutException(message)
@@ -169,6 +180,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
       onwards: Option[Seq[OnwardCollectionResponse]],
+      platform: Platform = Web,
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
@@ -187,7 +199,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     }
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Article", page.metadata.cacheTime)
+    post(ws, json, Configuration.rendering.baseURL + platform.dcrPath, page.metadata.cacheTime)
   }
 
   def getBlocks(

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -49,7 +49,7 @@ case object Web extends Platform {
   val dcrPath = "/Article"
 }
 case object MobileApps extends Platform {
-  val dcrPath = "/apps/Article"
+  val dcrPath = "/mobile-apps/Article"
 }
 
 // Introduced as CAPI error handling elsewhere would smother these otherwise


### PR DESCRIPTION

You can now enable this for a Frontend url by adding `/mobile-apps` to the end of a url, eg:

http://localhost:9000/technology/2022/dec/20/elon-musk-breaks-silence-after-10-million-twitter-users-vote-for-him-to-step-down/mobile-apps

See also https://github.com/guardian/dotcom-rendering/pull/6818