### PR TITLE
feat: remove slash from labs cards

### DIFF
--- a/common/app/views/fragments/commercial/cards/itemCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemCard.scala.html
@@ -4,6 +4,7 @@
 @import views.html.fragments.inlineSvg
 @import views.html.fragments.items.elements.facia_cards.image
 @import views.support.Commercial.CssClassBuilder
+@import experiments.{ActiveExperiments, RemoveKickerSlashes}
 
 @(item: layout.PaidCard,
   omnitureId: String,
@@ -23,8 +24,11 @@
         <h2 class="advert__title">
             @for(icon <- item.icon){@inlineSvg(icon, "icon")}
             @for(kicker <- item.kicker){
-                <span class="advert__kicker">@kicker</span>
-            }
+                @if(ActiveExperiments.isParticipating(RemoveKickerSlashes)) {
+                    <span class="advert__kicker__without_slash ">@kicker<br/></span>
+                } else {
+                    <span class="advert__kicker">@kicker</span>
+                }            }
             @Html(item.headline)
         </h2>
         <div class="advert__image-container

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -122,6 +122,10 @@
     color: $brightness-46;
 }
 
+.advert__kicker__without_slash {
+    color: $brightness-46;
+}
+
 .paidfor-container {
     display: flex;
     align-items: stretch;


### PR DESCRIPTION
## What does this change?
Add the fronts slash switch to the labs card. It also removes the slash and adds a linebreak if the user is within the variant.  
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/214069065-68399c54-ded8-4b52-8c6a-27bbbf3c1699.png
[after]: https://user-images.githubusercontent.com/20416599/214066939-e0aeb409-72fa-498c-af7b-bba31a26954f.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
