### PR TITLE
Add fashion statement to css label override

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -247,7 +247,8 @@
 .email-sub__form--thrasher-the-breakdown,
 .email-sub__form--thrasher-the-long-read,
 .email-sub__form--thrasher-house-to-home,
-.email-sub__form--thrasher-five-great-reads {
+.email-sub__form--thrasher-five-great-reads,
+.email-sub__form--thrasher-fashion-statement {
 
     .email-sub__thrasher-embed-label {
         color: $brightness-7;


### PR DESCRIPTION
## What does this change?

Adds CSS override to the Fashion Statement newsletter turning the label text from white to black

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/74301289/209101569-5f2a8212-10ce-4a9e-af0e-c978ae917bdc.png
[after]: https://user-images.githubusercontent.com/74301289/210766462-733d86e8-5d2b-45fb-becd-978a1ed5aaa0.png

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
