### PR TITLE
Fix old `sonatypeRepo` config

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -53,9 +53,8 @@ object ProjectSettings {
       <dependencies>
         <exclude org="commons-logging" module="commons-logging"><!-- Conflicts with jcl-over-slf4j in Play. --></exclude>
       </dependencies>,
-    resolvers ++= Seq(
+    resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
       Resolver.typesafeRepo("releases"),
-      Resolver.sonatypeRepo("releases"),
       "Spy" at "https://files.couchbase.com/maven2/",
     ),
     update / evictionWarningOptions := EvictionWarningOptions.default


### PR DESCRIPTION
In [February 2021](https://central.sonatype.org/news/20210223_new-users-on-s01/) Sonatype started spreading its OSS Maven artifact hosting across 2 repository hosts, so we need to use the plural `sonatypeOssRepos` (introduced with sbt/librarymanagement#393) rather than the deprecated singular `sonatypeRepo`. Otherwise we get this warning in the build:

```
Use sonatypeOssRepos instead e.g. `resolvers ++= Resolver.sonatypeOssRepos("snapshots")`
```

I managed to miss this when I was doing https://github.com/guardian/frontend/pull/25781, tho' I caught it elsewhere (https://github.com/guardian/frontend/pull/25781#discussion_r1049426252)!

I making this change partly just to see if Prout reports the merge correctly.
