### PR TITLE
Update to Commercial Admin Page

### DIFF
--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -103,9 +103,7 @@
                         <li><a href="https://docs.google.com/document/d/10Mxxta6ypxAduVXJFp19uRoWtALQmAubdKtBwq7AqZ0/edit">
                             Commercial Development Handbook</a></li>
                         <li><a href="https://github.com/guardian/commercial-tools">Commercial tools repo</a></li>
-                        <li><a href="@Configuration.Elk.kibanaUrl/s/dotcom/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3d,to:now))&_a=(columns:!(),filters:!(),index:'50201630-bd0f-11e9-92b3-f10623802d36',interval:auto,query:(language:kuery,query:'%22Building%20DFP%20session%20failed%22'),sort:!(!('@timestamp',desc)))">
-                            "Building DFP Session Failed"
-                        </a></li>
+                        <li><a href="@Configuration.Elk.kibanaUrl/s/dotcom/goto/49ee37b0-b42d-11ed-9b92-7fe459a3d219">"Building DFP Session Failed"</a></li>
 
                     </ul>
                 </div>

--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -100,14 +100,13 @@
                 <div class="panel-heading">Links to useful resources.</div>
                 <div class="panel-body">
                     <ul>
+                        <li><a href="https://docs.google.com/document/d/10Mxxta6ypxAduVXJFp19uRoWtALQmAubdKtBwq7AqZ0/edit">
+                            Commercial Development Handbook</a></li>
                         <li><a href="https://github.com/guardian/commercial-tools">Commercial tools repo</a></li>
-                        <li><a href="https://dfp-playground.appspot.com/">DFP API playground</a></li>
-                        <li><a href="https://dfpgpt.appspot.com/">DFP targeting playground</a></li>
-                        <li><a href="@Configuration.Elk.kibanaUrl/goto/2d8984bcc7d3a4abf03b6f2b5e8acf6a">
-                            Failing Commercial Feeds
+                        <li><a href="@Configuration.Elk.kibanaUrl/s/dotcom/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-3d,to:now))&_a=(columns:!(),filters:!(),index:'50201630-bd0f-11e9-92b3-f10623802d36',interval:auto,query:(language:kuery,query:'%22Building%20DFP%20session%20failed%22'),sort:!(!('@timestamp',desc)))">
+                            "Building DFP Session Failed"
                         </a></li>
-                        <li><a href="https://docs.google.com/a/guardian.co.uk/document/d/1Imf0MN9Gx_tWMgQBk21LyDZsKz6DVLEyJyOPLveJ_Gk">
-                            Troubleshooting Guide</a></li>
+
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## What does this change?
This is an update to the links on the Commercial Tools page as part of frontend admin application. https://frontend.gutools.co.uk/commercial

This updates the links in the "Resources" section to remove some that no longer work, and add some that do.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?

The links are now more relevant than previously.

## Checklist

### Does this affect other platforms?

No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
