### PR TITLE
Use headOption in case list is empty

### DIFF
--- a/common/app/common/commercial/hosted/HostedMetadata.scala
+++ b/common/app/common/commercial/hosted/HostedMetadata.scala
@@ -19,7 +19,7 @@ object HostedMetadata {
     val productionOffice = item.fields.flatMap(_.productionOffice.map(_.name)).getOrElse("")
     val owner = {
       val hostedTag = item.tags.find(_.paidContentType.contains("HostedContent"))
-      val sponsorship = hostedTag.flatMap(_.activeSponsorships).map(_.head)
+      val sponsorship = hostedTag.flatMap(_.activeSponsorships).flatMap(_.headOption)
       sponsorship.map(_.sponsorName).getOrElse("")
     }
 


### PR DESCRIPTION
## What does this change?

Uses `headOption` instead of `head` to access the head of a potentially-empty list.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

An edge case arose in which Preview crashed because it was trying to access `head` on an empty list.

In this case it looks like this bug allowed us to notice a genuine configuration issue in one of the article's tags. But the root issue seems to be in the contract between TagManager and CAPI, so it seems like the issue should be surfaced upstream, and Frontend should try to recover as well as possible if the issue is passed down. I'm not 100% sure what the intended functionality of this code is, but the `getOrElse` on the next line suggests to me that the `sponsorship` property wasn't intended to be mandatory in the original code, either.

I've done a test deployment to CODE, but I'm not sure how to properly test the new functionality beyond that.