### PR TITLE
Bump commercial-bundle v1.9.0 + add ab test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -77,6 +77,25 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-eager-prebid",
+    "Test running prebid earlier in the page lifecycle",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 4, 30)),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
+    "ab-no-carrot-ads-near-newsletter-signup-blocks",
+    "Test the impact of preventing spacefinder from positioning carrot ads near newsletter signup blocks",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 4, 4)),
+    exposeClientSide = true,
+  )
+  Switch(
+    ABTests,
     "ab-sign-in-gate-copy-test-jan-2023",
     "Test the impact of changing the copy in the sign in gate",
     owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "Test running prebid earlier in the page lifecycle",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 4, 30)),
+    sellByDate = Some(LocalDate.of(2023, 5, 1)),
     exposeClientSide = true,
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -87,15 +87,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-no-carrot-ads-near-newsletter-signup-blocks",
-    "Test the impact of preventing spacefinder from positioning carrot ads near newsletter signup blocks",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 4, 4)),
-    exposeClientSide = true,
-  )
-  Switch(
-    ABTests,
     "ab-sign-in-gate-copy-test-jan-2023",
     "Test the impact of changing the copy in the sign in gate",
     owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^11.0.0",
-		"@guardian/commercial-bundle": "1.8.0",
+		"@guardian/commercial-bundle": "1.9.0",
 		"@guardian/commercial-core": "^5.4.5",
 		"@guardian/consent-management-platform": "^11.0.0",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^11.0.0",
-		"@guardian/commercial-bundle": "^1.6.0",
+		"@guardian/commercial-bundle": "1.8.0",
 		"@guardian/commercial-core": "^5.4.5",
 		"@guardian/consent-management-platform": "^11.0.0",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { billboardsInMerch } from './tests/billboards-in-merch';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
+import { eagerPrebid } from './tests/eager-prebid';
 import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
@@ -21,4 +22,5 @@ export const concurrentTests: readonly ABTest[] = [
 	integrateIma,
 	billboardsInMerch,
 	elementsManager,
+	eagerPrebid,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/eager-prebid.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/eager-prebid.ts
@@ -4,10 +4,10 @@ import { bypassMetricsSampling } from '../utils';
 export const eagerPrebid: ABTest = {
 	id: 'EagerPrebid',
 	author: '@commercial-dev',
-	start: '2023-03-13',
-	expiry: '2023-05-01',
-	audience: 5 / 100,
-	audienceOffset: 35 / 100,
+	start: '2023-03-23',
+	expiry: '2023-04-7',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
 	audienceCriteria: 'All pageviews',
 	successMeasure:
 		'Ads lazy load faster, without affecting the page load time',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/eager-prebid.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/eager-prebid.ts
@@ -1,0 +1,24 @@
+import type { ABTest } from '@guardian/ab-core';
+import { bypassMetricsSampling } from '../utils';
+
+export const eagerPrebid: ABTest = {
+	id: 'EagerPrebid',
+	author: '@commercial-dev',
+	start: '2023-03-13',
+	expiry: '2023-03-30',
+	audience: 5 / 100,
+	audienceOffset: 35 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Ads lazy load faster, without affecting the page load time',
+	description: 'Test the impact of running prebid on page load',
+	variants: [
+		{ id: 'control', test: bypassMetricsSampling },
+		{ id: 'variant-20', test: bypassMetricsSampling },
+		{ id: 'variant-17', test: bypassMetricsSampling },
+		{ id: 'variant-15', test: bypassMetricsSampling },
+		{ id: 'variant-12', test: bypassMetricsSampling },
+		{ id: 'variant-10', test: bypassMetricsSampling },
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/eager-prebid.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/eager-prebid.ts
@@ -5,7 +5,7 @@ export const eagerPrebid: ABTest = {
 	id: 'EagerPrebid',
 	author: '@commercial-dev',
 	start: '2023-03-13',
-	expiry: '2023-03-30',
+	expiry: '2023-05-01',
 	audience: 5 / 100,
 	audienceOffset: 35 / 100,
 	audienceCriteria: 'All pageviews',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11791,7 +11791,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@github:guardian/prebid.js#2e3b96d":
+prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,10 +2243,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-11.0.0.tgz#2800fd98aefbea532799c5df158710980e9f7596"
   integrity sha512-xEaYvsSvfs9J5mxibS6FUD4AqqjVS89m/KSI/652uWf7MfT6qJvxIedFGg3vkompXhF7oNXMLQSL8eNiKUqW7g==
 
-"@guardian/commercial-bundle@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.8.0.tgz#b3418358c1a1a0d374e91e85631d3812f74589ee"
-  integrity sha512-W2v0SVv5obTPuwNTfHKMjFFRGClkszUB8bnSDpXceRKeKI4RQgaY28IyA9k904JPDosXX2OjKBTTaDPHnJ8yTQ==
+"@guardian/commercial-bundle@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.9.0.tgz#e6d23e89e398838fc492743fedce76460fdf993c"
+  integrity sha512-sVJeS5/rXHB73RV7wxB5tMhjnQcyqPByaP1fReJE9gHmtO0O2UEl+A++YnBTGUH3WymiBo5nYl0WbGtMY5f2qg==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^5.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11791,7 +11791,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-prebid.js@guardian/prebid.js#2e3b96d:
+"prebid.js@github:guardian/prebid.js#2e3b96d":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,10 +2243,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-11.0.0.tgz#2800fd98aefbea532799c5df158710980e9f7596"
   integrity sha512-xEaYvsSvfs9J5mxibS6FUD4AqqjVS89m/KSI/652uWf7MfT6qJvxIedFGg3vkompXhF7oNXMLQSL8eNiKUqW7g==
 
-"@guardian/commercial-bundle@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.6.0.tgz#c683c8b0191db780ff3f283fc67feee1249ed66c"
-  integrity sha512-KUtyTdmhJ1KRC0fzuWN1gwGN+bTmiuIeEeUpvI3tTarAGdvFR+XONCAut0fu5S56ViOD/0qu6oZIysAXlPgTbg==
+"@guardian/commercial-bundle@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.8.0.tgz#b3418358c1a1a0d374e91e85631d3812f74589ee"
+  integrity sha512-W2v0SVv5obTPuwNTfHKMjFFRGClkszUB8bnSDpXceRKeKI4RQgaY28IyA9k904JPDosXX2OjKBTTaDPHnJ8yTQ==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^5.4.4"
@@ -11791,7 +11791,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-prebid.js@guardian/prebid.js#2e3b96d:
+"prebid.js@github:guardian/prebid.js#2e3b96d":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?
Bump commercial-bundle to v1.9.0

Changes:
* Add smooth transitions to sfdebug ([#836](https://github.com/guardian/commercial-core/issues/836)) ([72e6398](https://github.com/guardian/commercial-core/commit/72e6398e6d3fddbf816ef5797e1e36eb257b9a25))
* Make spacefinder ignore thumbnails ([#830](https://github.com/guardian/commercial-core/issues/830)) ([20ed194](https://github.com/guardian/commercial-core/commit/20ed194739a79169881a4971558189d3a1c8d744))
* Eager prebid ab test (https://github.com/guardian/commercial-core/issues/811) ([867cfab](https://github.com/guardian/commercial-core/commit/867cfab77ee30fcf8aa330d21e54d6a832ee83ad))

Also adds the 0%  ab test in the ab test PR

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
