### PR TITLE
Replace linebreak with block element

### DIFF
--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -79,7 +79,7 @@
                                     <div class="fc-item__header">
                                         <h2 class="fc-item__title">
                                             <a @Html(card.header.url.hrefWithRel) class="fc-item__link" data-link-name="article">
-                                                <div class="fc-item__kicker">Podcast<br /></div>
+                                                <div class="fc-item__kicker">Podcast</div>
                                                 <div class="u-faux-block-link__cta fc-item__headline">
                                                     <span class="js-headline-text">@RemoveOuterParaHtml(card.header.headline)</span>
                                                 </div>

--- a/common/app/views/fragments/commercial/cards/itemCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemCard.scala.html
@@ -23,7 +23,7 @@
         <h2 class="advert__title">
             @for(icon <- item.icon){@inlineSvg(icon, "icon")}
             @for(kicker <- item.kicker){
-                    <span class="advert__kicker">@kicker<br/></span>
+                    <div class="advert__kicker">@kicker</div>
             }
             @Html(item.headline)
         </h2>

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -25,7 +25,7 @@
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
     @if(isPaidFor) {
         @articleLink {
-            <span class="fc-item__kicker">Advertiser content</span><br />
+            <div class="fc-item__kicker">Advertiser content</div>
             @headline()
         }
 
@@ -33,8 +33,7 @@
         @header.kicker match {
             case Some(kicker) => {
                 @articleLink {
-                    <span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span>
-                    <br />
+                    <div class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</div>
                     @headline()
                 }
             }


### PR DESCRIPTION
## What does this change?

Instead of using a `<br />` to create a visual line break between kicker and headline on fronts cards, wrap the kicker in a `<div>` (which is a `display: block;` element by default) instead.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/37048459/215754732-52707743-5e71-40be-8648-f3b6d2152fae.png) | ![image](https://user-images.githubusercontent.com/37048459/215755287-5a5e4630-30ed-4daf-9b58-d06d7d16f09d.png) |
|![image](https://user-images.githubusercontent.com/37048459/215755530-d97e9e67-807d-41aa-a29d-54141857cc9a.png)|![image](https://user-images.githubusercontent.com/37048459/215755454-d28a00ed-0c4e-4714-908c-ce59b22d3c4d.png)|
|![image](https://user-images.githubusercontent.com/37048459/215755690-40dacbb0-aefc-40a4-a3f8-901cc8ec4eae.png)|![image](https://user-images.githubusercontent.com/37048459/215755773-5f7132d3-7f16-43e4-8fb8-2d5361cd74dd.png)|


## What is the value of this and can you measure success?

More semantic for accessibility purposes, see: [DCR #7077](https://github.com/guardian/dotcom-rendering/issues/7077) and [DCR #7050](https://github.com/guardian/dotcom-rendering/issues/7050).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
