### PR TITLE
Stop refreshing Identity cookie only sessions

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -12,7 +12,7 @@ import {
     getUserFromCookie,
     reset,
     updateUsername,
-    getUserFromApiWithRefreshedCookie,
+    getUserFromApi,
 } from 'common/modules/identity/api';
 import { avatarify } from 'common/modules/discussion/user-avatars';
 import { init as initValidationEmail } from 'common/modules/identity/validation-email';
@@ -327,11 +327,10 @@ class CommentBox extends Component {
             if (comment.body.length > this.options.maxLength) {
                 this.error(
                     'COMMENT_TOO_LONG',
-                    `<b>Comments must be shorter than ${
-                        this.options.maxLength
+                    `<b>Comments must be shorter than ${this.options.maxLength
                     } characters.</b>` +
-                        `Yours is currently ${comment.body.length -
-                            this.options.maxLength} character(s) too long.`
+                    `Yours is currently ${comment.body.length -
+                    this.options.maxLength} character(s) too long.`
                 );
             }
 
@@ -356,11 +355,11 @@ class CommentBox extends Component {
         };
 
         if (!this.getUserData().emailVerified) {
-            // Cookie could be stale so lets refresh and check from the api
+            // Cookie could be stale so lets check from the api
             const createdDate = new Date(this.getUserData().accountCreatedDate);
 
             if (createdDate > this.options.priorToVerificationDate) {
-                return getUserFromApiWithRefreshedCookie().then(response => {
+                return getUserFromApi().then(response => {
                     if (
                         response.user.statusFields.userEmailValidated === true
                     ) {
@@ -546,7 +545,7 @@ class CommentBox extends Component {
                 const parentCommentSpout = this.getElem('parent-comment-spout');
                 const spoutOffset = replyToAuthor
                     ? replyToAuthor.offsetLeft +
-                      replyToAuthor.getBoundingClientRect().width / 2
+                    replyToAuthor.getBoundingClientRect().width / 2
                     : false;
 
                 if (parentCommentSpout && spoutOffset) {

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.spec.js
@@ -1,5 +1,5 @@
 import { CommentBox } from 'common/modules/discussion/comment-box';
-import { getUserFromApiWithRefreshedCookie as getUserFromApiWithRefreshedCookie_ } from 'common/modules/identity/api';
+import { getUserFromApi as getUserFromApi_ } from 'common/modules/identity/api';
 import { postComment as postComment_ } from 'common/modules/discussion/api';
 
 jest.mock('lib/config', () => ({
@@ -7,7 +7,7 @@ jest.mock('lib/config', () => ({
 }));
 jest.mock('lib/mediator');
 jest.mock('common/modules/discussion/user-avatars', () => ({
-    avatarify() {},
+    avatarify() { },
 }));
 jest.mock('common/modules/identity/api', () => ({
     getUserFromCookie: jest.fn().mockReturnValue({
@@ -15,7 +15,7 @@ jest.mock('common/modules/identity/api', () => ({
         id: 1,
         accountCreatedDate: new Date(1392719401338),
     }),
-    getUserFromApiWithRefreshedCookie: jest.fn().mockReturnValue(
+    getUserFromApi: jest.fn().mockReturnValue(
         Promise.resolve({
             user: {
                 statusFields: {
@@ -31,7 +31,7 @@ jest.mock('common/modules/discussion/api', () => ({
     getUser: jest.fn(),
 }));
 
-const getUserFromApiWithRefreshedCookie = (getUserFromApiWithRefreshedCookie_);
+const getUserFromApi = (getUserFromApi_);
 const postComment = (postComment_);
 
 describe('Comment box', () => {
@@ -164,7 +164,7 @@ describe('Comment box', () => {
             if (commentBody && commentBody instanceof HTMLTextAreaElement) {
                 commentBody.value = validCommentText;
 
-                getUserFromApiWithRefreshedCookie.mockReturnValueOnce(
+                getUserFromApi.mockReturnValueOnce(
                     Promise.resolve({
                         user: {
                             statusFields: {

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -238,14 +238,6 @@ const getUserCookie = (): string | null => getCookie({ name: cookieName });
 
 export const getUrl = (): string => profileRoot;
 
-export const getUserFromApiWithRefreshedCookie = (): Promise<unknown> => {
-	const endpoint = `${idApiRoot}/user/me?refreshCookie=true`;
-	return fetch(endpoint, {
-		mode: 'cors',
-		credentials: 'include',
-	}).then((resp) => resp.json());
-};
-
 export const refreshOktaSession = (returnUrl: string): void => {
 	const endpoint = `${profileRoot}/signin/refresh?returnUrl=${returnUrl}`;
 	window.location.replace(endpoint);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11791,7 +11791,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@github:guardian/prebid.js#2e3b96d":
+prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?

In preparation for migrating all users to Okta we have to make sure that all users are currently using Okta sessions.

Anyone who has signed in using the sign in, reauthentication, or registration pages since [2022-09-13](https://github.com/guardian/gateway/pull/1890) will be getting Okta sessions by default.

However there are still a small subset of users who will have stayed logged into the site since before Okta sessions were set and were getting refreshed every 30 days.

This PR removes the ability to refresh Identity only sessions, and will now only refresh Identity cookies if an Okta session currently exists through the use of the `refreshOktaSession` method.

This redirects to `https://profile.theguardian.com/signin/refresh`. This endpoint checks if they have a valid Okta session, if they do we refresh the Okta session, along with the Identity cookies and redirect the user back to the page that they were on. If a user doesn't have an Okta session, but only has existing identity cookies, then we don't refresh anything and redirect the user back. This means after a maximum of 90 days from after this PR is merged in anyone with only an identity session will automatically be logged out.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

I can't see that the session refreshing functionality has been ported to DCR yet.

## Tested

- [x] Locally
- [x] CODE

