### PR TITLE
Conditionally render ad close button

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -24,6 +24,9 @@ const shouldRenderLabel = (adSlotNode: HTMLElement): boolean =>
 		).length
 	);
 
+const shouldRenderCloseButton = (adSlotNode: HTMLElement): boolean =>
+	adSlotNode.classList.contains('ad-slot--mobile-sticky');
+
 const createAdCloseDiv = (): HTMLElement => {
 	const buttonDiv: HTMLElement = document.createElement('button');
 	buttonDiv.className = 'ad-slot__close-button';
@@ -100,10 +103,12 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
 				adSlotNode.setAttribute('ad-label-text', adLabelContent);
-				adSlotNode.insertBefore(
-					createAdCloseDiv(),
-					adSlotNode.firstChild,
-				);
+				if (shouldRenderCloseButton(adSlotNode)) {
+					adSlotNode.insertBefore(
+						createAdCloseDiv(),
+						adSlotNode.firstChild,
+					);
+				}
 				if (renderAdTestLabel) {
 					adSlotNode.insertBefore(
 						createAdTestCookieRemovalLink(adTestCookieName),


### PR DESCRIPTION
## What does this change?
Only renders the ad slot close button div if the ad type is mobile sticky. Previously this div was rendered for all ad slots and set to display:none. This change removes the div where it isn't used.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [X] On CODE (optional)
