### PR TITLE
Switch Left and Right in Eithers

### DIFF
--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -110,7 +110,7 @@ class AtomPageController(
   ): Action[AnyContent] =
     Action.async { implicit request =>
       lookup(s"atom/$atomType/$id") map {
-        case Left(atom: AudioAtom) => {
+        case Right(atom: AudioAtom) => {
 
           /*
           mark: 57cadc98-16c0-49ac-8bba-c96144c488a7
@@ -133,25 +133,25 @@ class AtomPageController(
           val html2: Html = views.html.fragments.atoms.audio(atom.id, Html(html1), css, js)
           Ok(html2)
         }
-        case Left(atom: ChartAtom) =>
+        case Right(atom: ChartAtom) =>
           renderAtom(ChartAtomPage(atom, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
-        case Left(atom: GuideAtom) =>
+        case Right(atom: GuideAtom) =>
           renderAtom(GuideAtomPage(atom, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
-        case Left(atom: InteractiveAtom) =>
+        case Right(atom: InteractiveAtom) =>
           renderAtom(
             InteractiveAtomPage(atom, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar),
           )
-        case Left(atom: MediaAtom) =>
+        case Right(atom: MediaAtom) =>
           renderAtom(MediaAtomPage(atom, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
-        case Left(atom: ProfileAtom) =>
+        case Right(atom: ProfileAtom) =>
           renderAtom(ProfileAtomPage(atom, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
-        case Left(atom: QandaAtom) =>
+        case Right(atom: QandaAtom) =>
           renderAtom(QandaAtomPage(atom, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
-        case Left(atom: TimelineAtom) =>
+        case Right(atom: TimelineAtom) =>
           renderAtom(TimelineAtomPage(atom, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
-        case Left(_) =>
+        case Right(_) =>
           renderOther(NotFound)
-        case Right(other) =>
+        case Left(other) =>
           renderOther(other)
       }
     }
@@ -161,11 +161,11 @@ class AtomPageController(
       TinyResponse.noContent(Some("POST, OPTIONS"))
     }
 
-  private def lookup(path: String)(implicit request: RequestHeader): Future[Either[Atom, Result]] = {
+  private def lookup(path: String)(implicit request: RequestHeader): Future[Either[Result, Atom]] = {
     val edition = Edition(request)
     contentApiClient
       .getResponse(contentApiClient.item(path, edition))
-      .map(makeAtom _ andThen { _.toLeft(NotFound) })
+      .map(makeAtom _ andThen { _.toRight(NotFound) })
       .recover(convertApiExceptions)
   }
 

--- a/applications/app/controllers/EmbedController.scala
+++ b/applications/app/controllers/EmbedController.scala
@@ -17,12 +17,12 @@ class EmbedController(contentApiClient: ContentApiClient, val controllerComponen
   def render(path: String): Action[AnyContent] =
     Action.async { implicit request =>
       lookup(path) map {
-        case Left(model)  => renderVideo(EmbedPage(model, model.trail.headline))
-        case Right(other) => renderOther(other)
+        case Right(model) => renderVideo(EmbedPage(model, model.trail.headline))
+        case Left(other)  => renderOther(other)
       }
     }
 
-  private def lookup(path: String)(implicit request: RequestHeader): Future[Either[Video, Result]] = {
+  private def lookup(path: String)(implicit request: RequestHeader): Future[Either[Result, Video]] = {
     val edition = Edition(request)
 
     log.info(s"Fetching video: $path for edition $edition")
@@ -37,8 +37,8 @@ class EmbedController(contentApiClient: ContentApiClient, val controllerComponen
       val modelOption: Option[Video] = response.content.map(Content(_)).collect { case v: Video => v }
 
       modelOption match {
-        case Some(x) => Left(x)
-        case _       => Right(NotFound)
+        case Some(x) => Right(x)
+        case _       => Left(NotFound)
       }
     }
 

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -27,10 +27,10 @@ class GalleryController(contentApiClient: ContentApiClient, val controllerCompon
     val isTrail = request.getBooleanParameter("trail") getOrElse false
 
     lookup(path, index, isTrail) map {
-      case Left(model) if model.gallery.content.isExpired =>
+      case Right(model) if model.gallery.content.isExpired =>
         RenderOtherStatus(Gone) // TODO - delete this line after switching to new content api
-      case Left(model)  => renderGallery(model)
-      case Right(other) => RenderOtherStatus(other)
+      case Right(model) => renderGallery(model)
+      case Left(other)  => RenderOtherStatus(other)
     }
   }
 
@@ -38,8 +38,8 @@ class GalleryController(contentApiClient: ContentApiClient, val controllerCompon
     Action.async { implicit request =>
       val index = request.getIntParameter("index") getOrElse 1
       lookup(path, index, isTrail = false) map {
-        case Right(other) => RenderOtherStatus(other)
-        case Left(model)  => Cached(model) { JsonComponent.fromWritable(model.gallery.lightbox.javascriptConfig) }
+        case Left(other)  => RenderOtherStatus(other)
+        case Right(model) => Cached(model) { JsonComponent.fromWritable(model.gallery.lightbox.javascriptConfig) }
       }
     }
 

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -43,8 +43,8 @@ class ImageContentController(
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] =
     image(Edition(request), path).map {
-      case Left(content) => renderImageContent(content)
-      case Right(result) => RenderOtherStatus(result)
+      case Right(content) => renderImageContent(content)
+      case Left(result)   => RenderOtherStatus(result)
     }
 
   private def isSupported(c: ApiContent) = c.isImageContent

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -30,8 +30,8 @@ class MediaController(contentApiClient: ContentApiClient, val controllerComponen
   def renderInfoJson(path: String): Action[AnyContent] =
     Action.async { implicit request =>
       lookup(path) map {
-        case Left(model)  => MediaInfo(expired = false, shouldHideAdverts = model.media.content.shouldHideAdverts)
-        case Right(other) => MediaInfo(expired = other.header.status == GONE, shouldHideAdverts = true)
+        case Right(model) => MediaInfo(expired = false, shouldHideAdverts = model.media.content.shouldHideAdverts)
+        case Left(other)  => MediaInfo(expired = other.header.status == GONE, shouldHideAdverts = true)
       } map { mediaInfo =>
         Cached(60)(JsonComponent.fromWritable(withRefreshStatus(Json.toJson(mediaInfo).as[JsObject])))
       }
@@ -70,8 +70,8 @@ class MediaController(contentApiClient: ContentApiClient, val controllerComponen
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] =
     lookup(path) map {
-      case Left(model)  => renderMedia(model)
-      case Right(other) => RenderOtherStatus(other)
+      case Right(model) => renderMedia(model)
+      case Left(other)  => RenderOtherStatus(other)
     }
 
   private def isSupported(c: ApiContent) = c.isVideo || c.isAudio

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -75,11 +75,11 @@ class QuizController(
         quiz.map(QuizAnswersPage(answers, s"${Configuration.site.host}/$path", _))
       }
 
-      maybePage.toLeft(NotFound)
+      maybePage.toRight(NotFound)
     }
     result recover convertApiExceptions map {
-      case Left(page)   => Ok(ContentHtmlPage.html(page))
-      case Right(other) => RenderOtherStatus(other)
+      case Right(page) => Ok(ContentHtmlPage.html(page))
+      case Left(other) => RenderOtherStatus(other)
     }
   }
 

--- a/applications/app/services/ImageQuery.scala
+++ b/applications/app/services/ImageQuery.scala
@@ -16,7 +16,7 @@ trait ImageQuery extends ConciergeRepository {
   def image(edition: Edition, path: String)(implicit
       request: RequestHeader,
       context: ApplicationContext,
-  ): Future[Either[ImageContentPage, PlayResult]] = {
+  ): Future[Either[PlayResult, ImageContentPage]] = {
     log.info(s"Fetching image content: $path for edition ${edition.id}")
     val response = contentApiClient.getResponse(
       contentApiClient
@@ -26,10 +26,10 @@ trait ImageQuery extends ConciergeRepository {
       val mainContent = response.content.filter(_.isImageContent).map(Content(_))
       mainContent
         .map {
-          case content: ImageContent => Left(ImageContentPage(content, StoryPackages(content.metadata.id, response)))
-          case _                     => Right(NotFound)
+          case content: ImageContent => Right(ImageContentPage(content, StoryPackages(content.metadata.id, response)))
+          case _                     => Left(NotFound)
         }
-        .getOrElse(Right(NotFound))
+        .getOrElse(Left(NotFound))
     }
 
     response recover convertApiExceptions

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -381,8 +381,8 @@ class LiveBlogController(
       .map(responseToModelOrResult(range, filterKeyEvents, topicResult))
       .recover(convertApiExceptions)
       .flatMap {
-        case Left((model, blocks)) => render(model, blocks)
-        case Right(other)          => Future.successful(RenderOtherStatus(other))
+        case Right((model, blocks)) => render(model, blocks)
+        case Left(other)            => Future.successful(RenderOtherStatus(other))
       }
   }
 
@@ -390,16 +390,16 @@ class LiveBlogController(
       range: BlockRange,
       filterKeyEvents: Boolean,
       topicResult: Option[TopicResult],
-  )(response: ItemResponse)(implicit request: RequestHeader): Either[(PageWithStoryPackage, Blocks), Result] = {
+  )(response: ItemResponse)(implicit request: RequestHeader): Either[Result, (PageWithStoryPackage, Blocks)] = {
     val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
-    val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
+    val supportedContentResult: Either[Result, ContentType] = ModelOrResult(supportedContent, response)
     val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
 
-    val content = supportedContentResult.left.flatMap {
+    val content = supportedContentResult.flatMap {
       case minute: Article if minute.isTheMinute =>
-        Left(MinutePage(minute, StoryPackages(minute.metadata.id, response)), blocks)
+        Right(MinutePage(minute, StoryPackages(minute.metadata.id, response)), blocks)
       case liveBlog: Article if liveBlog.isLiveBlog && request.isEmail =>
-        Left(MinutePage(liveBlog, StoryPackages(liveBlog.metadata.id, response)), blocks)
+        Right(MinutePage(liveBlog, StoryPackages(liveBlog.metadata.id, response)), blocks)
       case liveBlog: Article if liveBlog.isLiveBlog =>
         createLiveBlogModel(
           liveBlog,
@@ -407,11 +407,10 @@ class LiveBlogController(
           range,
           filterKeyEvents,
           topicResult,
-        ).left
-          .map(_ -> blocks)
+        ).map(_ -> blocks)
       case unknown =>
         log.error(s"Requested non-liveblog: ${unknown.metadata.id}")
-        Right(InternalServerError)
+        Left(InternalServerError)
     }
 
     content

--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -65,7 +65,7 @@ object LiveBlogHelpers extends GuLogging {
       range: BlockRange,
       filterKeyEvents: Boolean,
       topicResult: Option[TopicResult],
-  ): Either[LiveBlogPage, Status] = {
+  ): Either[Status, LiveBlogPage] = {
 
     val pageSize = if (liveBlog.content.tags.tags.map(_.id).contains("sport/sport")) 30 else 10
 
@@ -99,7 +99,7 @@ object LiveBlogHelpers extends GuLogging {
           content = liveBlog.content.copy(metadata = liveBlog.content.metadata.copy(cacheTime = cacheTime)),
         )
 
-        Left(
+        Right(
           LiveBlogPage(
             article = liveBlogCache,
             currentPage = pageModel,
@@ -108,7 +108,7 @@ object LiveBlogHelpers extends GuLogging {
           ),
         )
       }
-      .getOrElse(Right(NotFound))
+      .getOrElse(Left(NotFound))
 
   }
 

--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -7,18 +7,15 @@ import model._
 import implicits.ItemResponses
 import java.net.URI
 
-// TODO 'Convention dictates that Left is used for failure and Right is used for success.'
-// We got this the other way around, it not an error, but we should fix it.
-// Assuming that 'I can serve this to the user' is the least error state.
 object ModelOrResult extends Results with GuLogging {
 
   def apply[T](item: Option[T], response: ItemResponse, maybeSection: Option[ApiSection] = None)(implicit
       request: RequestHeader,
-  ): Either[T, Result] =
+  ): Either[Result, T] =
     item
       .map(i => ItemOrRedirect(i, response, maybeSection))
-      .orElse(InternalRedirect(response).map(Right(_)))
-      .getOrElse(Right(NoCache(NotFound)))
+      .orElse(InternalRedirect(response).map(Left(_)))
+      .getOrElse(Left(NoCache(NotFound)))
 }
 
 // Content API owns the URL space, if they say this belongs on a different URL then we follow
@@ -26,34 +23,34 @@ private object ItemOrRedirect extends ItemResponses with GuLogging {
 
   def apply[T](item: T, response: ItemResponse, maybeSection: Option[ApiSection])(implicit
       request: RequestHeader,
-  ): Either[T, Result] =
+  ): Either[Result, T] =
     maybeSection match {
       case Some(section) => redirectSection(item, request, section)
       case None          => redirectArticle(item, response, request)
     }
 
-  private def redirectArticle[T](item: T, response: ItemResponse, request: RequestHeader): Either[T, Result] = {
+  private def redirectArticle[T](item: T, response: ItemResponse, request: RequestHeader): Either[Result, T] = {
     canonicalPath(response) match {
       case Some(canonicalPath) if canonicalPath != request.pathWithoutModifiers && !request.isModified =>
-        Right(Found(canonicalPath + paramString(request)))
-      case _ => Left(item)
+        Left(Found(canonicalPath + paramString(request)))
+      case _ => Right(item)
     }
 
   }
 
-  private def redirectSection[T](item: T, request: RequestHeader, section: ApiSection): Either[T, Result] = {
+  private def redirectSection[T](item: T, request: RequestHeader, section: ApiSection): Either[Result, T] = {
 
     if (
       request.path.endsWith("/all") &&
       pathWithoutEdition(section) != request.path.stripSuffix("/all")
     )
-      Right(Found(pathWithoutEdition(section) + "/all"))
+      Left(Found(pathWithoutEdition(section) + "/all"))
     else if (
       request.getQueryString("page").exists(_ != "1") &&
       pathWithoutEdition(section) != request.path
     )
-      Right(Found(s"${pathWithoutEdition(section)}?${request.rawQueryString}"))
-    else Left(item)
+      Left(Found(s"${pathWithoutEdition(section)}?${request.rawQueryString}"))
+    else Right(item)
 
   }
 

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -33,9 +33,9 @@ object `package`
       request: RequestHeader,
       context: ApplicationContext,
       log: Logger,
-  ): PartialFunction[Throwable, Either[T, Result]] = {
+  ): PartialFunction[Throwable, Either[Result, T]] = {
 
-    convertApiExceptionsWithoutEither.andThen(Right(_))
+    convertApiExceptionsWithoutEither.andThen(Left(_))
   }
 
   def convertApiExceptionsWithoutEither[T](implicit

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -30,8 +30,8 @@ trait IndexControllerCommon
     Action.async { implicit request =>
       logGoogleBot(request)
       index(leftSide, rightSide, inferPage(request), request.isRss).map {
-        case Left(page)   => renderFaciaFront(page)
-        case Right(other) => other
+        case Right(page) => renderFaciaFront(page)
+        case Left(other) => other
       }
     }
 
@@ -58,8 +58,8 @@ trait IndexControllerCommon
   def renderTrails(path: String): Action[AnyContent] =
     Action.async { implicit request =>
       index(Edition(request), path, inferPage(request), request.isRss) map {
-        case Left(model)     => renderTrailsFragment(model)
-        case Right(notFound) => notFound
+        case Right(model)   => renderTrailsFragment(model)
+        case Left(notFound) => notFound
       }
     }
 
@@ -79,7 +79,7 @@ trait IndexControllerCommon
         logGoogleBot(request)
         index(Edition(request), path, inferPage(request), request.isRss) map {
           // if no content is returned (as often happens with old/expired/migrated microsites) return 404 rather than an empty page
-          case Left(model) =>
+          case Right(model) =>
             if (model.contents.nonEmpty) renderFaciaFront(model)
             else
               Cached(60)(
@@ -93,7 +93,7 @@ trait IndexControllerCommon
                   ),
                 ),
               )
-          case Right(other) => RenderOtherStatus(other)
+          case Left(other) => RenderOtherStatus(other)
         }
     }
 

--- a/common/test/common/ModelOrResultTest.scala
+++ b/common/test/common/ModelOrResultTest.scala
@@ -87,7 +87,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
     ModelOrResult(
       item = Some(TestModel),
       response = stubResponse,
-    ) should be(Left(TestModel))
+    ) should be(Right(TestModel))
   }
 
   it should "internal redirect to an article if it has shown up at the wrong server" in {
@@ -95,7 +95,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
       ModelOrResult(
         item = None,
         response = stubResponse.copy(content = Some(testArticle)),
-      ).value
+      ).left.value
     }
 
     status(notFound) should be(200)
@@ -107,7 +107,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
       ModelOrResult(
         item = None,
         response = stubResponse.copy(content = Some(testVideo)),
-      ).value
+      ).left.value
     }
 
     status(notFound) should be(200)
@@ -119,7 +119,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
       ModelOrResult(
         item = None,
         response = stubResponse.copy(content = Some(testGallery)),
-      ).value
+      ).left.value
     }
 
     status(notFound) should be(200)
@@ -131,7 +131,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
       ModelOrResult(
         item = None,
         response = stubResponse.copy(content = Some(testAudio)),
-      ).value
+      ).left.value
     }
 
     status(notFound) should be(200)
@@ -143,7 +143,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
       ModelOrResult(
         item = None,
         response = stubResponse.copy(content = Some(testContent)),
-      ).value
+      ).left.value
     }
 
     status(notFound) should be(404)
@@ -154,7 +154,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
       ModelOrResult(
         item = None,
         response = stubResponse.copy(tag = Some(articleTag)),
-      ).value
+      ).left.value
     }
 
     status(notFound) should be(200)
@@ -168,7 +168,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
       ModelOrResult(
         item = None,
         response = stubResponse.copy(section = Some(testSection)),
-      ).value
+      ).left.value
     }
 
     status(notFound) should be(200)


### PR DESCRIPTION
## What does this change?

Switches the `Left` and `Right` types associated with the `ModelOrResult` object, and refactors the controllers which use this object (either directly or indirectly).

## Why?

The convention in Scala is to use `Right` as the 'success' condition, as noted in this comment on the `ModelOrResult` object:

https://github.com/guardian/frontend/blame/f5604316a946a4113807de3fe2af74ed79307877/common/app/common/ModelOrResult.scala#L10-L12

As of Scala 2.13 it looks like [treating `Right` as the error case is deprecated](https://github.com/scala/scala/releases/tag/v2.13.0) and elsewhere in Frontend we use `Right` as the success case:

https://github.com/guardian/frontend/blob/0657f594e2fd51125d28df9048c48d6eede26bb6/admin/app/model/deploys/RiffRaff.scala#L49-50

So in accordance with our recommendation to follow [the principle of least surprise](https://github.com/guardian/recommendations/blob/main/coding-with-empathy.md#recommendations) in our code, it makes sense to standardise on the broader convention, where possible. (As much as it pains me, as a left-handed developer 😢😅.)

## Testing

I've done a test deployment in CODE and clicked around a bit, including in apps like Preview which sometimes have surprising dependencies on e.g. Article code. There were no obvious issues, and I'm hoping that this is a case where the type system and tests will give us some security. But having said that, it feels like quite a big (and not-strictly-necessary) change, so I'd appreciate any thoughts about whether we can be confident that won't break anything!