### PR TITLE
Add Ozone user sync iframe

### DIFF
--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -1,10 +1,13 @@
 <html>
 	<body>
 		<iframe
-			src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie-with-consent.html"
-			height="0"
-			width="0"
+			title="User Sync"
+			width="1"
+			height="1"
 			sandbox="allow-scripts allow-same-origin"
+			frameborder="0"
+			src="https://elb.the-ozone-project.com/static/load-cookie.html"
+			id="ozone-load-cookie"
 		></iframe>
 		<iframe
 			src="https://guardian.amp.permutive.com/amp-iframe.html?project=d6691a17-6fdb-4d26-85d6-b3dd27f55f08&key=359ba275-5edd-4756-84f8-21a24369ce0b"


### PR DESCRIPTION
## What does this change?

Remove the old Appnexus user sync iframe for AMP, and replace with the new Ozone one. This is basically copied verbatim from their setup guide, hence why it uses a 1x1 size instead of 0x0 (this is fine anyway as the iframe is hidden 1px above the nav on AMP).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This is required as part of the setup guide for Ozone's server-to-server integration on AMP.

### Tested

- [ ] Locally
- [X] On CODE (optional)

We'll also confirm with Ozone that this works from their end.