### PR TITLE
Remove completed ab tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,16 +67,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-teads-cookieless",
-    "Test UX impact of cookieless Teads",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 3, 31)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-billboards-in-merch",
     "Test the commercial impact of showing billboard adverts in merchandising slots",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -57,16 +57,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-liveblog-desktop-outstream",
-    "Test the impact of enabling outstream on inline2+ on liveblogs on desktop",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 3, 31)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-billboards-in-merch",
     "Test the commercial impact of showing billboard adverts in merchandising slots",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -57,16 +57,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-remove-prebid-a9-canada",
-    "Remove the initialisation of Prebid and A9 in the Canada region",
-    owners = Seq(Owner.withGithub("domlander")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 1, 31)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-liveblog-desktop-outstream",
     "Test the impact of enabling outstream on inline2+ on liveblogs on desktop",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -560,14 +560,4 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
-
-  val teadsCookieless: Switch = Switch(
-    group = Commercial,
-    name = "teads-cookieless",
-    description = "Enable the Teads cookieless tag on articles and liveblogs",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
 }

--- a/static/src/javascripts/projects/commercial/modules/teads-cookieless.ts
+++ b/static/src/javascripts/projects/commercial/modules/teads-cookieless.ts
@@ -15,7 +15,6 @@ const initTeadsCookieless = async (): Promise<void> => {
 
 	if (
 		hasConsent &&
-		window.guardian.config.switches.teadsCookieless &&
 		allowedContentTypes.includes(window.guardian.config.page.contentType)
 	) {
 		window.teads_analytics = window.teads_analytics ?? {};


### PR DESCRIPTION
## What does this change?

Removes the following AB tests:
- Prebid/A9 Canada
- Teads cookieless
- Liveblog desktop Outstream

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

These AB tests have finished running.