### PR TITLE
Add `immutable` to static assets `cache-control`

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -47,7 +47,7 @@ deployments:
     type: aws-s3
     parameters:
       bucket: aws-frontend-static
-      cacheControl: public, max-age=315360000
+      cacheControl: public, max-age=315360000, immutable
       prefixStack: false
       publicReadAcl: false
   update-ami:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

adds the [`immutable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=opt%2Dout%20option.-,immutable,-The%20immutable%20response) directive to the assets `cache-control` header

## Why?

tells browsers (currently safari and firefox, ~40% of page views) they don't need to revalidate static assets

## Linked PR

https://github.com/guardian/dotcom-rendering/pull/7158

With assistance from @davidfurey 👍 