### PR TITLE
Fix "show" button not working when rendering a slim header

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -220,7 +220,9 @@ const bootStandard = () => {
         handleMembershipAccess();
     }
 
-    if(window.guardian.config.switches.headerTopNav) {
+    if(window.guardian.config.switches.headerTopNav
+        && document.querySelector('.header-top-nav')
+        ) {
         headerTopNavInit();
     } else {
         newHeaderInit();


### PR DESCRIPTION
## What does this change?

There are two different types of headers: a regular and a slim one, each of which have respective .scala.html and .js files.

At the moment, the slim header (e.g. found on galleries like [this one](https://www.theguardian.com/news/gallery/2023/feb/15/earthquake-dog-rescue-and-cyclone-gabrielle-wednesdays-best-photos)) gets loaded following a check in [HtmlPage.scala](https://github.com/guardian/frontend/blob/main/common/app/html/HtmlPage.scala#L34), looking at both whether the headerTopNav switch is active and if the page should have a slim header. 

But the javascript that determines what gets loaded on to the page (see [main.js](https://github.com/guardian/frontend/blob/main/static/src/javascripts/bootstraps/standard/main.js#L223)) only looks at whether the headerTopNav switch is active, which it now is. Therefore the header-top-nav.js will get loaded on all pages, even if it has a slim header (when it should be using new-header.js instead), and even though the html doesn't match up, which means the "show" button on pages with a slim header does nothing. 

This adds a check that the headerTopNav element is in the DOM to initialise its associated javascript, otherwise it uses new-header.js instead.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="902" alt="image" src="https://user-images.githubusercontent.com/102960844/220181641-84e3fd53-914c-4aae-b84f-937f72ed2515.png">

## What is the value of this and can you measure success?

Closes [issue 7211](https://github.com/guardian/dotcom-rendering/issues/7211) 

The show button now actually works on a page like [this gallery](https://www.theguardian.com/news/gallery/2023/feb/15/earthquake-dog-rescue-and-cyclone-gabrielle-wednesdays-best-photos).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
