### PR TITLE
feat: Add DiscussionSettings to onwards cards

### DIFF
--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -4,10 +4,11 @@ import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RenderingFormat
 import common._
 import contentapi.ContentApiClient
+import layout.DiscussionSettings
 import model.ContentFormat
 import model.dotcomrendering.OnwardCollectionResponse
 import play.api.libs.json._
-import services.{OphanApi, OphanDeeplyReadItem}
+import services.{FaciaContentConvert, OphanApi, OphanDeeplyReadItem}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -104,6 +105,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       starRating = None,
       avatarUrl = None,
       branding = None,
+      discussion = DiscussionSettings.fromTrail(FaciaContentConvert.contentToFaciaContent(content)),
     )
   }
 

--- a/common/app/model/dotcomrendering/Trail.scala
+++ b/common/app/model/dotcomrendering/Trail.scala
@@ -4,7 +4,7 @@ import com.github.nscala_time.time.Imports.DateTimeZone
 import com.gu.commercial.branding.{Branding, BrandingType, Dimensions, Logo => CommercialLogo}
 import common.{Edition, LinkTo}
 import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
-import layout.ContentCard
+import layout.{ContentCard, DiscussionSettings}
 import model.{Article, ContentFormat, ImageMedia, InlineImage, Pillar}
 import model.pressed.PressedContent
 import play.api.libs.json.{Json, Writes}
@@ -32,6 +32,7 @@ case class Trail(
     starRating: Option[Int],
     avatarUrl: Option[String],
     branding: Option[Branding],
+    discussion: DiscussionSettings,
 )
 
 object Trail {
@@ -49,6 +50,8 @@ object Trail {
   implicit val logoWrites = Json.writes[CommercialLogo]
 
   implicit val brandingWrites = Json.writes[Branding]
+
+  implicit val discussionWrites = Json.writes[DiscussionSettings]
 
   implicit val OnwardItemWrites = Json.writes[Trail]
 
@@ -129,6 +132,7 @@ object Trail {
       starRating = contentCard.starRating,
       avatarUrl = contentCardToAvatarUrl(contentCard),
       branding = contentCard.branding,
+      discussion = contentCard.discussionSettings,
     )
   }
 
@@ -163,6 +167,7 @@ object Trail {
       starRating = content.card.starRating,
       avatarUrl = None,
       branding = content.branding(Edition(request)),
+      discussion = DiscussionSettings.fromTrail(content),
     )
   }
 }


### PR DESCRIPTION
## What does this change?

Adds a discussion field to our Onwards JSON responses so that we can decide if we need to add the discussion anchor to Onward cards on server render. Right now we're getting accessibility errors on our onwards containers because they have empty anchor links from Articles that don't have discussion sessions.

We already have the `discussion` field on Front cards.

Part of https://github.com/guardian/dotcom-rendering/issues/6111

### Before


```json
{
    "heading": "Related stories",
    "trails": [
        {
            "url": "http://localhost:9000/film/2023/jan/16/monstrous-maestro-cate-blanchett-cancel-culture-tar",
            "linkText": "Monstrous maestro: why is Cate Blanchett’s cancel culture film Tár angering so many people?",
            "showByline": false,
            "byline": "Xan Brooks",
            "masterImage": "https://media.guim.co.uk/243f613c40a8bf3d9faf590e1927063e5527e5fc/1950_612_3161_1898/master/3161.jpg",
            "image": "https://i.guim.co.uk/img/media/243f613c40a8bf3d9faf590e1927063e5527e5fc/1950_612_3161_1898/master/3161.jpg?width=300&quality=85&auto=format&fit=max&s=aee883de42025b1415bca6e71b4b8746",
            "carouselImages": {
                "300": "https://i.guim.co.uk/img/media/243f613c40a8bf3d9faf590e1927063e5527e5fc/1950_612_3161_1898/master/3161.jpg?width=300&quality=85&auto=format&fit=max&s=aee883de42025b1415bca6e71b4b8746",
                "460": "https://i.guim.co.uk/img/media/243f613c40a8bf3d9faf590e1927063e5527e5fc/1950_612_3161_1898/master/3161.jpg?width=460&quality=85&auto=format&fit=max&s=e9bc87653f098e0330ef2018b4d43070"
            },
            "isLiveBlog": false,
            "pillar": "culture",
            "designType": "Feature",
            "format": {
                "design": "FeatureDesign",
                "theme": "CulturePillar",
                "display": "StandardDisplay"
            },
            "webPublicationDate": "2023-01-16T06:00:35.000Z",
            "headline": "Monstrous maestro: why is Cate Blanchett’s cancel culture film Tár angering so many people?",
            "shortUrl": "https://www.theguardian.com/p/n55qx"
        }
    ]
}
```

### After

```json
{
    "heading": "Related stories",
    "trails": [
        {
            "url": "http://localhost:9000/film/2023/jan/16/monstrous-maestro-cate-blanchett-cancel-culture-tar",
            "linkText": "Monstrous maestro: why is Cate Blanchett’s cancel culture film Tár angering so many people?",
            "showByline": false,
            "byline": "Xan Brooks",
            "masterImage": "https://media.guim.co.uk/243f613c40a8bf3d9faf590e1927063e5527e5fc/1950_612_3161_1898/master/3161.jpg",
            "image": "https://i.guim.co.uk/img/media/243f613c40a8bf3d9faf590e1927063e5527e5fc/1950_612_3161_1898/master/3161.jpg?width=300&quality=85&auto=format&fit=max&s=aee883de42025b1415bca6e71b4b8746",
            "carouselImages": {
                "300": "https://i.guim.co.uk/img/media/243f613c40a8bf3d9faf590e1927063e5527e5fc/1950_612_3161_1898/master/3161.jpg?width=300&quality=85&auto=format&fit=max&s=aee883de42025b1415bca6e71b4b8746",
                "460": "https://i.guim.co.uk/img/media/243f613c40a8bf3d9faf590e1927063e5527e5fc/1950_612_3161_1898/master/3161.jpg?width=460&quality=85&auto=format&fit=max&s=e9bc87653f098e0330ef2018b4d43070"
            },
            "isLiveBlog": false,
            "pillar": "culture",
            "designType": "Feature",
            "format": {
                "design": "FeatureDesign",
                "theme": "CulturePillar",
                "display": "StandardDisplay"
            },
            "webPublicationDate": "2023-01-16T06:00:35.000Z",
            "headline": "Monstrous maestro: why is Cate Blanchett’s cancel culture film Tár angering so many people?",
            "shortUrl": "https://www.theguardian.com/p/n55qx",
            "discussion": {
                "isCommentable": true,
                "isClosedForComments": true,
                "discussionId": "/p/n55qx"
            }
        }
    ]
}
```