### PR TITLE
Show video icon when there is no main media

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -63,7 +63,12 @@ data-test-id="facia-card"
                     </div>
                 }
 
-                case _ => {}
+                case _ => {
+                    <div class="fc-item__media-meta">
+                        @inlineSvg("video-icon", "icon")
+                       <span class="u-h">Video</span>
+                    </div>
+                }
             }
         }
 


### PR DESCRIPTION
## What does this change?

When main media is surprised, the video icon will now continue to show. This functionality has been requested by central production & digi eds

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - This is already the behaviour in DCR
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/225681057-d792bb8c-af0b-4deb-9d82-e18bd3c0ddd6.png
[after]: https://user-images.githubusercontent.com/9575458/225680764-60e2149f-73da-4873-a276-a1b3e41056cf.png



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
