### PR TITLE
Bump deps commercial, guardian and typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^10.0.0",
-		"@guardian/commercial-bundle": "^1.4.1",
+		"@guardian/commercial-bundle": "^1.5.1",
 		"@guardian/commercial-core": "^5.4.4",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
 		"tcp-ping": "^0.1.1",
 		"ts-jest": "^26.4.4",
 		"ts-loader": "^8.0.12",
-		"typescript": "^4.1.3",
+		"typescript": "~4.9.5",
 		"uglify-js": "^2.7.4",
 		"uglifyjs-webpack-plugin": "^1.2.5",
 		"webpack": "^4.46.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@guardian/commercial-bundle": "^1.5.1",
 		"@guardian/commercial-core": "^5.4.5",
 		"@guardian/consent-management-platform": "^11.0.0",
-		"@guardian/core-web-vitals": "^2.0.1",
+		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"@emotion/core": "^10.0.27",
 		"@emotion/react": "^11.1.5",
 		"@emotion/styled": "^10.0.27",
-		"@guardian/ab-core": "^2.0.0",
+		"@guardian/ab-core": "^4.0.0",
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@guardian/braze-components": "^10.0.0",
 		"@guardian/commercial-bundle": "^1.5.1",
 		"@guardian/commercial-core": "^5.4.5",
-		"@guardian/consent-management-platform": "^10.11.1",
+		"@guardian/consent-management-platform": "^11.0.0",
 		"@guardian/core-web-vitals": "^2.0.1",
 		"@guardian/libs": "^14.0.0",
 		"@guardian/shimport": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@guardian/commercial-core": "^5.4.5",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",
-		"@guardian/libs": "^13.1.0",
+		"@guardian/libs": "^14.0.0",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "^9.0.0",
 		"@guardian/source-react-components": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^10.0.0",
 		"@guardian/commercial-bundle": "^1.5.1",
-		"@guardian/commercial-core": "^5.4.4",
+		"@guardian/commercial-core": "^5.4.5",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/core-web-vitals": "^2.0.1",
 		"@guardian/libs": "^13.1.0",

--- a/static/src/javascripts/lib/detect-breakpoint.spec.ts
+++ b/static/src/javascripts/lib/detect-breakpoint.spec.ts
@@ -99,7 +99,6 @@ describe('getCurrentBreakpoint', () => {
 	it.each(widths)(
 		'For %f, gets the correct breakpoint: %s',
 		(width, breakpoint) => {
-			// @ts-expect-error -- not read-only in test
 			window.innerWidth = width;
 			expect(getCurrentBreakpoint()).toEqual(breakpoint);
 		},
@@ -135,9 +134,7 @@ describe('getCurrentTweakpoint', () => {
 	it.each(tweakpointsWidths)(
 		'For %f, gets the correct tweakpoint: %s',
 		(width, tweakpoint) => {
-			// @ts-expect-error -- not read-only in test
 			window.innerWidth = width;
-
 			expect(getCurrentTweakpoint()).toEqual(tweakpoint);
 		},
 	);

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.ts
@@ -38,6 +38,8 @@ type PermutiveSchema = {
 	};
 };
 
+type PermutiveConfigValue = string | string[] | boolean | null | undefined;
+
 const isEmpty = (
 	value:
 		| boolean
@@ -64,7 +66,7 @@ const removeEmpty = <
 		if (typeof payload[key] === 'object') {
 			removeEmpty(payload[key]);
 		}
-		if (isEmpty(payload[key])) {
+		if (isEmpty(payload[key] as PermutiveConfigValue)) {
 			delete payload[key];
 		}
 	}

--- a/static/src/javascripts/projects/common/modules/experiments/__fixtures__/ab-test.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/__fixtures__/ab-test.ts
@@ -36,7 +36,7 @@ export const genAbTest = (
 export const genRunnableAbTestWhereControlIsRunnable = (
 	id: string,
 	canRun?: boolean,
-): Runnable => {
+): Runnable<ABTest> => {
 	const abTest = genAbTest(id, canRun);
 	return { ...abTest, variantToRun: abTest.variants[0] };
 };
@@ -44,7 +44,7 @@ export const genRunnableAbTestWhereControlIsRunnable = (
 export const genRunnableAbTestWhereVariantIsRunnable = (
 	id: string,
 	canRun?: boolean,
-): Runnable => {
+): Runnable<ABTest> => {
 	const abTest = genAbTest(id, canRun);
 	return { ...abTest, variantToRun: abTest.variants[1] };
 };

--- a/static/src/javascripts/projects/common/modules/experiments/ab-core.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-core.ts
@@ -88,12 +88,17 @@ export const runnableTest = (test: ABTest): Runnable<ABTest> | null => {
 export const allRunnableTests = (
 	tests: readonly ABTest[],
 ): ReadonlyArray<Runnable<ABTest>> =>
-	tests.reduce<ReadonlyArray<Runnable<ABTest>>>((accumulator, currentValue) => {
-		const rt = runnableTest(currentValue);
-		return rt ? [...accumulator, rt] : accumulator;
-	}, []);
+	tests.reduce<ReadonlyArray<Runnable<ABTest>>>(
+		(accumulator, currentValue) => {
+			const rt = runnableTest(currentValue);
+			return rt ? [...accumulator, rt] : accumulator;
+		},
+		[],
+	);
 
-export const firstRunnableTest = (tests: readonly ABTest[]): Runnable<ABTest> | null =>
+export const firstRunnableTest = (
+	tests: readonly ABTest[],
+): Runnable<ABTest> | null =>
 	tests
 		.map((test: ABTest) => runnableTest(test))
 		.find((rt?: Runnable<ABTest> | null) => rt !== null) ?? null;

--- a/static/src/javascripts/projects/common/modules/experiments/ab-core.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-core.ts
@@ -67,7 +67,7 @@ const computeVariantFromMvtCookie = (test: ABTest): Variant | null => {
 //
 // This function can be called at any time, before or after participations are
 // persisted to localStorage. It should always give the same result for a given pageview.
-export const runnableTest = (test: ABTest): Runnable | null => {
+export const runnableTest = (test: ABTest): Runnable<ABTest> | null => {
 	const fromUrl = getVariantFromUrl(test);
 	const fromLocalStorage = getVariantFromLocalStorage(test);
 	const fromCookie = computeVariantFromMvtCookie(test);
@@ -87,13 +87,13 @@ export const runnableTest = (test: ABTest): Runnable | null => {
 
 export const allRunnableTests = (
 	tests: readonly ABTest[],
-): readonly Runnable[] =>
-	tests.reduce<readonly Runnable[]>((accumulator, currentValue) => {
+): ReadonlyArray<Runnable<ABTest>> =>
+	tests.reduce<ReadonlyArray<Runnable<ABTest>>>((accumulator, currentValue) => {
 		const rt = runnableTest(currentValue);
 		return rt ? [...accumulator, rt] : accumulator;
 	}, []);
 
-export const firstRunnableTest = (tests: readonly ABTest[]): Runnable | null =>
+export const firstRunnableTest = (tests: readonly ABTest[]): Runnable<ABTest> | null =>
 	tests
 		.map((test: ABTest) => runnableTest(test))
-		.find((rt?: Runnable | null) => rt !== null) ?? null;
+		.find((rt?: Runnable<ABTest> | null) => rt !== null) ?? null;

--- a/static/src/javascripts/projects/common/modules/experiments/ab-ophan.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-ophan.ts
@@ -64,7 +64,7 @@ const buildOphanSubmitter = (
  */
 const registerCompleteEvent =
 	(complete: boolean) =>
-	(test: Runnable): void => {
+	(test: Runnable<ABTest>): void => {
 		const variant = test.variantToRun;
 		const listener =
 			(complete ? variant.success : variant.impression) ?? noop;
@@ -76,14 +76,14 @@ const registerCompleteEvent =
 		}
 	};
 
-export const registerCompleteEvents = (tests: readonly Runnable[]): void =>
+export const registerCompleteEvents = (tests: ReadonlyArray<Runnable<ABTest>>): void =>
 	tests.forEach(registerCompleteEvent(true));
 
-export const registerImpressionEvents = (tests: readonly Runnable[]): void =>
+export const registerImpressionEvents = (tests: ReadonlyArray<Runnable<ABTest>>): void =>
 	tests.filter(defersImpression).forEach(registerCompleteEvent(false));
 
 export const buildOphanPayload = (
-	tests: readonly Runnable[],
+	tests: ReadonlyArray<Runnable<ABTest>>,
 ): OphanABPayload => {
 	try {
 		const testsConfig = window.guardian.config.tests ?? {};
@@ -112,6 +112,6 @@ export const buildOphanPayload = (
 		return {};
 	}
 };
-export const trackABTests = (tests: readonly Runnable[]): void =>
+export const trackABTests = (tests: ReadonlyArray<Runnable<ABTest>>): void =>
 	submit(buildOphanPayload(tests));
 export { buildOphanSubmitter };

--- a/static/src/javascripts/projects/common/modules/experiments/ab-ophan.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-ophan.ts
@@ -76,11 +76,13 @@ const registerCompleteEvent =
 		}
 	};
 
-export const registerCompleteEvents = (tests: ReadonlyArray<Runnable<ABTest>>): void =>
-	tests.forEach(registerCompleteEvent(true));
+export const registerCompleteEvents = (
+	tests: ReadonlyArray<Runnable<ABTest>>,
+): void => tests.forEach(registerCompleteEvent(true));
 
-export const registerImpressionEvents = (tests: ReadonlyArray<Runnable<ABTest>>): void =>
-	tests.filter(defersImpression).forEach(registerCompleteEvent(false));
+export const registerImpressionEvents = (
+	tests: ReadonlyArray<Runnable<ABTest>>,
+): void => tests.filter(defersImpression).forEach(registerCompleteEvent(false));
 
 export const buildOphanPayload = (
 	tests: ReadonlyArray<Runnable<ABTest>>,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-utils.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-utils.ts
@@ -17,7 +17,7 @@ export const isTestSwitchedOn = (testId: string): boolean =>
 	!!window.guardian.config.switches[`ab${testId}`];
 
 export const runnableTestsToParticipations = (
-	runnableTests: readonly Runnable[],
+	runnableTests: ReadonlyArray<Runnable<ABTest>>,
 ): Participations =>
 	runnableTests.reduce(
 		(participations: Participations, { id: testId, variantToRun }) => ({

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.ts
@@ -1,4 +1,4 @@
-import type { Runnable } from '@guardian/ab-core';
+import type { ABTest, Runnable } from '@guardian/ab-core';
 import {
 	getAsyncTestsToRun,
 	getSynchronousTestsToRun,
@@ -271,7 +271,7 @@ describe('A/B', () => {
 				...expectedSynchronousTestsToRun,
 			};
 
-			const checkTests = (tests: readonly Runnable[]) =>
+			const checkTests = (tests: ReadonlyArray<Runnable<ABTest>>) =>
 				expect(runnableTestsToParticipations(tests)).toEqual(
 					expectedTestsToRun,
 				);

--- a/static/src/javascripts/projects/common/modules/experiments/ab.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.ts
@@ -25,8 +25,9 @@ import {
 export const getSynchronousTestsToRun = memoize(() =>
 	allRunnableTests(concurrentTests),
 );
-export const getAsyncTestsToRun = (): Promise<ReadonlyArray<Runnable<ABTest>>> =>
-	Promise.all([]).then((tests) => tests.filter(Boolean));
+export const getAsyncTestsToRun = (): Promise<
+	ReadonlyArray<Runnable<ABTest>>
+> => Promise.all([]).then((tests) => tests.filter(Boolean));
 
 // This excludes epic & banner tests
 export const getSynchronousParticipations = (): Participations =>

--- a/static/src/javascripts/projects/common/modules/experiments/ab.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.ts
@@ -25,7 +25,7 @@ import {
 export const getSynchronousTestsToRun = memoize(() =>
 	allRunnableTests(concurrentTests),
 );
-export const getAsyncTestsToRun = (): Promise<readonly Runnable[]> =>
+export const getAsyncTestsToRun = (): Promise<ReadonlyArray<Runnable<ABTest>>> =>
 	Promise.all([]).then((tests) => tests.filter(Boolean));
 
 // This excludes epic & banner tests

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,6 +2247,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
   integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
 
+"@guardian/ab-core@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-4.0.0.tgz#50c1fc076437e594b367f6e8d9469a3d9b97a78e"
+  integrity sha512-l6Ot/anisLKyoLZOp8koW7Ia5JFOtmZkB0sfgdWajv5+N0w0UScUVoImEdPlFstM1anSd3FvV8D3UgYkRzAang==
+
 "@guardian/atom-renderer@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.2.2.tgz#db10b98ed73636c4bd6941ec103c9f60ff15549e"
@@ -2284,25 +2289,21 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-10.0.0.tgz#9ff9f6e3cfb681f309808c6e47d0e2cf1a012650"
   integrity sha512-cpR3NBmZrUfCvUlBphbVelLAgcuVth4Lo7M1Ohk7dhfgFrocrie/oQT1ZOWX6a90DuAEQZuKTlebmbHJ0XlFcQ==
 
-"@guardian/commercial-bundle@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.4.1.tgz#e38bdc08981fb38e9d2f89107bb42341b85774b7"
-  integrity sha512-QTdOV8SUFh7MLGQmOWsWyDfhXFNc5lql3sOU8WsGkKXSLmBMMYYRwt+96+JADr7gt7PrmFgP/7swNTiKbIx4jw==
+"@guardian/commercial-bundle@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.5.1.tgz#2b6f4c69de5e4f07117c72dd284547e82ab9b858"
+  integrity sha512-2+vVfzMAbrk41OlAHjvw3AWKESC42KtrldiYLgKDWJ3WfhskEByZR0vYfH1AQH9gUhDF2vPI3GdR1l8IldecmQ==
   dependencies:
-    "@guardian/ab-core" "^2.0.0"
-    "@guardian/commercial-core" "^5.3.0"
+    "@guardian/ab-core" "^4.0.0"
+    "@guardian/commercial-core" "^5.4.4"
     "@guardian/consent-management-platform" "11.0.0"
-    "@guardian/core-web-vitals" "^1.0.0"
-    "@guardian/eslint-config-typescript" "^3.0.0"
-    "@guardian/libs" "^10.0.0"
-    "@guardian/prettier" "^2.1.1"
-    "@guardian/source-foundations" "^9.0.0"
+    "@guardian/core-web-vitals" "^4.0.0"
+    "@guardian/libs" "^14.0.0"
+    "@guardian/source-foundations" "^10.0.1"
     "@guardian/support-dotcom-components" "^1.0.7"
     "@octokit/core" "^4.0.5"
-    csstype "^3.1.1"
     fastdom "^1.0.11"
     lodash-es "^4.17.21"
-    madge "^5.0.1"
     ophan-tracker-js "^1.4.0"
     prebid.js guardian/prebid.js#2e3b96d
     process "^0.11.10"
@@ -2310,13 +2311,6 @@
     tslib "^2.4.1"
     web-vitals "^2.1.2"
     wolfy87-eventemitter "^5.2.9"
-
-"@guardian/commercial-core@^5.3.0":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.2.tgz#1c07bf0655d5dadc015ef6d54e7f40a864e83562"
-  integrity sha512-jy59ewwnJ3210gh7OSuYe2E0z6wQcWcDvDzG96tfvhvKaA0j35YW3Mex7/WkvBIRgOoBIGFLi3pvEjIja5Qa4Q==
-  dependencies:
-    type-fest "2.12.2"
 
 "@guardian/commercial-core@^5.4.4":
   version "5.4.4"
@@ -2337,15 +2331,15 @@
   dependencies:
     "@guardian/libs" "^7.1.4"
 
-"@guardian/core-web-vitals@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-1.0.1.tgz#f3bbf7e60a82d988228698f054664cadc9cd0886"
-  integrity sha512-F7vCWwXA5YbSEEMcn28+Xe6pXLCqqFA5h6E+pzvmLyL21y7v5UsAU+A59BB7k3yJLaFXyYi3sSRXxXGPxkCvog==
-
 "@guardian/core-web-vitals@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-2.0.1.tgz#b04f12ff36f66db800a68b81b65eedfc86289211"
   integrity sha512-xm5oDtRBu37KPmiT61z+E/Wz3HHifayJjVMwd/nfLxNRd1eFOVmplaeTDtygGKy4KjIwX90R5j/Sjs9apTVnLA==
+
+"@guardian/core-web-vitals@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-4.0.0.tgz#e09bf40ee896ae92c0223fa57399b1b0b5f9bdb2"
+  integrity sha512-LDXnDhsNApO9v8LrXPK1AHMZYoa457tYjqjHnXNSxleHHoyeS3ehB4qohdDMpWv76F8DLUVMXBTZ/8EbQce3sA==
 
 "@guardian/eslint-config-typescript@^0.7.0":
   version "0.7.0"
@@ -2355,27 +2349,6 @@
     "@guardian/eslint-config" "^0.7.0"
     "@typescript-eslint/eslint-plugin" "4.29.2"
     "@typescript-eslint/parser" "4.29.2"
-
-"@guardian/eslint-config-typescript@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/eslint-config-typescript/-/eslint-config-typescript-3.0.0.tgz#0902bc55db40fff835d00d0b6d381eadebd72ac1"
-  integrity sha512-CTVAgD2L/pZ3r2AxGyb0HiEb8AZXETLEximFTgUMoaqnHzGDCUw3iB1oJ6lrDZvX4mQQgdJoSg/iiCn9SLXfeA==
-  dependencies:
-    "@guardian/eslint-config" "2.0.3"
-    "@typescript-eslint/eslint-plugin" "5.45.0"
-    "@typescript-eslint/parser" "5.45.0"
-    eslint-import-resolver-typescript "3.5.2"
-    eslint-plugin-import "2.26.0"
-    typescript "4.2.2"
-
-"@guardian/eslint-config@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-2.0.3.tgz#ad4447a1789a11dc76e2fb99e03eda48938deb84"
-  integrity sha512-28LdijL5IVn5jsWo3KEZxNxD25v3T3fh52P9OEfPSbbufuprEfdfPBZECE+kna5OTWm8pecW8VCOeJ2mi8awDA==
-  dependencies:
-    eslint-config-prettier "8.5.0"
-    eslint-plugin-eslint-comments "3.2.0"
-    eslint-plugin-import "2.26.0"
 
 "@guardian/eslint-config@^0.7.0":
   version "0.7.0"
@@ -2397,12 +2370,17 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-13.1.0.tgz#5a7a0ec9e2d432fc3176884072b9c7c22a00a95b"
   integrity sha512-iffG2zIDmMtIHSesClxmimZIwAce3IBbSEihX0IRK65Lm2TSIfsb8ZRFRsMYDW+GE2h3yKFuU8tqVKvQXpzXQg==
 
+"@guardian/libs@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.0.0.tgz#07022b652430a1c5d6b16f8aa105ae3d73da4e7c"
+  integrity sha512-rB4h4FlD3EcoCY66f3xjO7alnXiimPOynL9znvX/xP2nAVpG4UyedJnIpupw4KPqJuB0lZMih6EeXq0a1XnI3w==
+
 "@guardian/libs@^7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
   integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
 
-"@guardian/prettier@^2.1.1", "@guardian/prettier@^2.1.5":
+"@guardian/prettier@^2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-2.1.5.tgz#715fff5b110006408f92a3fe2a803ad0e4c79e06"
   integrity sha512-4fehERf5HHS9Nkaw+4u5EZ1OrFEHL4lYhLUWkpwEx4VmHI+RgcMezfDfosb3TD8cPFCKakrpdQEJUwNP283SJw==
@@ -2413,6 +2391,13 @@
   integrity sha512-o35TxvMFfpQTGL6flW0ggIfU4tPlXp0PqY9vPL2Fx+68qy+s+uX4T0+dN3+JeoBad9QrRZoHfZPALvZlrRWfHw==
   dependencies:
     tslib "^2.0.0"
+
+"@guardian/source-foundations@^10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-10.0.1.tgz#fe9d5d1bee9dd1b0d3d579d21a99f6051aa47649"
+  integrity sha512-q7FHvQO2JN463SHRjLNKeywW8KUfjoao6oiULoyHssI07saol2rE0W8BdPCeD9337FNztiOxMGOmXWSBUIdYJw==
+  dependencies:
+    mini-svg-data-uri "1.4.4"
 
 "@guardian/source-foundations@^9.0.0":
   version "9.0.1"
@@ -2981,18 +2966,6 @@
   resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.6.3.tgz#3a21fc90578d682c7cc36ecb5487664a026a4ca0"
   integrity sha512-Q3x88t04BYd9glJYAClm/B0FMhEEIj69ExKQhbCjXWVuH7M5gvRdfImNiZQq5QevgeYcKwhPmO2CEkYhTO5Vig==
 
-"@pkgr/utils@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.1.tgz#0a9b06ffddee364d6642b3cd562ca76f55b34a03"
-  integrity sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==
-  dependencies:
-    cross-spawn "^7.0.3"
-    is-glob "^4.0.3"
-    open "^8.4.0"
-    picocolors "^1.0.0"
-    tiny-glob "^0.2.9"
-    tslib "^2.4.0"
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
@@ -3268,11 +3241,6 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/semver@^7.3.12":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
-
 "@types/serve-index@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"
@@ -3359,21 +3327,6 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/eslint-plugin@5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.0.tgz#ffa505cf961d4844d38cfa19dcec4973a6039e41"
-  integrity sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.45.0"
-    "@typescript-eslint/type-utils" "5.45.0"
-    "@typescript-eslint/utils" "5.45.0"
-    debug "^4.3.4"
-    ignore "^5.2.0"
-    natural-compare-lite "^1.4.0"
-    regexpp "^3.2.0"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
-
 "@typescript-eslint/eslint-plugin@^4.12.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
@@ -3422,16 +3375,6 @@
     "@typescript-eslint/typescript-estree" "4.29.2"
     debug "^4.3.1"
 
-"@typescript-eslint/parser@5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.45.0.tgz#b18a5f6b3cf1c2b3e399e9d2df4be40d6b0ddd0e"
-  integrity sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.45.0"
-    "@typescript-eslint/types" "5.45.0"
-    "@typescript-eslint/typescript-estree" "5.45.0"
-    debug "^4.3.4"
-
 "@typescript-eslint/parser@^4.12.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
@@ -3458,24 +3401,6 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
-"@typescript-eslint/scope-manager@5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.45.0.tgz#7a4ac1bfa9544bff3f620ab85947945938319a96"
-  integrity sha512-noDMjr87Arp/PuVrtvN3dXiJstQR1+XlQ4R1EvzG+NMgXi8CuMCXpb8JqNtFHKceVSQ985BZhfRdowJzbv4yKw==
-  dependencies:
-    "@typescript-eslint/types" "5.45.0"
-    "@typescript-eslint/visitor-keys" "5.45.0"
-
-"@typescript-eslint/type-utils@5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.45.0.tgz#aefbc954c40878fcebeabfb77d20d84a3da3a8b2"
-  integrity sha512-DY7BXVFSIGRGFZ574hTEyLPRiQIvI/9oGcN8t1A7f6zIs6ftbrU0nhyV26ZW//6f85avkwrLag424n+fkuoJ1Q==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "5.45.0"
-    "@typescript-eslint/utils" "5.45.0"
-    debug "^4.3.4"
-    tsutils "^3.21.0"
-
 "@typescript-eslint/types@4.29.2":
   version "4.29.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.2.tgz#fc0489c6b89773f99109fb0aa0aaddff21f52fcd"
@@ -3485,11 +3410,6 @@
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
-
-"@typescript-eslint/types@5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.45.0.tgz#794760b9037ee4154c09549ef5a96599621109c5"
-  integrity sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==
 
 "@typescript-eslint/typescript-estree@4.29.2":
   version "4.29.2"
@@ -3517,33 +3437,6 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.0.tgz#f70a0d646d7f38c0dfd6936a5e171a77f1e5291d"
-  integrity sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==
-  dependencies:
-    "@typescript-eslint/types" "5.45.0"
-    "@typescript-eslint/visitor-keys" "5.45.0"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/utils@5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.45.0.tgz#9cca2996eee1b8615485a6918a5c763629c7acf5"
-  integrity sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==
-  dependencies:
-    "@types/json-schema" "^7.0.9"
-    "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.45.0"
-    "@typescript-eslint/types" "5.45.0"
-    "@typescript-eslint/typescript-estree" "5.45.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-    semver "^7.3.7"
-
 "@typescript-eslint/visitor-keys@4.29.2":
   version "4.29.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.2.tgz#d2da7341f3519486f50655159f4e5ecdcb2cd1df"
@@ -3559,14 +3452,6 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
-
-"@typescript-eslint/visitor-keys@5.45.0":
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.0.tgz#e0d160e9e7fdb7f8da697a5b78e7a14a22a70528"
-  integrity sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==
-  dependencies:
-    "@typescript-eslint/types" "5.45.0"
-    eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -6157,11 +6042,6 @@ csstype@^3.0.2, csstype@^3.0.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
   integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
 
-csstype@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
-  integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
-
 curl@cujojs/curl#0.8.9:
   version "0.8.9"
   resolved "https://codeload.github.com/cujojs/curl/tar.gz/261841045bc488c438d34347b588adfc1855faf1"
@@ -6295,13 +6175,6 @@ debug@^4.3.2:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -6890,14 +6763,6 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.10.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
-  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
-
 enhanced-resolve@^5.3.2:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
@@ -7109,11 +6974,6 @@ eslint-config-prettier@8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
-eslint-config-prettier@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
-  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
-
 eslint-config-prettier@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
@@ -7126,19 +6986,6 @@ eslint-import-resolver-node@^0.3.5, eslint-import-resolver-node@^0.3.6:
   dependencies:
     debug "^3.2.7"
     resolve "^1.20.0"
-
-eslint-import-resolver-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.2.tgz#9431acded7d898fd94591a08ea9eec3514c7de91"
-  integrity sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==
-  dependencies:
-    debug "^4.3.4"
-    enhanced-resolve "^5.10.0"
-    get-tsconfig "^4.2.0"
-    globby "^13.1.2"
-    is-core-module "^2.10.0"
-    is-glob "^4.0.3"
-    synckit "^0.8.4"
 
 eslint-import-resolver-webpack@^0.13.0:
   version "0.13.2"
@@ -7165,13 +7012,6 @@ eslint-module-utils@^2.6.2, eslint-module-utils@^2.7.1:
     debug "^3.2.7"
     find-up "^2.1.0"
     pkg-dir "^2.0.0"
-
-eslint-module-utils@^2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
-  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
-  dependencies:
-    debug "^3.2.7"
 
 eslint-plugin-cypress@^2.12.1:
   version "2.12.1"
@@ -7211,25 +7051,6 @@ eslint-plugin-import@2.24.0:
     read-pkg-up "^3.0.0"
     resolve "^1.20.0"
     tsconfig-paths "^3.9.0"
-
-eslint-plugin-import@2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
-  integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
-  dependencies:
-    array-includes "^3.1.4"
-    array.prototype.flat "^1.2.5"
-    debug "^2.6.9"
-    doctrine "^2.1.0"
-    eslint-import-resolver-node "^0.3.6"
-    eslint-module-utils "^2.7.3"
-    has "^1.0.3"
-    is-core-module "^2.8.1"
-    is-glob "^4.0.3"
-    minimatch "^3.1.2"
-    object.values "^1.1.5"
-    resolve "^1.22.0"
-    tsconfig-paths "^3.14.1"
 
 eslint-plugin-import@^2.22.1:
   version "2.25.3"
@@ -7351,11 +7172,6 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
-
-eslint-visitor-keys@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
-  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^2.7.0:
   version "2.13.1"
@@ -8475,11 +8291,6 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-get-tsconfig@^4.2.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.4.0.tgz#64eee64596668a81b8fce18403f94f245ee0d4e5"
-  integrity sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==
-
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -8594,12 +8405,7 @@ globals@^9.2.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
-globalyzer@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.0.tgz#cb76da79555669a1519d5a8edf093afaa0bf1465"
-  integrity sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==
-
-globby@^11.0.1, globby@^11.1.0:
+globby@^11.0.1:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -8622,17 +8428,6 @@ globby@^11.0.3:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
-
-globby@^13.1.2:
-  version "13.1.3"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.3.tgz#f62baf5720bcb2c1330c8d4ef222ee12318563ff"
-  integrity sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==
-  dependencies:
-    dir-glob "^3.0.1"
-    fast-glob "^3.2.11"
-    ignore "^5.2.0"
-    merge2 "^1.4.1"
-    slash "^4.0.0"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -8659,11 +8454,6 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
-
-globrex@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
-  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 globule@^1.0.0:
   version "1.3.3"
@@ -9429,13 +9219,6 @@ is-ci@^3.0.0:
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
   dependencies:
     ci-info "^3.2.0"
-
-is-core-module@^2.10.0, is-core-module@^2.8.1:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
-  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
-  dependencies:
-    has "^1.0.3"
 
 is-core-module@^2.2.0, is-core-module@^2.4.0, is-core-module@^2.7.0, is-core-module@^2.8.0:
   version "2.8.0"
@@ -10432,13 +10215,6 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
-  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
-  dependencies:
-    minimist "^1.2.0"
-
 json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -11244,13 +11020,6 @@ minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimist@1.1.x:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
@@ -11466,11 +11235,6 @@ natives@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
   integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
-
-natural-compare-lite@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
-  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -11875,15 +11639,6 @@ open@^8.0.9:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
   integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
-  dependencies:
-    define-lazy-prop "^2.0.0"
-    is-docker "^2.1.1"
-    is-wsl "^2.2.0"
-
-open@^8.4.0:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
-  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
   dependencies:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
@@ -12591,7 +12346,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-prebid.js@guardian/prebid.js#2e3b96d:
+"prebid.js@github:guardian/prebid.js#2e3b96d":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:
@@ -13243,7 +12998,7 @@ regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.1.0, regexpp@^3.2.0:
+regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -13449,7 +13204,7 @@ resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-resolve@^1.22.0, resolve@^1.9.0:
+resolve@^1.9.0:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -13859,13 +13614,6 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.7:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
-  dependencies:
-    lru-cache "^6.0.0"
-
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -14117,11 +13865,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-slash@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
-  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -14777,14 +14520,6 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-synckit@^0.8.4:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.5.tgz#b7f4358f9bb559437f9f167eb6bc46b3c9818fa3"
-  integrity sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==
-  dependencies:
-    "@pkgr/utils" "^2.3.1"
-    tslib "^2.5.0"
-
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -14942,14 +14677,6 @@ timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
-
-tiny-glob@^0.2.9:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.9.tgz#2212d441ac17928033b110f8b3640683129d31e2"
-  integrity sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==
-  dependencies:
-    globalyzer "0.1.0"
-    globrex "^0.1.2"
 
 tiny-hashes@1.0.1:
   version "1.0.1"
@@ -15126,16 +14853,6 @@ tsconfig-paths@^3.11.0, tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tsconfig-paths@^3.14.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
-  integrity sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==
-  dependencies:
-    "@types/json5" "^0.0.29"
-    json5 "^1.0.2"
-    minimist "^1.2.6"
-    strip-bom "^3.0.0"
-
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -15145,11 +14862,6 @@ tslib@^2.0.0, tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
-tslib@^2.4.0, tslib@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslib@^2.4.1:
   version "2.4.1"
@@ -15277,11 +14989,6 @@ typescript-tuple@^2.2.1:
   integrity sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==
   dependencies:
     typescript-compare "^0.0.2"
-
-typescript@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
-  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 typescript@^3.9.5, typescript@^3.9.7:
   version "3.9.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,17 +2324,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.5.tgz#2a2fa51b3c06e193f5ffb685a28ffc4b9788eeed"
   integrity sha512-06HK6V4fOpe9JSsV+hCzSgAmlSHSojTs0U7zEvDsfPCeGEWUjSrAsesmJ2EeM8oxpQZbNt8EL8Kxzn32QMCO4g==
 
-"@guardian/consent-management-platform@11.0.0":
+"@guardian/consent-management-platform@11.0.0", "@guardian/consent-management-platform@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-11.0.0.tgz#240083bbe4e8c4c22410cfa4c867b608e7c0e92f"
   integrity sha512-j97gI5NbhVLXy1s8465lyT/w/nU3K+HewkfHIQ/NLOvzBS2mmcgB6A6sRXsKCOYRt4W8eNoTX5xgAdemFgvLAw==
-
-"@guardian/consent-management-platform@^10.11.1":
-  version "10.11.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.11.1.tgz#fa01a9262963ac07df9476e591d14601efbc4588"
-  integrity sha512-7dKcKZ3L/Y/hG9MB6i1invZmTVL6EepIv1ioGCW7uR9MVhWcuIGR1MJqKWMIzQgtZ2p0CXtSzKQOvbRtfX5fxQ==
-  dependencies:
-    "@guardian/libs" "^7.1.4"
 
 "@guardian/core-web-vitals@^2.0.1":
   version "2.0.1"
@@ -2374,11 +2367,6 @@
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.0.0.tgz#07022b652430a1c5d6b16f8aa105ae3d73da4e7c"
   integrity sha512-rB4h4FlD3EcoCY66f3xjO7alnXiimPOynL9znvX/xP2nAVpG4UyedJnIpupw4KPqJuB0lZMih6EeXq0a1XnI3w==
-
-"@guardian/libs@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
-  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
 
 "@guardian/prettier@^2.1.5":
   version "2.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2370,11 +2370,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
   integrity sha512-OdWReBHRWhdbErVmS15hihVzlkdU8DkKrjDsUIN0P8QZiF4twuzcU3qsPwto2UfibAwPkWqKkNwH1k8b6xNclA==
 
-"@guardian/libs@^13.1.0":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-13.1.0.tgz#5a7a0ec9e2d432fc3176884072b9c7c22a00a95b"
-  integrity sha512-iffG2zIDmMtIHSesClxmimZIwAce3IBbSEihX0IRK65Lm2TSIfsb8ZRFRsMYDW+GE2h3yKFuU8tqVKvQXpzXQg==
-
 "@guardian/libs@^14.0.0":
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.0.0.tgz#07022b652430a1c5d6b16f8aa105ae3d73da4e7c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,11 +2329,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-11.0.0.tgz#240083bbe4e8c4c22410cfa4c867b608e7c0e92f"
   integrity sha512-j97gI5NbhVLXy1s8465lyT/w/nU3K+HewkfHIQ/NLOvzBS2mmcgB6A6sRXsKCOYRt4W8eNoTX5xgAdemFgvLAw==
 
-"@guardian/core-web-vitals@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-2.0.1.tgz#b04f12ff36f66db800a68b81b65eedfc86289211"
-  integrity sha512-xm5oDtRBu37KPmiT61z+E/Wz3HHifayJjVMwd/nfLxNRd1eFOVmplaeTDtygGKy4KjIwX90R5j/Sjs9apTVnLA==
-
 "@guardian/core-web-vitals@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-4.0.0.tgz#e09bf40ee896ae92c0223fa57399b1b0b5f9bdb2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2319,6 +2319,11 @@
   dependencies:
     type-fest "2.12.2"
 
+"@guardian/commercial-core@^5.4.5":
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.5.tgz#2a2fa51b3c06e193f5ffb685a28ffc4b9788eeed"
+  integrity sha512-06HK6V4fOpe9JSsV+hCzSgAmlSHSojTs0U7zEvDsfPCeGEWUjSrAsesmJ2EeM8oxpQZbNt8EL8Kxzn32QMCO4g==
+
 "@guardian/consent-management-platform@11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-11.0.0.tgz#240083bbe4e8c4c22410cfa4c867b608e7c0e92f"
@@ -12346,7 +12351,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@github:guardian/prebid.js#2e3b96d":
+prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -14973,10 +14973,10 @@ typescript@^3.9.5, typescript@^3.9.7:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.1.3:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@~4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 ua-parser-js@1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,11 +2242,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/ab-core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
-  integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
-
 "@guardian/ab-core@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-4.0.0.tgz#50c1fc076437e594b367f6e8d9469a3d9b97a78e"


### PR DESCRIPTION
## What does this change?

Bump:

- @guardian/commercial-bundle@^1.5.1
- @guardian/commercial-core@^5.4.5 (mostly redundant as just to satisfy deprecated code)
- @guardian packages
- typescript@~4.9.5 to align with csnx and commercial

Fixed some types which were mostly copied from commercial thank you @Jakeii 

### Tested

- [ ] Locally
- [x] On CODE (optional)
