### PR TITLE
Bump `closure-compiler` to latest version

### DIFF
--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -35,9 +35,6 @@ object JsMinifier {
     options.setWarningLevel(DiagnosticGroups.INVALID_CASTS, CheckLevel.WARNING)
     options.setWarningLevel(DiagnosticGroups.CHECK_USELESS_CODE, CheckLevel.WARNING)
 
-    /* Disable some check */
-//    options.setWarningLevel(DiagnosticGroups.ES3, CheckLevel.OFF)
-
     //Aggressive
     //options.setWarningLevel(DiagnosticGroups.DUPLICATE_VARS, CheckLevel.WARNING)
     //options.setWarningLevel(DiagnosticGroups.MISSING_PROPERTIES, CheckLevel.WARNING)

--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -19,11 +19,10 @@ object JsMinifier {
     /* Checks */
     options.setCheckTypes(true)
     options.setCheckSuspiciousCode(true)
-    options.setReportMissingOverride(CheckLevel.WARNING)
-    options.setCheckProvides(CheckLevel.WARNING)
-    options.setCheckGlobalNamesLevel(CheckLevel.WARNING)
-    options.setBrokenClosureRequiresLevel(CheckLevel.WARNING)
-    options.setCheckGlobalThisLevel(CheckLevel.WARNING)
+    options.setStrictModeInput(true)
+    options.setWarningLevel(DiagnosticGroups.MISSING_OVERRIDE, CheckLevel.WARNING)
+    options.setWarningLevel(DiagnosticGroups.MISSING_PROVIDE, CheckLevel.WARNING)
+    options.setWarningLevel(DiagnosticGroups.GLOBAL_THIS, CheckLevel.WARNING)
 
     //Aggressive, you need all JS variable defined somewhere for it not to throw (Such as window or navigator)
     //options.setCheckSymbols(true)
@@ -33,18 +32,17 @@ object JsMinifier {
     options.setWarningLevel(DiagnosticGroups.DEPRECATED_ANNOTATIONS, CheckLevel.WARNING)
     options.setWarningLevel(DiagnosticGroups.DEBUGGER_STATEMENT_PRESENT, CheckLevel.WARNING)
     options.setWarningLevel(DiagnosticGroups.CHECK_REGEXP, CheckLevel.WARNING)
-    options.setWarningLevel(DiagnosticGroups.UNNECESSARY_CASTS, CheckLevel.WARNING)
     options.setWarningLevel(DiagnosticGroups.INVALID_CASTS, CheckLevel.WARNING)
     options.setWarningLevel(DiagnosticGroups.CHECK_USELESS_CODE, CheckLevel.WARNING)
 
     /* Disable some check */
-    options.setWarningLevel(DiagnosticGroups.ES3, CheckLevel.OFF)
+//    options.setWarningLevel(DiagnosticGroups.ES3, CheckLevel.OFF)
 
     //Aggressive
     //options.setWarningLevel(DiagnosticGroups.DUPLICATE_VARS, CheckLevel.WARNING)
     //options.setWarningLevel(DiagnosticGroups.MISSING_PROPERTIES, CheckLevel.WARNING)
 
-    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT6_STRICT)
+    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2016)
     options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT3)
 
     options
@@ -65,8 +63,8 @@ object JsMinifier {
     if (result.warnings.isEmpty && result.errors.isEmpty && result.success) {
       compiler.toSource
     } else {
-      val errors: List[String] = result.errors.map(_.toString).toList
-      val warnings: List[String] = result.warnings.map(_.toString).toList
+      val errors: List[String] = result.errors.toArray().map(_.toString).toList
+      val warnings: List[String] = result.warnings.toArray().map(_.toString).toList
       val errorString: String = s"${errors.mkString("\n")}\n${warnings.mkString("\n")}}"
       throw new RuntimeException(errorString)
     }

--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -39,7 +39,7 @@ object JsMinifier {
     //options.setWarningLevel(DiagnosticGroups.DUPLICATE_VARS, CheckLevel.WARNING)
     //options.setWarningLevel(DiagnosticGroups.MISSING_PROPERTIES, CheckLevel.WARNING)
 
-    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2016)
+    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2015)
     options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT3)
 
     options

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -81,8 +81,8 @@
             return false;
         }
 
-        var now = new Date().getTime();
-        var lastContribution = new Date(value).getTime();
+        var now = new window.Date().getTime();
+        var lastContribution = new window.Date(value).getTime();
         var diffDays = Math.ceil((now - lastContribution) / (1000 * 3600 * 24));
 
         return diffDays <= 180;

--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -31,7 +31,7 @@ function guardianPolyfilled() {
 (function (document, window) {
     var src;
     var script;
-    var pendingScripts = [];
+    var pendingScripts = new window.Array();
     var firstScript = document.scripts[0];
 
     @defining(if(PolyfillIO.isSwitchedOn) {
@@ -39,10 +39,10 @@ function guardianPolyfilled() {
     } else {
       Static("javascripts/vendor/polyfillio.fallback.js")
     }) { polyfillioUrl =>
-        var scripts = [
+        var scripts = new window.Array(
             '@polyfillioUrl',
             '@Static(s"javascripts/graun.$bootModule.js")'
-        ];
+        );
     }
 
     @if(PolyfillIOFallbackMin.isSwitchedOn) {
@@ -50,7 +50,7 @@ function guardianPolyfilled() {
     }
 
     function stateChange() {
-        var pendingScript;
+        var pendingScript = new window.Array();
         while (pendingScripts[0] && pendingScripts[0].readyState == 'loaded') {
             pendingScript = pendingScripts.shift();
             pendingScript.onreadystatechange = null;

--- a/common/app/templates/inlineJS/blocking/polyfills/raf.scala.js
+++ b/common/app/templates/inlineJS/blocking/polyfills/raf.scala.js
@@ -5,18 +5,18 @@
 // requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
 // MIT license
 (function (window) {
-    var lastTime, vendors;
 
     if (!window.requestAnimationFrame) {
-        lastTime = 0;
-        vendors = ['ms', 'moz', 'webkit', 'o'];
+        var vendors = new window.Array('ms', 'moz', 'webkit', 'o');
+        var lastTime = 0;
+
         for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
             window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
             window.cancelAnimationFrame = window[vendors[x]+'CancelAnimationFrame'] || window[vendors[x]+'CancelRequestAnimationFrame'];
         }
 
         window.requestAnimationFrame = function(callback, element) {
-            var currTime = new Date().getTime();
+            var currTime = new window.Date().getTime();
             var timeToCall = Math.max(0, 16 - (currTime - lastTime));
             var id = window.setTimeout(function() { callback(currTime + timeToCall); },
               timeToCall);

--- a/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
+++ b/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
@@ -48,7 +48,7 @@
     // Old here means iOS 3-7.
     // For usage stats see http://david-smith.org/iosversionstats/
     function isOlderIOSDevice() {
-        return /.*(iPhone|iPad|iPod; CPU) OS ([34567])_\d+.*/.test(navigator.userAgent);
+        return (new window.RegExp(/.*(iPhone|iPad|iPod; CPU) OS ([34567])_\d+.*/)).test(navigator.userAgent);
     };
 
     function isIpad() {

--- a/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js
@@ -14,8 +14,9 @@ try {
 
             // Short version of cookie.get(), inspired by Google Analytics' code
             var cookieData = (function(a) {
-                var d = [],
-                    e = document.cookie.split(";");
+                var d = new window.Array(),
+                    e = new window.Array();
+                e = document.cookie.split(";");
                 a = RegExp("^\\s*" + a + "=\\s*(.*?)\\s*$");
                 for (var b = 0; b < e.length; b++) {
                     var f = e[b].match(a);

--- a/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js
@@ -3,7 +3,7 @@
 (function (window, document) {
 
     function getCookieValue(name) {
-        var nameEq = name + "=",
+        var nameEq = new window.String(name + "="),
             cookies = document.cookie.split(';'),
             value = null;
         cookies.forEach(function (cookie) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val awsSqs = "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion
   val awsSsm = "com.amazonaws" % "aws-java-sdk-ssm" % awsVersion
   val awsElasticloadbalancing = "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion
-  val closureCompiler = "com.google.javascript" % "closure-compiler" % "v20150901"
+  val closureCompiler = "com.google.javascript" % "closure-compiler" % "v20230228"
   val commonsHttpClient = "commons-httpclient" % "commons-httpclient" % "3.1"
   val commonsLang = "commons-lang" % "commons-lang" % "2.6"
   val commonsIo = "commons-io" % "commons-io" % "2.5"


### PR DESCRIPTION
## What does this change?
`closure-compiler` is used to compile and optimise the JavaScript from the twirl templates. This PR bumps it to the latest version and gets rid of 3 vulnerabilities coming from the version of `com.google.protobuf:protobuf-java` this library was using.

Co-authored-by: JamieB-gu<53781962+JamieB-gu@users.noreply.github.com>
Co-authored-by: Alex Sanders<alex.sanders@guardian.co.uk>

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
