### PR TITLE
Extend liveblog server-side ads AB test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -79,7 +79,7 @@ object ServerSideLiveblogInlineAds
       description =
         "Test whether we can load liveblog inline ads server-side without negative effects on user experience or revenue",
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
-      sellByDate = LocalDate.of(2023, 2, 1),
+      sellByDate = LocalDate.of(2023, 3, 1),
       participationGroup = Perc5A,
     )
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.ts
@@ -116,7 +116,9 @@ const defineSlot = (
 
 	const googletagSizeMapping = buildGoogletagSizeMapping(sizeMapping);
 	if (!googletagSizeMapping) {
-		throw new Error(`Could not define slot for ${id}`);
+		throw new Error(
+			`Could not define slot for ${id}. A googletag size mapping could not be created.`,
+		);
 	}
 
 	const sizes = collectSizes(googletagSizeMapping);


### PR DESCRIPTION
## What does this change?

- Extend liveblog server-side ads AB test
- (unrelated) Adds extra logging information to an advert create error

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This test expires tomorrow and there might be value in keeping it running for a little while longer.

