### PR TITLE
Replace kicker separator with new line on fronts-based emails

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -25,7 +25,7 @@
     @row(Seq("headline")) {
         <a @Html(card.header.url.hrefWithRel) class="fc-link">
             @card.header.kicker.map { kicker =>
-                <span class="fc__kicker">@Html(kicker.kickerHtml) <span class="kicker-separator">/</span></span>
+                <div class="fc__kicker">@Html(kicker.kickerHtml) </div>
             }
 
             @if(card.header.quoted) {

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -152,10 +152,6 @@ $cta-font-color: #000000;
     font-family: 'Guardian Egyptian Web Header', Georgia, serif;
 }
 
-.kicker-seperator {
-    font-family: 'Guardian Egyptian Web Headline', Georgia, serif;
-}
-
 .review-stars {
     padding: 6px $gutter 0;
 


### PR DESCRIPTION
## What does this change?

There have been some recent changes to move the kicker onto a new line instead of simply separating the tag from the headline.  This PR aligns fronts based emails with these recent web and app changes.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |

[before1]: https://user-images.githubusercontent.com/74301289/217238134-431f9430-c2f5-4abe-8a3d-c91390905969.png
[before2]: https://user-images.githubusercontent.com/74301289/217788452-ce9dd92c-bc7a-46af-8091-280dc131b35e.png

[after1]: https://user-images.githubusercontent.com/74301289/217237950-a16e63b8-ed60-42e7-b084-429fb3a91bfa.png
[after2]: https://user-images.githubusercontent.com/74301289/217788710-7ba4ee12-1c8e-42db-9602-783d14dc55df.png

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
