### PR TITLE
Header notification click tracking

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/linkTracking.spec.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/linkTracking.spec.ts
@@ -1,0 +1,68 @@
+import type { OphanComponentType } from '@guardian/libs';
+import { addTrackingToUrl } from './linkTracking';
+
+describe('addTrackingToUrl', () => {
+	it('adds acquisitionData to a URL without query string args', () => {
+		const url = 'https://manage.theguardian.com/settings';
+		const componentType: OphanComponentType = 'RETENTION_HEADER';
+		const ophanComponent = {
+			componentType,
+			id: 'settings',
+			labels: ['label-1'],
+		};
+
+		const urlWithTracking = addTrackingToUrl(
+			url,
+			ophanComponent,
+			'https://www.theguardian.com/uk',
+			'page-view-id-123',
+		);
+
+		expect(urlWithTracking).toEqual(
+			'https://manage.theguardian.com/settings?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22settings%22%2C%22componentType%22%3A%22RETENTION_HEADER%22%2C%22campaignCode%22%3A%22settings%22%2C%22referrerPageviewId%22%3A%22page-view-id-123%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22labels%22%3A%5B%22label-1%22%5D%7D',
+		);
+	});
+
+	it('adds acquisitionData to a URL with existing query string args', () => {
+		const url = 'https://manage.theguardian.com/settings?foo=bar';
+		const componentType: OphanComponentType = 'RETENTION_HEADER';
+		const ophanComponent = {
+			componentType,
+			id: 'settings',
+			labels: ['label-1'],
+		};
+
+		const urlWithTracking = addTrackingToUrl(
+			url,
+			ophanComponent,
+			'https://www.theguardian.com/uk',
+			'page-view-id-123',
+		);
+
+		expect(urlWithTracking).toEqual(
+			'https://manage.theguardian.com/settings?foo=bar&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22settings%22%2C%22componentType%22%3A%22RETENTION_HEADER%22%2C%22campaignCode%22%3A%22settings%22%2C%22referrerPageviewId%22%3A%22page-view-id-123%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22labels%22%3A%5B%22label-1%22%5D%7D',
+		);
+	});
+
+	it('replaces an existing acquisitionData param', () => {
+		const url =
+			'https://manage.theguardian.com/settings?acquisitionData=existing';
+		const componentType: OphanComponentType = 'RETENTION_HEADER';
+		const ophanComponent = {
+			componentType,
+			id: 'settings',
+			labels: ['label-1'],
+		};
+
+		const urlWithTracking = addTrackingToUrl(
+			url,
+			ophanComponent,
+			'https://www.theguardian.com/uk',
+			'page-view-id-123',
+		);
+
+		expect(urlWithTracking).toEqual(
+			'https://manage.theguardian.com/settings?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22settings%22%2C%22componentType%22%3A%22RETENTION_HEADER%22%2C%22campaignCode%22%3A%22settings%22%2C%22referrerPageviewId%22%3A%22page-view-id-123%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22labels%22%3A%5B%22label-1%22%5D%7D',
+		);
+	});
+});

--- a/static/src/javascripts/projects/common/modules/navigation/linkTracking.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/linkTracking.ts
@@ -1,0 +1,30 @@
+import type { OphanComponent } from '@guardian/libs';
+
+const ACQ_QS_ARG = 'acquisitionData';
+
+export const addTrackingToUrl = (
+	urlString: string,
+	ophanComponent: OphanComponent,
+	referrerUrl: string,
+	referrerPageviewId: string,
+): string => {
+	const acquisitionData = JSON.stringify({
+		source: 'GUARDIAN_WEB',
+		componentId: ophanComponent.id,
+		componentType: ophanComponent.componentType,
+		campaignCode: ophanComponent.id,
+		referrerPageviewId,
+		referrerUrl,
+		labels: ophanComponent.labels,
+	});
+
+	const url = new URL(urlString);
+	const qs = new URLSearchParams(url.search);
+	if (qs.has(ACQ_QS_ARG)) {
+		qs.delete(ACQ_QS_ARG);
+	}
+	qs.set(ACQ_QS_ARG, acquisitionData);
+	url.search = qs.toString();
+
+	return url.toString();
+};

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.ts
@@ -3,6 +3,7 @@ import { getUserFromCookie, isUserLoggedIn } from 'common/modules/identity/api';
 import fastdom from 'lib/fastdom-promise';
 import { bufferedNotificationListener } from '../bufferedNotificationListener';
 import {
+	submitClickEvent,
 	submitInsertEvent,
 	submitViewEvent,
 } from '../commercial/acquisitions-ophan';
@@ -60,6 +61,22 @@ const trackNotificationsInsert = (
 	);
 	if (ophanComponent) {
 		submitInsertEvent(ophanComponent);
+	}
+};
+
+const setupTrackNotificationsClick = (
+	el: Element,
+	target: string,
+	notifications: HeaderNotification[],
+): void => {
+	const ophanComponent = buildOphanComponentWithNotifications(
+		target,
+		notifications,
+	);
+	if (ophanComponent) {
+		el.addEventListener('click', () => {
+			submitClickEvent(ophanComponent);
+		});
 	}
 };
 
@@ -162,6 +179,11 @@ const addNotifications = (notifications: HeaderNotification[]): void => {
 								trackNotificationsInsert(target, notifications);
 								setupTrackNotificationsView(
 									notificationsContainerEl,
+									target,
+									notifications,
+								);
+								setupTrackNotificationsClick(
+									menuItem,
 									target,
 									notifications,
 								);


### PR DESCRIPTION
## What does this change?

This PR introduces:

* Ophan click tracking on header dropdown links when notification(s) are present
* Adding `acquisitionData` param to the dropdown link when notification(s) are present.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) - Already done in guardian/dotcom-rendering#6736

## Screenshots

<img width="532" alt="Screenshot 2023-01-12 at 13 22 37" src="https://user-images.githubusercontent.com/379839/212077905-e0396433-f2b4-49b7-8871-cbbef6ebaeff.png">

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

So that we can know how users are responding to header notifications.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
