### PR TITLE
Reposition the external link icon after the headline on cards

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -6,19 +6,13 @@
 @import implicits.ItemKickerImplicits._
 
 @headline() = {
-@if(header.quoted) {
     <span class="@labelCssClasses fc-item__headline">
-        @fragments.inlineSvg("garnett-quote", "icon")
+        @if(header.quoted){ @fragments.inlineSvg("garnett-quote", "icon")}
         <span class="js-headline-text">@RemoveOuterParaHtml(header.headline)</span>
+        @if(header.isExternal) { @fragments.inlineSvg("external-link", "icon")}
     </span>
 }
-@if(header.isExternal) {
-    <span class="@labelCssClasses fc-item__headline">
-        <span class="js-headline-text">@RemoveOuterParaHtml(header.headline)</span>
-        @fragments.inlineSvg("external-link", "icon")
-    </span>
-}
-}
+
 
 @articleLink(html: Html) = {
     <a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -5,17 +5,19 @@
 @import layout.FrontendLatestSnap
 @import implicits.ItemKickerImplicits._
 
-@icon = {
-@if(header.isExternal) {
-    @fragments.inlineSvg("external-link", "icon")
-}
-@if(header.quoted) {
-    @fragments.inlineSvg("garnett-quote", "icon")
-}
-}
-
 @headline() = {
-    <span class="@labelCssClasses fc-item__headline">@icon <span class="js-headline-text">@RemoveOuterParaHtml(header.headline)</span></span>
+@if(header.quoted) {
+    <span class="@labelCssClasses fc-item__headline">
+        @fragments.inlineSvg("garnett-quote", "icon")
+        <span class="js-headline-text">@RemoveOuterParaHtml(header.headline)</span>
+    </span>
+}
+@if(header.isExternal) {
+    <span class="@labelCssClasses fc-item__headline">
+        <span class="js-headline-text">@RemoveOuterParaHtml(header.headline)</span>
+        @fragments.inlineSvg("external-link", "icon")
+    </span>
+}
 }
 
 @articleLink(html: Html) = {


### PR DESCRIPTION
## What does this change?
Following the removal of the slash on cards, design have requested we move the external link icon to the end of the headline instead of the start. The quote icons remain in the same position as before, at the beginning of the headline.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before  (icon moved)    | After (icon moved)      |
|-------------|------------|
| ![before-icon][] | ![after-icon][] |

[before-icon]: https://user-images.githubusercontent.com/20416599/215748326-1f21e36a-492b-4ea6-b5f0-2a6b2192ce09.png
[after-icon]: https://user-images.githubusercontent.com/20416599/215748343-fcf5493b-cf2b-45b1-a076-e7fcaec95012.png

| Before  (quote not changed)    | After (quote not changed)    |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/215748418-f2f072b4-bd63-4833-bc5c-b47e20b66ad4.png
[after]: https://user-images.githubusercontent.com/20416599/215748418-f2f072b4-bd63-4833-bc5c-b47e20b66ad4.png


## What is the value of this and can you measure success?
n/a

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
