### PR TITLE
Sampling Sentry errors: handle sampling in application code

### DIFF
--- a/static/src/javascripts/lib/report-error.spec.ts
+++ b/static/src/javascripts/lib/report-error.spec.ts
@@ -12,9 +12,18 @@ jest.mock('raven-js', () => ({
 }));
 
 describe('report-error', () => {
+	beforeEach(() => {
+		jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+	});
+
+	afterEach(() => {
+		jest.spyOn(global.Math, 'random').mockRestore();
+		jest.resetAllMocks();
+	});
+
 	const error = new Error('Something broke.');
 	const tags = { test: 'testValue' };
-	const ravenMetaData = { tags: tags, sampleRate: 1 };
+	const ravenMetaData = { tags: tags };
 
 	test('Does NOT throw an error', () => {
 		expect(() => {
@@ -36,5 +45,11 @@ describe('report-error', () => {
 			error,
 			ravenMetaData,
 		);
+	});
+
+	test('Applies a sampling rate that prevents a sample of errors being reporting', () => {
+		reportError(error, tags, false, 1 / 100);
+
+		expect(fakeRaven.captureException).not.toHaveBeenCalled();
 	});
 });

--- a/static/src/javascripts/lib/report-error.ts
+++ b/static/src/javascripts/lib/report-error.ts
@@ -21,7 +21,9 @@ const convertError = (err: unknown): Error => {
  *  for uncaught exceptions. This is optional because sometimes we log errors for tracking
  *  non-error data.
  * @param sampleRate - A sampling rate to apply to events, used for highly frequent errors.
- *  A value of 0 will send no events, and a value of 1 will send all events (default).
+ *  A value of 0 will send no events, and a value of 1 (default) will send an event for
+ *  users that have downloaded the raven client (0.8% of all users).
+ *  See https://github.com/guardian/frontend/blob/faf2bb4f5e4aa123d1da86ea98cbd693c4e8ffd0/static/src/javascripts/lib/raven.ts#L68
  */
 const reportError = (
 	err: unknown,


### PR DESCRIPTION
## What does this change?

Adds some logic to handle the sampling of specific errors to our application code.

## What is the value of this and can you measure success?

This functionality was added in #25790 but it currently isn't working as intended. `sampleRate` may be set during [Raven's configuration](https://docs.sentry.io/clients/javascript/config/), but not at error reporting time. 

This change adds some logic to manually apply a sample rate using JavaScript's built-in random number generator. It preserves the `reportError` API .

> **Note** 
> the more modern `@sentry/browser` client allows for [more granular sampling options](https://docs.sentry.io/platforms/javascript/configuration/sampling/#sampling-error-events).