### PR TITLE
Create 0% Elements Manager AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,7 +68,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-elements-manager",
-    "Show billboard adverts in merchandising slots to browsers in the variant",
+    "Test serving GEM assets in ad slots on page",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
     sellByDate = Some(LocalDate.of(2023, 6, 30)),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,6 +67,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-elements-manager",
+    "Show billboard adverts in merchandising slots to browsers in the variant",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 6, 30)),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
     "ab-no-carrot-ads-near-newsletter-signup-blocks",
     "Test the impact of preventing spacefinder from positioning carrot ads near newsletter signup blocks",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { billboardsInMerch } from './tests/billboards-in-merch';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
+import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import { noCarrotAdsNearNewsletterSignupBlocks } from './tests/no-carrot-ads-near-newsletter-signup-blocks';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
@@ -21,4 +22,5 @@ export const concurrentTests: readonly ABTest[] = [
 	integrateIma,
 	billboardsInMerch,
 	noCarrotAdsNearNewsletterSignupBlocks,
+	elementsManager,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/elements-manager.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/elements-manager.ts
@@ -1,0 +1,19 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const elementsManager: ABTest = {
+	id: 'ElementsManager',
+	author: '@commercial-dev',
+	start: '2023-02-23',
+	expiry: '2023-06-30',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in only',
+	successMeasure: 'Able to serve GEM assets in ad slots on page',
+	description: 'Test serving GEM assets in ad slots on page',
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

- Creates a 0% AB test to use for Guardian Elements Manager.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes ([DCR PR](https://github.com/guardian/dotcom-rendering/pull/7323))

## Why?

So that we can incrementally add features to Elements Manager.