### PR TITLE
Switch off server-side liveblog ad test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -71,7 +71,7 @@ object ServerSideLiveblogInlineAds
         "Test whether we can load liveblog inline ads server-side without negative effects on user experience or revenue",
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
       sellByDate = LocalDate.of(2023, 6, 1),
-      participationGroup = Perc5A,
+      participationGroup = Perc0A,
     )
 
 object PoorDeviceConnectivity


### PR DESCRIPTION
## What does this change?

Sets the participation group of the server-side liveblog inline ad test to 0%.

## Why

The AB test has now reached sample size so the results can be analysed.