### PR TITLE
Move new kicker design out from behind 0% test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,7 +14,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       HeaderTopBarSearchCapi,
       ServerSideLiveblogInlineAds,
       CalloutElements,
-      RemoveKickerSlashes,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -44,15 +43,6 @@ object OfferHttp3
       owners = Seq(Owner.withGithub("paulmr")),
       sellByDate = LocalDate.of(2023, 1, 31),
       participationGroup = Perc0B,
-    )
-
-object RemoveKickerSlashes
-    extends Experiment(
-      name = "remove-kicker-slashes",
-      description = "Implement kickers without slashes on fronts cards. Used to iterate on feature before launch.",
-      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2023, 2, 1),
-      participationGroup = Perc0C,
     )
 
 object EuropeNetworkFront

--- a/common/app/implicits/ItemKickerImplicits.scala
+++ b/common/app/implicits/ItemKickerImplicits.scala
@@ -39,31 +39,6 @@ object ItemKickerImplicits {
         case _: FreeHtmlKickerWithLink => Set(fcItemKicker)
       }
 
-    /**
-      * @return a set of classes for kickers. It should be the same as the set returned by `linkClasses` for
-      *         each case, except that it will include an extra class which removes the `:after` pseudo-element
-      *         added by the standard kicker styles.
-      *
-     * This allows us to keep the rest of the kicker styling while just targeting the 'slash'. Once the
-      * `RemoveKickerSlash` test has completed the original `.fc-item__kicker:after` rule should be removed,
-      * and uses of this method should be switched back to using `linkClasses` instead.
-      */
-    def linkClassesWithoutSlash: Set[String] = {
-      val WithoutSlash = "fc-item__kicker--without-slash"
-      itemKicker match {
-        case BreakingNewsKicker        => Set(fcItemKicker, WithoutSlash, fcItemKickerBreakingNews)
-        case LiveKicker                => Set(fcItemKicker, WithoutSlash, fcItemKickerBreakingNews)
-        case AnalysisKicker            => Set(fcItemKicker, WithoutSlash)
-        case ReviewKicker              => Set(fcItemKicker, WithoutSlash)
-        case CartoonKicker             => Set(fcItemKicker, WithoutSlash)
-        case _: PodcastKicker          => Set(fcItemKicker, WithoutSlash)
-        case _: TagKicker              => Set(fcItemKicker, WithoutSlash)
-        case _: SectionKicker          => Set(fcItemKicker, WithoutSlash)
-        case _: FreeHtmlKicker         => Set(fcItemKicker, WithoutSlash)
-        case _: FreeHtmlKickerWithLink => Set(fcItemKicker, WithoutSlash)
-      }
-    }
-
     def kickerHtml: String =
       itemKicker match {
         case BreakingNewsKicker                 => "Breaking news"

--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -9,8 +9,6 @@
 @import conf.audio.FlagshipFrontContainer
 @import conf.AudioFlagship
 
-@import experiments.{ActiveExperiments, RemoveKickerSlashes}
-
 @(containerDefinition: layout.FaciaContainer, frontProperties: FrontProperties)(implicit request: RequestHeader)
 
 
@@ -80,21 +78,12 @@
                                 <div class="fc-podcast-container__episode-details">
                                     <div class="fc-item__header">
                                         <h2 class="fc-item__title">
-                                        @if(ActiveExperiments.isParticipating(RemoveKickerSlashes)) {
                                             <a @Html(card.header.url.hrefWithRel) class="fc-item__link" data-link-name="article">
-                                                <div class="fc-item__kicker fc-item__kicker--without-slash">Podcast<br /></div>
+                                                <div class="fc-item__kicker">Podcast<br /></div>
                                                 <div class="u-faux-block-link__cta fc-item__headline">
                                                     <span class="js-headline-text">@RemoveOuterParaHtml(card.header.headline)</span>
                                                 </div>
                                             </a>
-                                        } else {
-                                            <a @Html(card.header.url.hrefWithRel) class="fc-item__link" data-link-name="article">
-                                                <div class="fc-item__kicker">Podcast</div>
-                                                <div class="u-faux-block-link__cta fc-item__headline">
-                                                    <span class="js-headline-text">@RemoveOuterParaHtml(card.header.headline)</span>
-                                                </div>
-                                            </a>
-                                        }
                                         </h2>
                                     </div>
                                     <div class="fc-item__standfirst-wrapper">

--- a/common/app/views/fragments/commercial/cards/itemCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemCard.scala.html
@@ -4,7 +4,6 @@
 @import views.html.fragments.inlineSvg
 @import views.html.fragments.items.elements.facia_cards.image
 @import views.support.Commercial.CssClassBuilder
-@import experiments.{ActiveExperiments, RemoveKickerSlashes}
 
 @(item: layout.PaidCard,
   omnitureId: String,
@@ -24,11 +23,8 @@
         <h2 class="advert__title">
             @for(icon <- item.icon){@inlineSvg(icon, "icon")}
             @for(kicker <- item.kicker){
-                @if(ActiveExperiments.isParticipating(RemoveKickerSlashes)) {
-                    <span class="advert__kicker__without_slash ">@kicker<br/></span>
-                } else {
-                    <span class="advert__kicker">@kicker</span>
-                }            }
+                    <span class="advert__kicker">@kicker<br/></span>
+            }
             @Html(item.headline)
         </h2>
         <div class="advert__image-container

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -4,7 +4,6 @@
 @import views.support._
 @import layout.FrontendLatestSnap
 @import implicits.ItemKickerImplicits._
-@import experiments.{ActiveExperiments, RemoveKickerSlashes}
 
 @icon = {
 @if(header.isExternal) {
@@ -23,65 +22,27 @@
     <a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>
 }
 
-@*
-The code inside this block is being largely duplicated while a new kicker format is
-being developed behind a 0% test (the `RemoveKickerSlashes` test).
-Once all of the changes for this new format have been made, the codepath for the old
-format will be removed from this template.
-nb. If any other changes are made to the kicker in prod before the switch is made, please
-replicate these changes in both codepaths.
-*@
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
-    @* New version, behind test: remove slash from kicker and add line break after *@
-    @if(ActiveExperiments.isParticipating(RemoveKickerSlashes)) {
-        @if(isPaidFor) {
-            @articleLink {
-                <span class="fc-item__kicker fc-item__kicker--without-slash">Advertiser content</span>
-                @headline()
-            }
-
-        } else {
-            @header.kicker match {
-                case Some(kicker) => {
-                    @articleLink {
-                        <span class="@kicker.linkClassesWithoutSlash.mkString(" ")">@Html(kicker.kickerHtml)</span>
-                        <br />
-                        @headline()
-                    }
-                }
-                case _ => {
-                    @articleLink {
-                        @headline()
-                    }
-                }
-            }
+    @if(isPaidFor) {
+        @articleLink {
+            <span class="fc-item__kicker">Advertiser content</span>
+            @headline()
         }
-        @*
-        Old version which is served if request is not participating in the test.
-        This codepath will be removed once the new format is released publicly.
-        *@
+
     } else {
-        @if(isPaidFor) {
-            @articleLink {
-                <span class="fc-item__kicker--with-slash">Advertiser content</span>
-                @headline()
-            }
-
-        } else {
-            @header.kicker match {
-                case Some(kicker) => {
-                    @articleLink {
-                        <span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span>
-                        @headline()
-                    }
+        @header.kicker match {
+            case Some(kicker) => {
+                @articleLink {
+                    <span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span>
+                    <br />
+                    @headline()
                 }
-                case _ => {
-                    @articleLink {
-                        @headline()
-                    }
+            }
+            case _ => {
+                @articleLink {
+                    @headline()
                 }
             }
         }
-
     }
 }

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -25,7 +25,7 @@
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
     @if(isPaidFor) {
         @articleLink {
-            <span class="fc-item__kicker">Advertiser content</span>
+            <span class="fc-item__kicker">Advertiser content</span><br />
             @headline()
         }
 

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -111,18 +111,6 @@
 }
 
 .advert__kicker {
-    &::after {
-        content: '/';
-        display: inline-block;
-        margin-left: .2em;
-        color: mix(#ffffff, $brightness-46, 20%);
-
-    }
-
-    color: $brightness-46;
-}
-
-.advert__kicker__without_slash {
     color: $brightness-46;
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -216,20 +216,6 @@ $fc-item-gutter: $gs-gutter / 4;
 .fc-item__kicker {
     position: relative;
     font-weight: 700;
-
-    &:after {
-        content: '/';
-        display: inline-block;
-        font-weight: 900;
-        margin-left: 4px;
-    }
-}
-
-.fc-item__kicker.fc-item__kicker--without-slash,
-.fc-item__kicker--breaking-news.fc-item__kicker--without-slash {
-    &:after {
-        content: none;
-    }
 }
 
 .fc-item__byline {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -425,14 +425,6 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-.fc-item__kicker.fc-item__kicker--without-slash,
-.fc-item__kicker--breaking-news.fc-item__kicker--without-slash {
-    &:after {
-        content: none;
-    }
-}
-
-
 // dream snaps
 .fc-item__kicker--dreamsnap {
     @include fs-header(2);


### PR DESCRIPTION
## What does this change?

It moves the new kicker design out from behind a 0% test, thereby releasing it across Frontend-rendered pages.
- [x] Remove the experiment and the codepaths which were switching design based on the experiment.
- [x] Update the kicker class styling to the new design, and remove the classes which were added for the test.

The test code was introduced in #25845, #25841 and #25861.

Part of [DCR 6943](https://github.com/guardian/dotcom-rendering/issues/6943).

## Screenshots

From CODE deployment:

<img width="959" alt="image" src="https://user-images.githubusercontent.com/37048459/215459624-504efbb7-6a15-4d72-a566-3269305c10cd.png">
<img width="977" alt="image" src="https://user-images.githubusercontent.com/37048459/215460218-f9b94dc5-635b-44f9-9250-00c16c36cb44.png">
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/37048459/215464420-12f7b9dc-fc86-44d9-abfa-63c8aa05638d.png">
![Uploading image.png…]()


### Accessibility

This change shouldn't introduce any new accessibility issues in terms of contrast or semantics, aside from using a `<br />` tag to create the line-break, which is arguably unsemantic (see DCR PR [#7050](https://github.com/guardian/dotcom-rendering/pull/7050)). We will fix this in a separate PR in both DCR and Frontend.

As pointed out recently by @rhystmills this design change should improve the screen-reader experience because it removes the `/` pseudo-element which is often announced as 'slash'.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
