### PR TITLE
Add missing argument to DevFilters & fixes project dev-build

### DIFF
--- a/dev-build/app/http/DevFilters.scala
+++ b/dev-build/app/http/DevFilters.scala
@@ -57,5 +57,6 @@ class DevFilters(implicit
     applicationContext: ApplicationContext,
     executionContext: ExecutionContext,
 ) extends HttpFilters {
-  override def filters: Seq[EssentialFilter] = new DevJsonExtensionFilter :: new DevCacheWarningFilter :: Filters.common
+  override def filters: Seq[EssentialFilter] =
+    new DevJsonExtensionFilter :: new DevCacheWarningFilter :: Filters.common(frontend.devbuild.BuildInfo)
 }


### PR DESCRIPTION
## What does this change?

Trying to run the dev-build project currently leads to a compilation error: 

 ![before][] 

[before]: https://user-images.githubusercontent.com/102960844/209826017-ea986c1b-21aa-41b5-be47-372bb5795022.png

This seems to be following the change made while [making it possible for Prout to see the commit id we're running in Prod](https://github.com/guardian/frontend/pull/25795), which added a FrontendBuildInfo argument to the Filters.common method. This was added to a few of the projects (e.g. [admin](https://github.com/guardian/frontend/pull/25795/files#diff-acf6202a2b1d41bdc3ed8ce99706fba6747add4518f78d2809afb3883e61cf26:~:text=Filters.common-,val%20filters%3A%20List%5BEssentialFilter%5D%20%3D%20adminAuthFilter%20%3A%3A%20Filters,%7D,-%7D)) but not to the dev-build one, hence this change. 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Following this change, I was able to run the dev-build project locally.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
