### PR TITLE
Bump com.squareup.okhttp3:okhttp to 4.10.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -80,7 +80,7 @@ object Dependencies {
   val atomRenderer = "com.gu" %% "atom-renderer" % "1.2.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7"
-  val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"
+  val okhttp = "com.squareup.okhttp3" % "okhttp" % "4.10.0"
 
   /*
     Note: Although frontend compiles and passes all the current tests when jackson is removed, be careful that this


### PR DESCRIPTION
To address vulnerability: https://app.snyk.io/org/guardian-dotcom-n2y/project/02277008-74db-46d3-890a-722cfaa70e3f#issue-SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044
