### PR TITLE
Bump org.jsoup:jsoup@1.10.3 to org.jsoup:jsoup@1.15.3

### DIFF
--- a/admin/test/pagepresser/InteractiveHtmlCleanerTest.scala
+++ b/admin/test/pagepresser/InteractiveHtmlCleanerTest.scala
@@ -23,7 +23,7 @@ import scala.io.Source
     val expectedDoc = Jsoup.parse(expectedCleanedDocFromSource.mkString)
 
     val actualResult = InteractiveHtmlCleaner.removeScripts(originalDoc)
-    actualResult.html().replace(" ", "") should be(expectedDoc.html().replace(" ", ""))
+    actualResult should be(expectedDoc)
   }
 
 }

--- a/admin/test/pagepresser/InteractiveHtmlCleanerTest.scala
+++ b/admin/test/pagepresser/InteractiveHtmlCleanerTest.scala
@@ -20,10 +20,10 @@ import scala.io.Source
       getClass.getClassLoader
         .getResourceAsStream("pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html"),
     )
-    val expectedDoc = Jsoup.parse(expectedCleanedDocFromSource.mkString)
+    val expectedDoc = Jsoup.parse(expectedCleanedDocFromSource.mkString);
 
-    val actualResult = InteractiveHtmlCleaner.removeScripts(originalDoc)
-    actualResult should be(expectedDoc)
+    val actualResult = InteractiveHtmlCleaner.removeScripts(originalDoc);
+    actualResult.toString().replaceAll("\\s+", "") should be(expectedDoc.toString().replaceAll("\\s+", ""))
   }
 
 }

--- a/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
@@ -844,7 +844,7 @@
 </noscript>
 <!-- END Nielsen Online SiteCensus V6.0 -->
 <!-- Google Code for Remarketing Tag -->
-<!--
+<!--------------------------------------------------
 Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup
 --------------------------------------------------->
 <noscript>

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -79,17 +79,14 @@ import scala.util.matching.Regex
     val html = Jsoup.parse(contentAsString(result))
 
     val videoEl = html.getElementsByTag("video")
-    val sources = videoEl.html.split("\n").toList
+    val sources = videoEl.select("source")
 
-    sources.length should be(3)
+    sources.size() should be(3)
 
-    val m3u8 = new Regex("\"video/m3u8\">$").findFirstIn(sources(0).trim())
-    val mp4 = new Regex("\"video/mp4\">$").findFirstIn(sources(1).trim())
-    val webm = new Regex("\"video/webm\">$").findFirstIn(sources(2).trim())
+    sources.get(0).attr("type") should equal("video/m3u8")
+    sources.get(1).attr("type") should equal("video/mp4")
+    sources.get(2).attr("type") should equal("video/webm")
 
-    m3u8.isDefined should be(true)
-    mp4.isDefined should be(true)
-    webm.isDefined should be(true)
   }
 
   val audioUrl = "/news/audio/2019/may/16/facing-up-europe-far-right-podcast"

--- a/common/app/common/HTML.scala
+++ b/common/app/common/HTML.scala
@@ -2,8 +2,8 @@ package common
 
 import org.apache.commons.lang.StringEscapeUtils
 import org.jsoup.Jsoup
-import org.jsoup.safety.Whitelist
+import org.jsoup.safety.Safelist
 
 object HTML {
-  def noHtml(headline: String): String = StringEscapeUtils.unescapeHtml(Jsoup.clean(headline, Whitelist.none()))
+  def noHtml(headline: String): String = StringEscapeUtils.unescapeHtml(Jsoup.clean(headline, Safelist.none()))
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -14,7 +14,7 @@ import layout.ContentWidths.GalleryMedia
 import model.content.{Atoms, MediaAssetPlatform, MediaAtom, QuizAtom}
 import model.pressed._
 import org.jsoup.{Jsoup, nodes}
-import org.jsoup.safety.Whitelist
+import org.jsoup.safety.Safelist
 import com.github.nscala_time.time.Imports._
 import play.api.libs.json._
 import views.support._
@@ -453,7 +453,7 @@ object Content {
         .toSeq
         .distinct,
       javascriptReferences = apiContent.references.toSeq.map(ref => Reference.toJavaScript(ref.id)),
-      wordCount = Jsoup.clean(fields.body, Whitelist.none()).split("\\s+").length,
+      wordCount = Jsoup.clean(fields.body, Safelist.none()).split("\\s+").length,
       showByline =
         fapiutils.ResolvedMetaData.fromContentAndTrailMetaData(apiContent, TrailMetaData.empty, cardStyle).showByline,
       rawOpenGraphImage = FacebookShareUseTrailPicFirstSwitch.isSwitchedOn

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -11,7 +11,7 @@ import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.jsoup.safety.{Cleaner, Whitelist}
+import org.jsoup.safety.{Cleaner, Safelist}
 import play.api.libs.json.Json._
 import play.api.libs.json.Writes
 import play.api.mvc.{RequestHeader, Result}
@@ -200,12 +200,12 @@ object cleanTrailText {
 }
 
 object StripHtmlTags {
-  def apply(html: String): String = Jsoup.clean(html, "", Whitelist.none())
+  def apply(html: String): String = Jsoup.clean(html, "", Safelist.none())
 }
 
 object StripHtmlTagsAndUnescapeEntities {
   def apply(html: String): String = {
-    val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
+    val doc = new Cleaner(Safelist.none()).clean(Jsoup.parse(html))
     val stripped = doc.body.html
     val unescaped = StringEscapeUtils.unescapeHtml(stripped)
     unescaped.replace("\"", "&#34;") //double quotes will break HTML attributes

--- a/common/test/common/HtmlCleanerTest.scala
+++ b/common/test/common/HtmlCleanerTest.scala
@@ -33,7 +33,7 @@ class InteractiveImmersiveHtmlCleanerTest extends AnyFlatSpec with Matchers {
 
     val cleanedDoc = InteractiveImmersiveHtmlCleaner.hideReaderRevenue(doc)
     val cleanEl = cleanedDoc.getElementsByTag("script").first()
-    cleanEl.text() should equal(
+    cleanEl.data() should equal(
       "window.guardian.config.page.shouldHideReaderRevenue=true",
     )
   }

--- a/common/test/common/HtmlCleanerTest.scala
+++ b/common/test/common/HtmlCleanerTest.scala
@@ -32,7 +32,8 @@ class InteractiveImmersiveHtmlCleanerTest extends AnyFlatSpec with Matchers {
               |</html>""".stripMargin)
 
     val cleanedDoc = InteractiveImmersiveHtmlCleaner.hideReaderRevenue(doc)
-    cleanedDoc.getElementsByTag("script").text() should equal(
+    val cleanEl = cleanedDoc.getElementsByTag("script").first()
+    cleanEl.text() should equal(
       "window.guardian.config.page.shouldHideReaderRevenue=true",
     )
   }

--- a/common/test/html/BrazeEmailFormatterTest.scala
+++ b/common/test/html/BrazeEmailFormatterTest.scala
@@ -55,13 +55,9 @@ class BrazeEmailFormatterTest extends AnyFlatSpec with Matchers {
         |<head></head>
         |<body>
         |<h2>Heading text</h2>
-        |<p>Paragraph.</p>
-        |<br>
-        |<div>
-        |<span>My name is:</span> Bill
-        |</div>
-        |<a href="/link/?##braze_utm##">some link</a>
-        |<a href="https://www.theguardian.com/environment/2018/sep/26/dont-post-crisp-packets-royal-mail-begs-packaging-protesters?##braze_utm##">article link</a>
+        |<p>Paragraph.</p> <br>
+        |<div><span>My name is:</span> Bill
+        |</div> <a href="/link/?##braze_utm##">some link</a> <a href="https://www.theguardian.com/environment/2018/sep/26/dont-post-crisp-packets-royal-mail-begs-packaging-protesters?##braze_utm##">article link</a>
         |<table>
         |<tbody>
         |<tr>
@@ -105,8 +101,7 @@ class BrazeEmailFormatterTest extends AnyFlatSpec with Matchers {
       """<!doctype html>
         |<html>
         |<head></head>
-        |<body>
-        |<a href="%%unsub_center_url%%">unsubscribe</a>
+        |<body><a href="%%unsub_center_url%%">unsubscribe</a>
         |</body>
         |</html>""".stripMargin
 

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -24,7 +24,7 @@ import scala.xml.XML
 class TemplatesTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
   "RemoveOuterPara" should "remove outer paragraph tags" in {
-    RemoveOuterParaHtml(" <P> foo <b>bar</b> </p> ").body should be(" foo <b>bar</b> ")
+    RemoveOuterParaHtml(" <P> foo <b>bar</b> </p> ").body should be("foo <b>bar</b>")
   }
 
   it should "not modify text that is not enclosed in p tags" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   val mockWs = "de.leanovate.play-mockws" %% "play-mockws" % "2.6.2" % Test
   val jodaTime = "joda-time" % "joda-time" % "2.9.9"
   val jodaConvert = "org.joda" % "joda-convert" % "1.8.3"
-  val jSoup = "org.jsoup" % "jsoup" % "1.10.3"
+  val jSoup = "org.jsoup" % "jsoup" % "1.15.3"
   val json4s = "org.json4s" %% "json4s-native" % "4.0.4"
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.5.7" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test


### PR DESCRIPTION
## What does this change?

This patches snyk vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGJSOUP-1567345

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/110032454/214804203-8dd86507-ea63-4e02-8068-9dc4b2a67b96.png">

Swapped Whitelist defs with Safelist

Change: removed previously deprecated methods and classes (including org.jsoup.safety.Whitelist; use [org.jsoup.safety.Safelist](https://jsoup.org/apidocs/org/jsoup/safety/Safelist.html) instead).

https://jsoup.org/news/release-1.15.1

Also rewrote a flakey test as a newer implementation of the jsoup.parse() function seems to render slightly different output with regards to new lines.


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
