### PR TITLE
Bump commercial-bundle to `1.4.1` and commercial-core to `5.4.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^10.0.0",
-		"@guardian/commercial-bundle": "^1.4.0",
+		"@guardian/commercial-bundle": "^1.4.1",
 		"@guardian/commercial-core": "^5.4.3",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^10.0.0",
 		"@guardian/commercial-bundle": "^1.4.1",
-		"@guardian/commercial-core": "^5.4.3",
+		"@guardian/commercial-core": "^5.4.4",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",
 		"@guardian/libs": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,10 +2318,10 @@
   dependencies:
     type-fest "2.12.2"
 
-"@guardian/commercial-core@^5.4.3":
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.3.tgz#054d4cfe9cf026e54e73b099ba3cc088cca9ee85"
-  integrity sha512-6uAzzALVa/KQoYu0xpS/IQ6PwIX9S0X3MDkhEwyuVgX33ptO8vGPxJHAuSc9wp0Q3s+nYlSa4xaWGMkiEGcbDQ==
+"@guardian/commercial-core@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.4.tgz#671064c6fb495b6876c43520b6b9d622cd20b450"
+  integrity sha512-mYerRRQ5YXfUr8hINbLn1MEe6JLa0S7E/yAJIfSSVc1TC1BrsZ2LUnZ6rN3ZWy8ktgFLFAWUgJHZgF+dvYF58g==
   dependencies:
     type-fest "2.12.2"
 
@@ -12591,7 +12591,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@github:guardian/prebid.js#2e3b96d":
+prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,10 +2284,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-10.0.0.tgz#9ff9f6e3cfb681f309808c6e47d0e2cf1a012650"
   integrity sha512-cpR3NBmZrUfCvUlBphbVelLAgcuVth4Lo7M1Ohk7dhfgFrocrie/oQT1ZOWX6a90DuAEQZuKTlebmbHJ0XlFcQ==
 
-"@guardian/commercial-bundle@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.4.0.tgz#7653958f38bc90325f4686cf870451e55ddf9904"
-  integrity sha512-Y8FA4+fxbRilCj0S+2MDDyrm0usDUtQgF7wV3bcxDodDNefQsHvzf7vSQF3uSdtpYSNzPsSkTQTQt7u9DOI1Xg==
+"@guardian/commercial-bundle@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.4.1.tgz#e38bdc08981fb38e9d2f89107bb42341b85774b7"
+  integrity sha512-QTdOV8SUFh7MLGQmOWsWyDfhXFNc5lql3sOU8WsGkKXSLmBMMYYRwt+96+JADr7gt7PrmFgP/7swNTiKbIx4jw==
   dependencies:
     "@guardian/ab-core" "^2.0.0"
     "@guardian/commercial-core" "^5.3.0"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/commercial-bundle` to `1.4.1`.

Also, whilst we're here, bump `@guardian/commercial-core` to `5.4.4` (thanks @arelra).

## Why

To get our latest changes from https://github.com/guardian/commercial/pull/818.

