### PR TITLE
Remove prebid a9 canada ab test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -57,16 +57,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-remove-prebid-a9-canada",
-    "Remove the initialisation of Prebid and A9 in the Canada region",
-    owners = Seq(Owner.withGithub("domlander")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 1, 31)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-liveblog-desktop-outstream",
     "Test the impact of enabling outstream on inline2+ on liveblogs on desktop",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),


### PR DESCRIPTION
## What does this change?

Removes the Prebid/A9 Canada AB test

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This AB test finished a while ago. We forgot to remove this test.