### PR TITLE
Remove 'isNotAdFree' check

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -60,12 +60,6 @@ object FrontChecks {
     !faciaPage.isNetworkFront
   }
 
-  def isNotAdFree()(implicit request: RequestHeader): Boolean = {
-    // We don't support the signed in experience
-    // See: https://github.com/guardian/dotcom-rendering/issues/5926
-    !Commercial.isAdFree(request)
-  }
-
   def hasNoPageSkin(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
     // We don't support page skin ads
     // See: https://github.com/guardian/dotcom-rendering/issues/5490
@@ -129,7 +123,6 @@ object FaciaPicker extends GuLogging {
     Map(
       ("allCollectionsAreSupported", FrontChecks.allCollectionsAreSupported(faciaPage)),
       ("hasNoWeatherWidget", FrontChecks.hasNoWeatherWidget(faciaPage)),
-      ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
       ("hasNoSlideshows", FrontChecks.hasNoSlideshows(faciaPage)),
       ("hasNoPaidCards", FrontChecks.hasNoPaidCards(faciaPage)),


### PR DESCRIPTION
DCR supports ad free requests on fronts now, so we don't need to check for this when deciding which fronts DCR can render.

Part of [supporting ad free on DCR fronts](https://github.com/guardian/dotcom-rendering/issues/6379)

## Does this change need to be reproduced in dotcom-rendering ?

>**Warning**
>Should not be merged until the corresponding DCR PR has been merged: https://github.com/guardian/dotcom-rendering/pull/7449

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)