### PR TITLE
Refactor: make use of maybeSection more explicit

### DIFF
--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -26,10 +26,11 @@ private object ItemOrRedirect extends ItemResponses with GuLogging {
 
   def apply[T](item: T, response: ItemResponse, maybeSection: Option[ApiSection])(implicit
       request: RequestHeader,
-  ): Either[T, Result] = {
-
-    maybeSection map redirectSection(item, request) getOrElse redirectArticle(item, response, request)
-  }
+  ): Either[T, Result] =
+    maybeSection match {
+      case Some(section) => redirectSection(item, request, section)
+      case None          => redirectArticle(item, response, request)
+    }
 
   private def redirectArticle[T](item: T, response: ItemResponse, request: RequestHeader): Either[T, Result] = {
     canonicalPath(response) match {
@@ -40,7 +41,7 @@ private object ItemOrRedirect extends ItemResponses with GuLogging {
 
   }
 
-  private def redirectSection[T](item: T, request: RequestHeader)(section: ApiSection): Either[T, Result] = {
+  private def redirectSection[T](item: T, request: RequestHeader, section: ApiSection): Either[T, Result] = {
 
     if (
       request.path.endsWith("/all") &&


### PR DESCRIPTION
Replace mapping over `maybeSection` with a pattern match, and refactor `redirectSection` so that it takes section as an explicit parameter, rather than a curried, implicit one.

I believe that the `match` pattern will be more readable to future developers coming from other languages, and is in line with how we've been writing code elsewhere in Frontend recently.

Combined with making the `section` parameter explicit in `redirectSection`, this should make the use of `maybeSection` clearer to developers who are not immersed in Scala. (Using myself as an example here!)

Co-authored-by: Jacob jacob.winch@guardian.co.uk

cc. @jacobwinch 

## Reproduction in DCR, effects on UI, etc.

This should be a no-op refactor in terms of the actual functionality, so it shouldn't have any up or downstream impacts.

