### PR TITLE
Record metrics for all server-side tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -8,12 +8,6 @@ const defaultClientSideTests: ABTest[] = [
 	integrateIma,
 ];
 
-const serverSideTests: ServerSideABTest[] = [
-	/* linter, please keep this array multi-line */
-	'poorDeviceConnectivityVariant',
-	'poorDeviceConnectivityControl',
-];
-
 /**
  * Function to check whether metrics should be captured for the current page
  * @param tests - optional array of ABTest to check against.
@@ -26,10 +20,7 @@ const shouldCaptureMetrics = (tests = defaultClientSideTests): boolean => {
 	);
 
 	const userInServerSideTest =
-		window.guardian.config.tests !== undefined &&
-		Object.keys(window.guardian.config.tests).some((test) =>
-			String(serverSideTests).includes(test),
-		);
+		Object.keys(window.guardian.config.tests ?? {}).length > 0;
 
 	const forceSendMetrics = Boolean(getUrlVars().forceSendMetrics);
 


### PR DESCRIPTION
## What does this change?

Record metrics for all server-side tests.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes – https://github.com/guardian/dotcom-rendering/pull/7450

## What is the value of this and can you measure success?

When running a server-side test, we always need to ensure that the experiment does not negatively affect our metrics and they should always be measured.

Teams frequently forget to set this value, which leads to test having to run longer to capture significant metrics.

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
