### PR TITLE
fix: add edition to ophan record

### DIFF
--- a/static/src/javascripts/lib/capture-ophan-info.js
+++ b/static/src/javascripts/lib/capture-ophan-info.js
@@ -44,6 +44,11 @@ const captureOphanInfo = () => {
         ophanInfo = { ...ophanInfo, ...{ experiences: 'dcrCouldRender' } };
     }
 
+    const edition = config.get('page.edition', false);
+    if (edition) {
+        ophanInfo = { ...ophanInfo, ...{ edition } };
+    }
+
     ophan.record({
         ...ophanInfo,
         ...{


### PR DESCRIPTION
## What does this change?
Fixes https://github.com/guardian/dotcom-rendering/issues/7075

Adds the edition data to the ophan data that gets recorded.

<img width="1496" alt="Screenshot 2023-02-08 at 17 25 57" src="https://user-images.githubusercontent.com/31692/217607614-85d5f292-3f86-4987-81cb-5e0d1c1f13fb.png">


