### PR TITLE
Bump identity libs to 3.255

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.254"
+  val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
   val capiVersion = "19.2.1"
   val faciaVersion = "4.0.5"


### PR DESCRIPTION
## What does this change?

Removes indirect dependency on an old version of http4s in `identity-auth-play`. I haven't found a changelog for this release of `identity-auth-play` but the only other code changes seem to be removing a resubscription endpoint that I can't find any reference to in the Frontend codebase: https://github.com/guardian/identity/compare/v3.254...v3.255

I did a test deployment on CODE and nothing seemed to fall over. I'm open to any suggestions on how to test it more thoroughly though!
