### PR TITLE
Fix dev mode commercial bundle location

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,5 +1,6 @@
 const webpackMerge = require('webpack-merge');
 const config = require('./webpack.config.js');
+const CopyPlugin = require("copy-webpack-plugin");
 
 module.exports = webpackMerge.smart(config, {
     devtool: 'inline-source-map',
@@ -8,4 +9,17 @@ module.exports = webpackMerge.smart(config, {
         filename: `graun.[name].js`,
         chunkFilename: `graun.[name].js`,
     },
+    plugins: [
+        // Copy the commercial bundle dist to Frontend's static output location:
+        // static/target/javascripts/commercial
+        // In development mode the hashed directory structure is discarded and all files are copied to '/commercial'
+        new CopyPlugin({
+            patterns: [
+              {
+                  from: "node_modules/@guardian/commercial-bundle/dist",
+                  to: "commercial/[name].[ext]"
+              },
+            ],
+        }),
+    ],
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,8 @@ const CircularDependencyPlugin = require('circular-dependency-plugin');
 const webpack = require('webpack');
 const CopyPlugin = require("copy-webpack-plugin");
 
+const isDEV = process.env.NODE_ENV !== 'production';
+
 module.exports = {
     entry: {
         standard: path.join(
@@ -166,7 +168,10 @@ module.exports = {
         }),
         new CopyPlugin({
           patterns: [
-            { from: "node_modules/@guardian/commercial-bundle/dist", to: "commercial" },
+            {
+                from: "node_modules/@guardian/commercial-bundle/dist",
+                to: isDEV ? "commercial/[name].[ext]" : "commercial"
+            },
           ],
         }),
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,6 @@ const CircularDependencyPlugin = require('circular-dependency-plugin');
 const webpack = require('webpack');
 const CopyPlugin = require("copy-webpack-plugin");
 
-const isDEV = process.env.NODE_ENV !== 'production';
-
 module.exports = {
     entry: {
         standard: path.join(
@@ -165,18 +163,6 @@ module.exports = {
 
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-        }),
-        // Copy the commercial bundle dist to Frontend's static output location:
-        // static/target/javascripts/commercial
-        // In development mode the hashed directory structure is discarded and all files are copied to '/commercial'
-        // In production mode the hashed directory structure is copied as is
-        new CopyPlugin({
-          patterns: [
-            {
-                from: "node_modules/@guardian/commercial-bundle/dist",
-                to: isDEV ? "commercial/[name].[ext]" : "commercial"
-            },
-          ],
         }),
     ],
     externals: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -166,6 +166,10 @@ module.exports = {
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         }),
+        // Copy the commercial bundle dist to Frontend's static output location:
+        // static/target/javascripts/commercial
+        // In development mode the hashed directory structure is discarded and all files are copied to '/commercial'
+        // In production mode the hashed directory structure is copied as is
         new CopyPlugin({
           patterns: [
             {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -4,6 +4,7 @@ const Visualizer = require('webpack-visualizer-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
     .BundleAnalyzerPlugin;
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+const CopyPlugin = require("copy-webpack-plugin");
 
 const config = require('./webpack.config.js');
 
@@ -15,6 +16,16 @@ module.exports = webpackMerge.smart(config, {
     },
     devtool: 'source-map',
     plugins: [
+        // Copy the commercial bundle dist to Frontend's static output location:
+        // static/target/javascripts/commercial
+        new CopyPlugin({
+            patterns: [
+              {
+                  from: "node_modules/@guardian/commercial-bundle/dist",
+                  to: "commercial"
+              },
+            ],
+        }),
         new webpack.optimize.AggressiveMergingPlugin({
             // delicate number: stops enhanced-no-commercial and enhanced
             // being merged into one

--- a/yarn.lock
+++ b/yarn.lock
@@ -11791,7 +11791,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@github:guardian/prebid.js#2e3b96d":
+prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?

A fix for a regression in ad rendering in development mode.

When running Frontend in development mode the commercial bundle files are not found in the expected target location so ads don't render.

This change updates the Webpack CopyPlugin to copy commercial bundle dist files to `/static/target/javascripts/commercial` as follows:

- dev: the commercial bundle hashed directories are discarded and all files are copied to `commercial/`
- prod: the commercial bundle hashed directories are copied without modification


## Screenshots

Development mode:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before-app][] | ![after-app][] |

[before]: https://user-images.githubusercontent.com/7014230/225984840-1ff5e449-551c-4659-b82c-2ac6c6986d12.png
[after]: https://user-images.githubusercontent.com/7014230/225984867-12bbd5b1-c2eb-4b16-9d21-75cc17ff3273.png

[before-app]: https://user-images.githubusercontent.com/7014230/225985251-a9fb60ea-56e4-4b8e-a49b-40bd299957ef.png
[after-app]: https://user-images.githubusercontent.com/7014230/225985327-76712526-9511-432c-afb0-fc54ae3b5c45.png


### Tested

- [x] Locally
- [ ] On CODE (optional)
