### PR TITLE
WIP: Pass JSON version of CAPI content to DCR data model

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -168,7 +168,7 @@ class ArticleController(
       case Right(article: Article) =>
         Right((ArticlePage(article, StoryPackages(article.metadata.id, response)), blocks))
       case Left(r) => Left(r)
-      case _       => Left(NotFound)
+      case _        => Left(NotFound)
     }
   }
 

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -168,7 +168,7 @@ class ArticleController(
       case Right(article: Article) =>
         Right((ArticlePage(article, StoryPackages(article.metadata.id, response)), blocks))
       case Left(r) => Left(r)
-      case _        => Left(NotFound)
+      case _       => Left(NotFound)
     }
   }
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -17,6 +17,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       BorkFID,
       ActionCardRedesign,
       Okta,
+      DCRCapiData,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -119,4 +120,13 @@ object Okta
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 7, 24),
       participationGroup = Perc0E,
+    )
+
+object DCRCapiData
+    extends Experiment(
+      name = "dcr-capi-data",
+      description = "Pass unmodified CAPI data straight to DCR alongside the existing model",
+      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
+      sellByDate = LocalDate.of(2023, 5, 1),
+      participationGroup = Perc1D,
     )

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -112,21 +112,6 @@ case class DotcomRenderingDataModel(
 object DotcomRenderingDataModel {
 
   implicit val pageElementWrites = PageElement.pageElementWrites
-  implicit val apiContentWrites = new Writes[CAPIContent] {
-    def writes(model: CAPIContent) = {
-      Json.obj(
-        "id" -> model.id,
-        "type" -> JsString(model.`type`.toString),
-        "sectionId" -> model.sectionId,
-        "sectionName" -> model.sectionName,
-        "webPublicationDate" -> model.webPublicationDate.map(_.iso8601),
-        "webTitle" -> model.webTitle,
-        "webUrl" -> model.webUrl,
-        "apiUrl" -> model.apiUrl,
-//        "fields" -> model.fields,
-      )
-    }
-  }
 
   implicit val writes = new Writes[DotcomRenderingDataModel] {
     def writes(model: DotcomRenderingDataModel) = {

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -111,18 +111,6 @@ case class DotcomRenderingDataModel(
 
 object DotcomRenderingDataModel {
 
-  // we Json.parse this into a JsValue to ensure we get the raw JSON
-  // from the Content API rather than a Json.stringified version
-  private def contentApiToJsonValue(apiContent: CAPIContent): JsValue = {
-    val protocolFactory = new TSimpleJSONProtocol.Factory
-
-    val buffer = new java.io.ByteArrayOutputStream
-    val protocol = protocolFactory.getProtocol(new TIOStreamTransport(buffer))
-
-    CAPIContent.encode(apiContent, protocol)
-    Json.parse(new String(buffer.toByteArray, "UTF-8"))
-  }
-
   implicit val pageElementWrites = PageElement.pageElementWrites
   implicit val apiContentWrites = new Writes[CAPIContent] {
     def writes(model: CAPIContent) = {
@@ -217,6 +205,18 @@ object DotcomRenderingDataModel {
 
       ElementsEnhancer.enhanceDcrObject(obj)
     }
+  }
+
+  // we Json.parse this into a JsValue to ensure we get the raw JSON
+  // from the Content API rather than a Json.stringified version
+  private def contentApiToJsonValue(apiContent: CAPIContent): JsValue = {
+    val protocolFactory = new TSimpleJSONProtocol.Factory
+
+    val buffer = new java.io.ByteArrayOutputStream
+    val protocol = protocolFactory.getProtocol(new TIOStreamTransport(buffer))
+
+    CAPIContent.encode(apiContent, protocol)
+    Json.parse(new String(buffer.toByteArray, "UTF-8"))
   }
 
   def toJson(model: DotcomRenderingDataModel): String = {

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -9,7 +9,7 @@ import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
-import experiments.ActiveExperiments
+import experiments.{ActiveExperiments, DCRCapiData, DCRFronts}
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
@@ -106,7 +106,7 @@ case class DotcomRenderingDataModel(
     showTableOfContents: Boolean,
     lang: Option[String],
     isRightToLeftLang: Boolean,
-    capiContent: CAPIContent,
+    capiContent: Option[CAPIContent],
 )
 
 object DotcomRenderingDataModel {
@@ -185,7 +185,7 @@ object DotcomRenderingDataModel {
         "showTableOfContents" -> model.showTableOfContents,
         "lang" -> model.lang,
         "isRightToLeftLang" -> model.isRightToLeftLang,
-        "capiContent" -> contentApiToJsonValue(model.capiContent),
+        "capiContent" -> model.capiContent.map(contentApiToJsonValue),
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -509,6 +509,10 @@ object DotcomRenderingDataModel {
 
     val selectedTopics = topicResult.map(topic => Seq(Topic(topic.`type`, topic.name)))
 
+    val participatingInCapiTest = ActiveExperiments.isParticipating(DCRCapiData)(request)
+    println(participatingInCapiTest)
+    val capiContent = if (participatingInCapiTest) Some(content.apiContent) else None
+
     DotcomRenderingDataModel(
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
@@ -581,6 +585,7 @@ object DotcomRenderingDataModel {
       capiContent = content.apiContent,
       lang = content.fields.lang,
       isRightToLeftLang = content.fields.isRightToLeftLang,
+      capiContent = capiContent,
     )
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -1,6 +1,6 @@
 package model.dotcomrendering
 
-import com.gu.contentapi.client.model.v1.{Block => APIBlock, Blocks => APIBlocks}
+import com.gu.contentapi.client.model.v1.{Block => APIBlock, Blocks => APIBlocks, Content => CAPIContent}
 import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
 import common.Maps.RichMap
@@ -104,11 +104,27 @@ case class DotcomRenderingDataModel(
     showTableOfContents: Boolean,
     lang: Option[String],
     isRightToLeftLang: Boolean,
+    capiContent: CAPIContent,
 )
 
 object DotcomRenderingDataModel {
 
   implicit val pageElementWrites = PageElement.pageElementWrites
+  implicit val apiContentWrites = new Writes[CAPIContent] {
+    def writes(model: CAPIContent) = {
+      Json.obj(
+        "id" -> model.id,
+        "type" -> JsString(model.`type`.toString),
+        "sectionId" -> model.sectionId,
+        "sectionName" -> model.sectionName,
+        "webPublicationDate" -> model.webPublicationDate.map(_.iso8601),
+        "webTitle" -> model.webTitle,
+        "webUrl" -> model.webUrl,
+        "apiUrl" -> model.apiUrl,
+//        "fields" -> model.fields,
+      )
+    }
+  }
 
   implicit val writes = new Writes[DotcomRenderingDataModel] {
     def writes(model: DotcomRenderingDataModel) = {
@@ -182,6 +198,7 @@ object DotcomRenderingDataModel {
         "showTableOfContents" -> model.showTableOfContents,
         "lang" -> model.lang,
         "isRightToLeftLang" -> model.isRightToLeftLang,
+        "capiContent" -> model.capiContent,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -564,6 +581,7 @@ object DotcomRenderingDataModel {
       showTableOfContents = content.fields.showTableOfContents.getOrElse(false),
       lang = content.fields.lang,
       isRightToLeftLang = content.fields.isRightToLeftLang,
+      capiContent = content.apiContent,
     )
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -107,8 +107,6 @@ case class DotcomRenderingDataModel(
     lang: Option[String],
     isRightToLeftLang: Boolean,
     capiContent: CAPIContent,
-    lang: Option[String],
-    isRightToLeftLang: Boolean,
 )
 
 object DotcomRenderingDataModel {
@@ -205,6 +203,7 @@ object DotcomRenderingDataModel {
         "capiContent" -> contentApiToJsonValue(model.capiContent),
         "lang" -> model.lang,
         "isRightToLeftLang" -> model.isRightToLeftLang,
+        "capiContent" -> model.capiContent,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -597,8 +596,6 @@ object DotcomRenderingDataModel {
       webURL = content.metadata.webUrl,
       promotedNewsletter = newsletter,
       showTableOfContents = content.fields.showTableOfContents.getOrElse(false),
-      lang = content.fields.lang,
-      isRightToLeftLang = content.fields.isRightToLeftLang,
       capiContent = content.apiContent,
       lang = content.fields.lang,
       isRightToLeftLang = content.fields.isRightToLeftLang,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -201,9 +201,6 @@ object DotcomRenderingDataModel {
         "lang" -> model.lang,
         "isRightToLeftLang" -> model.isRightToLeftLang,
         "capiContent" -> contentApiToJsonValue(model.capiContent),
-        "lang" -> model.lang,
-        "isRightToLeftLang" -> model.isRightToLeftLang,
-        "capiContent" -> model.capiContent,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -107,6 +107,8 @@ case class DotcomRenderingDataModel(
     lang: Option[String],
     isRightToLeftLang: Boolean,
     capiContent: CAPIContent,
+    lang: Option[String],
+    isRightToLeftLang: Boolean,
 )
 
 object DotcomRenderingDataModel {
@@ -201,6 +203,8 @@ object DotcomRenderingDataModel {
         "lang" -> model.lang,
         "isRightToLeftLang" -> model.isRightToLeftLang,
         "capiContent" -> contentApiToJsonValue(model.capiContent),
+        "lang" -> model.lang,
+        "isRightToLeftLang" -> model.isRightToLeftLang,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -596,6 +600,8 @@ object DotcomRenderingDataModel {
       lang = content.fields.lang,
       isRightToLeftLang = content.fields.isRightToLeftLang,
       capiContent = content.apiContent,
+      lang = content.fields.lang,
+      isRightToLeftLang = content.fields.isRightToLeftLang,
     )
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -1,5 +1,7 @@
 package model.dotcomrendering
 
+import org.apache.thrift.transport.TIOStreamTransport
+import org.apache.thrift.protocol.TSimpleJSONProtocol
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, Blocks => APIBlocks, Content => CAPIContent}
 import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
@@ -109,6 +111,18 @@ case class DotcomRenderingDataModel(
 
 object DotcomRenderingDataModel {
 
+  // we Json.parse this into a JsValue to ensure we get the raw JSON
+  // from the Content API rather than a Json.stringified version
+  private def contentApiToJsonValue(apiContent: CAPIContent): JsValue = {
+    val protocolFactory = new TSimpleJSONProtocol.Factory
+
+    val buffer = new java.io.ByteArrayOutputStream
+    val protocol = protocolFactory.getProtocol(new TIOStreamTransport(buffer))
+
+    CAPIContent.encode(apiContent, protocol)
+    Json.parse(new String(buffer.toByteArray, "UTF-8"))
+  }
+
   implicit val pageElementWrites = PageElement.pageElementWrites
   implicit val apiContentWrites = new Writes[CAPIContent] {
     def writes(model: CAPIContent) = {
@@ -198,7 +212,7 @@ object DotcomRenderingDataModel {
         "showTableOfContents" -> model.showTableOfContents,
         "lang" -> model.lang,
         "isRightToLeftLang" -> model.isRightToLeftLang,
-        "capiContent" -> model.capiContent,
+        "capiContent" -> contentApiToJsonValue(model.capiContent),
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)

--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -33,7 +33,7 @@ class MostViewedVideoController(
         .map { response =>
           val videos = response.results.toList.map(apiContent => {
             val content = Content.make(apiContent)
-            Video.make(content)
+            Video.make(content, apiContent)
           })
 
           val seriesTitle = response.results.toList.lift(1).flatMap { result =>


### PR DESCRIPTION
Co-Authored-By: Pascal Honoré <6035518+shtukas@users.noreply.github.com>
Co-Authored-By: Jamie B <53781962+JamieB-gu@users.noreply.github.com>
Co-Authored-By: Georges Lebreton <102960844+Georges-GNM@users.noreply.github.com>
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>
Co-Authored-By: Pete F <37048459+bryophyta@users.noreply.github.com>

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
