### PR TITLE
Fix `CardStyle` for `SpecialReportAlt`

### DIFF
--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -11,20 +11,31 @@ object CardStylePicker {
 
   def apply(content: CapiContent): CardStyle = {
     val tags = content.tags.map(_.id).toSeq
-    extractCampaigns(tags) match {
-      case Nil                                                                         => CardStyle(content, TrailMetaData.empty)
-      case campaign :: Nil if campaign.id.toString.toLowerCase() == "specialreportalt" => SpecialReportAlt
-      case _                                                                           => SpecialReport
+    val campaigns = extractCampaigns(tags)
+    campaigns match {
+      case Nil => CardStyle(content, TrailMetaData.empty)
+      case _   => getCardStyleForReport(campaigns)
     }
   }
 
   def apply(content: FaciaContent): CardStyle = {
     val tags = FaciaContentUtils.tags(content).map(_.id)
-    extractCampaigns(tags) match {
-      case Nil                                                                         => FaciaContentUtils.cardStyle(content)
-      case campaign :: Nil if campaign.id.toString.toLowerCase() == "specialreportalt" => SpecialReportAlt
-      case _                                                                           => SpecialReport
+    val campaigns = extractCampaigns(tags)
+    campaigns match {
+      case Nil => FaciaContentUtils.cardStyle(content)
+      case _   => getCardStyleForReport(campaigns)
     }
+  }
+
+  def getCardStyleForReport(campaigns: List[Campaign]): CardStyle = {
+    if (containsSpecialReportAltCampaign(campaigns)) SpecialReportAlt else SpecialReport
+  }
+
+  private def containsSpecialReportAltCampaign(campaigns: List[Campaign]): Boolean = {
+    val specialReportAltCampaigns = campaigns.filter(campaign =>
+      campaign.fields.asInstanceOf[ReportFields].campaignId.toLowerCase() == "specialreportalt",
+    )
+    specialReportAltCampaigns.nonEmpty
   }
 
   private def extractCampaigns(tags: Seq[String]): List[Campaign] = {

--- a/common/test/model/CardStylePickerTest.scala
+++ b/common/test/model/CardStylePickerTest.scala
@@ -1,0 +1,33 @@
+package model
+
+import com.gu.facia.api.utils.{SpecialReport, SpecialReportAlt}
+import com.gu.targeting.client.{Campaign, ReportFields, Rule}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.UUID
+
+class CardStylePickerTest extends AnyFlatSpec with Matchers {
+
+  def createCampaign(campaignId: String) =
+    Campaign(
+      id = UUID.randomUUID(),
+      name = "Campaign",
+      rules = List(Rule(requiredTags = List("tag1", "tag2"), lackingTags = List("tag3"), matchAllTags = true)),
+      priority = 1,
+      activeFrom = None,
+      activeUntil = None,
+      displayOnSensitive = true,
+      fields = ReportFields(campaignId),
+    )
+
+  "CardStylePicker.getCampaignCardStyle" should "return SpecialReportAlt CardStyle when a SpecialReportAlt campaign is present" in {
+    val campaign = createCampaign("SpecialReportAlt")
+    CardStylePicker.getCardStyleForReport(List(campaign)) shouldBe SpecialReportAlt
+  }
+
+  it should "return SpecialReport CardStyle in any other report campaign" in {
+    val campaign = createCampaign("ThePandoraPapers")
+    CardStylePicker.getCardStyleForReport(List(campaign)) shouldBe SpecialReport
+  }
+}

--- a/common/test/model/CardStylePickerTest.scala
+++ b/common/test/model/CardStylePickerTest.scala
@@ -1,7 +1,7 @@
 package model
 
-import com.gu.facia.api.utils.{SpecialReport, SpecialReportAlt}
-import com.gu.targeting.client.{Campaign, ReportFields, Rule}
+import com.gu.targeting.client.{Campaign, EpicFields, ReportFields, Rule}
+import model.CardStylePicker.{OtherCampaign, SpecialReportAltCampaign, SpecialReportCampaign}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -9,7 +9,7 @@ import java.util.UUID
 
 class CardStylePickerTest extends AnyFlatSpec with Matchers {
 
-  def createCampaign(campaignId: String) =
+  def createReportCampaign(campaignId: String) =
     Campaign(
       id = UUID.randomUUID(),
       name = "Campaign",
@@ -21,13 +21,33 @@ class CardStylePickerTest extends AnyFlatSpec with Matchers {
       fields = ReportFields(campaignId),
     )
 
-  "CardStylePicker.getCampaignCardStyle" should "return SpecialReportAlt CardStyle when a SpecialReportAlt campaign is present" in {
-    val campaign = createCampaign("SpecialReportAlt")
-    CardStylePicker.getCardStyleForReport(List(campaign)) shouldBe SpecialReportAlt
+  val epicCampaign =
+    Campaign(
+      id = UUID.randomUUID(),
+      name = "Campaign",
+      rules = List(Rule(requiredTags = List("tag1", "tag2"), lackingTags = List("tag3"), matchAllTags = true)),
+      priority = 1,
+      activeFrom = None,
+      activeUntil = None,
+      displayOnSensitive = true,
+      fields = EpicFields("Epic-campaign"),
+    )
+
+  "CardStylePicker.getCampaignType" should "return SpecialReportAltCampaign when a SpecialReportAlt campaign is present" in {
+    val reportCampaign = createReportCampaign("SpecialReportAlt")
+    CardStylePicker.getCampaignType(List(reportCampaign, epicCampaign)) shouldBe SpecialReportAltCampaign
   }
 
-  it should "return SpecialReport CardStyle in any other report campaign" in {
-    val campaign = createCampaign("ThePandoraPapers")
-    CardStylePicker.getCardStyleForReport(List(campaign)) shouldBe SpecialReport
+  it should "return SpecialReportCampaign in any other report campaign" in {
+    val reportCampaign = createReportCampaign("ThePandoraPapers")
+    CardStylePicker.getCampaignType(List(epicCampaign, reportCampaign)) shouldBe SpecialReportCampaign
+  }
+
+  it should "return OtherCampaign if no campaign is present" in {
+    CardStylePicker.getCampaignType(List.empty) shouldBe OtherCampaign
+  }
+
+  it should "return OtherCampaign if any other non-Report type of campaign is present" in {
+    CardStylePicker.getCampaignType(List(epicCampaign)) shouldBe OtherCampaign
   }
 }


### PR DESCRIPTION
## What does this change?

Fixes a bug where all the Reports (including the `SpecialReportAlt`) were getting the `SpecialReport` `CardStyle`. This PR adds the correct check in the facia-press layer but also exposes some of the visual bugs of the SpecialReportAlt in the rendering layer. These will be fixed in following PRs, starting from #25984. These bugs won't be visible to the readers as we currently don't have SpecialReportAlt content published live. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No. It's only a `facia-press` change. 
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="653" alt="image" src="https://user-images.githubusercontent.com/19683595/225917294-dccdbe05-1fe1-440e-a23a-b9a77ac23919.png"> | ![image](https://user-images.githubusercontent.com/19683595/226291380-94f84f0a-3e97-4074-8f28-9aea755b6dbc.png) |
| <img width="635" alt="image" src="https://user-images.githubusercontent.com/19683595/226095806-1e9566c7-c0ca-464f-85b5-cd8cca5da067.png"> | <img width="758" alt="image" src="https://user-images.githubusercontent.com/19683595/226095610-5aaa56a5-d33c-47fd-9e6d-d75d72f0c218.png"> |

### Special Reports still look good
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/226292052-88478f31-f91f-43ef-a9ce-b0c0f1e985d2.png) | ![image](https://user-images.githubusercontent.com/19683595/226291816-7a182f59-0aad-40fd-a573-d940d9cceef4.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
