### PR TITLE
Filter out ad creation error when using DuckDuckGo

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
@@ -18,14 +18,17 @@ const createAdvert = (
 		}`;
 
 		log('commercial', errMsg);
-		reportError(
-			new Error(errMsg),
-			{
-				feature: 'commercial',
-			},
-			false,
-			1 / 100,
-		);
+
+		if (!navigator.userAgent.includes('DuckDuckGo')) {
+			reportError(
+				new Error(errMsg),
+				{
+					feature: 'commercial',
+				},
+				false,
+				1 / 100,
+			);
+		}
 
 		return null;
 	}


### PR DESCRIPTION
## What does this change?
If the user is using DuckDuckGo as their browser, the 'could not create ad slot' error will no longer be sent to Sentry. At the moment, DuckDuckGo accounts for about 35% of the 'could not create ad slot' errors. We know these are caused by DuckDuckGo blocking the google scripts needed for ad slot creation, so blocking these errors from being logged in Sentry will reduce noise, as well as significantly reducing the overall number of these errors.