### PR TITLE
Improve weather widget accessibility and styles

### DIFF
--- a/common/app/views/fragments/inlineSvg.scala.html
+++ b/common/app/views/fragments/inlineSvg.scala.html
@@ -2,11 +2,12 @@
 
 @import views.support.setSvgClasses
 
-<span @title.map{ t => title="@t" } class="inline-@file @if(path){inline-@path} @classes.mkString(" ")" @if(isPresentation){role="presentation" aria-hidden="true"}>
+<span class="inline-@file @if(path){inline-@path} @classes.mkString(" ")" @if(isPresentation){role="presentation" aria-hidden="true"}>
     @defining((
         path + "/" + file + ".svg",
-        classes ++ Seq("inline-" + file, "inline-" + path)
-    )) { case (pathToSvg, classNames) =>
-        @Html(setSvgClasses(common.Assets.inlineSvg(pathToSvg), classNames))
+        classes ++ Seq("inline-" + file, "inline-" + path),
+        title
+    )) { case (pathToSvg, classNames, title) =>
+        @Html(setSvgClasses(common.Assets.inlineSvg(pathToSvg), classNames, title))
     }
 </span>

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -753,12 +753,15 @@ case class AtomsCleaner(
 }
 
 object setSvgClasses {
-  def apply(svg: String, classes: Seq[String] = List()): String = {
+  def apply(svg: String, classes: Seq[String] = List(), label: Option[String] = None): String = {
     val document = Jsoup.parse(svg)
     val svgHtml = document.getElementsByTag("svg")
     val modifiedClasses = classes.map(_.concat("__svg")).mkString(" ")
 
     svgHtml.addClass(modifiedClasses)
+    label.map(text => {
+      svgHtml.attr("aria-label", text)
+    })
     svgHtml.toString
   }
 }

--- a/onward/app/views/weatherFragments/cityForecast.scala.html
+++ b/onward/app/views/weatherFragments/cityForecast.scala.html
@@ -5,11 +5,11 @@
 
 @for((forecast, index) <- forecasts.drop(1).zipWithIndex) {
     @defining(forecast.temperatureForEdition(Edition(request))) { temp =>
-        <li class="forecast__item forecast__item--@index" aria-label="@(s"${forecast.hourString}: ${temp}, ${forecast.weatherText.toLowerCase()}.")" role="text">
+        <li class="forecast__item forecast__item--@index">
             <div class="weather__time" aria-hidden="true">
                 <time class="weather__time-value">@forecast.hourString</time>
             </div>
-            @fragments.inlineSvg(s"weather-${forecast.weatherIcon}", "weather", Seq("weather__icon", "js-weather-icon"), Some(forecast.weatherText), true)
+            @fragments.inlineSvg(s"weather-${forecast.weatherIcon}", "weather", Seq("weather__icon", "js-weather-icon"), Some(s"${forecast.hourString}: ${temp}, ${forecast.weatherText.toLowerCase()}."))
             <div class="weather__temp" aria-hidden="true">
                 <span class="weather__temp-value">@temp</span>
             </div>

--- a/onward/app/views/weatherFragments/cityWeather.scala.html
+++ b/onward/app/views/weatherFragments/cityWeather.scala.html
@@ -20,11 +20,11 @@
                 Close change location</span> @fragments.inlineSvg("close", "icon", List("weather__close-icon"))
             </button>
         </div>
-        <div class="u-unstyled forecast__item forecast__item--current js-weather-current" aria-label="@(s"The weather now: ${math.round(temp.Value)}°${temp.Unit}, ${weatherResponse.WeatherText.toLowerCase()}")">
+        <div class="forecast__item forecast__item--current js-weather-current">
             <div class="weather__time" aria-hidden="true">
                 <span class="weather__time-value">Now</span>
             </div>
-            @fragments.inlineSvg(s"weather-${weatherResponse.WeatherIcon}", "weather", Seq("weather__icon", "js-weather-icon"), Some(weatherResponse.WeatherText), true)
+            @fragments.inlineSvg(s"weather-${weatherResponse.WeatherIcon}", "weather", Seq("weather__icon", "js-weather-icon"), Some(s"The weather now: ${math.round(temp.Value)}°${temp.Unit}, ${weatherResponse.WeatherText.toLowerCase()}"))
             <div class="weather__temp" aria-hidden="true">
                 <span class="weather__temp js-weather-temp">@math.round(temp.Value)°@temp.Unit</span>
             </div>

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -194,7 +194,7 @@ $weather-large-size: 50px;
         font-weight: 400;
         width: 100%;
         display: block;
-        padding: 0 2rem 0 2rem;
+        padding: 0 2rem;
         box-sizing: border-box;
         transition: background-color .2s ease-in-out;
 
@@ -243,7 +243,7 @@ $weather-large-size: 50px;
 .weather__close-location,
 .weather__edit-location {
     position: absolute;
-    top: 0.7rem;
+    top: .7rem;
     display: block;
     z-index: 5;
 
@@ -253,11 +253,11 @@ $weather-large-size: 50px;
 }
 
 .weather__close-location {
-    right: 0.6rem;
+    right: .6rem;
 }
 
 .weather__edit-location {
-    left: 0.6rem;
+    left: .6rem;
     pointer-events: none;
 }
 

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -190,11 +190,11 @@ $weather-large-size: 50px;
         border-radius: 16px;
         height: 32px;
         line-height: 32px;
-        cursor: pointer;
+        cursor: text;
         font-weight: 400;
         width: 100%;
         display: block;
-        padding: 0 35px 0 30px;
+        padding: 0 2rem 0 2rem;
         box-sizing: border-box;
         transition: background-color .2s ease-in-out;
 
@@ -243,7 +243,7 @@ $weather-large-size: 50px;
 .weather__close-location,
 .weather__edit-location {
     position: absolute;
-    top: ($gs-baseline / 2) + 2px;
+    top: 0.7rem;
     display: block;
     z-index: 5;
 
@@ -253,11 +253,11 @@ $weather-large-size: 50px;
 }
 
 .weather__close-location {
-    right: 8px;
+    right: 0.6rem;
 }
 
 .weather__edit-location {
-    left: 8px;
+    left: 0.6rem;
     pointer-events: none;
 }
 


### PR DESCRIPTION
## What does this change?

The weather widget had a frustrating issue with VoiceOver, which reads 'group' or 'empty group' at the end of each weather summary. The weather widget appears in our main block before the actual articles so screenreader users will always encounter it first - therefore it's good to make it as screenreader-friendly as possible.

This PR solves the 'group' issue by adding an aria-label directly on the weather `svg` rather than as a title to an element at a higher level in the DOM. It also solves this issue for our `inline-svg` generally. The label has been previously added as a title for a parent span rather than as an `aria-label` on the `svg` itself, so the span was being read as a 'group', this PR instead adds an `aria-label` directly to the svg.

#### Before:
(Note - 'empty group' read after weather summaries)

https://user-images.githubusercontent.com/34686302/213442540-ed36e321-7dca-4048-b8d6-2e412893da19.mp4 

#### After: 
(The visual outline now appears on the svg rather than the whole weather summary, but the audio experience is improved, which I think is more important to prioritise)
 
https://user-images.githubusercontent.com/34686302/213442679-3b6d3748-2771-4daa-ab26-21e2046e9a94.mp4

The PR also makes some minor style changes to centre the weather search icons vertically in their search bar:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/34686302/213444033-7db22063-4a19-42b6-b463-b2602a8c0d37.png) | ![image](https://user-images.githubusercontent.com/34686302/213444063-72e78e9e-9119-4194-9b36-b7a6e5229054.png) |

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
