### PR TITLE
Press "The Guardian: independence matters" article

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -88,6 +88,7 @@ object PressedContent {
     "/cities/ng-interactive/2016/nov/10/subterranean-london",
     "/music/2016/nov/11/the-future-50-the-rising-stars-to-look-out-for",
     "/science/2016/nov/21/magic-numbers-can-maths-equations-be-beautiful",
+    "/info/ng-interactive/2016/nov/22/the-guardian-independence-matters",
     "/film/2016/nov/29/the-50-best-uk-films-of-2016-full-list",
     "/film/2016/nov/29/50-best-us-film-of-2016-the-full-list",
     "/music/2016/nov/30/the-best-albums-of-2016",


### PR DESCRIPTION
## What does this change?

Adds a membership interactive, "[The Guardian: independence matters](https://www.theguardian.com/info/ng-interactive/2016/nov/22/the-guardian-independence-matters)" to the list of pressed pages.


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="1464" alt="image" src="https://user-images.githubusercontent.com/102960844/219040690-d364d7c4-f00d-4ebc-b99e-e0a9fe3f7403.png">

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/102960844/219041077-1392545c-7e34-4090-97d8-b03683b25374.png">

