### PR TITLE
Collapse empty ad slots for PDC test

### DIFF
--- a/common/app/views/fragments/page/head/stylesheets/styles.scala.html
+++ b/common/app/views/fragments/page/head/stylesheets/styles.scala.html
@@ -2,6 +2,7 @@
 
 @import conf.switches.Switches.{FontSwitch}
 @import views.support.Commercial.isAdFree
+@import experiments.{ActiveExperiments, PoorDeviceConnectivity}
 @import conf.Static
 
 @if(FontSwitch.isSwitchedOn) {
@@ -60,7 +61,7 @@
 @styles.linkCss
 <!--<![endif]-->
 <style class="js-loggable">
-    @if(isAdFree(request)) {
+    @if(isAdFree(request) || ActiveExperiments.isParticipating(PoorDeviceConnectivity)) {
         @Html(common.Assets.css.adFree)
     }
 </style>

--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -5,6 +5,7 @@
 @import conf.Static
 @import html.HtmlPageHelpers.{ContentCSSFile}
 @import views.support.Commercial.isAdFree
+@import experiments.{ActiveExperiments, PoorDeviceConnectivity}
 
 @if(FontSwitch.isSwitchedOn) {
     @fragments.fontFaces()
@@ -77,7 +78,7 @@
 
 <!--<![endif]-->
 <style class="js-loggable">
-    @if(isAdFree(request)) {
+    @if(isAdFree(request) || ActiveExperiments.isParticipating(PoorDeviceConnectivity)) {
         @Html(common.Assets.css.adFree)
     }
 </style>


### PR DESCRIPTION
## What does this change?

adds a check for participation in the `PoorDeviceConnectivity` experiment to the ad slot hiding CSS

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

