### PR TITLE
feat: Add method for calling DCR for Apps to DotcomRenderingService

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.contentapi.client.model.v1.{Blocks, ItemResponse, Content => ApiContent}
 import common._
 import contentapi.ContentApiClient
-import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}
+import implicits.{AmpFormat, AppsFormat, EmailFormat, HtmlFormat, JsonFormat}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import model._
@@ -126,13 +126,18 @@ class ArticleController(
           article,
           blocks,
           pageType,
-          filterKeyEvents = false,
-          false,
-          newsletter = newsletter,
-          topicResult = None,
+          newsletter,
         )
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
+      case AppsFormat =>
+        remoteRenderer.getAppsArticle(
+          ws,
+          article,
+          blocks,
+          pageType,
+          newsletter,
+        )
     }
   }
 

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -205,7 +205,7 @@ class LiveBlogController(
               blog,
               blocks,
               pageType,
-              None,
+              newsletter = None,
               filterKeyEvents,
               request.forceLive,
               availableTopics,

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -185,7 +185,7 @@ class LiveBlogController(
                 blog,
                 blocks,
                 pageType,
-                None,
+                newsletter = None,
                 filterKeyEvents,
                 request.forceLive,
                 availableTopics,
@@ -196,7 +196,7 @@ class LiveBlogController(
               Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
             }
           case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType, None, filterKeyEvents)
+            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType, newsletter = None, filterKeyEvents)
           case (blog: LiveBlogPage, AmpFormat) =>
             Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
           case (blog: LiveBlogPage, AppsFormat) =>

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.{Block, Blocks, ItemResponse, Content =
 import common.`package`.{convertApiExceptions => _, renderFormat => _}
 import common._
 import contentapi.ContentApiClient
-import implicits.{AmpFormat, HtmlFormat}
+import implicits.{AmpFormat, AppsFormat, HtmlFormat}
 import model.Cached.WithoutRevalidationResult
 import model.LiveBlogHelpers._
 import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
@@ -185,10 +185,10 @@ class LiveBlogController(
                 blog,
                 blocks,
                 pageType,
+                None,
                 filterKeyEvents,
                 request.forceLive,
                 availableTopics,
-                newsletter = None,
                 topicResult,
               )
             } else {
@@ -196,9 +196,21 @@ class LiveBlogController(
               Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
             }
           case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType, newsletter = None, filterKeyEvents)
+            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType, None, filterKeyEvents)
           case (blog: LiveBlogPage, AmpFormat) =>
             Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+          case (blog: LiveBlogPage, AppsFormat) =>
+            remoteRenderer.getAppsArticle(
+              ws,
+              blog,
+              blocks,
+              pageType,
+              None,
+              filterKeyEvents,
+              request.forceLive,
+              availableTopics,
+              topicResult,
+            )
           case _ => Future.successful(NotFound)
         }
       }

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -23,10 +23,10 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       article: PageWithStoryPackage,
       blocks: Blocks,
       pageType: PageType,
+      newsletter: Option[NewsletterData],
       filterKeyEvents: Boolean,
       forceLive: Boolean,
       availableTopics: Option[Seq[Topic]],
-      newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -22,7 +22,7 @@ class DevParametersHttpRequestHandler(
 
   /*
     IMPORTANT
-    these params are only whitelisted on dev machines, they will not make it through the CDN on www.theguardian.com
+    these params are only allowed on dev machines, they will not make it through the CDN on www.theguardian.com
     this means that the server side **CANNOT** rely on them. They may be used by Javascript, or simply in the
     development environment
    */
@@ -53,8 +53,9 @@ class DevParametersHttpRequestHandler(
     "pbjs_debug", // set to `true` to enable prebid debugging,
     "amzn_debug_mode", // set to `1` to enable A9 debugging
     "force-braze-message", // JSON encoded representation of "extras" data from Braze
-    "dcr",
+    "dcr", // force page to render in DCR
     "topics", // used for filtering the liveblog blocks
+    "apps", // force page to render in Apps format
   )
 
   val commercialParams = Seq(

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -55,7 +55,6 @@ class DevParametersHttpRequestHandler(
     "force-braze-message", // JSON encoded representation of "extras" data from Braze
     "dcr", // force page to render in DCR
     "topics", // used for filtering the liveblog blocks
-    "apps", // force page to render in Apps format
   )
 
   val commercialParams = Seq(

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -69,9 +69,11 @@ trait Requests {
 
     lazy val isRss: Boolean = r.path.endsWith("/rss")
 
-    lazy val isAmp: Boolean = r.getQueryString("amp").isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host)
+    lazy val isAmp: Boolean = r
+      .getQueryString("amp")
+      .isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host) || r.getQueryString("dcr").contains("amp")
 
-    lazy val isApps: Boolean = r.getQueryString("apps").isDefined
+    lazy val isApps: Boolean = r.getQueryString("dcr").contains("apps")
 
     lazy val isEmail: Boolean = r.getQueryString("format").exists(_.contains("email")) || r.path.endsWith(
       EMAIL_SUFFIX,

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -18,6 +18,7 @@ case object HtmlFormat extends RequestFormat
 case object JsonFormat extends RequestFormat
 case object EmailFormat extends RequestFormat
 case object AmpFormat extends RequestFormat
+case object AppsFormat extends RequestFormat
 case class TerritoryHeader(territory: TargetedTerritory, headerString: String)
 
 object GUHeaders {
@@ -51,7 +52,11 @@ trait Requests {
     def getBooleanParameter(name: String): Option[Boolean] = getParameter(name).map(_.toBoolean)
 
     def getRequestFormat: RequestFormat =
-      if (isJson) JsonFormat else if (isEmail) EmailFormat else if (isAmp) AmpFormat else HtmlFormat
+      if (isJson) JsonFormat
+      else if (isEmail) EmailFormat
+      else if (isAmp) AmpFormat
+      else if (isApps) AppsFormat
+      else HtmlFormat
 
     lazy val isJson: Boolean = r.getQueryString("callback").isDefined || r.path.endsWith(".json")
 
@@ -65,6 +70,8 @@ trait Requests {
     lazy val isRss: Boolean = r.path.endsWith("/rss")
 
     lazy val isAmp: Boolean = r.getQueryString("amp").isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host)
+
+    lazy val isApps: Boolean = r.getQueryString("apps").isDefined
 
     lazy val isEmail: Boolean = r.getQueryString("format").exists(_.contains("email")) || r.path.endsWith(
       EMAIL_SUFFIX,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -141,28 +141,59 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       pageType: PageType,
       newsletter: Option[NewsletterData],
       filterKeyEvents: Boolean = false,
-  )(implicit request: RequestHeader): Future[Result] = {
+  )(implicit request: RequestHeader): Future[Result] =
+    baseArticleRequest("/AMPArticle", ws, page, blocks, pageType, filterKeyEvents, false, None, newsletter, None)
 
-    val dataModel = page match {
-      case liveblog: LiveBlogPage =>
-        DotcomRenderingDataModel.forLiveblog(
-          liveblog,
-          blocks,
-          request,
-          pageType,
-          filterKeyEvents,
-          forceLive = false,
-          newsletter = newsletter,
-          topicResult = None,
-        )
-      case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter)
-    }
-    val json = DotcomRenderingDataModel.toJson(dataModel)
-
-    post(ws, json, Configuration.rendering.baseURL + "/AMPArticle", page.metadata.cacheTime)
-  }
+  def getAppsArticle(
+      ws: WSClient,
+      page: PageWithStoryPackage,
+      blocks: Blocks,
+      pageType: PageType,
+      newsletter: Option[NewsletterData],
+      filterKeyEvents: Boolean = false,
+      forceLive: Boolean = false,
+      availableTopics: Option[Seq[Topic]] = None,
+      topicResult: Option[TopicResult] = None,
+  )(implicit request: RequestHeader): Future[Result] =
+    baseArticleRequest(
+      "/AppsArticle",
+      ws,
+      page,
+      blocks,
+      pageType,
+      filterKeyEvents,
+      forceLive,
+      availableTopics,
+      newsletter,
+      topicResult,
+    )
 
   def getArticle(
+      ws: WSClient,
+      page: PageWithStoryPackage,
+      blocks: Blocks,
+      pageType: PageType,
+      newsletter: Option[NewsletterData],
+      filterKeyEvents: Boolean = false,
+      forceLive: Boolean = false,
+      availableTopics: Option[Seq[Topic]] = None,
+      topicResult: Option[TopicResult] = None,
+  )(implicit request: RequestHeader): Future[Result] =
+    baseArticleRequest(
+      "/Article",
+      ws,
+      page,
+      blocks,
+      pageType,
+      filterKeyEvents,
+      forceLive,
+      availableTopics,
+      newsletter,
+      topicResult,
+    )
+
+  private def baseArticleRequest(
+      path: String,
       ws: WSClient,
       page: PageWithStoryPackage,
       blocks: Blocks,
@@ -190,7 +221,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     }
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Article", page.metadata.cacheTime)
+    post(ws, json, Configuration.rendering.baseURL + path, page.metadata.cacheTime)
   }
 
   def getBlocks(


### PR DESCRIPTION
## What does this change?

- Adds a new method to DotcomRenderingService for rendering Articles using the new `/AppsArticle` route
- Refactors `getArticle`, `getAmpArticle`, and `getAppsArticle` to share liveblog blocks fetching behavior.
- Adds a new `AppsFormat` format which is applied when `?dcr=apps` is added to a URl
- Uses `/AppsArticle` in the LiveBlog and Article controllers when rendering in `AppFormat`

Closes https://github.com/guardian/dotcom-rendering/issues/7060

## Why `?apps` ?

~~This pattern already exists for AMP articles by using the `?amp` parameter so it makes sense to re-use it for Apps. This makes it really easy to switch between different formats as the URL structure remains the same just the parameters change.~~

We're using the DCR query parameter now to decide which platform to render on.

## Should this really go in the same app & controller as regular web pages?

Maybe, maybe not. You could argue the case that we put all apps related controllers into its own service. But as it stands supporting the Apps rendering format fits quite neatly into our existing controllers for Articles.

There may be a case where we split DCR related controllers onto a seperate service at some point, but I'm not sure now is the right time.  Currently DCR itself is a monolith and likely our bottleneck when it comes to scaling up.

I'm working on a full RFC doc for this.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/7258

## Screenshots

<img width="895" alt="image" src="https://user-images.githubusercontent.com/21217225/221636756-11066ec6-dc4c-4d1d-9ca5-d498187f75bd.png">
