### PR TITLE
use AMIgo recipe `ubuntu-focal-frontend-base-ARM-java11`

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -58,5 +58,5 @@ deployments:
       cloudFormationStackName: frontend
       amiParametersToTags:
         AMI:
-          Recipe: frontend-base-ARM-java11
+          Recipe: ubuntu-focal-frontend-base-ARM-java11
           AmigoStage: PROD


### PR DESCRIPTION
## What does this change?

- updates Frontend's Ubuntu version to Focal (20), using AMIgo recipe [`ubuntu-focal-frontend-base-ARM-java11`](https://amigo.gutools.co.uk/recipes/ubuntu-focal-frontend-base-ARM-java11). The new AMIgo Recipe has some changes:
  - drops `cloud-watch-logs` in favour of `cloud-watch-logs-agent`, because the former is deprecated
  - adds `ubuntu-init`. This was previously included in the base image
  - uses a base image of [`ARM ubuntu-focal (20.04 LTS)`](https://amigo.gutools.co.uk/base-images/ARM%20ubuntu-focal%20(20.04%20LTS))
-  the previous recipe [`frontend-base-ARM-java11`](https://amigo.gutools.co.uk/recipes/frontend-base-ARM-java11) uses Ubuntu 18 (Bionic) which is reaching End of Life soon. This change is part of https://github.com/guardian/dotcom-rendering/issues/7268

## Deployment plan

> **Warning**
> PR https://github.com/guardian/platform/pull/1518 must be merged before this one. It adds support for Python 3 in the instance bootstrap script, which runs each time an instance of a Frontend application is started. The new AMI for Frontend only supports Python 3, and drops support for Python 2.
>
> Merging this PR before the change in Platform results in [failed instance starts](https://riffraff.gutools.co.uk/deployment/view/fc268ba7-c35f-4efa-b2c4-e93b3b3eaae3)

1. Merge https://github.com/guardian/platform/pull/1518
2. Merge this PR

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [x] On CODE (optional)
  - [Successful deploy](https://riffraff.gutools.co.uk/deployment/view/4497635e-e6a1-45d1-9f1e-c464c1412eb3)
