### PR TITLE
Fix various SpecialReportAlt bugs

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -338,6 +338,14 @@ $block-height: 58px;
     color: #ffffff;
 }
 
+.fc-item--pillar-special-report-alt {
+    .fc-item__meta {
+        .inline-icon {
+            fill: $special-report-alt-dark;
+        }
+    }
+}
+
 .fc-item__meta {
     @include fs-textSans(1);
     color: $brightness-46;

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -415,7 +415,7 @@ $pillars: (
     background-color: $special-report-alt-faded;
 
     .fc-item__container.u-faux-block-link--hover {
-        background-color: darken($special-report-alt-faded, 2%);
+        background-color: darken($special-report-alt-pastel, 5%);
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -282,6 +282,10 @@
     // if pillar news we override news pallete with opinion palette for comment cards
     &.fc-item--pillar-news {
         @include colours(map-get($pillars, opinion));
+
+        &.fc-item--pillar-special-report-alt {
+            @include colours(map-get($pillars, special-report-alt));
+        }
     }
 }
 

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -284,14 +284,33 @@
         @include colours(map-get($pillars, opinion));
 
         &.fc-item--pillar-special-report-alt {
-            @include colours(map-get($pillars, special-report-alt));
+            background-color: $special-report-alt-faded;
+
+            .fc-item__timestamp,
+            .fc-trail__count--commentcount {
+                background-color: $special-report-alt-faded;
+            }
+
+            .fc-item__meta {
+                color: $special-report-alt-dark;
+            }
+
+            .fc-item__container.u-faux-block-link--hover {
+                background-color: darken($special-report-alt-pastel, 5%);
+
+                .fc-item__timestamp,
+                .fc-trail__count--commentcount {
+                    background-color: darken($special-report-alt-pastel, 5%);
+
+                }
+            }
         }
     }
 }
 
 .fc-item--pillar-special-report-alt {
     .fc-item__container > .fc-item__meta {
-        @include multiline(3, rgba(60, 60, 60, .3));
+        @include multiline(3, rgba(112, 112, 112, .3));
 
         display: flex;
         position: absolute;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-interview.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-interview.scss
@@ -11,3 +11,4 @@
 @include overide-interview-headline-colours(arts, $culture-dark, $culture-pastel);
 @include overide-interview-headline-colours(lifestyle, $lifestyle-dark, $news-pastel);
 @include overide-interview-headline-colours(special-report, #ffffff, #ffffff);
+@include overide-interview-headline-colours(special-report-alt, $special-report-alt-dark, $special-report-alt-dark);

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -61,13 +61,7 @@
         // darken on hover
         .u-faux-block-link--hover {
             @if $pillar == special-report-alt {
-                background-color: darken($color1, 2%);
-            } @else {
-                background-color: darken($color1, 5%);
-            }
-
-            @if $pillar == special-report-alt {
-                background-color: darken($color1, 2%);
+                background-color: darken($special-report-alt-pastel, 5%);
             } @else {
                 background-color: darken($color1, 5%);
             }

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
@@ -121,7 +121,7 @@
 
     &:hover,
     .u-faux-block-link--hover {
-        background-color: darken($special-report-alt-faded, 2%);
+        background-color: darken($special-report-alt-pastel, 5%);
     }
 
     .fc-sublink__link {


### PR DESCRIPTION
## What does this change?
Fixes various visual bugs in SpecialReportAlt fronts cards:

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No. DCR has proper visual testing in place so these bugs where never introduced in https://github.com/guardian/dotcom-rendering/pull/6314
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

This is a more general screenshot but more detailed can be found in PR comments.

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/226952364-68b105a7-fa05-4350-a80d-193a5ad02d1a.png) | ![image](https://user-images.githubusercontent.com/19683595/226951781-fe965db9-8e78-44b8-a72c-01ab4ab8c7f6.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
