### PR TITLE
reduce spacing under logo on mobile

### DIFF
--- a/static/src/stylesheets/layout/nav/_header-top-nav.scss
+++ b/static/src/stylesheets/layout/nav/_header-top-nav.scss
@@ -155,7 +155,7 @@ from scrolling */
     float: right;
     margin-top: 10px;
     margin-right: $veggie-burger + 12px;
-    margin-bottom: $gs-baseline * 2;
+    margin-bottom: 10px;
 
     @include mq(mobileMedium) {
         margin-right: $gs-gutter / 2;


### PR DESCRIPTION
## What does this change?
Reduces to the spacing on the logo [to match DCR](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/Logo.tsx#L20).

Part of https://github.com/guardian/dotcom-rendering/issues/6436

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/31692/208718760-30acea62-bc21-4f21-9594-46ecdeee2ec7.png

[after]: https://user-images.githubusercontent.com/31692/208718802-05a26275-b9f5-4f2c-9d42-24d744510577.png

