### PR TITLE
feat: Log `X-Request-ID` and pass it on to DCR

### DIFF
--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -24,6 +24,7 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
       "Fastly-SSL",
       "Fastly-Digest",
       "Accept-Encoding", // TODO remove if seen after 2021/09/03
+      "X-Request-ID"
     )
 
     val allHeadersFields = request

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -65,10 +65,14 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val start = currentTimeMillis()
 
-    val resp = ws
+    val req = ws
       .url(endpoint)
       .withRequestTimeout(timeout)
       .addHttpHeaders("Content-Type" -> "application/json")
+
+    request.headers.get("X-Request-ID").foreach(requestId => req.addHttpHeaders("X-Request-ID"-> requestId))
+
+    val resp = req
       .post(payload)
 
     resp.foreach(_ => {


### PR DESCRIPTION
## What does this change?

As part of https://github.com/guardian/fastly-edge-cache/pull/958 and https://github.com/guardian/platform/pull/1505 I'm attempting to add new ways of tracing requests through our various platforms.

This PR gets Frontend to log the new `X-Request-ID` header and forwards it on to DCR for further tracing there.

https://http.dev/x-request-id