### PR TITLE
Rename 'guui' methods to 'DCR' methods

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -89,7 +89,10 @@ class ArticleController(
     List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
   }
 
-  private def getGuuiJson(article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): String = {
+  /**
+    * Returns a JSON representation of the payload that's sent to DCR when rendering the Article.
+    */
+  private def getDCRJson(article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): String = {
     val pageType: PageType = PageType(article, request, context)
     val newsletter = newsletterService.getNewsletterForArticle(article)
     val edition = Edition(request)
@@ -111,7 +114,7 @@ class ArticleController(
     val pageType: PageType = PageType(article, request, context)
     request.getRequestFormat match {
       case JsonFormat if request.forceDCR =>
-        Future.successful(common.renderJson(getGuuiJson(article, blocks), article).as("application/json"))
+        Future.successful(common.renderJson(getDCRJson(article, blocks), article).as("application/json"))
       case JsonFormat =>
         Future.successful(common.renderJson(getJson(article), article))
       case EmailFormat =>

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -127,8 +127,14 @@ class LiveBlogController(
 
       mapModel(path, range, filter, topicResult) {
         case (blog: LiveBlogPage, _) if rendered.contains(false) => getJsonForFronts(blog)
+
+        /**
+          * When DCR requests new blocks from the client, it will add a `lastUpdate` parameter.
+          * If no such parameter is present, we should return a JSON representation of the whole
+          * payload that would be sent to DCR when initially server side rendering the LiveBlog page.
+          */
         case (blog: LiveBlogPage, blocks) if request.forceDCR && lastUpdate.isEmpty =>
-          Future.successful(renderGuuiJson(blog, blocks, filter, availableTopics, topicResult, messageUs))
+          Future.successful(renderDCRJson(blog, blocks, filter, availableTopics, topicResult, messageUs))
         case (blog: LiveBlogPage, blocks) =>
           getJson(
             blog,
@@ -362,7 +368,10 @@ class LiveBlogController(
     }
   }
 
-  private[this] def renderGuuiJson(
+  /**
+    * Returns a JSON representation of the payload that's sent to DCR when rendering the whole LiveBlog page.
+    */
+  private[this] def renderDCRJson(
       blog: LiveBlogPage,
       blocks: Blocks,
       filterKeyEvents: Boolean,


### PR DESCRIPTION
The `guui` naming convention no longer fits with how we refer to the service, and is not used widely in this codebase.

I'm renaming the `getGuuiJson` and `renderGuuiJson` methods to refer to DCR instead, to reflect current naming of the service.

I've also added comments explaining what these methods do, and for the liveblog case I've also added a comment explaining why `lastUpdate` is used to determine which render method to use. This is just my inference from context though, so please take with a pinch of salt, or please feel free to correct me!

## What does this change?

This should be a no-op refactor.
