### PR TITLE
Spacefinder visualiser: annotate paragraphs even when no adverts inserted

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/space-filler.ts
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.ts
@@ -6,6 +6,15 @@ import type {
 import { findSpace, SpaceError } from 'common/modules/spacefinder';
 import raven from 'lib/raven';
 
+const fireSpacefillerCompleteEvent = (
+	options: SpacefinderOptions | undefined,
+): void => {
+	if (options?.debug) {
+		const event = new CustomEvent('spacefiller-complete');
+		document.dispatchEvent(event);
+	}
+};
+
 class SpaceFiller {
 	queue = Promise.resolve(true);
 
@@ -24,16 +33,14 @@ class SpaceFiller {
 			findSpace(rules, options)
 				.then((paragraphs: HTMLElement[]) => writer(paragraphs))
 				.then(() => {
-					if (options?.debug) {
-						const event = new CustomEvent('adverts-created');
-						document.dispatchEvent(event);
-					}
+					fireSpacefillerCompleteEvent(options);
 				})
 				.then(() => {
 					return true;
 				})
 				.catch((ex) => {
 					if (ex instanceof SpaceError) {
+						fireSpacefillerCompleteEvent(options);
 						return false;
 					}
 					throw ex;

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.ts
@@ -208,7 +208,7 @@ const runDebugTool = (
 	rules: SpacefinderRules,
 ): void => {
 	document.addEventListener(
-		'adverts-created',
+		'spacefiller-complete',
 		() => {
 			if (rules.minAbove && rules.body instanceof HTMLElement) {
 				debugMinAbove(rules.body, rules.minAbove);
@@ -222,7 +222,7 @@ const runDebugTool = (
 
 const createAdvertBorder = (advert: HTMLElement): void => {
 	document.addEventListener(
-		'adverts-created',
+		'spacefiller-complete',
 		() => {
 			advert.style.cssText += `outline: 4px solid ${colours.darkRed};`;
 		},


### PR DESCRIPTION
## What does this change?

There was a bug which stopped the spacefinder visualiser running when there were no winning paragraphs.

For example, this page has no `inline1` ad (and therefore no annotations):

https://www.theguardian.com/tv-and-radio/2022/dec/16/its-snowtime-your-bumper-christmas-tv-guide?sfdebug=1

While this page has no `inline2+` ads:

https://www.theguardian.com/film/2023/feb/14/cut-off-from-the-main-how-films-about-islands-reflect-our-anxious-divided-times?sfdebug=2

This is happening because of the ([questionable?](https://github.com/guardian/frontend/blob/3da904f8e14737ad7413f66aff4152e213beeaab/static/src/javascripts/projects/common/modules/spacefinder.ts#L459-L462)) way we handle the case where no winning paragraphs are returned. We throw an exception which means the `'adverts-created'` event [never gets fired](https://github.com/guardian/frontend/blob/41fa18da7ecda494cfc568dc03b7f8de8d1306bb/static/src/javascripts/projects/common/modules/article/space-filler.ts#L26-L31). 

The fix is to fire an `'adverts-created'` event where the exception is handled too.

I also renamed `'adverts-created'` to `'spacefiller-complete'` to reflect the fact that no adverts were necessarily created. Happy to hear other suggestions!

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2023-02-14 at 15 49 11](https://user-images.githubusercontent.com/7423751/218788124-73a4c6df-ed8c-4f99-9a16-3118c251024b.png) | ![Screenshot 2023-02-14 at 15 49 03](https://user-images.githubusercontent.com/7423751/218788143-1cabf38a-93ef-4011-b453-2db446337c2e.png) |

## What is the value of this and can you measure success?

If no adverts are inserted, it's helpful to understand why.

### Tested

- [x] Locally
- [ ] On CODE (optional)


