### PR TITLE
bump capi version to 19.1.2

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -177,6 +177,8 @@ object PressedContentFormat {
         case JsString("GuardianLabs")         => JsSuccess(com.gu.contentapi.client.utils.GuardianLabs)
         case JsString("AdvertisementFeature") => JsSuccess(com.gu.contentapi.client.utils.AdvertisementFeature)
         case JsString("Newsletter")           => JsSuccess(com.gu.contentapi.client.utils.Newsletter)
+        case JsString("Profile")              => JsSuccess(com.gu.contentapi.client.utils.Profile)
+        case JsString("Timeline")             => JsSuccess(com.gu.contentapi.client.utils.Timeline)
         case _                                => JsError(s"Unknown design type: '$json'")
       }
     override def writes(dt: DesignType): JsValue =
@@ -198,6 +200,8 @@ object PressedContentFormat {
         case com.gu.contentapi.client.utils.GuardianLabs         => JsString("GuardianLabs")
         case com.gu.contentapi.client.utils.AdvertisementFeature => JsString("AdvertisementFeature")
         case com.gu.contentapi.client.utils.Newsletter           => JsString("Newsletter")
+        case com.gu.contentapi.client.utils.Profile              => JsString("Profile")
+        case com.gu.contentapi.client.utils.Timeline             => JsString("Timeline")
       }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.1.1"
+  val capiVersion = "19.1.2"
   val faciaVersion = "4.0.4"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?
Bump CAPI version to 19.1.2 and extends format to include profile and timeline
