### PR TITLE
Bump `commercial-core` to `5.4.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^8.1.3",
-    "@guardian/commercial-core": "^5.2.1",
+    "@guardian/commercial-core": "^5.4.0",
     "@guardian/consent-management-platform": "^10.11.1",
     "@guardian/core-web-vitals": "^2.0.1",
     "@guardian/libs": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,10 +2171,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.3.tgz#47adc4892716904a62afa62da66f31eae059d56b"
   integrity sha512-Tol4O7A3ErmzgCd9YtkajJUfCps/1RCNXhtaUBwgT8u0OUPRmfk4jjD7cS3nok5gDTEUVemKwT2yysx1CxfWaw==
 
-"@guardian/commercial-core@^5.2.1":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.2.1.tgz#8b36cea466f4232f1bc06df9fe1efbbfd141d089"
-  integrity sha512-IH5K9j1DUXyDXoFsp6Ve+/wMkzmcislfU3Hh6y4TM8L5INmxoUnRETiySjEjP2uVY6FLhrxYqQqgXd8rbnAOKg==
+"@guardian/commercial-core@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.0.tgz#cfee79a2eebdb1b774152003573b364c6ce7ec1d"
+  integrity sha512-J054cBZ7jk7icnRlPiJa2CE3A6pmuT+V1Pv6gKyBMxzh2NnDGZe6/h/UByQepisUJU3s8J4uZ6Z/1/vts/6pRg==
   dependencies:
     type-fest "2.12.2"
 


### PR DESCRIPTION
## What does this change?

Bumps `commercial-core` to `5.4.0` to bring in this change:

> Add new targeting key-value `rc` ("Recently Published Content")
> https://github.com/guardian/commercial-core/pull/782 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

So we can allow line items to target content based on date of publication.

### Tested

- [ ] Locally
- [x] On CODE (optional)