### PR TITLE
Bump guardian/prettier to 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"@babel/register": "^7.11.5",
 		"@babel/runtime": "^7.11.2",
 		"@guardian/eslint-config-typescript": "^0.7.0",
-		"@guardian/prettier": "^2.1.5",
+		"@guardian/prettier": "^3.0.0",
 		"@types/google.analytics": "^0.0.42",
 		"@types/googletag": "^1.1.3",
 		"@types/jest": "^26.0.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,10 +2317,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.0.0.tgz#07022b652430a1c5d6b16f8aa105ae3d73da4e7c"
   integrity sha512-rB4h4FlD3EcoCY66f3xjO7alnXiimPOynL9znvX/xP2nAVpG4UyedJnIpupw4KPqJuB0lZMih6EeXq0a1XnI3w==
 
-"@guardian/prettier@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-2.1.5.tgz#715fff5b110006408f92a3fe2a803ad0e4c79e06"
-  integrity sha512-4fehERf5HHS9Nkaw+4u5EZ1OrFEHL4lYhLUWkpwEx4VmHI+RgcMezfDfosb3TD8cPFCKakrpdQEJUwNP283SJw==
+"@guardian/prettier@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-3.0.0.tgz#7a313372b7e6919298999dc801a23f5b69f008f0"
+  integrity sha512-o1g0tYVniUNFxWoCp3DbK33gTebDmvYORN6oeV+lXvqa9YyhslswzGkmV0mSRErXmla0H+pIlnfF0Ve7fb0Mfw==
 
 "@guardian/shimport@^1.0.2":
   version "1.0.2"


### PR DESCRIPTION
## What does this change?

Bumps `@guardian/prettier` dependency.

## Testing

As far as I can tell the only major change in this version is in the peer-dep version of tslib. It looks like we're already using that, and I didn't spot any new warnings/errors from `yarn` when upgrading, so as far as I can tell this upgrade shouldn't require any code changes.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
