### PR TITLE
Set liveblog server ads test to 0%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -69,8 +69,8 @@ object ServerSideLiveblogInlineAds
       description =
         "Test whether we can load liveblog inline ads server-side without negative effects on user experience or revenue",
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
-      sellByDate = LocalDate.of(2023, 3, 1),
-      participationGroup = Perc5A,
+      sellByDate = LocalDate.of(2023, 6, 1),
+      participationGroup = Perc0C,
     )
 
 object CalloutElements


### PR DESCRIPTION
## What does this change?

Set the Liveblog Server-side ad slots AB test from 5% to 0%.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The test is complete and the results analysed. We may run this test again soon with slightly different settings, so this test is not being deleted just yet.