### PR TITLE
Remove `github` prefix from prebid reference

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11791,7 +11791,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@github:guardian/prebid.js#2e3b96d":
+prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
The snyk CI job was failing, [complaining about an out of sync `yarn.lock` file](https://github.com/guardian/frontend/actions/runs/4470556765/jobs/7854494765). The updated `yarn.lock` in this commit is the result of running `yarn install`. It removes the `github:` prefix from a prebid reference that was added last week when updating the `@guardian/commercial-bundle` package in #25982 

I've verified that the snyk job runs successfully for this branch: [passing snyk job](https://github.com/guardian/frontend/actions/runs/4477309178/jobs/7868679579).

