### PR TITLE
fix: header CTA spacing fix

### DIFF
--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -14,7 +14,7 @@
 
     @include mq(tablet) {
         padding-top: 4px;
-        padding-bottom: 20px;
+        padding-bottom: 12px;
     }
 
     @include mq(desktop) {


### PR DESCRIPTION
## What does this change?
Removes some excess spacing on the CTA in the header.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

This is replicating DCR

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/31692/212049986-793a6a19-9e57-4967-bc7d-18c122c693f0.png
[after]: https://user-images.githubusercontent.com/31692/212049983-f063a63b-ffb1-4110-ab32-45b8a1b3ad0f.png

