### PR TITLE
logo spacing and top bar link spacing

### DIFF
--- a/static/src/stylesheets/layout/nav/_header-top-nav.scss
+++ b/static/src/stylesheets/layout/nav/_header-top-nav.scss
@@ -34,10 +34,15 @@ from scrolling */
         display: flex;
         justify-content: start;
         font-weight: bold;
+        height: 30px;
         padding-right: 96px;
+        padding-left: 12px;
 
         @include mq($from: desktop) {
             justify-content: end;
+            height: 35px;
+            padding-right: 0;
+            padding-left: 0;
         }
 
         a.top-bar__item {
@@ -54,12 +59,15 @@ from scrolling */
             }
 
             @include mq($until: desktop) {
+                font-weight: 400;
                 padding: 3px 10px;
             }
         }
     }
 
     .header-top-nav__item {
+        display: flex;
+        align-items: center;
         position: relative;
         margin-right: 0;
 
@@ -153,7 +161,7 @@ from scrolling */
 
 .header-top-nav__logo {
     float: right;
-    margin-top: 10px;
+    margin-top: 6px;
     margin-right: $veggie-burger + 12px;
     margin-bottom: 10px;
 
@@ -167,7 +175,7 @@ from scrolling */
 
     @include mq(desktop) {
         margin-top: 5px;
-        margin-bottom: $gs-baseline + ($gs-baseline / 2);
+        margin-bottom: 12px;
         position: relative;
         z-index: $zindex-main-menu + 1;
     }


### PR DESCRIPTION
## What does this change?
Standardises spacing on DCR and frontend headers.

- More logo spacing standardising on mobile
- Removes large spacing on left hand side on desktop


# DCR | Frontend
## Before (mobile)
<img width="1232" alt="Screenshot 2022-12-20 at 17 08 43" src="https://user-images.githubusercontent.com/31692/208725294-0c7076cc-bb8e-4509-861e-1f9896a8e8c7.png">


## After (mobile)
<img width="1235" alt="Screenshot 2022-12-20 at 17 06 51" src="https://user-images.githubusercontent.com/31692/208725265-1c25385b-95e0-4cbc-879c-fe9b239c4e39.png">

## Before (desktop)
<img width="1232" alt="Screenshot 2022-12-20 at 17 12 32" src="https://user-images.githubusercontent.com/31692/208725948-e046806c-eff2-4b41-b13b-8f2f1202c77e.png">
<img width="1232" alt="Screenshot 2022-12-20 at 17 12 40" src="https://user-images.githubusercontent.com/31692/208725952-7e0cf368-6045-4312-a353-0e5e51f4711e.png">

## After (desktop)
<img width="1232" alt="Screenshot 2022-12-20 at 17 12 32" src="https://user-images.githubusercontent.com/31692/208725948-e046806c-eff2-4b41-b13b-8f2f1202c77e.png">
<img width="1232" alt="Screenshot 2022-12-20 at 17 13 49" src="https://user-images.githubusercontent.com/31692/208726204-5e83af94-9903-4eb9-8ff2-0ab6a2da4bbc.png">


