### PR TITLE
Support exposing genuine git commit ids to Prout

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,7 +1,14 @@
 {
     "checkpoints": {
-        "PROD": {
-            "url": "https://frontend.gutools.co.uk/deploys?stage=PROD&pageSize=50",
+        "FRONTS-PROD": {
+            "url": "https://www.theguardian.com/uk",
+            "overdue": "30M",
+            "messages": {
+                "seen": "prout/seen.md"
+            }
+        },
+        "ADMIN-PROD": {
+            "url": "https://frontend.gutools.co.uk/login",
             "overdue": "30M",
             "messages": {
                 "seen": "prout/seen.md"

--- a/admin/app/http/AdminFilters.scala
+++ b/admin/app/http/AdminFilters.scala
@@ -25,5 +25,5 @@ class AdminFilters(httpConfiguration: HttpConfiguration)(implicit
     httpConfiguration,
   )
 
-  val filters: List[EssentialFilter] = adminAuthFilter :: Filters.common
+  val filters: List[EssentialFilter] = adminAuthFilter :: Filters.common(frontend.admin.BuildInfo)
 }

--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import akka.actor.ActorSystem
-import app.{FrontendApplicationLoader, FrontendComponents}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle
 import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, DCRMetrics, EmailSubsciptionMetrics}
@@ -92,6 +92,7 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
     DCRMetrics.DCRRequestCountMetric,
   )
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.applications.BuildInfo
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -1,6 +1,6 @@
 import akka.actor.ActorSystem
 import http.{CommonFilters, CorsHttpErrorHandler}
-import app.{FrontendApplicationLoader, FrontendComponents}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
@@ -45,6 +45,7 @@ trait AppComponents extends FrontendComponents {
 
   lazy val appIdentity = ApplicationIdentity("archive")
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.archive.BuildInfo
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -1,7 +1,7 @@
 import _root_.commercial.targeting.TargetingLifecycle
 import agents.CuratedContentAgent
 import akka.actor.ActorSystem
-import app.{FrontendApplicationLoader, FrontendComponents}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common.Assets.DiscussionExternalAssetsLifecycle
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
@@ -88,6 +88,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers with Topi
     DCRMetrics.DCRRequestCountMetric,
   )
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.article.BuildInfo
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]

--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import akka.actor.ActorSystem
-import app.{FrontendApplicationLoader, FrontendComponents}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle
 import commercial.controllers.{CommercialControllers, HealthCheck}
@@ -74,6 +74,7 @@ trait AppComponents extends FrontendComponents with CommercialControllers with C
 
   lazy val appIdentity = ApplicationIdentity("commercial")
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.commercial.BuildInfo
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]

--- a/common/app/app/FrontendBuildInfo.scala
+++ b/common/app/app/FrontendBuildInfo.scala
@@ -1,0 +1,5 @@
+package app
+
+trait FrontendBuildInfo {
+  val gitCommitId: String
+}

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -1,7 +1,7 @@
 import akka.actor.ActorSystem
 import dev.DevAssetsController
 import http.{CommonFilters, CorsHttpErrorHandler}
-import app.{FrontendApplicationLoader, FrontendComponents}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
@@ -46,6 +46,7 @@ trait AppComponents extends FrontendComponents with DiscussionControllers with D
 
   lazy val appIdentity = ApplicationIdentity("discussion")
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.discussion.BuildInfo
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   def actorSystem: ActorSystem

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -1,6 +1,6 @@
 import agents.MostViewedAgent
 import akka.actor.ActorSystem
-import app.{FrontendApplicationLoader, FrontendComponents}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
@@ -71,6 +71,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
     DCRMetrics.DCRRequestCountMetric,
   )
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.facia.BuildInfo
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters ++ wire[PreloadFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 

--- a/identity/app/http/IdentityFilters.scala
+++ b/identity/app/http/IdentityFilters.scala
@@ -9,5 +9,6 @@ import scala.concurrent.ExecutionContext
 class IdentityFilters(implicit mat: Materializer, context: ApplicationContext, executionContext: ExecutionContext)
     extends HttpFilters {
 
-  val filters = new HeaderLoggingFilter :: new StrictTransportSecurityHeaderFilter :: Filters.common
+  val filters =
+    new HeaderLoggingFilter :: new StrictTransportSecurityHeaderFilter :: Filters.common(frontend.identity.BuildInfo)
 }

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -1,6 +1,6 @@
 import akka.actor.ActorSystem
 import http.{CommonFilters, CorsHttpErrorHandler}
-import app.{FrontendApplicationLoader, FrontendComponents}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import business.{StocksData, StocksDataLifecycle}
 import com.softwaremill.macwire._
 import common._
@@ -83,6 +83,7 @@ trait AppComponents extends FrontendComponents with OnwardControllers with Onwar
     ContentApiMetrics.ContentApiRequestsMetric,
   )
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.onward.BuildInfo
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]

--- a/preview/app/http/PreviewFilters.scala
+++ b/preview/app/http/PreviewFilters.scala
@@ -24,7 +24,9 @@ class PreviewFilters(
     httpConfiguration,
   )
 
-  val filters = previewAuthFilter :: new NoCacheFilter :: new ContentSecurityPolicyFilter :: Filters.common
+  val filters = previewAuthFilter :: new NoCacheFilter :: new ContentSecurityPolicyFilter :: Filters.common(
+    frontend.preview.BuildInfo,
+  )
 }
 
 // OBVIOUSLY this is only for the preview server

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,13 +18,15 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 /*
    Without setting VersionScheme.Always here on `scala-xml`, sbt 1.8.0 will raise fatal 'version conflict' errors when

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import akka.actor.ActorSystem
-import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
@@ -58,6 +58,7 @@ trait AppComponents extends FrontendComponents {
     ContentApiMetrics.ContentApiRequestsMetric,
   )
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.rss.BuildInfo
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
   def actorSystem: ActorSystem

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -1,6 +1,6 @@
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import app.{FrontendApplicationLoader, FrontendComponents}
+import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import common._
@@ -83,6 +83,7 @@ trait AppComponents
 
   lazy val appIdentity = ApplicationIdentity("sport")
 
+  val frontendBuildInfo: FrontendBuildInfo = frontend.sport.BuildInfo
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]


### PR DESCRIPTION
One of the action items of this retro:
https://docs.google.com/document/d/1xNtvBELOISYXyosLO0yKrl3GEQx61lrUvoRbY_Hgedk/edit#heading=h.dnxdemhjrv8p

We want to embed the git commit id into the artifact and expose it into our http endpoints so that Prout knows exactly what commit id we're running in prod. This PR makes it possible for Prout to see the commit id in the `x-gu-frontend-git-commit-id` http response header.

This PR also adds two checkpoints:
* https://www.theguardian.com/uk
* https://frontend.gutools.co.uk/login

Depends on this Prout PR: https://github.com/guardian/prout/pull/79

Co-authored-by: Roberto Tyley <roberto.tyley@guardian.co.uk>
Co-authored-by: Georges Lebreton <georges.lebreton@guardian.co.uk>
Co-authored-by: Daniel Clifton <daniel.clifton@guardian.co.uk>

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
