### PR TITLE
bump `@guardian/commercial-core` to `5.4.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^8.1.3",
-    "@guardian/commercial-core": "^5.4.2",
+    "@guardian/commercial-core": "^5.4.3",
     "@guardian/consent-management-platform": "^10.11.1",
     "@guardian/core-web-vitals": "^2.0.1",
     "@guardian/libs": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,10 +2171,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.3.tgz#47adc4892716904a62afa62da66f31eae059d56b"
   integrity sha512-Tol4O7A3ErmzgCd9YtkajJUfCps/1RCNXhtaUBwgT8u0OUPRmfk4jjD7cS3nok5gDTEUVemKwT2yysx1CxfWaw==
 
-"@guardian/commercial-core@^5.4.2":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.2.tgz#1c07bf0655d5dadc015ef6d54e7f40a864e83562"
-  integrity sha512-jy59ewwnJ3210gh7OSuYe2E0z6wQcWcDvDzG96tfvhvKaA0j35YW3Mex7/WkvBIRgOoBIGFLi3pvEjIja5Qa4Q==
+"@guardian/commercial-core@^5.4.3":
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.3.tgz#054d4cfe9cf026e54e73b099ba3cc088cca9ee85"
+  integrity sha512-6uAzzALVa/KQoYu0xpS/IQ6PwIX9S0X3MDkhEwyuVgX33ptO8vGPxJHAuSc9wp0Q3s+nYlSa4xaWGMkiEGcbDQ==
   dependencies:
     type-fest "2.12.2"
 


### PR DESCRIPTION
contains a bug fix (https://github.com/guardian/commercial-core/pull/803) for offline counting

dcr equivalent: https://github.com/guardian/dotcom-rendering/pull/7286