### PR TITLE
Bump SWC bundle experiment to 10%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -25,7 +25,7 @@ object DCRJavascriptBundle
       description = "DCR Javascript bundle experiment",
       owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2024, 4, 1),
-      participationGroup = Perc1A,
+      participationGroup = Perc10A,
     )
 
 object DCRFronts


### PR DESCRIPTION
## What does this change?

Increase the sample rate for the `dcrJavascriptBundle` test from 1% to 10%.

We wish to gather more data for analysis and also rule out any issues from the recent core-js regression in control.

## Does this change need to be reproduced in dotcom-rendering ?

Related Sentry sampling adjustment: https://github.com/guardian/dotcom-rendering/pull/7005



