### PR TITLE
fix: change log level to info when title starts with 1-9

### DIFF
--- a/admin/app/indexes/TagPages.scala
+++ b/admin/app/indexes/TagPages.scala
@@ -91,7 +91,7 @@ class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
     val maybeFirstChar = Try(badCharacters.replaceAllIn(asAscii(s).toLowerCase, "").charAt(0)).toOption
 
     if (maybeFirstChar.isEmpty) {
-      log.error(s"Tag without alpha index, being shoved into 1-9: $s")
+      log.info(s"Tag without alpha index, being shoved into 1-9: $s")
     }
 
     maybeFirstChar.filterNot(_.isDigit).map(_.toString).getOrElse("1-9")


### PR DESCRIPTION
## What does this change?

Sets the logging level for an [expected and tested state](https://github.com/guardian/frontend/blob/main/admin/test/indexes/TagPagesTest.scala#L46-L56) to `info` to avoid clogging up our logs when searching for real errors.

@bryophyta [has made the same point (point 3)](https://github.com/guardian/frontend/issues/25785#issuecomment-1366853945).

We could probably rewrite the method to be a little more clear.

