### PR TITLE
Remove redundant date-time check

### DIFF
--- a/common/app/conf/audio/FlagshipContainer.scala
+++ b/common/app/conf/audio/FlagshipContainer.scala
@@ -8,14 +8,10 @@ trait FlagshipContainer {
 
   val londonTimezone = ZoneId.of("Europe/London")
 
-  // Aug 17 at 3am
-  private val tifOnHolsStart = ZonedDateTime.of(2019, 8, 17, 3, 15, 0, 0, londonTimezone)
-  // Sep 2 at 2am
-  private val tifOnHolsEnd = ZonedDateTime.of(2019, 9, 2, 3, 15, 0, 0, londonTimezone)
-
   //The container should appear at 03:15 on Monday, and disappear at 03:15 on Saturday
   private val threeHoursFifteenMinutes = Duration.ofHours(3) plus Duration.ofMinutes(15)
   private val weekend = Set(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+
   private def isWeekend(dateTime: ZonedDateTime): Boolean =
     weekend(dateTime.minus(threeHoursFifteenMinutes).getDayOfWeek())
 
@@ -26,7 +22,5 @@ trait FlagshipContainer {
   def isFlagshipContainer(id: String): Boolean = containerIds.contains(id)
 
   def displayFlagshipContainer(now: ZonedDateTime = ZonedDateTime.now(londonTimezone)): Boolean =
-    switch.isSwitchedOn &&
-      (now.isBefore(tifOnHolsStart) || now.isAfter(tifOnHolsEnd)) &&
-      !isWeekend(now)
+    switch.isSwitchedOn && !isWeekend(now)
 }

--- a/common/test/conf/audio/FlagshipFrontContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipFrontContainerSpec.scala
@@ -15,26 +15,6 @@ class FlagshipFrontContainerSpec extends AnyFlatSpec with Matchers with BeforeAn
     FlagshipFrontContainerSwitch.switchOn()
   }
 
-  it should "return true if the team is on not holiday yet" in {
-    val dateTime = ZonedDateTime.parse("2019/08/17 03:14", formatter)
-    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
-  }
-
-  it should "return false if the team is on holiday" in {
-    val dateTime = ZonedDateTime.parse("2019/08/17 03:15", formatter)
-    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
-  }
-
-  it should "return false if the team is still on holiday" in {
-    val dateTime = ZonedDateTime.parse("2019/09/02 03:15", formatter)
-    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
-  }
-
-  it should "return true if the team is not on holiday anymore" in {
-    val dateTime = ZonedDateTime.parse("2019/09/02 03:16", formatter)
-    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
-  }
-
   it should "return true if Tuesday" in {
     val dateTime = ZonedDateTime.parse("2018/11/06 00:00", formatter)
     dateTime.getDayOfWeek should be(DayOfWeek.TUESDAY)


### PR DESCRIPTION
The removed code was checking whether the current date was either side of two other dates, but both of those dates are now in the past so it always returns true and can be removed.