### PR TITLE
Use bucketSsmKey for static assets

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,7 +10,7 @@ templates:
     type: autoscaling
     parameters:
       bucketSsmKey: /account/services/dotcom-artifact.bucket
-     
+
       warmupGrace: 60
     dependencies:
     - frontend-static
@@ -46,7 +46,7 @@ deployments:
   frontend-static:
     type: aws-s3
     parameters:
-      bucket: aws-frontend-static
+      bucketSsmKey: /account/services/dotcom-static.bucket
       cacheControl: public, max-age=315360000, immutable
       prefixStack: false
       publicReadAcl: false


### PR DESCRIPTION
## What does this change?

Uses `bucketSsmKey` field to look up the destination for static assets, as per DevX recommendations now that it's available for this resource type (see this [comment on a previous attempt to implement it](https://github.com/guardian/frontend/pull/25708#discussion_r1030592952) and [DCR issue #7098](https://github.com/guardian/dotcom-rendering/issues/7098)).

