### PR TITLE
Include messageUs data in dcr model

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -127,6 +127,7 @@ class ArticleController(
           blocks,
           pageType,
           newsletter,
+          messageUs = None,
         )
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))

--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -7,7 +7,7 @@ import model.{ApplicationContext, TopicsApiResponse}
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 import renderers.DotcomRenderingService
-import services.{NewsletterService, NewspaperBookSectionTagAgent, NewspaperBookTagAgent, S3Client}
+import services.{NewsletterService, NewspaperBookSectionTagAgent, NewspaperBookTagAgent, S3Client, MessageUsService}
 import services.newsletters.NewsletterSignupAgent
 import topics.{TopicService}
 
@@ -18,6 +18,7 @@ trait ArticleControllers {
   def remoteRender: DotcomRenderingService
   def topicS3Client: S3Client[TopicsApiResponse]
   def topicService: TopicService
+  def messageUsService: MessageUsService
   def newsletterSignupAgent: NewsletterSignupAgent
   def curatedContentAgent: CuratedContentAgent
 

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -67,7 +67,7 @@ class LiveBlogController(
       val filter = shouldFilter(filterKeyEvents)
       val topicResult = if (filter) None else getTopicResult(path, topics)
       val availableTopics = topicService.getAvailableTopics(path)
-      val messageUs = messageUsService.getBlogMessageUsConfigData(path)
+      val messageUs = messageUsService.getBlogMessageUsConfigData(path).map(c => MessageUsData(c.formId))
 
       page.map(ParseBlockId.fromPageParam) match {
         case Some(ParsedBlockId(id)) =>
@@ -127,7 +127,7 @@ class LiveBlogController(
       mapModel(path, range, filter, topicResult) {
         case (blog: LiveBlogPage, _) if rendered.contains(false) => getJsonForFronts(blog)
         case (blog: LiveBlogPage, blocks) if request.forceDCR && lastUpdate.isEmpty =>
-          Future.successful(renderGuuiJson(blog, blocks, filter, availableTopics, topicResult))
+          Future.successful(renderGuuiJson(blog, blocks, filter, availableTopics, topicResult, messageUs))
         case (blog: LiveBlogPage, blocks) =>
           getJson(
             blog,

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -67,7 +67,7 @@ class LiveBlogController(
       val filter = shouldFilter(filterKeyEvents)
       val topicResult = if (filter) None else getTopicResult(path, topics)
       val availableTopics = topicService.getAvailableTopics(path)
-      val messageUs = messageUsService.getBlogMessageUsConfigData(path)
+      val messageUs = messageUsService.getBlogMessageUsData(path)
 
       page.map(ParseBlockId.fromPageParam) match {
         case Some(ParsedBlockId(id)) =>
@@ -123,7 +123,7 @@ class LiveBlogController(
       val topicResult = getTopicResult(path, topics)
       val range = getRange(lastUpdate, page, topicResult)
       val availableTopics = topicService.getAvailableTopics(path)
-      val messageUs = messageUsService.getBlogMessageUsConfigData(path)
+      val messageUs = messageUsService.getBlogMessageUsData(path)
 
       mapModel(path, range, filter, topicResult) {
         case (blog: LiveBlogPage, _) if rendered.contains(false) => getJsonForFronts(blog)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -67,7 +67,7 @@ class LiveBlogController(
       val filter = shouldFilter(filterKeyEvents)
       val topicResult = if (filter) None else getTopicResult(path, topics)
       val availableTopics = topicService.getAvailableTopics(path)
-      val messageUs = messageUsService.getBlogMessageUsConfigData(path).map(c => MessageUsData(c.formId))
+      val messageUs = messageUsService.getBlogMessageUsConfigData(path)
 
       page.map(ParseBlockId.fromPageParam) match {
         case Some(ParsedBlockId(id)) =>
@@ -123,6 +123,7 @@ class LiveBlogController(
       val topicResult = getTopicResult(path, topics)
       val range = getRange(lastUpdate, page, topicResult)
       val availableTopics = topicService.getAvailableTopics(path)
+      val messageUs = messageUsService.getBlogMessageUsConfigData(path)
 
       mapModel(path, range, filter, topicResult) {
         case (blog: LiveBlogPage, _) if rendered.contains(false) => getJsonForFronts(blog)

--- a/article/app/services/MessageUsService.scala
+++ b/article/app/services/MessageUsService.scala
@@ -36,7 +36,7 @@ class MessageUsService(messageUsS3Client: S3Client[MessageUsConfigData]) extends
       }
   }
 
-  def getBlogMessageUsConfigData(blogId: String): Option[MessageUsData] = {
+  def getBlogMessageUsData(blogId: String): Option[MessageUsData] = {
     messageUsConfigData.get().flatMap(_.get(blogId)).map(c => MessageUsData(c.formId))
   }
 

--- a/article/app/services/MessageUsService.scala
+++ b/article/app/services/MessageUsService.scala
@@ -1,7 +1,7 @@
 package services
 
 import common.{Box, GuLogging}
-import model.{MessageUsConfigData, MessageUsData}
+import model.{MessageUsConfigData}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -36,7 +36,7 @@ class MessageUsService(messageUsS3Client: S3Client[MessageUsConfigData]) extends
       }
   }
 
-  def getBlogMessageUsConfigData(blogId: String): Option[MessageUsData] = {
+  def getBlogMessageUsConfigData(blogId: String): Option[MessageUsConfigData] = {
     messageUsConfigData.get().flatMap(_.get(blogId))
   }
 

--- a/article/app/services/MessageUsService.scala
+++ b/article/app/services/MessageUsService.scala
@@ -1,7 +1,7 @@
 package services
 
 import common.{Box, GuLogging}
-import model.{MessageUsConfigData}
+import model.{MessageUsConfigData, MessageUsData}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -36,8 +36,8 @@ class MessageUsService(messageUsS3Client: S3Client[MessageUsConfigData]) extends
       }
   }
 
-  def getBlogMessageUsConfigData(blogId: String): Option[MessageUsConfigData] = {
-    messageUsConfigData.get().flatMap(_.get(blogId))
+  def getBlogMessageUsConfigData(blogId: String): Option[MessageUsData] = {
+    messageUsConfigData.get().flatMap(_.get(blogId)).map(c => MessageUsData(c.formId))
   }
 
   def getAllMessageUsConfigData: Option[Map[String, MessageUsConfigData]] = {

--- a/article/app/services/MessageUsService.scala
+++ b/article/app/services/MessageUsService.scala
@@ -1,7 +1,7 @@
 package services
 
 import common.{Box, GuLogging}
-import model.MessageUsConfigData
+import model.{MessageUsConfigData, MessageUsData}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -36,7 +36,7 @@ class MessageUsService(messageUsS3Client: S3Client[MessageUsConfigData]) extends
       }
   }
 
-  def getBlogMessageUsConfigData(blogId: String): Option[MessageUsConfigData] = {
+  def getBlogMessageUsConfigData(blogId: String): Option[MessageUsData] = {
     messageUsConfigData.get().flatMap(_.get(blogId))
   }
 

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -3,7 +3,7 @@ package test
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
 import model.Cached.RevalidatableResult
 import model.dotcomrendering.{OnwardCollectionResponse, PageType}
-import model.{ApplicationContext, Cached, LiveBlogPage, PageWithStoryPackage, Topic, TopicResult}
+import model.{ApplicationContext, Cached, LiveBlogPage, PageWithStoryPackage, Topic, TopicResult, MessageUsData}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
@@ -28,6 +28,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       forceLive: Boolean,
       availableTopics: Option[Seq[Topic]],
       topicResult: Option[TopicResult],
+      messageUs: Option[MessageUsData],
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     requestedBlogs.enqueue(article)

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatestplus.mockito.MockitoSugar
 import model.{LiveBlogPage, Topic, TopicResult, TopicType}
 import topics.TopicService
-import services.NewsletterService
+import services.{NewsletterService, MessageUsService}
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
 
 @DoNotDiscover class LiveBlogControllerTest
@@ -31,6 +31,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
 
   trait Setup {
     var fakeTopicService = mock[TopicService]
+    var fakeMessageUsService = mock[MessageUsService]
     var fakeDcr = new DCRFake()
     val topicResult = TopicResult(
       name = "Fifa",
@@ -72,6 +73,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
       fakeDcr,
       new NewsletterService(new NewsletterSignupAgent(new NewsletterApi(wsClient))),
       fakeTopicService,
+      fakeMessageUsService,
     )
   }
 

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -70,7 +70,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
     )
 
     when(
-      fakeMessageUsService.getBlogMessageUsConfigData(path),
+      fakeMessageUsService.getBlogMessageUsData(path),
     ) thenReturn Some(
       messageUsResult,
     )
@@ -321,7 +321,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
 
   it should "return no message us data, if not available" in new Setup {
     when(
-      fakeMessageUsService.getBlogMessageUsConfigData(path),
+      fakeMessageUsService.getBlogMessageUsData(path),
     ) thenReturn None
 
     val fakeRequest = FakeRequest(
@@ -341,7 +341,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
     status(result) should be(200)
 
     val content = contentAsString(result)
-    content should not include("\"messageUs\":{\"formId\":\"mock-form-id\"}")
+    content should not include ("\"messageUs\":{\"formId\":\"mock-form-id\"}")
   }
 
   "getTopicResult" should "returns none given no automatic filter query parameter" in new Setup {

--- a/article/test/services/MessageUsServiceTest.scala
+++ b/article/test/services/MessageUsServiceTest.scala
@@ -76,7 +76,7 @@ class MessageUsServiceTest
     val messageUsService = new MessageUsService(fakeClient)
 
     val refreshJob = Await.result(messageUsService.refreshMessageUsData(), 1.second)
-    val result = messageUsService.getBlogMessageUsConfigData("key2")
+    val result = messageUsService.getBlogMessageUsData("key2")
 
     result should equal(None)
   }
@@ -87,7 +87,7 @@ class MessageUsServiceTest
     val messageUsService = new MessageUsService(fakeClient)
 
     val refreshJob = Await.result(messageUsService.refreshMessageUsData(), 1.second)
-    val result = messageUsService.getBlogMessageUsConfigData("key1")
+    val result = messageUsService.getBlogMessageUsData("key1")
 
     val expected = MessageUsData(formId = "form1")
     result should equal(Some(expected))

--- a/article/test/services/MessageUsServiceTest.scala
+++ b/article/test/services/MessageUsServiceTest.scala
@@ -1,6 +1,6 @@
 package services
 
-import model.MessageUsConfigData
+import model.{MessageUsConfigData, MessageUsData}
 import org.mockito.ArgumentMatchers.{startsWith, eq => mockitoEq}
 import org.mockito.Matchers.{any, anyString}
 import org.scalatest.BeforeAndAfterAll
@@ -89,6 +89,7 @@ class MessageUsServiceTest
     val refreshJob = Await.result(messageUsService.refreshMessageUsData(), 1.second)
     val result = messageUsService.getBlogMessageUsConfigData("key1")
 
-    result should equal(Some(successResponse))
+    val expected = MessageUsData(formId = "form1")
+    result should equal(Some(expected))
   }
 }

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -3,7 +3,12 @@ package model
 import play.api.libs.json.{Format, Json}
 
 case class MessageUsConfigData(articleId: String, formId: String)
+case class MessageUsData(formId: String)
 
 object MessageUsConfigData {
   implicit val MessageUsConfigDataJf: Format[MessageUsConfigData] = Json.format[MessageUsConfigData]
+}
+
+object MessageUsData {
+  implicit val MessageUsDataJf: Format[MessageUsData] = Json.format[MessageUsData]
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -22,6 +22,7 @@ import model.{
   PageWithStoryPackage,
   Topic,
   TopicResult,
+  MessageUsData,
 }
 import navigation._
 import play.api.libs.json._
@@ -41,6 +42,7 @@ case class DotcomRenderingDataModel(
     main: String,
     availableTopics: Option[Seq[Topic]],
     selectedTopics: Option[Seq[Topic]],
+    messageUs: Option[MessageUsData],
     filterKeyEvents: Boolean,
     pinnedPost: Option[Block],
     keyEvents: List[Block],
@@ -112,6 +114,7 @@ object DotcomRenderingDataModel {
       val obj = Json.obj(
         "availableTopics" -> model.availableTopics,
         "selectedTopics" -> model.selectedTopics,
+        "messageUs" -> model.messageUs,
         "version" -> model.version,
         "headline" -> model.headline,
         "standfirst" -> model.standfirst,
@@ -216,6 +219,7 @@ object DotcomRenderingDataModel {
       availableTopics = None,
       newsletter = None,
       topicResult = None,
+      messageUs = None,
     )
   }
 
@@ -249,6 +253,7 @@ object DotcomRenderingDataModel {
       availableTopics = None,
       newsletter = newsletter,
       topicResult = None,
+      messageUs = None,
     )
   }
 
@@ -274,6 +279,7 @@ object DotcomRenderingDataModel {
       availableTopics: Option[Seq[Topic]] = None,
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
+      messageUs: Option[MessageUsData],
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
       Pagination(
@@ -332,6 +338,7 @@ object DotcomRenderingDataModel {
       availableTopics,
       newsletter,
       topicResult,
+      messageUs,
     )
   }
 
@@ -353,6 +360,7 @@ object DotcomRenderingDataModel {
       availableTopics: Option[Seq[Topic]],
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
+      messageUs: Option[MessageUsData],
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
@@ -492,6 +500,7 @@ object DotcomRenderingDataModel {
       mainMediaElements = mainMediaElements,
       matchUrl = matchData.map(_.matchUrl),
       matchType = matchData.map(_.matchType),
+      messageUs = messageUs,
       nav = Nav(page, edition),
       openGraphData = page.getOpenGraphProperties,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -143,7 +143,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       newsletter: Option[NewsletterData],
       filterKeyEvents: Boolean = false,
   )(implicit request: RequestHeader): Future[Result] =
-    baseArticleRequest("/AMPArticle", ws, page, blocks, pageType, filterKeyEvents, false, None, newsletter, None)
+    baseArticleRequest("/AMPArticle", ws, page, blocks, pageType, filterKeyEvents, false, None, newsletter, None, None)
 
   def getAppsArticle(
       ws: WSClient,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -31,6 +31,7 @@ import model.{
   RelatedContentItem,
   Topic,
   TopicResult,
+  MessageUsData,
 }
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
@@ -154,6 +155,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       forceLive: Boolean = false,
       availableTopics: Option[Seq[Topic]] = None,
       topicResult: Option[TopicResult] = None,
+      messageUs: Option[MessageUsData] = None,
   )(implicit request: RequestHeader): Future[Result] =
     baseArticleRequest(
       "/AppsArticle",
@@ -166,6 +168,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       availableTopics,
       newsletter,
       topicResult,
+      messageUs,
     )
 
   def getArticle(
@@ -178,6 +181,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       forceLive: Boolean = false,
       availableTopics: Option[Seq[Topic]] = None,
       topicResult: Option[TopicResult] = None,
+      messageUs: Option[MessageUsData] = None,
   )(implicit request: RequestHeader): Future[Result] =
     baseArticleRequest(
       "/Article",
@@ -190,6 +194,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       availableTopics,
       newsletter,
       topicResult,
+      messageUs,
     )
 
   private def baseArticleRequest(
@@ -203,6 +208,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       availableTopics: Option[Seq[Topic]] = None,
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
+      messageUs: Option[MessageUsData],
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
@@ -216,6 +222,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
           availableTopics,
           newsletter,
           topicResult,
+          messageUs,
         )
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter)
     }


### PR DESCRIPTION
## What does this change?
This updates the DCR model for liveblogs, to include the message us data.

## Does this change need to be reproduced in dotcom-rendering ?
- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
[DCR will need to be updated to consume the messageUs data, and render the messageUs component accordingly](https://github.com/orgs/guardian/projects/80/views/1?pane=issue&itemId=19904585)

## Screenshots
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/26366706/224992380-d48cb8fa-8ed3-4993-aa41-8788c45f07fc.png">

messageUs value is present on code, when the message us data is present in s3 for this article

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/26366706/224992850-7ac0df9a-937d-4226-8d4a-b680a05aedc1.png">
After removing the object from s3, the messageUs value is no longer present



## Checklist

### Does this affect other platforms?

- [ ] AMP 
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [n/a] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [n/a] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [n/a] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
