### PR TITLE
Bumped capiVersion and added new formats to Formats.scala

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -177,6 +177,8 @@ object PressedContentFormat {
         case JsString("GuardianLabs")         => JsSuccess(com.gu.contentapi.client.utils.GuardianLabs)
         case JsString("AdvertisementFeature") => JsSuccess(com.gu.contentapi.client.utils.AdvertisementFeature)
         case JsString("Newsletter")           => JsSuccess(com.gu.contentapi.client.utils.Newsletter)
+        case JsString("Profile")              => JsSuccess(com.gu.contentapi.client.utils.Profile)
+        case JsString("Timeline")             => JsSuccess(com.gu.contentapi.client.utils.Timeline)
         case _                                => JsError(s"Unknown design type: '$json'")
       }
     override def writes(dt: DesignType): JsValue =
@@ -198,6 +200,8 @@ object PressedContentFormat {
         case com.gu.contentapi.client.utils.GuardianLabs         => JsString("GuardianLabs")
         case com.gu.contentapi.client.utils.AdvertisementFeature => JsString("AdvertisementFeature")
         case com.gu.contentapi.client.utils.Newsletter           => JsString("Newsletter")
+        case com.gu.contentapi.client.utils.Profile              => JsString("Profile")
+        case com.gu.contentapi.client.utils.Timeline             => JsString("Timeline")
       }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.1.1"
+  val capiVersion = "19.1.2"
   val faciaVersion = "4.0.4"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?

This updates frontend to use the `19.1.2` version of CAPI, and adds the two new design formats `Profile` and `Timeline`.

It was previously attempted to bump the capi-client version to `19.1.2` in https://github.com/guardian/frontend/pull/25873 but we had to [revert](https://github.com/guardian/frontend/pull/25874). We are now bumping the version after the relevant changes [have been made to DCR](https://github.com/guardian/dotcom-rendering/pull/7242).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - already merged in [this PR](https://github.com/guardian/dotcom-rendering/pull/7242)

## Screenshots

| Before (without the DCR changes)    | After      |
|-------------|------------|
| <img width="1327" alt="image" src="https://user-images.githubusercontent.com/19683595/220111220-6256fc91-197f-4451-8fa3-81568e934dc1.png"> | <img width="1434" alt="image" src="https://user-images.githubusercontent.com/19683595/220110597-75827379-1cc7-4ca5-9b7a-7acb348c81c9.png"> |

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [x] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
