### PR TITLE
Log reason why article isn't treated as a liveblog

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -430,6 +430,18 @@ class LiveBlogController(
           filterKeyEvents,
           topicResult,
         ).map(_ -> blocks)
+      case nonLiveBlogArticle: Article =>
+        /**
+          * If `isLiveBlog` is false, it must be because the article has no blocks, or lacks
+          * the `tone/minutebyminute` tag, or both.
+          * Logging these values will help us to identify which is causing the issue.
+          */
+        val hasBlocks = nonLiveBlogArticle.fields.blocks.nonEmpty;
+        val hasMinuteByMinuteTag = nonLiveBlogArticle.tags.isLiveBlog;
+        log.error(
+          s"Requested non-liveblog article as liveblog: ${nonLiveBlogArticle.metadata.id}: { hasBlocks: ${hasBlocks}, hasMinuteByMinuteTag: ${hasMinuteByMinuteTag} }",
+        )
+        Left(InternalServerError)
       case unknown =>
         log.error(s"Requested non-liveblog: ${unknown.metadata.id}")
         Left(InternalServerError)


### PR DESCRIPTION
## What does this change?

Adds a new case which will log the reason why an Article is not being treated as a liveblog. This should help with debugging particular issues by looking at the logs.

The error [was happening a non-trivial amount](https://logs.gutools.co.uk/s/dotcom/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15d,to:now))&_a=(columns:!(),filters:!(),index:'50201630-bd0f-11e9-92b3-f10623802d36',interval:auto,query:(language:kuery,query:%22science%2Fhead-quarters%2Flive%2F2014%22),sort:!(!('@timestamp',desc)))
) (400+ times in 15 days, with >1000 requests to these pages getting a 500 page).

I've addressed the issue with the most commonly erroring article with CP, so hopefully this number will go down, but the additional logging should help with addressing the remaining and future cases.


<img width="1327" alt="image" src="https://user-images.githubusercontent.com/37048459/225263671-55c001de-af8a-41ac-a8aa-b0a65ac944cf.png">



## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
