### PR TITLE
Differentiate embedTypes in SnapLink check

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -101,16 +101,24 @@ object FrontChecks {
     )
   }
 
-  def hasNoSnapLinkCards(faciaPage: PressedPage): Boolean = {
-    def containsSnapLink(collection: PressedCollection) = {
+  def hasNoUnsupportedSnapLinkCards(faciaPage: PressedPage): Boolean = {
+    def containsUnsupportedSnapLink(collection: PressedCollection) = {
       collection.curated.exists(card =>
         card match {
+          case card: LinkSnap if card.properties.embedType.contains("link") => false
+          // We don't support interactive embeds yet
+          case card: LinkSnap if card.properties.embedType.contains("interactive") => true
+          // We don't support json.html embeds yet
+          case card: LinkSnap if card.properties.embedType.contains("json.html") => true
+          // Because embedType is typed as Option[String] it's hard to know whether we've
+          // identified all possible embedTypes. If it's an unidentified embedType then
+          // assume we can't render it.
           case _: LinkSnap => true
           case _           => false
         },
       )
     }
-    !faciaPage.collections.exists(collection => containsSnapLink(collection))
+    !faciaPage.collections.exists(collection => containsUnsupportedSnapLink(collection))
   }
 
 }
@@ -126,7 +134,7 @@ object FaciaPicker extends GuLogging {
       ("hasNoSlideshows", FrontChecks.hasNoSlideshows(faciaPage)),
       ("hasNoPaidCards", FrontChecks.hasNoPaidCards(faciaPage)),
       ("hasNoRegionalAusTargetedContainers", FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage)),
-      ("hasNoSnapLinkCards", FrontChecks.hasNoSnapLinkCards(faciaPage)),
+      ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
     )
   }
 


### PR DESCRIPTION
There are a few different `embedType` values for SnapLinks, and DCR does support some of them, so this change makes our check for unsupported SnapLinks more fine-grained.

## Notes

### Support for `interactive` type

We have at least partial support for SnapLinks with the `interactive` embedType. At least some of the bugs are 'upstream' because (afaik) the design team is relying on some global styling present in Frontend that's not present in DCR. So it's possible that we do actually support these but I've left them as unsupported until we can verify, given that they look obviously broken most of the time at the moment.

See [Thrashers tickets in the Snaps and Thrashers DCR epic](https://github.com/guardian/dotcom-rendering/issues/7319).


### Tests

Tested on CODE, verified that `dcrCouldRender` now gets set to `true` when a page contains `embedType == link`.

### Checks

It doesn't need to be recreated in Dotcom and it shouldn't have any impact on the UI/UX, etc.