### PR TITLE
Bump "com.typesafe.play" % "sbt-plugin" % from "2.8.8" to "2.8.19" and "com.gu.play-googleauth" %% "play-v28" % from "2.1.1" to "2.2.7"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,7 @@ object Dependencies {
   val scalaTestPlusScalacheck = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "2.44.0"
-  val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.36"
+  val slf4jExt = "org.slf4j" % "slf4j-ext" % "2.0.5"
   val jerseyCore = "com.sun.jersey" % "jersey-core" % jerseyVersion
   val jerseyClient = "com.sun.jersey" % "jersey-client" % jerseyVersion
   val w3cSac = "org.w3c.css" % "sac" % "1.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,7 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.5.7" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.5"
-  val playGoogleAuth = "com.gu.play-googleauth" %% "play-v28" % "2.1.1"
+  val playGoogleAuth = "com.gu.play-googleauth" %% "play-v28" % "2.2.7"
   val playSecretRotation = "com.gu.play-secret-rotation" %% "play-v28" % "0.18"
   val playSecretRotationAwsSdk = "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.18"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,7 @@ object Dependencies {
   val scalaTestPlusScalacheck = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "2.44.0"
-  val slf4jExt = "org.slf4j" % "slf4j-ext" % "2.0.5"
+  val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.36"
   val jerseyCore = "com.sun.jersey" % "jersey-core" % jerseyVersion
   val jerseyClient = "com.sun.jersey" % "jersey-client" % jerseyVersion
   val w3cSac = "org.w3c.css" % "sac" % "1.3"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
   Resolver.typesafeRepo("releases"),
 )
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
 

--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -28,7 +28,7 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
       completionMatcher = completionMatcher,
       failureMatcher = failureMatcher,
       bufferSize = 1024,
-      overflowStrategy = OverflowStrategy.dropNew,
+      overflowStrategy = OverflowStrategy.dropTail,
     )
     .throttle(1, 500.millisecond, 1, ThrottleMode.Shaping)
     .to(Sink.actorRef(self, NotUsed, t => Failure(t)))


### PR DESCRIPTION
Co-Authored-By: Ashleigh Carr <ashcorr20@gmail.com>
Co-Authored-By: George B <705427+georgeblahblah@users.noreply.github.com>

## What does this change?

Bump "com.typesafe.play" % "sbt-plugin" % from "2.8.8" to "2.8.19" and "com.gu.play-googleauth" %% "play-v28" % from "2.1.1" to "2.2.7"

This reduces the number of high severity snyk vulnerabilites from 16 to 11.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
