### PR TITLE
Remove AMP Prebid switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -321,17 +321,6 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
-  // TODO Remove this switch once the per-server switches are being used on DCR
-  val ampPrebid: Switch = Switch(
-    group = CommercialPrebid,
-    name = "amp-prebid",
-    description = "Amp inventory is being auctioned through Prebid",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true, // Has to be true so that switch is exposed to dotcom-rendering
-  )
-
   val ampPrebidPubmatic: Switch = Switch(
     group = CommercialPrebid,
     name = "amp-prebid-pubmatic",


### PR DESCRIPTION
## What does this change?

Remove the generic AMP Prebid switch.

**Do not merge this until the new switches in #25881 is merged and being used in DCR.**

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Each Prebid server will be gated by its own specific switch, like on the web.

### Tested

- [ ] Locally
- [ ] On CODE (optional)