### PR TITLE
Bump commercial-core to 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^8.1.3",
-		"@guardian/commercial-core": "^5.1.1",
+		"@guardian/commercial-core": "^5.1.3",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",
 		"@guardian/libs": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,10 +2171,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.3.tgz#47adc4892716904a62afa62da66f31eae059d56b"
   integrity sha512-Tol4O7A3ErmzgCd9YtkajJUfCps/1RCNXhtaUBwgT8u0OUPRmfk4jjD7cS3nok5gDTEUVemKwT2yysx1CxfWaw==
 
-"@guardian/commercial-core@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.1.1.tgz#ee3ff71ea483fc9eff11837abf3c9f1ca6ffabef"
-  integrity sha512-G6ZFuWTGqJumrPL6Zqy4OBvBVWCaaDyAy0lMWePb573sa/jhqkyh0LaTob4TVoketyXPPvPdvH18/aBfx8BMQA==
+"@guardian/commercial-core@^5.1.3":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.1.3.tgz#f7e845d8ae6e8ee6eaaf51fcce3400d94db81a59"
+  integrity sha512-B7Sa7O0zHHP3jN36XdGHOZ9fAgjEMfRYuRURqX+ziiJE8+lmr7rkLX3MLgbYUJCIUfhagNkj559JZDXTLQoZ6g==
   dependencies:
     type-fest "2.12.2"
 


### PR DESCRIPTION
## What does this change?

Bump commercial-core to 5.1.3, in order to bring in the following two changes:
- https://github.com/guardian/commercial-core/pull/748
- https://github.com/guardian/commercial-core/pull/749

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The primary value of this bump is to bring in changes from [this PR](https://github.com/guardian/commercial-core/pull/748) - ensuring our commercial metrics payloads contain the _unified_ CMP timing information.

A secondary benefit is the new 320x480 portrait interstitial size will be available for subsequent work, without adding it to the size mappings in production just yet.

### Tested

- [ ] Locally
- [x] On CODE (optional) - **~TODO~**