### PR TITLE
Bump commercial bundle to `1.6.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^10.0.0",
-		"@guardian/commercial-bundle": "^1.5.2",
+		"@guardian/commercial-bundle": "^1.6.0",
 		"@guardian/commercial-core": "^5.4.5",
 		"@guardian/consent-management-platform": "^11.0.0",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,10 +2243,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-10.0.0.tgz#9ff9f6e3cfb681f309808c6e47d0e2cf1a012650"
   integrity sha512-cpR3NBmZrUfCvUlBphbVelLAgcuVth4Lo7M1Ohk7dhfgFrocrie/oQT1ZOWX6a90DuAEQZuKTlebmbHJ0XlFcQ==
 
-"@guardian/commercial-bundle@^1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.5.2.tgz#910ab1d9828059d30f9b61609e2a5f48279464a2"
-  integrity sha512-pJ1N4bP2N8ggQLK90YR2/nyBgTGt3xRxr0cX0aZiX9uYz6fw2Da6ef5LNnXZ4xOU86WjoF9Xswt7XSylLTqHbQ==
+"@guardian/commercial-bundle@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.6.0.tgz#c683c8b0191db780ff3f283fc67feee1249ed66c"
+  integrity sha512-KUtyTdmhJ1KRC0fzuWN1gwGN+bTmiuIeEeUpvI3tTarAGdvFR+XONCAut0fu5S56ViOD/0qu6oZIysAXlPgTbg==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^5.4.4"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/commercial-bundle` to `1.6.0`.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Why

Use the bundle that includes https://github.com/guardian/commercial/pull/826.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

