### PR TITLE
Bump DCRJavascriptBundle experiment to 20%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -25,7 +25,7 @@ object DCRJavascriptBundle
       description = "DCR Javascript bundle experiment",
       owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2024, 4, 1),
-      participationGroup = Perc10A,
+      participationGroup = Perc20A,
     )
 
 object DCRFronts


### PR DESCRIPTION
## What does this change?

Increase the sample rate for the DCRJavascriptBundle test from 10% to 20%.

We wish to gather more data for analysis.

## Does this change need to be reproduced in dotcom-rendering ?

Related change - https://github.com/guardian/dotcom-rendering/pull/7052
