### PR TITLE
Capture all core web vitals

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -10,6 +10,8 @@ const defaultClientSideTests: ABTest[] = [
 
 const serverSideTests: ServerSideABTest[] = [
 	/* linter, please keep this array multi-line */
+	'poorDeviceConnectivityVariant',
+	'poorDeviceConnectivityControl',
 ];
 
 /**


### PR DESCRIPTION
## What does this change?

Capture all core web vitals for users in the Poor Device Connectivity test.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes – https://github.com/guardian/dotcom-rendering/pull/7446

## What is the value of this and can you measure success?

More data – we forgot it in #25954 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)