### PR TITLE
Add showQuotedHeadline to Trail model

### DIFF
--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -77,6 +77,8 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
 
     val contentFormat: ContentFormat = ContentFormat(content.design, content.theme, content.display)
 
+    val faciaContentVersion = FaciaContentConvert.contentToFaciaContent(content)
+
     for {
       webPublicationDate <- content.webPublicationDate
       fields <- content.fields
@@ -105,7 +107,8 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       starRating = None,
       avatarUrl = None,
       branding = None,
-      discussion = DiscussionSettings.fromTrail(FaciaContentConvert.contentToFaciaContent(content)),
+      discussion = DiscussionSettings.fromTrail(faciaContentVersion),
+      showQuotedHeadline = faciaContentVersion.display.showQuotedHeadline,
     )
   }
 

--- a/common/app/model/dotcomrendering/Trail.scala
+++ b/common/app/model/dotcomrendering/Trail.scala
@@ -33,6 +33,7 @@ case class Trail(
     avatarUrl: Option[String],
     branding: Option[Branding],
     discussion: DiscussionSettings,
+    showQuotedHeadline: Boolean,
 )
 
 object Trail {
@@ -133,6 +134,7 @@ object Trail {
       avatarUrl = contentCardToAvatarUrl(contentCard),
       branding = contentCard.branding,
       discussion = contentCard.discussionSettings,
+      showQuotedHeadline = contentCard.displaySettings.showQuotedHeadline,
     )
   }
 
@@ -168,6 +170,7 @@ object Trail {
       avatarUrl = None,
       branding = content.branding(Edition(request)),
       discussion = DiscussionSettings.fromTrail(content),
+      showQuotedHeadline = content.display.showQuotedHeadline,
     )
   }
 }


### PR DESCRIPTION
## What does this change?

Adds `showQuotedHeadline` field to the `Trail` type in the DCR model.

## Why?

We need to decide whether to show quote marks on headlines that are passed as `Trail` (e.g. in the Most Viewed container). Currently we're relying on the `ArticleDesign` to add them to all Opinion cards, but this is leading to some false positives. It looks like Frontend itself uses the `showQuotedHeadline` field to decide whether to render quotes for these cards, so it makes sense to pass it to DCR, too.


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

Coordinated PR (to be merged after this): https://github.com/guardian/dotcom-rendering/pull/7313

