### PR TITLE
updates MessageUsConfigData model to include fields

### DIFF
--- a/article/test/services/MessageUsServiceTest.scala
+++ b/article/test/services/MessageUsServiceTest.scala
@@ -25,9 +25,9 @@ class MessageUsServiceTest
   val fakeClient = mock[S3Client[MessageUsConfigData]]
 
   val formFields = List(
-    NameField("nameField1", "name", "name", FieldType.Name),
-    EmailField("emailField1", "email", "email", FieldType.Email),
-    TextAreaField("textAreaField1", "textArea", "textArea", FieldType.TextArea),
+    NameField("nameField1", "name", "name", true, FieldType.Name),
+    EmailField("emailField1", "email", "email", true, FieldType.Email),
+    TextAreaField("textAreaField1", "textArea", "textArea", true, FieldType.TextArea),
   )
   val successResponse = MessageUsConfigData(articleId = "key1", formId = "form1", formFields = formFields)
 

--- a/article/test/services/MessageUsServiceTest.scala
+++ b/article/test/services/MessageUsServiceTest.scala
@@ -1,6 +1,6 @@
 package services
 
-import model.{MessageUsConfigData, MessageUsData}
+import model.{FieldType, EmailField, MessageUsConfigData, MessageUsData, NameField, TextAreaField}
 import org.mockito.ArgumentMatchers.{startsWith, eq => mockitoEq}
 import org.mockito.Matchers.{any, anyString}
 import org.scalatest.BeforeAndAfterAll
@@ -24,7 +24,12 @@ class MessageUsServiceTest
 
   val fakeClient = mock[S3Client[MessageUsConfigData]]
 
-  val successResponse = MessageUsConfigData(articleId = "key1", formId = "form1")
+  val formFields = List(
+    NameField("nameField1", "name", "name", FieldType.Name),
+    EmailField("emailField1", "email", "email", FieldType.Email),
+    TextAreaField("textAreaField1", "textArea", "textArea", FieldType.TextArea),
+  )
+  val successResponse = MessageUsConfigData(articleId = "key1", formId = "form1", formFields = formFields)
 
   "refreshMessageUsData" should "return successful future given one of the S3 object calls fails" in {
     when(fakeClient.getListOfKeys()) thenReturn Future.successful(List("key1", "key2"))

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -55,6 +55,10 @@ object FieldType extends Enumeration {
 
 }
 
+object MessageUsData {
+  implicit val MessageUsDataJf: Format[MessageUsData] = Json.format[MessageUsData]
+}
+
 object MessageUsConfigData {
 
   private val commonFieldReads = (JsPath \ "id").read[String] and
@@ -86,13 +90,7 @@ object MessageUsConfigData {
   implicit val nameFieldWrite = Json.writes[NameField]
   implicit val emailFieldWrite = Json.writes[EmailField]
   implicit val textAreaFieldWrite = Json.writes[TextAreaField]
-
   implicit val fieldWriteFmt: Writes[Field] = Json.writes[Field]
 
   implicit val MessageUsConfigDataJf: Format[MessageUsConfigData] = Json.format[MessageUsConfigData]
-
-}
-
-object MessageUsData {
-  implicit val MessageUsDataJf: Format[MessageUsData] = Json.format[MessageUsData]
 }

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -3,7 +3,7 @@ package model
 import model.FieldType.FieldType
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
-import play.api.libs.json.{Format, JsPath, JsResult, Json, Reads}
+import play.api.libs.json._
 
 import scala.language.implicitConversions
 
@@ -83,7 +83,14 @@ object MessageUsConfigData {
     }
   }
 
-  implicit val MessageUsConfigDataJf: Reads[MessageUsConfigData] = Json.reads[MessageUsConfigData]
+  implicit val nameFieldWrite = Json.writes[NameField]
+  implicit val emailFieldWrite = Json.writes[EmailField]
+  implicit val textAreaFieldWrite = Json.writes[TextAreaField]
+
+  implicit val fieldWriteFmt: Writes[Field] = Json.writes[Field]
+
+  implicit val MessageUsConfigDataJf: Format[MessageUsConfigData] = Json.format[MessageUsConfigData]
+
 }
 
 object MessageUsData {

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -90,6 +90,7 @@ object MessageUsConfigData {
   implicit val nameFieldWrite = Json.writes[NameField]
   implicit val emailFieldWrite = Json.writes[EmailField]
   implicit val textAreaFieldWrite = Json.writes[TextAreaField]
+
   implicit val fieldWriteFmt: Writes[Field] = Json.writes[Field]
 
   implicit val MessageUsConfigDataJf: Format[MessageUsConfigData] = Json.format[MessageUsConfigData]

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -35,9 +35,9 @@ case class TextAreaField(
     id: String,
     label: String = "textarea",
     name: String,
+    `type`: FieldType = FieldType.TextArea,
     minlength: Int = 0,
     maxlength: Int = 1000,
-    `type`: FieldType = FieldType.TextArea,
 ) extends Field
 
 object FieldType extends Enumeration {
@@ -64,9 +64,9 @@ object MessageUsConfigData {
     Reads.pure(FieldType.Name))(EmailField.apply _)
 
   implicit val textAreaFieldRead: Reads[TextAreaField] = (commonFieldReads and
+    Reads.pure(FieldType.Name) and
     (JsPath \ "minlength").read[Int] and
-    (JsPath \ "maxlength").read[Int] and
-    Reads.pure(FieldType.Name))(TextAreaField.apply _)
+    (JsPath \ "maxlength").read[Int])(TextAreaField.apply _)
 
   implicit val fieldReadFmt: Reads[Field] = Reads { js =>
     val fieldType = (JsPath \ "type").read[FieldType].reads(js)


### PR DESCRIPTION
## What does this change?
This PR adds formFields to the `MessageUsConfigData` case class. This change is following a change in `message-us-worker` lambda https://github.com/guardian/editorial-experience-lambda/pull/23 that fixes the json encoding for `Field`.

The main purpose of this change is that, we need to have the fields in the rendering service to be able to render and submit the forms. 
### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
