### PR TITLE
Spacefinder visualiser: show when blocking elements have been removed from DOM

### DIFF
--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import type {
 	SpacefinderExclusions,
 	SpacefinderItem,
@@ -64,6 +65,26 @@ const addHoverListener = (
 ) => {
 	tooClose.forEach((opponent) => {
 		candidate.addEventListener('mouseenter', () => {
+			if (!document.body.contains(opponent.element)) {
+				// The element blocking the candidate has been removed from the DOM
+				// since spacefinder ran. This means we aren't able to highlight it
+				// as usual, but we can still provide some details in the console
+				addOverlay(
+					candidate,
+					`Blocking element(s) removed from DOM: see console for details`,
+				);
+
+				log(
+					'commercial',
+					`Spacefinder: blocking element removed from DOM.\nCandidate:`,
+					candidate,
+					`\nBlocking element:`,
+					opponent.element,
+				);
+
+				return;
+			}
+
 			opponent.element.style.cssText = `
 				box-shadow: 0px 0px 0px 10px ${colours.red};
 				z-index:10;

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.ts
@@ -43,9 +43,9 @@ const exclusionTypes = {
 const isExclusionType = (type: string): type is keyof typeof exclusionTypes =>
 	type in exclusionTypes;
 
-const addDistanceExplainer = (element: HTMLElement, text: string) => {
+const addOverlay = (element: HTMLElement, text: string) => {
 	const explainer = document.createElement('div');
-	explainer.className = 'distanceExplainer sfdebug';
+	explainer.className = 'overlay sfdebug';
 	explainer.appendChild(document.createTextNode(text));
 	explainer.style.cssText = `
 		position:absolute;
@@ -70,7 +70,7 @@ const addHoverListener = (
 				position:relative
 			`;
 
-			addDistanceExplainer(
+			addOverlay(
 				opponent.element,
 				`${opponent.actual}px/${opponent.required}px`,
 			);
@@ -79,7 +79,7 @@ const addHoverListener = (
 		candidate.addEventListener('mouseleave', () => {
 			opponent.element.style.cssText = '';
 			document
-				.querySelectorAll('.distanceExplainer')
+				.querySelectorAll('.sfdebug.overlay')
 				.forEach((el) => el.remove());
 		});
 	});


### PR DESCRIPTION
## What does this change?

The spacefinder visualiser highlights paragraphs blue if they are too close to specific HTML elements (e.g. image, heading, ad-slot). If you hover over the paragraph, the visualiser highlights the blocking elements.

However, this functionality breaks if the blocking elements have been removed from the DOM since spacefinder ran. This can happen if ad slots are collapsed, for example. When you hover over the paragraph, nothing happens.

You can see this happening here:

https://www.theguardian.com/us-news/2022/dec/14/paul-pelosi-attack-suspect-evil-in-washington-harm-house-speaker?sfdebug=1

This PR changes the hover behaviour to display a message that the blocking element has been removed from the DOM since spacefinder ran. It also prints some more details in the console.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![Screenshot 2023-02-13 at 14 31 30](https://user-images.githubusercontent.com/7423751/218489938-67ca71ca-4055-4d7a-bd57-c469917473e4.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)
