### PR TITLE
Bump commercial-bundle to `1.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^10.0.0",
 		"@guardian/commercial-bundle": "1.5.0",
-		"@guardian/commercial-core": "^5.4.4",
+		"@guardian/commercial-core": "5.4.4",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",
 		"@guardian/libs": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^10.0.0",
-		"@guardian/commercial-bundle": "^1.4.1",
+		"@guardian/commercial-bundle": "1.5.0",
 		"@guardian/commercial-core": "^5.4.4",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,10 +2284,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-10.0.0.tgz#9ff9f6e3cfb681f309808c6e47d0e2cf1a012650"
   integrity sha512-cpR3NBmZrUfCvUlBphbVelLAgcuVth4Lo7M1Ohk7dhfgFrocrie/oQT1ZOWX6a90DuAEQZuKTlebmbHJ0XlFcQ==
 
-"@guardian/commercial-bundle@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.4.1.tgz#e38bdc08981fb38e9d2f89107bb42341b85774b7"
-  integrity sha512-QTdOV8SUFh7MLGQmOWsWyDfhXFNc5lql3sOU8WsGkKXSLmBMMYYRwt+96+JADr7gt7PrmFgP/7swNTiKbIx4jw==
+"@guardian/commercial-bundle@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.5.0.tgz#bd46249e388c200bf98e996f78572683589a4dc9"
+  integrity sha512-TohGpXv16M6lrKyZTH5/xGtPqkI4Zzm6WJLPVdJwr/U+vFxhLGhnECZZ8U+bXGvn7mF2e9hjofg6/9WuXR9tUA==
   dependencies:
     "@guardian/ab-core" "^2.0.0"
     "@guardian/commercial-core" "^5.3.0"
@@ -2312,11 +2312,9 @@
     wolfy87-eventemitter "^5.2.9"
 
 "@guardian/commercial-core@^5.3.0":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.2.tgz#1c07bf0655d5dadc015ef6d54e7f40a864e83562"
-  integrity sha512-jy59ewwnJ3210gh7OSuYe2E0z6wQcWcDvDzG96tfvhvKaA0j35YW3Mex7/WkvBIRgOoBIGFLi3pvEjIja5Qa4Q==
-  dependencies:
-    type-fest "2.12.2"
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.5.tgz#2a2fa51b3c06e193f5ffb685a28ffc4b9788eeed"
+  integrity sha512-06HK6V4fOpe9JSsV+hCzSgAmlSHSojTs0U7zEvDsfPCeGEWUjSrAsesmJ2EeM8oxpQZbNt8EL8Kxzn32QMCO4g==
 
 "@guardian/commercial-core@^5.4.4":
   version "5.4.4"
@@ -12591,7 +12589,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-prebid.js@guardian/prebid.js#2e3b96d:
+"prebid.js@github:guardian/prebid.js#2e3b96d":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2311,17 +2311,17 @@
     web-vitals "^2.1.2"
     wolfy87-eventemitter "^5.2.9"
 
-"@guardian/commercial-core@^5.3.0":
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.5.tgz#2a2fa51b3c06e193f5ffb685a28ffc4b9788eeed"
-  integrity sha512-06HK6V4fOpe9JSsV+hCzSgAmlSHSojTs0U7zEvDsfPCeGEWUjSrAsesmJ2EeM8oxpQZbNt8EL8Kxzn32QMCO4g==
-
-"@guardian/commercial-core@^5.4.4":
+"@guardian/commercial-core@5.4.4":
   version "5.4.4"
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.4.tgz#671064c6fb495b6876c43520b6b9d622cd20b450"
   integrity sha512-mYerRRQ5YXfUr8hINbLn1MEe6JLa0S7E/yAJIfSSVc1TC1BrsZ2LUnZ6rN3ZWy8ktgFLFAWUgJHZgF+dvYF58g==
   dependencies:
     type-fest "2.12.2"
+
+"@guardian/commercial-core@^5.3.0":
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.5.tgz#2a2fa51b3c06e193f5ffb685a28ffc4b9788eeed"
+  integrity sha512-06HK6V4fOpe9JSsV+hCzSgAmlSHSojTs0U7zEvDsfPCeGEWUjSrAsesmJ2EeM8oxpQZbNt8EL8Kxzn32QMCO4g==
 
 "@guardian/consent-management-platform@11.0.0":
   version "11.0.0"
@@ -12589,7 +12589,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@github:guardian/prebid.js#2e3b96d":
+prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?

Bump commercial-bundle to `1.5.0`.

I've purposefully dropped the caret here to avoid upgrading to `1.5.1`, which we'll upgrade separately, as it may contain a breaking TypeScript change.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)