### PR TITLE
IntegrateIma test back to 0% opt in

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -8,8 +8,8 @@ export const integrateIma: ABTest = {
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',
-	audience: 5 / 100,
-	audienceOffset: 30 / 100,
+	audience: 0,
+	audienceOffset: 0,
 	audienceCriteria: 'Opt in',
 	successMeasure:
 		'IMA integration works as expected without adversely affecting pages with videos',


### PR DESCRIPTION
## What does this change?

IntegrateIma test back to 0% opt in

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6896

