### PR TITLE
build(deps): bump @guardian/source-react-components-development-kitchen

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "^7.0.1",
 		"@guardian/source-react-components": "^9.1.1",
-		"@guardian/source-react-components-development-kitchen": "7.1.2",
+		"@guardian/source-react-components-development-kitchen": "8.2.0",
 		"@guardian/support-dotcom-components": "1.0.7",
 		"bean": "~1.0.14",
 		"bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,10 +2238,10 @@
   dependencies:
     mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components-development-kitchen@7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-7.1.2.tgz#0e475499216b4cced28835d391de4e8f6752a6ab"
-  integrity sha512-WQplsSK35Xx6HSkYR8/qX5fhHF5LeElkcpCJlscsgJttsjN8T5zBkxXQCBOsxQyzKvDlUmvZMEwr4gS7E94x+g==
+"@guardian/source-react-components-development-kitchen@8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-8.2.0.tgz#b7c9ff6b494f55d42e39acdde897193780dd1e76"
+  integrity sha512-1oDFsjgfEUStb7zTOo7NutBSt1L5OvaNPC9VUR8qvEqkQ31PfYmvBeIo5OEm9uHfvageUBcVS862jz9jn2PDvg==
 
 "@guardian/source-react-components@^9.1.1":
   version "9.1.1"


### PR DESCRIPTION
Opening a new PR because Dependabot's PRs aren't working with the snyk action.

The major change is due to a linting rule (`no-explicit-any`) and I can't find any obvious issues arising from that in this codebase. I've deployed this branch to CODE without any obvious problems.

I'm not sure what else to check, but I'm not totally confident that this is sufficient, so any thoughts are appreciated!

## Original Dependabot PR text (see #25814): 

Bumps [@guardian/source-react-components-development-kitchen](https://github.com/guardian/csnx) from 7.1.2 to 8.2.0.
- [Release notes](https://github.com/guardian/csnx/releases)
- [Commits](https://github.com/guardian/csnx/compare/@guardian/source-react-components-development-kitchen@7.1.2...@guardian/source-react-components-development-kitchen@8.2.0)

---
updated-dependencies:
- dependency-name: "@guardian/source-react-components-development-kitchen" dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>

