### PR TITLE
fix: extend offer-http3 switch till 31 January

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -42,7 +42,7 @@ object OfferHttp3
       name = "offer-http3",
       description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
       owners = Seq(Owner.withGithub("paulmr")),
-      sellByDate = LocalDate.of(2023, 1, 10),
+      sellByDate = LocalDate.of(2023, 1, 31),
       participationGroup = Perc0B,
     )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -51,7 +51,7 @@ object TableOfContents
       name = "table-of-contents",
       description = "When ON, a table of contents will be rendered for qualifying articles",
       owners = Seq(Owner.withName("journalism team")),
-      sellByDate = LocalDate.of(2023, 1, 10),
+      sellByDate = LocalDate.of(2023, 1, 31),
       participationGroup = Perc0C,
     )
 


### PR DESCRIPTION
Extends HTTP3 switch till 31 January 2023.
Extends `table-of-contents` switch till 31 January 2023.

[It doesn't appear that GitHub users are emailed](https://github.com/guardian/frontend/blob/main/admin/app/jobs/ExpiringSwitchesEmailJob.scala#L25), so this might be worth having a think about (potentially having only team owners or similar).