### PR TITLE
Stop truncating `sbt` output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,16 @@ import com.typesafe.sbt.web.SbtWeb.autoImport._
 import com.gu.Dependencies._
 import com.gu.ProjectSettings._
 
+/*
+We need to set a wide width here because otherwise the output from
+the `dependencyTree` command can get truncated, especially for nested projects.
+The output from `dependencyTree` is used by Snyk to monitor our dependencies.
+If the output is truncated, Snyk might report false positives.
+See
+https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated
+ */
+ThisBuild / asciiGraphWidth := 999999999
+
 val common = library("common")
   .settings(
     Test / javaOptions += "-Dconfig.file=common/conf/test.conf",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,7 +24,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 


### PR DESCRIPTION
## What does this change?

- Sets `sbt` `asciiGraphWidth` setting to a very wide value so that sbt's output is not truncated

## Why?

This project uses Snyk for vulnerability monitoring. Snyk uses the [`sbt-dependency-graph`](https://www.google.com/search?client=firefox-b-d&q=sbt-dependency-graph) plugin to determine the `sbt` dependency graph.

In some cases, the output from `sbt dependencyTree` can get very wide, especially for nested projects like `frontend`. With the default sbt settings, the output from `dependencyTree` is truncated. This truncation can cause Snyk to report [false positives](https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-projects-have-dependencies-truncated), as Snyk cannot determine the actual version of the dependency used in the project.

### Before/after output

This example is a sample taken from the entire `dependencyTree` output. Notice the `..` at the end of the "Before" column. The full, non-truncated output is in the "After" column.

| Before | After |
|--------|-------|
| `+-com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4 (evi..` | `+-com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4 (evicted by: 2.13.2)` |