### PR TITLE
Rename Euro 2024 qualifying listings

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -55,7 +55,7 @@ class LeagueTableController(
     "Women's Euro 2022",
     "World Cup 2022 qualifying",
     "Nations League",
-    "European Championship",
+    "Euro 2024 qualifying",
   )
 
   def sortedCompetitions: Seq[Competition] =

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -212,8 +212,8 @@ object CompetitionsProvider {
     Competition(
       "751",
       "/football/euro-2024",
-      "European Championship", // aka Euro 2024
-      "European Championship",
+      "Euro 2024 qualifying",
+      "Euro 2024 qualifying",
       "Internationals",
       showInTeamsList = true,
       tableDividers = List(2),


### PR DESCRIPTION
## What does this change?

Updates the name for the Euro 2024 qualifiers (introduced in #25988) to `Euro 2024 qualifying`, on a request from CP.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
