### PR TITLE
Add hidden field to all callout form fields

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -14,6 +14,7 @@ case class CalloutFormFieldBase(
     description: Option[String],
     required: Boolean,
     hideLabel: Boolean,
+    hidden: Boolean,
     label: String,
 ) extends CalloutFormField
 case class CalloutFormFieldRadio(
@@ -23,6 +24,7 @@ case class CalloutFormFieldRadio(
     description: Option[String],
     required: Boolean,
     hideLabel: Boolean,
+    hidden: Boolean,
     label: String,
     options: JsArray,
 ) extends CalloutFormField
@@ -33,6 +35,7 @@ case class CalloutFormFieldCheckbox(
     description: Option[String],
     required: Boolean,
     hideLabel: Boolean,
+    hidden: Boolean,
     label: String,
     options: JsArray,
 ) extends CalloutFormField
@@ -43,6 +46,7 @@ case class CalloutFormFieldSelect(
     description: Option[String],
     required: Boolean,
     hideLabel: Boolean,
+    hidden: Boolean,
     label: String,
     options: JsArray,
 ) extends CalloutFormField
@@ -85,7 +89,8 @@ object CalloutExtraction {
       hideLabel <- (item \ "hide_label").asOpt[String]
       label <- (item \ "label").asOpt[String]
     } yield {
-      CalloutFormFieldBase(id, type_, name, description, required == "1", hideLabel == "1", label)
+      val hidden = (item \ "hidden").asOpt[String].getOrElse("0")
+      CalloutFormFieldBase(id, type_, name, description, required == "1", hideLabel == "1", hidden == "1", label)
     }
   }
 
@@ -100,7 +105,18 @@ object CalloutExtraction {
       label <- (item \ "label").asOpt[String]
       options <- (item \ "options").asOpt[JsArray]
     } yield {
-      CalloutFormFieldRadio(id, type_, name, description, required == "1", hideLabel == "1", label, options)
+      val hidden = (item \ "hidden").asOpt[String].getOrElse("0")
+      CalloutFormFieldRadio(
+        id,
+        type_,
+        name,
+        description,
+        required == "1",
+        hideLabel == "1",
+        hidden == "1",
+        label,
+        options,
+      )
     }
   }
 
@@ -115,7 +131,18 @@ object CalloutExtraction {
       label <- (item \ "label").asOpt[String]
       options <- (item \ "options").asOpt[JsArray]
     } yield {
-      CalloutFormFieldCheckbox(id, type_, name, description, required == "1", hideLabel == "1", label, options)
+      val hidden = (item \ "hidden").asOpt[String].getOrElse("0")
+      CalloutFormFieldCheckbox(
+        id,
+        type_,
+        name,
+        description,
+        required == "1",
+        hideLabel == "1",
+        hidden == "1",
+        label,
+        options,
+      )
     }
   }
 
@@ -130,7 +157,18 @@ object CalloutExtraction {
       label <- (item \ "label").asOpt[String]
       options <- (item \ "options").asOpt[JsArray]
     } yield {
-      CalloutFormFieldSelect(id, type_, name, description, required == "1", hideLabel == "1", label, options)
+      val hidden = (item \ "hidden").asOpt[String].getOrElse("0")
+      CalloutFormFieldSelect(
+        id,
+        type_,
+        name,
+        description,
+        required == "1",
+        hideLabel == "1",
+        hidden == "1",
+        label,
+        options,
+      )
     }
   }
 

--- a/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
@@ -91,6 +91,7 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
             "label": "Share your experiences here",
             "id": "87320974",
             "type": "textarea",
+            "hidden": "1",
             "required": "1"
           },
           {
@@ -101,6 +102,7 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
             "label": "Name",
             "id": "87320975",
             "type": "text",
+            "hidden": "0",
             "required": "1"
           },
           {
@@ -181,6 +183,7 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
         Some("Please include as much detail as possible"),
         true,
         false,
+        true,
         "Share your experiences here",
       ),
       CalloutFormFieldBase(
@@ -190,6 +193,7 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
         Some("You do not need to use your full name"),
         true,
         false,
+        false,
         "Name",
       ),
       CalloutFormFieldRadio(
@@ -198,6 +202,7 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
         "can_we_publish_your_response",
         None,
         true,
+        false,
         false,
         "Can we publish your response?",
         expectedRadioOptions,


### PR DESCRIPTION
## What does this change?
This PR makes use of the hidden field returned in the Callout form fields (campaign response). This change is backward compatible, so if the hidden field is not there, it would set the value of the hidden field that is passed to DCR to false. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
