### PR TITLE
feat: add remove kicker experiment test to title.scala.html

### DIFF
--- a/common/app/implicits/ItemKickerImplicits.scala
+++ b/common/app/implicits/ItemKickerImplicits.scala
@@ -39,6 +39,31 @@ object ItemKickerImplicits {
         case _: FreeHtmlKickerWithLink => Set(fcItemKicker)
       }
 
+    /**
+      * @return a set of classes for kickers. It should be the same as the set returned by `linkClasses` for
+      *         each case, except that it will include an extra class which removes the `:after` pseudo-element
+      *         added by the standard kicker styles.
+      *
+     * This allows us to keep the rest of the kicker styling while just targeting the 'slash'. Once the
+      * `RemoveKickerSlash` test has completed the original `.fc-item__kicker:after` rule should be removed,
+      * and uses of this method should be switched back to using `linkClasses` instead.
+      */
+    def linkClassesWithoutSlash: Set[String] = {
+      val WithoutSlash = "fc-item__kicker--without-slash"
+      itemKicker match {
+        case BreakingNewsKicker        => Set(fcItemKicker, WithoutSlash, fcItemKickerBreakingNews)
+        case LiveKicker                => Set(fcItemKicker, WithoutSlash, fcItemKickerBreakingNews)
+        case AnalysisKicker            => Set(fcItemKicker, WithoutSlash)
+        case ReviewKicker              => Set(fcItemKicker, WithoutSlash)
+        case CartoonKicker             => Set(fcItemKicker, WithoutSlash)
+        case _: PodcastKicker          => Set(fcItemKicker, WithoutSlash)
+        case _: TagKicker              => Set(fcItemKicker, WithoutSlash)
+        case _: SectionKicker          => Set(fcItemKicker, WithoutSlash)
+        case _: FreeHtmlKicker         => Set(fcItemKicker, WithoutSlash)
+        case _: FreeHtmlKickerWithLink => Set(fcItemKicker, WithoutSlash)
+      }
+    }
+
     def kickerHtml: String =
       itemKicker match {
         case BreakingNewsKicker                 => "Breaking news"

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -4,29 +4,84 @@
 @import views.support._
 @import layout.FrontendLatestSnap
 @import implicits.ItemKickerImplicits._
+@import experiments.{ActiveExperiments, RemoveKickerSlashes}
 
 @icon = {
-    @if(header.isExternal) { @fragments.inlineSvg("external-link", "icon") }
-    @if(header.quoted) { @fragments.inlineSvg("garnett-quote", "icon") }
+@if(header.isExternal) {
+    @fragments.inlineSvg("external-link", "icon")
+}
+@if(header.quoted) {
+    @fragments.inlineSvg("garnett-quote", "icon")
+}
 }
 
 @headline() = {
     <span class="@labelCssClasses fc-item__headline">@icon <span class="js-headline-text">@RemoveOuterParaHtml(header.headline)</span></span>
 }
 
-@articleLink(html: Html) = {<a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>}
+@articleLink(html: Html) = {
+    <a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>
+}
 
+@*
+The code inside this block is being largely duplicated while a new kicker format is
+being developed behind a 0% test (the `RemoveKickerSlashes` test).
+Once all of the changes for this new format have been made, the codepath for the old
+format will be removed from this template.
+nb. If any other changes are made to the kicker in prod before the switch is made, please
+replicate these changes in both codepaths.
+*@
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
-    @if(isPaidFor) {
-        @articleLink{<span class="fc-item__kicker">Advertiser content</span> @headline()}
-    } else {
-        @header.kicker match {
-            case Some(kicker) => {
-                @articleLink{<span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span> @headline()}
+    @* New version, behind test: remove slash from kicker and add line break after *@
+    @if(ActiveExperiments.isParticipating(RemoveKickerSlashes)) {
+        @if(isPaidFor) {
+            @articleLink {
+                <span class="fc-item__kicker fc-item__kicker--without-slash">Advertiser content</span>
+                @headline()
             }
-            case _ => {
-                @articleLink{@headline()}
+
+        } else {
+            @header.kicker match {
+                case Some(kicker) => {
+                    @articleLink {
+                        <span class="@kicker.linkClassesWithoutSlash.mkString(" ")">@Html(kicker.kickerHtml)</span>
+                        <br />
+                        @headline()
+                    }
+                }
+                case _ => {
+                    @articleLink {
+                        @headline()
+                    }
+                }
             }
         }
+        @*
+        Old version which is served if request is not participating in the test.
+        This codepath will be removed once the new format is released publicly.
+        *@
+    } else {
+        @if(isPaidFor) {
+            @articleLink {
+                <span class="fc-item__kicker--with-slash">Advertiser content</span>
+                @headline()
+            }
+
+        } else {
+            @header.kicker match {
+                case Some(kicker) => {
+                    @articleLink {
+                        <span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span>
+                        @headline()
+                    }
+                }
+                case _ => {
+                    @articleLink {
+                        @headline()
+                    }
+                }
+            }
+        }
+
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -225,6 +225,13 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
+.fc-item__kicker.fc-item__kicker--without-slash,
+.fc-item__kicker--breaking-news.fc-item__kicker--without-slash {
+    &:after {
+        content: none;
+    }
+}
+
 .fc-item__byline {
     margin-bottom: 0;
     font-style: italic;

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -425,6 +425,14 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
+.fc-item__kicker.fc-item__kicker--without-slash,
+.fc-item__kicker--breaking-news.fc-item__kicker--without-slash {
+    &:after {
+        content: none;
+    }
+}
+
+
 // dream snaps
 .fc-item__kicker--dreamsnap {
     @include fs-header(2);


### PR DESCRIPTION
## What does this change?

It adds a codepath to the facia card title template which removes the trailing `/` from kickers if the request is in the `RemoveKickerSlashes` test condition. Part of [DCR #6943](https://github.com/guardian/dotcom-rendering/issues/6943).


- The `/` is added in by CSS as an `:after` pseudo-element. This branch removes this (without disrupting the rest of the kicker styling) by adding a rule with `:after { content: none; }` with higher specificity.
- The `linkClasses` method is duplicated, rather than trying to add new parameters and internal logic to the existing method. This means that the whole method can be deleted/renamed when the test is finished, which should be simpler than changing its internal method (and it also allows us to rely on the compiler more).

## Removing the test

We've tried to structure the test code so that it's straightforward to remove later; favouring temporary code duplication where necessary.

_Q. Why not duplicate all of the rules for `.fc-item__kicker` to a new class?_ 
A. We want to leave the rest of the styling intact, and this styling is spread across many different files where the `.fc-item__kicker` class is targeted.

Once the change is finalised in PROD, it should be possible to remove the original `:after` rule, which will allow us to remove the override rule added here, and also the extra class we're using for higher specificity. This requires a number of separate changes, but as long as the original rule is removed first, it won't matter if/when the other changes are made, so there's some safety in that.


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

The DCR version will be done as part of the migration work. See the tracker issue for this task: 

## Screenshots

There should only be visual differences behind the 0% test for now. My understanding is that design review will happen on the live site after this is merged.

Behind the test it looks like this:
<img width="228" alt="image" src="https://user-images.githubusercontent.com/37048459/214304639-6758302a-87b6-4cff-849c-16d6b00228c7.png">
<img width="326" alt="image" src="https://user-images.githubusercontent.com/37048459/214305697-23890cdd-3910-4407-97e4-dca8ad806dfe.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [x] Yes (please give details)

These should be covered by https://github.com/guardian/frontend/pull/25841

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
