### PR TITLE
Braze notification click events

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -275,7 +275,10 @@ const initialiseHeaderNotifications = (brazeCardsPromise) => {
                     ophanLabel: card.extras.ophanLabel,
                     logImpression: () => {
                         card.logImpression();
-                    }
+                    },
+                    logClick: () => {
+                        card.logCardClick();
+                    },
                 };
         })
 

--- a/static/src/javascripts/projects/common/modules/bufferedNotificationListener.spec.ts
+++ b/static/src/javascripts/projects/common/modules/bufferedNotificationListener.spec.ts
@@ -20,6 +20,7 @@ describe('bufferedNotificationListener', () => {
 				message: 'Your card has expired',
 				ophanLabel: 'settings-label',
 				logImpression: noOp,
+				logClick: noOp,
 			},
 		];
 
@@ -42,6 +43,7 @@ describe('bufferedNotificationListener', () => {
 					message: 'Your card has expired',
 					ophanLabel: 'settings-label',
 					logImpression: noOp,
+					logClick: noOp,
 				},
 			];
 			bufferedNotificationListener.emit(notifications);

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.ts
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.ts
@@ -56,10 +56,12 @@ const trackNotificationsInsert = (ophanComponent: OphanComponent): void => {
 
 const setupTrackNotificationsClick = (
 	el: Element,
+	notifications: HeaderNotification[],
 	ophanComponent: OphanComponent,
 ): void => {
 	el.addEventListener('click', () => {
 		submitClickEvent({ component: ophanComponent });
+		notifications.forEach((n) => n.logClick());
 	});
 };
 
@@ -185,6 +187,7 @@ const addNotifications = (notifications: HeaderNotification[]): void => {
 								);
 								setupTrackNotificationsClick(
 									menuItem,
+									notifications,
 									ophanComponent,
 								);
 								addTrackingToLink(menuItem, ophanComponent);

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -426,6 +426,7 @@ interface HeaderNotification {
 	message: string;
 	ophanLabel: string;
 	logImpression: () => void;
+	logClick: () => void;
 }
 interface Window {
 	// eslint-disable-next-line id-denylist -- this *is* the guardian object


### PR DESCRIPTION
When a user clicks a link in the header dropdown and it contains a braze notification, we want to send a tracking event to braze.

[DCR PR](https://github.com/guardian/dotcom-rendering/pull/7324)