### PR TITLE
Record count of offline event

### DIFF
--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -28,7 +28,12 @@
     @InlineJs(shouldEnhance(page.metadata).body, "shouldEnhance.js")
 
     // page config
+    // creates window.guardian
     @Html(config(page).body)
+
+    // record the number of times the browser goes offline during a pageview
+    window.guardian.offlineCount = 0;
+    window.addEventListener('offline', function incrementOfflineCount () { window.guardian.offlineCount++ });
 
     // apply render conditions
     @InlineJs(applyRenderConditions().body, "applyRenderConditions.js")

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^8.1.3",
-    "@guardian/commercial-core": "^5.4.0",
+    "@guardian/commercial-core": "^5.4.2",
     "@guardian/consent-management-platform": "^10.11.1",
     "@guardian/core-web-vitals": "^2.0.1",
     "@guardian/libs": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,10 +2171,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.3.tgz#47adc4892716904a62afa62da66f31eae059d56b"
   integrity sha512-Tol4O7A3ErmzgCd9YtkajJUfCps/1RCNXhtaUBwgT8u0OUPRmfk4jjD7cS3nok5gDTEUVemKwT2yysx1CxfWaw==
 
-"@guardian/commercial-core@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.0.tgz#cfee79a2eebdb1b774152003573b364c6ce7ec1d"
-  integrity sha512-J054cBZ7jk7icnRlPiJa2CE3A6pmuT+V1Pv6gKyBMxzh2NnDGZe6/h/UByQepisUJU3s8J4uZ6Z/1/vts/6pRg==
+"@guardian/commercial-core@^5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.2.tgz#1c07bf0655d5dadc015ef6d54e7f40a864e83562"
+  integrity sha512-jy59ewwnJ3210gh7OSuYe2E0z6wQcWcDvDzG96tfvhvKaA0j35YW3Mex7/WkvBIRgOoBIGFLi3pvEjIja5Qa4Q==
   dependencies:
     type-fest "2.12.2"
 


### PR DESCRIPTION
## What does this change?

Bump @guardian/commercial-core to v5.4.2

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/7283

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

This allows us to record `offlineCount` more accurately