### PR TITLE
Use correct unhandled promise event API

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -146,9 +146,8 @@ const addErrorHandler = () => {
     };
 
     // Report unhandled promise rejections
-    // https://github.com/cujojs/when/blob/master/docs/debug-api.md#browser-window-events
-    window.addEventListener('unhandledRejection', event => {
-        const error = event.detail.reason;
+    window.addEventListener('unhandledrejection', event => {
+        const error = event.reason;
 
         if (error && !error.reported) {
             raven.captureException(error);


### PR DESCRIPTION
## What does this change?

Update the global `unhandledrejection` handler to use the correct event listener name, and the correct event API

## What is the value of this and can you measure success?

This code was introduced 7 years ago in #11258 and is now slightly out of date. It was introduced when the Promise API was still stabilising and we were using a Promise/A+ compatibility library called [`when`](https://github.com/cujojs/when).

We removed `when` in #16668, a huge change at the time. This tiny handler was missed. 

The [browser window events API](https://github.com/cujojs/when/blob/master/docs/debug-api.md#browser-window-events)  defined by `when` differs from the modern `Promise` API in the following ways:

- the `unhandledRejection` event listener has been renamed [`unhandledrejection`](https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event)
- the [`PromiseRejectionEvent`](https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent) passed to the handler has been flattened – `event.details.reason` has been moved to `event.reason`

One – or the conjunction of both – of these inconsistencies is possibly responsible for [a high volume Sentry issue](https://sentry.io/organizations/the-guardian/issues/2778776754). The issue is so opaque, it's unclear if this change will fix the issue, reveal more about the issue or have no impact whatsoever. 

```
Message
[object Event]

Stack trace
Crashed in non-app: ./node_modules/raven-js/src/raven.js in Raven.prototype.captureMessage
[native code] in _promiseRejectionHandler
Called from: ./node_modules/raven-js/src/raven.js in wrapped
```

## Screenshots

<img width="1697" alt="Screenshot 2023-01-20 at 20 57 35" src="https://user-images.githubusercontent.com/5931528/213805399-13b10058-717b-43f2-8b83-f483ca30ba3d.png">

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

