### PR TITLE
Reduce `dcr-javascript-bundle` experiment to 1%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -24,7 +24,7 @@ object DCRJavascriptBundle
       description = "DCR Javascript bundle experiment",
       owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2024, 4, 1),
-      participationGroup = Perc20A,
+      participationGroup = Perc1A,
     )
 
 object DCRFronts


### PR DESCRIPTION
## What does this change?

Reduce `dcr-javascript-bundle` experiment back to 1%

The SWC bundle experiment has concluded so we can reduce the sample size back for the variant build to 1%

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - a related change to [switch off the variant build](https://github.com/guardian/dotcom-rendering/pull/7196)

