### PR TITLE
do not load the commercial bundle for ad free users

### DIFF
--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -13,6 +13,7 @@ import play.api.libs.json._
 import model.IpsosTags.getScriptTag
 import model.dotcomrendering.DotcomRenderingUtils.assetURL
 import play.api.mvc.RequestHeader
+import views.support.Commercial
 
 object JavaScriptPage {
 
@@ -100,6 +101,7 @@ object JavaScriptPage {
       ("discussionFrontendUrl", JsString(DiscussionAsset("discussion-frontend.preact.iife"))),
       ("brazeApiKey", JsString(Configuration.braze.apiKey)),
       ("ipsosTag", JsString(ipsos)),
+      ("isAdFree", JsBoolean(Commercial.isAdFree(request))),
     ) ++ commercialBundleUrl
   }.toMap
 }

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -167,10 +167,12 @@ const go = () => {
 
 
         // eslint-disable-next-line no-nested-ternary
-        const fetchCommercial = config.get('switches.commercial')
-            ? (markTime('commercial request'),
-                commercialBundle())
-            : Promise.resolve(fakeBootCommercial);
+        const fetchCommercial =
+            config.get('switches.commercial') &&
+            !config.get('page.isAdFree', false)
+                ? (markTime('commercial request'),
+                    commercialBundle())
+                : Promise.resolve(fakeBootCommercial);
 
 
         const fetchEnhanced = window.guardian.isEnhanced


### PR DESCRIPTION
## What does this change?

stop the commercial bundle loading at all for ad-free (i.e. paying) users

## Why?

we know on the server that we won't run the code, but we still force people to download it. the commercial code in turn still loads further libraries we also know we won't run. if we're not going to run, let's not load it.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes

See https://github.com/guardian/dotcom-rendering/pull/7223 for the affects on a DCR article