### PR TITLE
Update targeting client and model to include optional contacts field on callouts

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -46,14 +46,19 @@ case class CalloutFormFieldSelect(
     label: String,
     options: JsArray,
 ) extends CalloutFormField
-
 object CalloutFormField {
   implicit val CalloutFormFieldBaseWrites: Writes[CalloutFormFieldBase] = Json.writes[CalloutFormFieldBase]
   implicit val CalloutFormFieldRadioWrites: Writes[CalloutFormFieldRadio] = Json.writes[CalloutFormFieldRadio]
   implicit val CalloutFormFieldCheckboxWrites: Writes[CalloutFormFieldCheckbox] = Json.writes[CalloutFormFieldCheckbox]
   implicit val CalloutFormFieldSelectWrites: Writes[CalloutFormFieldSelect] = Json.writes[CalloutFormFieldSelect]
-
   implicit val CalloutFormFieldWrites: Writes[CalloutFormField] = Json.writes[CalloutFormField]
+}
+
+case class Contact(name: String, value: String, urlPrefix: String, guidance: Option[String])
+
+object Contact {
+  implicit val ContactWrites: Writes[Contact] = Json.writes[Contact]
+  implicit val ContactReads: Reads[Contact] = Json.reads[Contact]
 }
 
 object CalloutExtraction {
@@ -188,6 +193,8 @@ object CalloutExtraction {
       tagName <- (campaign \ "fields" \ "tagName").asOpt[String]
       formFields1 <- (campaign \ "fields" \ "formFields").asOpt[JsArray]
     } yield {
+      val contacts = (campaign \ "fields" \ "contacts").asOpt[Seq[Contact]]
+
       val formFields2 = formFields1.value
         .flatMap(formFieldItemToCalloutFormField)
         .toList
@@ -204,6 +211,7 @@ object CalloutExtraction {
         tagName,
         formFields2,
         isNonCollapsible.getOrElse(false),
+        contacts,
       )
     }
   }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -156,6 +156,7 @@ case class CalloutBlockElementV2(
     tagName: String,
     formFields: List[CalloutFormField],
     isNonCollapsible: Boolean,
+    contacts: Option[Seq[Contact]],
 ) extends PageElement
 
 object CalloutBlockElementV2 {

--- a/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
@@ -68,6 +68,21 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
         "callout": "Share your stories",
         "_type": "callout",
         "description": "<p>If you have been affected</p>",
+        "contacts": [
+        {
+        "name": "whatsapp",
+         "value": "+4488739383",
+        "urlPrefix": "http://whatsapp.com",
+        "guidance": "this is the guidance"
+        },
+        {
+        "name": "signal",
+         "value": "+4488736683",
+        "urlPrefix": "http://signal.com",
+        "guidance": "this is the guidance"
+
+        }
+        ],
         "formFields": [
           {
             "name": "share_your_experiences_here",
@@ -130,6 +145,12 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
       "callout-coronavirus",
       expectedRadioFields,
       false,
+      Some(
+        List(
+          Contact("whatsapp", "+4488739383", "http://whatsapp.com", Some("this is the guidance")),
+          Contact("signal", "+4488736683", "http://signal.com", Some("this is the guidance")),
+        ),
+      ),
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,7 +70,7 @@ object Dependencies {
   // logback2  to prevent "error: reference to logback is ambiguous;"
 
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
-  val targetingClient = "com.gu" %% "targeting-client" % "1.1.2"
+  val targetingClient = "com.gu" %% "targeting-client" % "1.1.4"
   val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.7.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.7"


### PR DESCRIPTION
## What does this change?
This PR bumps the targeting client to 1.1.4 which adds an optional contacts field on the callout model. This PR also updates the callout extraction method to extract this field and adds it to the model for DCR. 

There will be a secondary PR required on the DCR side to expect this new field. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
