### PR TITLE
Remove kicker slash from `Today In Focus` container (behind 0% test)

### DIFF
--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -9,6 +9,8 @@
 @import conf.audio.FlagshipFrontContainer
 @import conf.AudioFlagship
 
+@import experiments.{ActiveExperiments, RemoveKickerSlashes}
+
 @(containerDefinition: layout.FaciaContainer, frontProperties: FrontProperties)(implicit request: RequestHeader)
 
 
@@ -78,12 +80,21 @@
                                 <div class="fc-podcast-container__episode-details">
                                     <div class="fc-item__header">
                                         <h2 class="fc-item__title">
+                                        @if(ActiveExperiments.isParticipating(RemoveKickerSlashes)) {
+                                            <a @Html(card.header.url.hrefWithRel) class="fc-item__link" data-link-name="article">
+                                                <div class="fc-item__kicker fc-item__kicker--without-slash">Podcast<br /></div>
+                                                <div class="u-faux-block-link__cta fc-item__headline">
+                                                    <span class="js-headline-text">@RemoveOuterParaHtml(card.header.headline)</span>
+                                                </div>
+                                            </a>
+                                        } else {
                                             <a @Html(card.header.url.hrefWithRel) class="fc-item__link" data-link-name="article">
                                                 <div class="fc-item__kicker">Podcast</div>
                                                 <div class="u-faux-block-link__cta fc-item__headline">
                                                     <span class="js-headline-text">@RemoveOuterParaHtml(card.header.headline)</span>
                                                 </div>
                                             </a>
+                                        }
                                         </h2>
                                     </div>
                                     <div class="fc-item__standfirst-wrapper">


### PR DESCRIPTION
## What does this change?
Removes the trailing slash from kickers on the 'flagshipContainer' podcast card, and inserts a line break (all behind a 0% test).
Part of [DCR #6943](https://github.com/guardian/dotcom-rendering/issues/6943). Catches an edge case not covered by the initial Frontend implementation in #25845.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
|<img width="1351" alt="image" src="https://user-images.githubusercontent.com/37048459/215098766-38cb464b-e177-4463-89c2-de9cd4d43d99.png"> |<img width="1346" alt="image" src="https://user-images.githubusercontent.com/37048459/215098900-73e605a5-20c8-407e-afe6-9c256195b31c.png">|


[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
