### PR TITLE
Amend ad test label logic 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -104,7 +104,7 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 						adSlotNode.firstChild,
 					);
 				}
-				if (renderAdTestLabel) {
+				if (renderAdTestLabel && adTestCookieName) {
 					adSlotNode.insertBefore(
 						createAdTestCookieRemovalLink(adTestCookieName),
 						adSlotNode.firstChild,

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -4,8 +4,8 @@
  ],
  "../lib/detect-adblock.ts": [],
  "../lib/detect-breakpoint.ts": [
-  "../../../../node_modules/@guardian/source-foundations/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/detect-viewport.ts"
  ],
  "../lib/detect-google-proxy.ts": [],
@@ -162,7 +162,7 @@
  "../projects/commercial/modules/dfp/Advert.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/fastdom-promise.ts",
   "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
   "../projects/commercial/modules/dfp/define-slot.ts"
@@ -186,7 +186,7 @@
  ],
  "../projects/commercial/modules/dfp/define-slot.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/url.ts",
   "../projects/common/modules/commercial/lib/googletag-ad-size.ts",
@@ -346,7 +346,7 @@
   "../projects/common/modules/commercial/geo-utils.ts"
  ],
  "../projects/commercial/modules/dfp/refresh-on-resize.ts": [
-  "../../../../node_modules/@guardian/source-foundations/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/detect-breakpoint.ts",
   "../lib/mediator.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
@@ -492,7 +492,7 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/detect-breakpoint.ts",
   "../lib/fastdom-promise.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts"
@@ -543,7 +543,7 @@
  ],
  "../projects/commercial/modules/sticky-inlines.ts": [
   "../../../../node_modules/@guardian/libs/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/source-foundations/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/cjs/index.d.ts",
   "../lib/fastdom-promise.ts"
  ],
  "../projects/commercial/modules/teads-cookieless.ts": [


### PR DESCRIPTION
## What does this change?

Tiny change to the way that the 'clear' link for the ad test label is rendered, reducing the number of unnecessary divs being added to ad slots.
