### PR TITLE
Fix cardstyle for special report alt

### DIFF
--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -11,20 +11,31 @@ object CardStylePicker {
 
   def apply(content: CapiContent): CardStyle = {
     val tags = content.tags.map(_.id).toSeq
-    extractCampaigns(tags) match {
-      case Nil                                                                         => CardStyle(content, TrailMetaData.empty)
-      case campaign :: Nil if campaign.id.toString.toLowerCase() == "specialreportalt" => SpecialReportAlt
-      case _                                                                           => SpecialReport
+    val campaigns = extractCampaigns(tags)
+    campaigns match {
+      case Nil => CardStyle(content, TrailMetaData.empty)
+      case _   => getCardStyleForCampaign(campaigns)
     }
   }
 
   def apply(content: FaciaContent): CardStyle = {
     val tags = FaciaContentUtils.tags(content).map(_.id)
-    extractCampaigns(tags) match {
-      case Nil                                                                         => FaciaContentUtils.cardStyle(content)
-      case campaign :: Nil if campaign.id.toString.toLowerCase() == "specialreportalt" => SpecialReportAlt
-      case _                                                                           => SpecialReport
+    val campaigns = extractCampaigns(tags)
+    campaigns match {
+      case Nil => FaciaContentUtils.cardStyle(content)
+      case _   => getCardStyleForCampaign(campaigns)
     }
+  }
+
+  def getCardStyleForCampaign(campaigns: List[Campaign]): CardStyle = {
+    if (containsSpecialReportAltCampaign(campaigns)) SpecialReportAlt else SpecialReport
+  }
+
+  private def containsSpecialReportAltCampaign(campaigns: List[Campaign]): Boolean = {
+    val specialReportAltCampaigns = campaigns.filter(campaign =>
+      campaign.fields.asInstanceOf[ReportFields].campaignId.toLowerCase() == "specialreportalt",
+    )
+    specialReportAltCampaigns.nonEmpty
   }
 
   private def extractCampaigns(tags: Seq[String]): List[Campaign] = {

--- a/common/test/model/CardStylePickerTest.scala
+++ b/common/test/model/CardStylePickerTest.scala
@@ -1,0 +1,40 @@
+package model
+
+import com.gu.facia.api.utils.{SpecialReport, SpecialReportAlt}
+import com.gu.targeting.client.{Campaign, ReportFields, Rule}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.UUID
+
+class CardStylePickerTest extends AnyFlatSpec with Matchers {
+  "CardStylePicker.getCampaignCardStyle" should "return SpecialReportAlt CardStyle when a SpecialReportAlt campaign is present" in {
+    val campaign = Campaign(
+      id = UUID.randomUUID(),
+      name = "Campaign 1",
+      rules = List(Rule(requiredTags = List("tag1", "tag2"), lackingTags = List("tag3"), matchAllTags = true)),
+      priority = 1,
+      activeFrom = None,
+      activeUntil = None,
+      displayOnSensitive = true,
+      fields = ReportFields("SpecialReportAlt"),
+    )
+
+    CardStylePicker.getCardStyleForCampaign(List(campaign)) shouldBe SpecialReportAlt
+  }
+
+  it should "return SpecialReport CardStyle in any other report campaign" in {
+    val campaign = Campaign(
+      id = UUID.randomUUID(),
+      name = "Campaign 2",
+      rules = List(Rule(requiredTags = List("tag5", "tag6"), lackingTags = List("tag7"), matchAllTags = true)),
+      priority = 1,
+      activeFrom = None,
+      activeUntil = None,
+      displayOnSensitive = true,
+      fields = ReportFields("ThePandoraPapers"),
+    )
+
+    CardStylePicker.getCardStyleForCampaign(List(campaign)) shouldBe SpecialReport
+  }
+}

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -412,10 +412,10 @@ $pillars: (
         }
     }
 
-    background-color: $special-report-alt-faded !important;
+    background-color: $special-report-alt-faded;
 
     .fc-item__container.u-faux-block-link--hover {
-        background-color: $special-report-alt-faded !important;
+        background-color: $special-report-alt-faded;
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -419,7 +419,7 @@ $pillars: (
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {
-            background-color: $special-report-alt-dark !important;
+            background-color: transparent;
         }
     }
 


### PR DESCRIPTION
## What does this change?
TODO

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
