### PR TITLE
Create advert error: pass message through to Sentry

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
@@ -10,10 +10,12 @@ const createAdvert = (
 	try {
 		const advert = new Advert(adSlot, additionalSizes);
 		return advert;
-	} catch {
+	} catch (error) {
 		const errMsg = `Could not create advert. Ad slot: ${
 			adSlot.id
-		}. Additional Sizes: ${JSON.stringify(additionalSizes)}`;
+		}. Additional Sizes: ${JSON.stringify(additionalSizes)}. Error: ${
+			error instanceof Error ? error.message : 'Unknown error'
+		}`;
 
 		log('commercial', errMsg);
 		reportError(


### PR DESCRIPTION
## What does this change?

When an advert fails to be created and an error is reported to Sentry, include the caught error in the report.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We receive lots of errors in Sentry of this type. This will give us more information to help us debug.