### PR TITLE
Opt Out Advertising: check consent when in test

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.consentless.ts
+++ b/static/src/javascripts/bootstraps/commercial.consentless.ts
@@ -1,4 +1,4 @@
-import { onConsent } from '@guardian/consent-management-platform';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { initArticleInline } from 'commercial/modules/consentless/dynamic/article-inline';
 import { initLiveblogInline } from 'commercial/modules/consentless/dynamic/liveblog-inline';
 import { initFixedSlots } from 'commercial/modules/consentless/init-fixed-slots';
@@ -10,7 +10,7 @@ import {
 import { init as setAdTestCookie } from '../projects/commercial/modules/set-adtest-cookie';
 import { init as setAdTestInLabelsCookie } from '../projects/commercial/modules/set-adtest-in-labels-cookie';
 
-const bootConsentless = async (): Promise<void> => {
+const bootConsentless = async (consentState: ConsentState): Promise<void> => {
 	/*  In the consented ad stack, we set the ad free cookie for users who
 		don't consent to targeted ads in order to hide empty ads slots.
 		We remove the cookie here so that we can show Opt Out ads.
@@ -18,8 +18,6 @@ const bootConsentless = async (): Promise<void> => {
 		consentless ads are rolled out to all users.
  	*/
 	maybeUnsetAdFreeCookie(AdFreeCookieReasons.ConsentOptOut);
-
-	const consentState = await onConsent();
 
 	await Promise.all([
 		setAdTestCookie(),

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -214,17 +214,18 @@ const bootCommercial = async (): Promise<void> => {
  */
 const chooseAdvertisingTag = async () => {
 	const consentState = await onConsent();
-	if (getConsentFor('googletag', consentState)) {
+	// Only load the Opt Out tag in TCF regions when there is no consent for Googletag
+	if (consentState.tcfv2 && !getConsentFor('googletag', consentState)) {
+		void import(
+			/* webpackChunkName: "consentless" */
+			'./commercial.consentless'
+		).then(({ bootConsentless }) => bootConsentless(consentState));
+	} else {
 		if (window.guardian.mustardCut || window.guardian.polyfilled) {
 			void bootCommercial();
 		} else {
 			window.guardian.queue.push(bootCommercial);
 		}
-	} else {
-		void import(
-			/* webpackChunkName: "consentless" */
-			'./commercial.consentless'
-		).then(({ bootConsentless }) => bootConsentless(consentState));
 	}
 };
 

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -13,6 +13,10 @@
  */
 
 import { EventTimer } from '@guardian/commercial-core';
+import {
+	getConsentFor,
+	onConsent,
+} from '@guardian/consent-management-platform';
 import { log } from '@guardian/libs';
 import { initTeadsCookieless } from 'commercial/modules/teads-cookieless';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
@@ -205,15 +209,32 @@ const bootCommercial = async (): Promise<void> => {
 	}
 };
 
+/**
+ * Choose whether to launch Googletag or Opt Out tag (ootag) based on consent state
+ */
+const chooseAdvertisingTag = async () => {
+	const consentState = await onConsent();
+	if (getConsentFor('googletag', consentState)) {
+		if (window.guardian.mustardCut || window.guardian.polyfilled) {
+			void bootCommercial();
+		} else {
+			window.guardian.queue.push(bootCommercial);
+		}
+	} else {
+		void import(
+			/* webpackChunkName: "consentless" */
+			'./commercial.consentless'
+		).then(({ bootConsentless }) => bootConsentless(consentState));
+	}
+};
+
 /* Provide consentless advertising in the variant of a zero-percent test,
    regardless of consent state. This is currently just for testing purposes.
 
    If not in the variant, get the usual commercial experience
 */
 if (isInVariantSynchronous(consentlessAds, 'variant')) {
-	void import(
-		/* webpackChunkName: "consentless" */ './commercial.consentless'
-	).then(({ bootConsentless }) => bootConsentless());
+	void chooseAdvertisingTag();
 } else {
 	if (window.guardian.mustardCut || window.guardian.polyfilled) {
 		void bootCommercial();


### PR DESCRIPTION
Co-authored-by: Simon Byford <simon.byford@guardian.co.uk>

## What does this change?

This PR changes the behaviour in the consentless ads 0% test to take into account a browser's consent state to decide which third party advertising tag to launch (Googletag or Opt Out). Prior to this PR, we launched the Opt Out tag when you opt into the 0% AB test, regardless of your consent state.

We use consent state to determine which tag to launch. The rules are as follows:
- Always launch Googletag when in CCPA and Australia (as there's no way to opt out of a specific vendor).
- When in TCF, we check whether the browser has consented to the `googletag` vendor. If they have, we launch Googletag and if not we launch Opt Out.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Prior to this PR, we launch the Opt Out tag when you opt into the 0% AB test, regardless of your consent state. Now, when in the variant, this will take into account your consent state and decided which tag to launch based on that. This will mimic the behaviour of the commercial code as we roll out the test to a larger audience.

### Tested 

**TODO**

- [ ] Locally
- [x] On CODE (optional)
