### PR TITLE
Fix various visual bugs in`SpecialReportAlt` cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -483,10 +483,6 @@ $pillars: (
         }
     }
 
-    .fc-item__container.u-faux-block-link--hover {
-        background-color: darken($special-report-alt-faded, 2%);
-    }
-
     .fc-sublink__kicker {
         color: $special-report-alt-dark;
     }

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -412,10 +412,10 @@ $pillars: (
         }
     }
 
-    background-color: $special-report-alt-faded !important;
+    background-color: $special-report-alt-faded;
 
     .fc-item__container.u-faux-block-link--hover {
-        background-color: $special-report-alt-faded !important;
+        background-color: $special-report-alt-faded;
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -419,7 +419,7 @@ $pillars: (
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {
-            background-color: $special-report-alt-dark !important;
+            background-color: transparent;
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -415,7 +415,7 @@ $pillars: (
     background-color: $special-report-alt-faded;
 
     .fc-item__container.u-faux-block-link--hover {
-        background-color: $special-report-alt-faded;
+        background-color: darken($special-report-alt-faded, 2%);
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -17,11 +17,19 @@
         }
 
         .fc-item__headline {
-            color: #ffffff;
+            @if $pillar == special-report-alt {
+                color: $color2;
+            } @else {
+                color: #ffffff;
+            }
         }
 
         .fc-item__standfirst {
-            color: #ffffff;
+            @if $pillar == special-report-alt {
+                color: $color2;
+            } @else {
+                color: #ffffff;
+            }
         }
 
         .fc-item__meta {
@@ -39,7 +47,11 @@
         }
 
         .fc-sublink__link {
-            color: #ffffff;
+            @if $pillar == special-report-alt {
+                color: $color2;
+            } @else {
+                color: #ffffff;
+            }
         }
 
         .fc-sublink__kicker {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -60,9 +60,15 @@
 
         // darken on hover
         .u-faux-block-link--hover {
-            background-color: darken($color1, 5%);
+            @if $pillar == special-report-alt {
+                background-color: darken($color1, 2%);
+            } @else {
+                background-color: darken($color1, 5%);
+            }
 
-            .fc-item__kicker::before {
+            @if $pillar == special-report-alt {
+                background-color: darken($color1, 2%);
+            } @else {
                 background-color: darken($color1, 5%);
             }
         }
@@ -94,4 +100,4 @@
 @include overide-live-blog-colours(sport, $sport-dark, $sport-pastel);
 @include overide-live-blog-colours(arts, $culture-dark, $culture-pastel);
 @include overide-live-blog-colours(lifestyle, $lifestyle-dark, $lifestyle-pastel);
-@include overide-live-blog-colours(special-report-alt, $special-report-alt-pastel, $special-report-alt-dark);
+@include overide-live-blog-colours(special-report-alt, $special-report-alt-faded, $special-report-alt-dark);

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -82,3 +82,4 @@
 @include overide-live-blog-colours(sport, $sport-dark, $sport-pastel);
 @include overide-live-blog-colours(arts, $culture-dark, $culture-pastel);
 @include overide-live-blog-colours(lifestyle, $lifestyle-dark, $lifestyle-pastel);
+@include overide-live-blog-colours(special-report-alt, $special-report-alt-pastel, $special-report-alt-dark);

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
@@ -119,6 +119,11 @@
         color: $special-report-alt-dark;
     }
 
+    &:hover,
+    .u-faux-block-link--hover {
+        background-color: darken($special-report-alt-faded, 2%);
+    }
+
     .fc-sublink__link {
         color: $special-report-alt-dark;
     }


### PR DESCRIPTION
## What does this change?

#25991 applied the correct `CardStyle` in `SpecialReportAlt` cards. This PR is fixing some of the bugs that have been exposed. See comments in code for screenshots

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No. These bugs only occur in fronts rendered by frontend. DCR has storybook so these bugs where never introduced. Here's the [PR that added the `SpecialReportAlt` cards styles](https://github.com/guardian/dotcom-rendering/pull/6314).
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/226291380-94f84f0a-3e97-4074-8f28-9aea755b6dbc.png) | ![image](https://user-images.githubusercontent.com/19683595/226300922-b645f9be-bfef-4ca0-b05c-c16567cdff93.png) |


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
