### PR TITLE
Add a switch for personalisation copy

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -512,9 +512,9 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
-  val PersonaliseSignInAfterCheckoutGate = Switch(
+  val PersonaliseSignInGateAfterCheckout = Switch(
     SwitchGroup.Feature,
-    "personalise-sign-in-after-checkout-gate",
+    "personalise-sign-in-gate-after-checkout",
     "When ON, the sign in gate shows a personalised message to subscribers and supporters",
     owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),
     safeState = On,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -512,9 +512,9 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
-  val PersonaliseSignInAfterCheckout = Switch(
+  val PersonaliseSignInAfterCheckoutGate = Switch(
     SwitchGroup.Feature,
-    "personalise-sign-in-after-checkout",
+    "personalise-sign-in-after-checkout-gate",
     "When ON, the sign in gate shows a personalised message to subscribers and supporters",
     owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),
     safeState = On,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -512,5 +512,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+  val PersonaliseSignInAfterCheckout = Switch(
+    SwitchGroup.Feature,
+    "personalise-sign-in-after-checkout",
+    "When ON, the sign in gate shows a personalised message to subscribers and supporters",
+    owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -517,7 +517,7 @@ trait FeatureSwitches {
     "personalise-sign-in-gate-after-checkout",
     "When ON, the sign in gate shows a personalised message to subscribers and supporters",
     owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),
-    safeState = On,
+    safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
   )


### PR DESCRIPTION
## What does this change?

This adds to a switch to turn on or off the feature which personalises the copy in the sign in gate based on whether a user has recently supported or subscribed to the website. Corresponding DCR PR: https://github.com/guardian/dotcom-rendering/pull/7222

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
