### PR TITLE
Add snaps check to faciaPicker

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -4,6 +4,8 @@ import common.GuLogging
 import experiments.{ActiveExperiments, DCRFronts}
 import implicits.Requests._
 import model.PressedPage
+import model.facia.PressedCollection
+import model.pressed.{LatestSnap, LinkSnap}
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 
@@ -99,6 +101,18 @@ object FrontChecks {
     )
   }
 
+  def hasNoSnapLinkCards(faciaPage: PressedPage): Boolean = {
+    def containsSnapLink(collection: PressedCollection) = {
+      collection.curated.exists(card =>
+        card match {
+          case _: LinkSnap => true
+          case _           => false
+        },
+      )
+    }
+    !faciaPage.collections.exists(collection => containsSnapLink(collection))
+  }
+
 }
 
 object FaciaPicker extends GuLogging {
@@ -112,6 +126,7 @@ object FaciaPicker extends GuLogging {
       ("hasNoSlideshows", FrontChecks.hasNoSlideshows(faciaPage)),
       ("hasNoPaidCards", FrontChecks.hasNoPaidCards(faciaPage)),
       ("hasNoRegionalAusTargetedContainers", FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage)),
+      ("hasNoSnapLinkCards", FrontChecks.hasNoSnapLinkCards(faciaPage)),
     )
   }
 


### PR DESCRIPTION
## What does this change?

Adds a check in `FaciaPicker` to see whether any of the containers on a page include cards with type `LinkSnap` or `LatestSnap`. Support for these snaps is separate from support for regular cards, and currently we don't support them in DCR.

See #25922.

Co-authored-by: Ashleigh Carr <ashcorr20@gmail.com>

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Testing

I've tried a test deployment on CODE and `window.guardian.config.page.dcrCouldRender` for the `podcasts` front went from `true` to `false`, as desired. The `dcrCouldRender` value for the `obituaries` front remains `true`.

Both of these results are as intended. Given that the 1% test isn't live yet, I wonder whether it makes sense to merge this and then use the dashboard to get a clearer sense of whether it's working as intended more generally?