### PR TITLE
Don't load commercial JS for users with poor device connectivity

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -159,7 +159,8 @@ const go = () => {
 
 			if (
 				!config.get('switches.commercial') ||
-				config.get('page.isAdFree', false)
+				config.get('page.isAdFree', false) ||
+				config.get('tests.poorDeviceConnectivityVariant') === 'variant'
 			) {
 				return noop();
 			}


### PR DESCRIPTION
## What does this change?

- refactors the commercial JS loading (it was getting a bit hard to follow)
- prevents the commercial JS loading for users identified as having poor device connectivity (PDC)

in reality, the PDC cohort is currently a server-side experiment test group whose behaviour @guardian/open-journalism want to observe. 

we'll be adding/removing features to see if/how they influence behaviour, from a perf point of view.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/7340

