### PR TITLE
Change licensing NavLink label

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -232,7 +232,7 @@ object NavLinks {
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val guardianLive = NavLink("Live events", "https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown")
   val guardianPuzzlesApp = NavLink("Guardian Puzzles app", s"https://puzzles.theguardian.com/download")
-  val guardianLicensing = NavLink("Guardian content licensing site", s"https://licensing.theguardian.com/")
+  val guardianLicensing = NavLink("Guardian licensing", s"https://licensing.theguardian.com/")
   val jobsRecruiter = NavLink(
     "Hire with Guardian Jobs",
     "https://recruiters.theguardian.com/?utm_source=gdnwb&utm_medium=navbar&utm_campaign=Guardian_Navbar_Recruiters&CMP_TU=trdmkt&CMP_BUNIT=jobs",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -809,7 +809,7 @@
             "children" : [ ],
             "classList" : [ ]
         }, {
-            "title" : "Guardian content licensing site",
+            "title" : "Guardian licensing",
             "url" : "https://licensing.theguardian.com/",
             "children" : [ ],
             "classList" : [ ]
@@ -1375,7 +1375,7 @@
             "children" : [ ],
             "classList" : [ ]
         }, {
-            "title" : "Guardian content licensing site",
+            "title" : "Guardian licensing",
             "url" : "https://licensing.theguardian.com/",
             "children" : [ ],
             "classList" : [ ]
@@ -1977,12 +1977,13 @@
             "children" : [ ],
             "classList" : [ ]
         }, {
-            "title" : "Guardian content licensing site",
+            "title" : "Guardian licensing",
             "url" : "https://licensing.theguardian.com/",
             "children" : [ ],
             "classList" : [ ]
         } ]
     },
+    "tagPages" : [ "us-news/us-politics", "australia-news/australian-politics", "australia-news/australian-immigration-and-asylum", "australia-news/indigenous-australians", "uk/scotland", "uk/wales", "uk/northernireland", "world/europe-news", "world/americas", "world/asia", "world/africa", "world/middleeast", "business/economics", "business/banking", "business/retail", "business/stock-markets", "business/eurozone", "us/sustainable-business", "business/diversity-and-equality", "business/us-small-business", "environment/climate-change", "environment/climate-crisis", "environment/wildlife", "environment/energy", "environment/pollution", "money/property", "money/pensions", "money/savings", "money/debt", "money/work-and-careers", "cartoons/archive", "type/cartoon", "profile/editorial", "au/index/contributors", "index/contributors", "commentisfree/series/comment-is-free-weekly", "sport/rugby-union", "sport/cricket", "sport/tennis", "sport/cycling", "sport/golf", "sport/us-sport", "sport/horse-racing", "sport/rugbyleague", "sport/boxing", "sport/formulaone", "sport/nfl", "sport/mlb", "football/mls", "sport/nba", "sport/nhl", "sport/afl", "football/a-league", "sport/nrl", "music/classicalmusicandopera", "food", "tone/recipes", "lifeandstyle/health-and-wellbeing", "lifeandstyle/family", "lifeandstyle/home-and-garden", "lifeandstyle/love-and-sex", "au/lifeandstyle/fashion", "au/lifeandstyle/food-and-drink", "au/lifeandstyle/relationships", "au/lifeandstyle/health-and-wellbeing", "travel/uk", "travel/europe", "travel/usa", "travel/skiing", "travel/australasia", "travel/asia", "theguardian", "observer", "football/live", "football/tables", "football/competitions", "football/results", "football/fixtures", "crosswords/crossword-blog", "crosswords/series/crossword-editor-update", "crosswords/series/quick", "crosswords/series/cryptic", "crosswords/series/prize", "crosswords/series/weekend-crossword", "crosswords/series/quiptic", "crosswords/series/genius", "crosswords/series/speedy", "crosswords/series/everyman", "crosswords/series/azed", "fashion/beauty", "technology/motoring", "commentisfree/commentisfree", "education/education" ],
     "international" : {
         "newsPillar" : {
             "title" : "News",
@@ -2708,11 +2709,10 @@
             "children" : [ ],
             "classList" : [ ]
         }, {
-            "title" : "Guardian content licensing site",
+            "title" : "Guardian licensing",
             "url" : "https://licensing.theguardian.com/",
             "children" : [ ],
             "classList" : [ ]
         } ]
-    },
-    "tagPages" : [ "us-news/us-politics", "australia-news/australian-politics", "australia-news/australian-immigration-and-asylum", "australia-news/indigenous-australians", "uk/scotland", "uk/wales", "uk/northernireland", "world/europe-news", "world/americas", "world/asia", "world/africa", "world/middleeast", "business/economics", "business/banking", "business/retail", "business/stock-markets", "business/eurozone", "us/sustainable-business", "business/diversity-and-equality", "business/us-small-business", "environment/climate-change", "environment/climate-crisis", "environment/wildlife", "environment/energy", "environment/pollution", "money/property", "money/pensions", "money/savings", "money/debt", "money/work-and-careers", "cartoons/archive", "type/cartoon", "profile/editorial", "au/index/contributors", "index/contributors", "commentisfree/series/comment-is-free-weekly", "sport/rugby-union", "sport/cricket", "sport/tennis", "sport/cycling", "sport/golf", "sport/us-sport", "sport/horse-racing", "sport/rugbyleague", "sport/boxing", "sport/formulaone", "sport/nfl", "sport/mlb", "football/mls", "sport/nba", "sport/nhl", "sport/afl", "football/a-league", "sport/nrl", "music/classicalmusicandopera", "food", "tone/recipes", "lifeandstyle/health-and-wellbeing", "lifeandstyle/family", "lifeandstyle/home-and-garden", "lifeandstyle/love-and-sex", "au/lifeandstyle/fashion", "au/lifeandstyle/food-and-drink", "au/lifeandstyle/relationships", "au/lifeandstyle/health-and-wellbeing", "travel/uk", "travel/europe", "travel/usa", "travel/skiing", "travel/australasia", "travel/asia", "theguardian", "observer", "football/live", "football/tables", "football/competitions", "football/results", "football/fixtures", "crosswords/crossword-blog", "crosswords/series/crossword-editor-update", "crosswords/series/quick", "crosswords/series/cryptic", "crosswords/series/prize", "crosswords/series/weekend-crossword", "crosswords/series/quiptic", "crosswords/series/genius", "crosswords/series/speedy", "crosswords/series/everyman", "crosswords/series/azed", "fashion/beauty", "technology/motoring", "commentisfree/commentisfree", "education/education" ]
+    }
 }


### PR DESCRIPTION
Update the label for the licensing link in `NavLinks` from `Guardian content licensing site` to `Guardian licensing`.

Rebuild the `reference-navigation.json` file accordingly.

(nb. git shows a diff in the position of `tagPages`, but this is due to how the new json is built; from looking at previous history it appears that this key moves around in the file fairly regularly, so I don't think it's an important diff but I chose to stick with the built version, rather than trying to re-edit it manually and risk introducing bugs.)

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After (DCR)      | After (Frontend) |
|-------------|------------| --|
| <img width="286" alt="image" src="https://user-images.githubusercontent.com/37048459/220329427-266c7ae0-f0d7-469b-a7f5-beb384e75deb.png"> | <img width="318" alt="image" src="https://user-images.githubusercontent.com/37048459/220329344-aa01e657-ea43-47fc-b21c-c4205704879c.png"> | <img width="322" alt="image" src="https://user-images.githubusercontent.com/37048459/220329591-0e3b40b8-c9e5-4411-b617-55743858d854.png"> |

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
