### PR TITLE
Extend sellByDate for Europe experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -49,7 +49,7 @@ object EuropeNetworkFront
       name = "europe-network-front",
       description = "Test new europe network front",
       owners = Seq(Owner.withGithub("rowannekabalan")),
-      sellByDate = LocalDate.of(2023, 3, 1),
+      sellByDate = LocalDate.of(2023, 5, 31),
       participationGroup = Perc0D,
     )
 


### PR DESCRIPTION
## What does this change?

Extends sellByDate for Europe front experiment to the end of May (expected launch month)

Linked to PR #25444
