### PR TITLE
Experiment for poor device connectivity

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       DCRJavascriptBundle,
       HeaderTopBarSearchCapi,
       ServerSideLiveblogInlineAds,
+      PoorDeviceConnectivity,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -71,3 +72,14 @@ object ServerSideLiveblogInlineAds
       sellByDate = LocalDate.of(2023, 6, 1),
       participationGroup = Perc0C,
     )
+
+object PoorDeviceConnectivity
+    extends Experiment(
+      name = "poor-device-connectivity",
+      description = "Reduce the load of the site for users experiencing poor device connectivity",
+      owners = Seq(Owner.withEmail("open.journalism@theguardian.com")),
+      sellByDate = LocalDate.of(2023, 4, 4),
+      participationGroup = Perc20A,
+    ) {
+  override val extraHeader = Some(ExperimentHeader("X-GU-Poor-Device-Connectivity", "true"))
+}


### PR DESCRIPTION
## What does this change?

Add a 20% A/B test for poor device connectivity, requiring an extra header: `X-GU-Poor-Device-Connectivity`.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No – but we should implement most of the logic relying on it there
- [ ] Yes 
