### PR TITLE
fix: experiment can only run with extra header

### DIFF
--- a/common/app/experiments/Experiment.scala
+++ b/common/app/experiments/Experiment.scala
@@ -42,10 +42,10 @@ abstract case class Experiment(
   private def matchesExtraHeader(implicit requestHeader: RequestHeader): Boolean =
     extraHeader.map(h => checkHeader(h.key, _ == h.value)).getOrElse(true)
 
-  def canRun(implicit request: RequestHeader): Boolean = isSwitchedOn && priorCondition
+  def canRun(implicit request: RequestHeader): Boolean = isSwitchedOn && priorCondition && matchesExtraHeader
 
   def isParticipating[A](implicit request: RequestHeader, canCheck: CanCheckExperiment): Boolean =
-    canRun && matchesExtraHeader && inVariant
+    canRun && inVariant
 
   def isControl[A](implicit request: RequestHeader, canCheck: CanCheckExperiment): Boolean = canRun && inControl
   def value(implicit request: RequestHeader, canCheck: CanCheckExperiment): String = {


### PR DESCRIPTION
## What does this change?

Ensure control and variant groups are restricted
to the same conditions:

- priorCondition
- extraHeader (was missing from isControl)

![image](https://user-images.githubusercontent.com/76776/226973266-3c232325-0086-43d5-8c69-5a2dae3f168d.png)


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Currently, control groups are not affected by the check for the extra header, unlike variant groups.

This would greatly reduce the size of our control group for the poor device connectivity test: #25954 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
