### PR TITLE
feat(DotcomRenderingDataModel): add `lang`, `isRightToLeftLang` attrs

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -99,6 +99,7 @@ case class DotcomRenderingDataModel(
     isSpecialReport: Boolean, // Indicates whether the page is a special report.
     promotedNewsletter: Option[NewsletterData],
     showTableOfContents: Boolean,
+    lang: Option[String],
 )
 
 object DotcomRenderingDataModel {
@@ -174,6 +175,7 @@ object DotcomRenderingDataModel {
         "isSpecialReport" -> model.isSpecialReport,
         "promotedNewsletter" -> model.promotedNewsletter,
         "showTableOfContents" -> model.showTableOfContents,
+        "lang" -> model.lang,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -523,6 +525,7 @@ object DotcomRenderingDataModel {
       webURL = content.metadata.webUrl,
       promotedNewsletter = newsletter,
       showTableOfContents = content.fields.showTableOfContents.getOrElse(false),
+      lang = content.fields.lang,
     )
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -100,6 +100,7 @@ case class DotcomRenderingDataModel(
     promotedNewsletter: Option[NewsletterData],
     showTableOfContents: Boolean,
     lang: Option[String],
+    isRightToLeftLang: Boolean,
 )
 
 object DotcomRenderingDataModel {
@@ -176,6 +177,7 @@ object DotcomRenderingDataModel {
         "promotedNewsletter" -> model.promotedNewsletter,
         "showTableOfContents" -> model.showTableOfContents,
         "lang" -> model.lang,
+        "isRightToLeftLang" -> model.isRightToLeftLang,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -526,6 +528,7 @@ object DotcomRenderingDataModel {
       promotedNewsletter = newsletter,
       showTableOfContents = content.fields.showTableOfContents.getOrElse(false),
       lang = content.fields.lang,
+      isRightToLeftLang = content.fields.isRightToLeftLang,
     )
   }
 }


### PR DESCRIPTION
## What does this change?

- adds `lang` and `isRightToLeftLang` attrs to `DotcomRenderingDataModel`, so DCR could accommodate [languages other than English](https://github.com/guardian/dotcom-rendering/issues/7192).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No, but there is a related change: https://github.com/guardian/dotcom-rendering/pull/7199
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
