### PR TITLE
Add the FormFields to the messageUs data

### DIFF
--- a/article/app/services/MessageUsService.scala
+++ b/article/app/services/MessageUsService.scala
@@ -1,7 +1,7 @@
 package services
 
 import common.{Box, GuLogging}
-import model.{MessageUsConfigData}
+import model.{MessageUsConfigData, MessageUsData}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/article/app/services/MessageUsService.scala
+++ b/article/app/services/MessageUsService.scala
@@ -37,7 +37,7 @@ class MessageUsService(messageUsS3Client: S3Client[MessageUsConfigData]) extends
   }
 
   def getBlogMessageUsData(blogId: String): Option[MessageUsData] = {
-    messageUsConfigData.get().flatMap(_.get(blogId)).map(c => MessageUsData(c.formId))
+    messageUsConfigData.get().flatMap(_.get(blogId)).map(c => MessageUsData(c.formId, c.formFields))
   }
 
   def getAllMessageUsConfigData: Option[Map[String, MessageUsConfigData]] = {

--- a/article/app/services/MessageUsService.scala
+++ b/article/app/services/MessageUsService.scala
@@ -1,7 +1,7 @@
 package services
 
 import common.{Box, GuLogging}
-import model.{MessageUsConfigData, MessageUsData}
+import model.{MessageUsConfigData}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -10,7 +10,7 @@ import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatestplus.mockito.MockitoSugar
-import model.{LiveBlogPage, Topic, TopicResult, TopicType, MessageUsData}
+import model.{LiveBlogPage, Topic, TopicResult, TopicType, MessageUsData, FieldType, EmailField, MessageUsConfigData, NameField, TextAreaField}
 import topics.TopicService
 import services.{NewsletterService, MessageUsService}
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
@@ -42,6 +42,11 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
     )
     val messageUsResult = MessageUsData(
       formId = "mock-form-id",
+      formFields = List(
+        NameField("nameField1", "name", "name", true, FieldType.Name),
+        EmailField("emailField1", "email", "email", true, FieldType.Email),
+        TextAreaField("textAreaField1", "textArea", "textArea", true, FieldType.TextArea),
+      )
     )
 
     val fakeAvailableTopics = Vector(
@@ -316,7 +321,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
     status(result) should be(200)
 
     val content = contentAsString(result)
-    content should include("\"messageUs\":{\"formId\":\"mock-form-id\"}")
+    content should include("messageUs\":{\"formId\":\"mock-form-id\",\"formFields\":[{\"_type\":\"model.NameField\",\"id\":\"nameField1\",\"label\":\"name\",\"name\":\"name\",\"required\":true,\"type\":\"text\"},{\"_type\":\"model.EmailField\",\"id\":\"emailField1\",\"label\":\"email\",\"name\":\"email\",\"required\":true,\"type\":\"email\"},{\"_type\":\"model.TextAreaField\",\"id\":\"textAreaField1\",\"label\":\"textArea\",\"name\":\"textArea\",\"required\":true,\"type\":\"textarea\",\"minlength\":0,\"maxlength\":1000}]}")
   }
 
   it should "return no message us data, if not available" in new Setup {

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -10,7 +10,18 @@ import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatestplus.mockito.MockitoSugar
-import model.{LiveBlogPage, Topic, TopicResult, TopicType, MessageUsData, FieldType, EmailField, MessageUsConfigData, NameField, TextAreaField}
+import model.{
+  LiveBlogPage,
+  Topic,
+  TopicResult,
+  TopicType,
+  MessageUsData,
+  FieldType,
+  EmailField,
+  MessageUsConfigData,
+  NameField,
+  TextAreaField,
+}
 import topics.TopicService
 import services.{NewsletterService, MessageUsService}
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
@@ -46,7 +57,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
         NameField("nameField1", "name", "name", true, FieldType.Name),
         EmailField("emailField1", "email", "email", true, FieldType.Email),
         TextAreaField("textAreaField1", "textArea", "textArea", true, FieldType.TextArea),
-      )
+      ),
     )
 
     val fakeAvailableTopics = Vector(
@@ -321,7 +332,9 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
     status(result) should be(200)
 
     val content = contentAsString(result)
-    content should include("messageUs\":{\"formId\":\"mock-form-id\",\"formFields\":[{\"_type\":\"model.NameField\",\"id\":\"nameField1\",\"label\":\"name\",\"name\":\"name\",\"required\":true,\"type\":\"text\"},{\"_type\":\"model.EmailField\",\"id\":\"emailField1\",\"label\":\"email\",\"name\":\"email\",\"required\":true,\"type\":\"email\"},{\"_type\":\"model.TextAreaField\",\"id\":\"textAreaField1\",\"label\":\"textArea\",\"name\":\"textArea\",\"required\":true,\"type\":\"textarea\",\"minlength\":0,\"maxlength\":1000}]}")
+    content should include(
+      "messageUs\":{\"formId\":\"mock-form-id\",\"formFields\":[{\"_type\":\"model.NameField\",\"id\":\"nameField1\",\"label\":\"name\",\"name\":\"name\",\"required\":true,\"type\":\"text\"},{\"_type\":\"model.EmailField\",\"id\":\"emailField1\",\"label\":\"email\",\"name\":\"email\",\"required\":true,\"type\":\"email\"},{\"_type\":\"model.TextAreaField\",\"id\":\"textAreaField1\",\"label\":\"textArea\",\"name\":\"textArea\",\"required\":true,\"type\":\"textarea\",\"minlength\":0,\"maxlength\":1000}]}",
+    )
   }
 
   it should "return no message us data, if not available" in new Setup {

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -356,10 +356,13 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
       filterKeyEvents = Some(false),
       topics = None,
     )(fakeRequest)
+
     status(result) should be(200)
 
     val content = contentAsString(result)
-    content should not include ("\"messageUs\":{\"formId\":\"mock-form-id\"}")
+    content should not include (
+      "messageUs\":{\"formId\":\"mock-form-id\",\"formFields\":[{\"_type\":\"model.NameField\",\"id\":\"nameField1\",\"label\":\"name\",\"name\":\"name\",\"required\":true,\"type\":\"text\"},{\"_type\":\"model.EmailField\",\"id\":\"emailField1\",\"label\":\"email\",\"name\":\"email\",\"required\":true,\"type\":\"email\"},{\"_type\":\"model.TextAreaField\",\"id\":\"textAreaField1\",\"label\":\"textArea\",\"name\":\"textArea\",\"required\":true,\"type\":\"textarea\",\"minlength\":0,\"maxlength\":1000}]}",
+    )
   }
 
   "getTopicResult" should "returns none given no automatic filter query parameter" in new Setup {

--- a/article/test/services/MessageUsServiceTest.scala
+++ b/article/test/services/MessageUsServiceTest.scala
@@ -94,7 +94,7 @@ class MessageUsServiceTest
     val refreshJob = Await.result(messageUsService.refreshMessageUsData(), 1.second)
     val result = messageUsService.getBlogMessageUsData("key1")
 
-    val expected = MessageUsData(formId = "form1")
+    val expected = MessageUsData(formId = "form1", formFields = formFields)
     result should equal(Some(expected))
   }
 }

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -95,3 +95,7 @@ object MessageUsConfigData {
 
   implicit val MessageUsConfigDataJf: Format[MessageUsConfigData] = Json.format[MessageUsConfigData]
 }
+
+object MessageUsData {
+  implicit val MessageUsDataJf: Format[MessageUsData] = Json.format[MessageUsData]
+}

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -62,10 +62,10 @@ sealed trait FieldFormats {
     Reads.pure(FieldType.Name))(NameField.apply _)
 
   implicit val emailFieldRead: Reads[EmailField] = (commonFieldReads and
-    Reads.pure(FieldType.Name))(EmailField.apply _)
+    Reads.pure(FieldType.Email))(EmailField.apply _)
 
   implicit val textAreaFieldRead: Reads[TextAreaField] = (commonFieldReads and
-    Reads.pure(FieldType.Name) and
+    Reads.pure(FieldType.TextArea) and
     (JsPath \ "minlength").read[Int] and
     (JsPath \ "maxlength").read[Int])(TextAreaField.apply _)
 

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -44,9 +44,9 @@ case class TextAreaField(
 object FieldType extends Enumeration {
   type FieldType = Value
 
-  val Name: model.FieldType.Value = Value(1, "text")
-  val Email: model.FieldType.Value = Value(2, "email")
-  val TextArea: model.FieldType.Value = Value(3, "textarea")
+  val Name = Value(1, "text")
+  val Email = Value(2, "email")
+  val TextArea = Value(3, "textarea")
 
   implicit val format: Format[FieldType] = Json.formatEnum(this)
 
@@ -79,9 +79,9 @@ sealed trait FieldFormats {
     }
   }
 
-  implicit val nameFieldWrite: OWrites[NameField] = Json.writes[NameField]
-  implicit val emailFieldWrite: OWrites[EmailField] = Json.writes[EmailField]
-  implicit val textAreaFieldWrite: OWrites[TextAreaField] = Json.writes[TextAreaField]
+  implicit val nameFieldWrite = Json.writes[NameField]
+  implicit val emailFieldWrite = Json.writes[EmailField]
+  implicit val textAreaFieldWrite = Json.writes[TextAreaField]
 
   implicit val fieldWriteFmt: Writes[Field] = Json.writes[Field]
 }

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -3,7 +3,7 @@ package model
 import model.FieldType.FieldType
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
-import play.api.libs.json._
+import play.api.libs.json.{Format, JsPath, Json, Reads}
 
 import scala.language.implicitConversions
 
@@ -94,8 +94,4 @@ object MessageUsConfigData {
   implicit val fieldWriteFmt: Writes[Field] = Json.writes[Field]
 
   implicit val MessageUsConfigDataJf: Format[MessageUsConfigData] = Json.format[MessageUsConfigData]
-}
-
-object MessageUsData {
-  implicit val MessageUsDataJf: Format[MessageUsData] = Json.format[MessageUsData]
 }


### PR DESCRIPTION
## What does this change?
This includes the FormFields data in the messageUs data passed to DCR

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)
- https://github.com/orgs/guardian/projects/80/views/1?pane=issue&itemId=19904585

## Screenshots
On code - json for an liveblog with messageUs data in S3
<img width="383" alt="image" src="https://user-images.githubusercontent.com/26366706/225310385-7fb1ae66-d32e-4975-8296-68555f4a5ddc.png">


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
