### PR TITLE
update humans.txt

### DIFF
--- a/facia/public/humans.txt
+++ b/facia/public/humans.txt
@@ -1,6 +1,8 @@
-/* ---------------------------------------------------- */
-/* CURRENT                                              */
-/* ---------------------------------------------------- */
+
+Editor-in-Chief: C.P.Scott
+From: Bath, Somerset
+
+---
 
 Developer: Daniel Clifton
 From: Ipswich UK
@@ -183,13 +185,6 @@ Location: London, UK
 Developer: Georges Lebreton
 From: France
 Location: London, UK
-
-/* ---------------------------------------------------- */
-/* FORMER                                               */
-/* ---------------------------------------------------- */
-
-Editor-in-chief: C.P.Scott
-From: Bath, Somerset
 
 Developer Manager: Matt Chadburn
 Twitter: @commuterjoy


### PR DESCRIPTION
1. Put C.P.Scott in first position.
2. Remove the unnecessary distinction between current and former people (this will prevent having to make update PRs so often, at least the temptation of). 

There is no particular order in this file, which is also by design. 