### PR TITLE
Refactor index string fallbacks for Contributor Index

### DIFF
--- a/admin/app/jobs/RebuildIndexJob.scala
+++ b/admin/app/jobs/RebuildIndexJob.scala
@@ -103,7 +103,8 @@ class RebuildIndexJob(contentApiClient: ContentApiClient)(implicit executionCont
             * Concatenating these three strings therefore allows us to use firstName and webTitle as fallbacks
             * if lastName is None or "".
             * */
-          val indexString = tag.lastName.getOrElse("").trim + tag.firstName.getOrElse("").trim + tag.webTitle
+          val indexString =
+            tag.lastName.getOrElse("").trim.concat(tag.firstName.getOrElse("").trim).concat(tag.webTitle)
           tagPages.alphaIndexKey(indexString)
         })
 


### PR DESCRIPTION
## What does this change?

Replaces a chain of `orElse` statements with string concatenation. The previous structure didn't test whether `tags.lastName` was an empty string. Passing an empty string to `tagPages.alphaIndexKey` doesn't crash the job, but it [was leading to an error being logged](https://github.com/guardian/frontend/issues/25785#issuecomment-1366853945).

@jamesgorrie's PR #25832 will downgrade the error message to an info message. 

This PR should remove a significant proportion of the events which were triggering the logging statement in the first place. Using string concatenation here means that we don't need to explicitly test whether `lastName` is empty; if it _is_ empty then the first character in `firstName` will be used for the index (and likewise if `firstName` is also empty). This is a less 'lazy' approach as it will often involve evaluating values that don't get used, but the cost of eagerness here seems low because it just involves unwrapping some Options and concatenating three strings.

This PR should also affect the contributor indexes that are built by this job, because all the contributors with no `lastName` should now be indexed by their `firstName` or `webTitle` instead of the fallback index key of `1-9`. It looks like this was the intention of the original code, and in theory should be a more 'useful' index. However, it will still provide the 'wrong' bucketing and alphabetical ordering for those contributors who have no `lastName` set through human error (as opposed to the case where their name doesn't fit within the convention of a first and last name; in the latter cases ideally the affordances provided here would be used by editorial to produce the conventionally correct ordering based on the specifics of the case).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Tests

I deployed this to CODE last night and the errors seem to have dropped off since that deployment:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/37048459/212885228-3c84ce86-8845-4921-a0f0-99f202a83bc5.png">

Also, @ioannakok and I have verified that when the job runs with the code in this PR it does rebuild the indexes in S3 with contributors allocated as we'd expect (i.e. most of them have moved from [the `1-9` bucket](https://www.theguardian.com/index/contributors/1-9) into an alphabet bucket):

|Before|After|
|--|--|
|<img width="692" alt="the 1-9 page only has many entries for contributors: Frank, David Aaronovitch, Abahachi, etc." src="https://user-images.githubusercontent.com/37048459/213153673-24b2e832-cf9a-46ff-8811-28d2777efe44.png">|<img width="690" alt="the 1-9 page only has one entry now: Studio 20 NYU" src="https://user-images.githubusercontent.com/37048459/213147623-64aa2f23-bbd3-4b7b-81e2-770967af30a9.png">|
