### PR TITLE
Press `75 ways Trump made America dirtier and the planet warmer`

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -211,6 +211,7 @@ object PressedContent {
     "/environment/ng-interactive/2020/oct/05/the-guardian-climate-pledge-2020-environment-emergency-carbon-emissions",
     "/music/ng-interactive/2020/oct/07/the-months-best-album-reviews",
     "/world/ng-interactive/2020/oct/15/justice-on-trial-three-years-after-murder-daphne-caruana-galizia",
+    "/us-news/ng-interactive/2020/oct/20/trump-us-dirtier-planet-warmer-75-ways",
     "/us-news/ng-interactive/2020/oct/30/electoral-college-explained-how-biden-faces-an-uphill-battle-in-the-us-election",
     "/us-news/ng-interactive/2020/oct/30/build-your-own-us-election-result-plot-a-win-for-biden-or-trump",
     "/us-news/ng-interactive/2020/nov/07/how-did-joe-biden-win-presidency-visual-guide",


### PR DESCRIPTION
## What does this change?

Adds [75 ways Trump made America dirtier and the planet warmer](www.theguardian.com/us-news/ng-interactive/2020/oct/20/trump-us-dirtier-planet-warmer-75-ways) to the list of pressed pages.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots (of pressed version from S3)

<img width="1507" alt="image" src="https://user-images.githubusercontent.com/37048459/218111515-9befd291-0cbc-45e7-9c9e-4e98eeb133df.png">
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/37048459/218111579-47e22722-28bc-4754-ace3-22ac6c90b330.png">
