### PR TITLE
Set expanded-comments ad to sticky to top of screen

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comments-expanded-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/comments-expanded-advert.ts
@@ -17,7 +17,7 @@ const insertAd = (anchor: HTMLElement): Promise<void> => {
 	const adSlotContainer = document.createElement('div');
 	adSlotContainer.className = 'ad-slot-container';
 	adSlotContainer.style.position = 'sticky';
-	adSlotContainer.style.top = '1em';
+	adSlotContainer.style.top = '0';
 
 	adSlotContainer.appendChild(slot);
 


### PR DESCRIPTION
## What does this change?

Changes the top value of the sticky comments-expanded ad to zero.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9574885/216283990-e07659de-2883-428d-adcb-0e323bfa853c.png
[after]:  https://user-images.githubusercontent.com/9574885/216282858-1caee7c8-d073-4aea-b199-c3956d4d32ee.png

## What is the value of this and can you measure success?

Other sticky ads on article pages (inline2+) are sticky to the top of the screen, without any gap. This change is to bring consistency.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
