### PR TITLE
Fix clock in SpecialReportAlt card

### DIFF
--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -1,17 +1,32 @@
+@import model.pressed.SpecialReportAlt
 @(item: layout.ContentCard)(implicit request: RequestHeader)
 
 @import views.support.GuDateFormatLegacy
 
+
+
 <div class="fc-item__meta js-item__meta">
     @for(publishedAt <- item.webPublicationDate; timeStampDisplay <- item.timeStampDisplay) {
-        <time class="fc-item__timestamp@if(timeStampDisplay.javaScriptUpdate){ js-item__timestamp}"
-        datetime="@publishedAt.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
-        data-timestamp="@publishedAt.getMillis"
-        data-relativeformat="short">
-            @fragments.inlineSvg("clock", "icon")
-        <span class="fc-timestamp__text">
-            <span class="u-h">Published: </span>@GuDateFormatLegacy(publishedAt, timeStampDisplay.formatString)
-        </span>
-        </time>
+        @if(item.cardStyle == SpecialReportAlt) {
+            <time class="fc-item__timestamp_dark@if(timeStampDisplay.javaScriptUpdate) { js-item__timestamp}"
+            datetime="@publishedAt.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+            data-timestamp="@publishedAt.getMillis"
+            data-relativeformat="short">
+                @fragments.inlineSvg("clock", "icon")
+                <span class="fc-timestamp__text">
+                    <span class="u-h">Published: </span>@GuDateFormatLegacy(publishedAt, timeStampDisplay.formatString)
+                </span>
+            </time>
+        } else {
+            <time class="fc-item__timestamp@if(timeStampDisplay.javaScriptUpdate) { js-item__timestamp}"
+            datetime="@publishedAt.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+            data-timestamp="@publishedAt.getMillis"
+            data-relativeformat="short">
+                @fragments.inlineSvg("clock", "icon")
+                <span class="fc-timestamp__text">
+                    <span class="u-h">Published: </span>@GuDateFormatLegacy(publishedAt, timeStampDisplay.formatString)
+                </span>
+            </time>
+        }
     }
 </div>

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -399,6 +399,19 @@ $block-height: 58px;
     svg {
         height: 11px;
         width: 11px;
+
+    }
+}
+
+.fc-item__timestamp_dark .inline-icon {
+    height: 11px;
+    width: 11px;
+    margin-top: 1px;
+
+    svg {
+        height: 11px;
+        width: 11px;
+        fill: $special-report-alt-dark;
     }
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -483,10 +483,6 @@ $pillars: (
         }
     }
 
-    .fc-item__container.u-faux-block-link--hover {
-        background-color: darken($special-report-alt-faded, 2%);
-    }
-
     .fc-sublink__kicker {
         color: $special-report-alt-dark;
     }

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -412,10 +412,10 @@ $pillars: (
         }
     }
 
-    background-color: $special-report-alt-faded !important;
+    background-color: $special-report-alt-faded;
 
     .fc-item__container.u-faux-block-link--hover {
-        background-color: $special-report-alt-faded !important;
+        background-color: $special-report-alt-faded;
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -419,7 +419,7 @@ $pillars: (
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {
-            background-color: $special-report-alt-dark !important;
+            background-color: transparent;
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -415,7 +415,7 @@ $pillars: (
     background-color: $special-report-alt-faded;
 
     .fc-item__container.u-faux-block-link--hover {
-        background-color: $special-report-alt-faded;
+        background-color: darken($special-report-alt-faded, 2%);
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -17,11 +17,19 @@
         }
 
         .fc-item__headline {
-            color: #ffffff;
+            @if $pillar == special-report-alt {
+                color: $color2;
+            } @else {
+                color: #ffffff;
+            }
         }
 
         .fc-item__standfirst {
-            color: #ffffff;
+            @if $pillar == special-report-alt {
+                color: $color2;
+            } @else {
+                color: #ffffff;
+            }
         }
 
         .fc-item__meta {
@@ -39,7 +47,11 @@
         }
 
         .fc-sublink__link {
-            color: #ffffff;
+            @if $pillar == special-report-alt {
+                color: $color2;
+            } @else {
+                color: #ffffff;
+            }
         }
 
         .fc-sublink__kicker {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -60,9 +60,15 @@
 
         // darken on hover
         .u-faux-block-link--hover {
-            background-color: darken($color1, 5%);
+            @if $pillar == special-report-alt {
+                background-color: darken($color1, 2%);
+            } @else {
+                background-color: darken($color1, 5%);
+            }
 
-            .fc-item__kicker::before {
+            @if $pillar == special-report-alt {
+                background-color: darken($color1, 2%);
+            } @else {
                 background-color: darken($color1, 5%);
             }
         }
@@ -94,4 +100,4 @@
 @include overide-live-blog-colours(sport, $sport-dark, $sport-pastel);
 @include overide-live-blog-colours(arts, $culture-dark, $culture-pastel);
 @include overide-live-blog-colours(lifestyle, $lifestyle-dark, $lifestyle-pastel);
-@include overide-live-blog-colours(special-report-alt, $special-report-alt-pastel, $special-report-alt-dark);
+@include overide-live-blog-colours(special-report-alt, $special-report-alt-faded, $special-report-alt-dark);

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -82,3 +82,4 @@
 @include overide-live-blog-colours(sport, $sport-dark, $sport-pastel);
 @include overide-live-blog-colours(arts, $culture-dark, $culture-pastel);
 @include overide-live-blog-colours(lifestyle, $lifestyle-dark, $lifestyle-pastel);
+@include overide-live-blog-colours(special-report-alt, $special-report-alt-pastel, $special-report-alt-dark);

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
@@ -119,6 +119,11 @@
         color: $special-report-alt-dark;
     }
 
+    &:hover,
+    .u-faux-block-link--hover {
+        background-color: darken($special-report-alt-faded, 2%);
+    }
+
     .fc-sublink__link {
         color: $special-report-alt-dark;
     }


### PR DESCRIPTION
## What does this change?
Index fronts show a clock and time of publication. This PR fixes those for `SpecialReportAlt` in order to match the designs.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No. It has already implemented in https://github.com/guardian/dotcom-rendering/pull/6314.
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/226300922-b645f9be-bfef-4ca0-b05c-c16567cdff93.png) | ![image](https://user-images.githubusercontent.com/19683595/226308052-ef6f90fe-5350-4a35-8614-e795c4dfc36b.png) |


### Other pillars stay the same

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/226308152-abcee9e1-ed09-4c05-bf18-7547c76e65d7.png) | ![image](https://user-images.githubusercontent.com/19683595/226308152-abcee9e1-ed09-4c05-bf18-7547c76e65d7.png) |
| ![image](https://user-images.githubusercontent.com/19683595/226308399-0ca55932-64f0-42e7-bce7-7feb0cd7774a.png) | ![image](https://user-images.githubusercontent.com/19683595/226308399-0ca55932-64f0-42e7-bce7-7feb0cd7774a.png) |


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
