### PR TITLE
Separate AMP Prebid switches

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -321,10 +321,41 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
+  // TODO Remove this switch once the per-server switches are being used on DCR
   val ampPrebid: Switch = Switch(
     group = CommercialPrebid,
     name = "amp-prebid",
     description = "Amp inventory is being auctioned through Prebid",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true, // Has to be true so that switch is exposed to dotcom-rendering
+  )
+
+  val ampPrebidPubmatic: Switch = Switch(
+    group = CommercialPrebid,
+    name = "amp-prebid-pubmatic",
+    description = "Amp inventory is being auctioned through Pubmatic's Prebid Server",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true, // Has to be true so that switch is exposed to dotcom-rendering
+  )
+
+  val ampPrebidCriteo: Switch = Switch(
+    group = CommercialPrebid,
+    name = "amp-prebid-criteo",
+    description = "Amp inventory is being auctioned through Criteo's Prebid Server",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true, // Has to be true so that switch is exposed to dotcom-rendering
+  )
+
+  val ampPrebidOzone: Switch = Switch(
+    group = CommercialPrebid,
+    name = "amp-prebid-ozone",
+    description = "Amp inventory is being auctioned through Ozone's Prebid Server",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -339,7 +339,7 @@ trait PrebidSwitches {
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = true, // Has to be true so that switch is exposed to dotcom-rendering
+    exposeClientSide = true,
   )
 
   val ampPrebidCriteo: Switch = Switch(
@@ -349,7 +349,7 @@ trait PrebidSwitches {
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = true, // Has to be true so that switch is exposed to dotcom-rendering
+    exposeClientSide = true,
   )
 
   val ampPrebidOzone: Switch = Switch(
@@ -359,7 +359,7 @@ trait PrebidSwitches {
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = true, // Has to be true so that switch is exposed to dotcom-rendering
+    exposeClientSide = true,
   )
 
   val prebidUserSync: Switch = Switch(


### PR DESCRIPTION
## What does this change?

Add three new switches to the commercial group on the switch board. Each controls whether to enable communication with a third party Prebid server on AMP.

We'll hang on to the generic "ampPrebid" switch for now until these new switches have been integrated.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We'll be integrating new Prebid Servers into our AMP setup. Following the pattern on the web, it makes sense to have unique switches for each one, rather than one switch.

### Tested

- [ ] Locally
- [x] On CODE (optional)