### PR TITLE
hide newsletter 6029 from newsletters page

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -11,80 +11,92 @@
     "https://manage.theguardian.com/email-prefs"
 }
 
+@*
+    Temporary change - the newsletter with this number needs to be
+    set up in advance but hidden on this page until the journalism
+    it refers to is published.
+*@
+@listIdOfEmailToExclude = @{
+    6029
+}
+
 @emailListCategoryList(theme: String, emailListings: List[NewsletterResponse]) = {
     <div class="newsletters-category__heading">
         @theme
     </div>
     <div class="newsletter-card__wrapper">
     @emailListings.zipWithRowInfo.map { case (emailListing, row) =>
-        <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
-            <div class="newsletter-card__content js-newsletter-content">
-                <div class="newsletter-card__name">
-                    @emailListing.name
-                </div>
-                <div>
-                    @emailListing.description
-                </div>
-            </div>
 
-            <div class="newsletter-card__meta js-newsletter-meta">
-
-                <div class="newsletter-card__frequency">
-                    @fragments.inlineSvg("clock", "icon", List("old-article-message--clock"))
-                    @emailListing.frequency
-                </div>
-
-
-                <div class="signup-confirmation is-hidden js-signup-confirmation">
-                    <div class="signup-confirmation__success-headline-container">
-                        @fragments.inlineSvg("envelope", "icon")
-                        <h3 class="signup-confirmation--heading">@Html(emailListing.emailEmbed.successHeadline)</h3>
+        @if(emailListing.listId != listIdOfEmailToExclude) {
+            <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
+                <div class="newsletter-card__content js-newsletter-content">
+                    <div class="newsletter-card__name">
+                        @emailListing.name
                     </div>
-                    <div class="newsletter-card__content">
-                        <p class="signup-confirmation--description">@Html(emailListing.emailEmbed.successDescription)</p>
+                    <div>
+                        @emailListing.description
                     </div>
                 </div>
 
-                <div class="signup-confirmation is-hidden js-signup-fail-message">
-                    <div class="signup-confirmation__success-headline-container">
-                        @fragments.inlineSvg("cross", "icon")
-                        <h3 class="signup-confirmation--heading">Sign up failed</h3>
+                <div class="newsletter-card__meta js-newsletter-meta">
+
+                    <div class="newsletter-card__frequency">
+                        @fragments.inlineSvg("clock", "icon", List("old-article-message--clock"))
+                        @emailListing.frequency
                     </div>
-                    <div class="newsletter-card__content">
-                        <p class="signup-confirmation--description">Please try again or contact <a href="mailto:customer.help@@theguardian.com" target="_blank">customer.help@@theguardian.com</a></p>
-                    </div>
-                </div>
 
-                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.identityName">
-                    @if(EmailSignupRecaptcha.isSwitchedOn) {
-                        @fragments.email.signup.recaptchaContainer()
-                    }
-                    @helper.CSRF.formField
-                    <label aria-hidden="true">
-                        <input tabindex="-1" class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
-                    </label>
-                    <label>
-                        <span class="u-h">email address</span>
-                        <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
-                    </label>
-                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" aria-hidden="true"/>
 
-                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.identityName" type="submit" value="@emailListing.listIdV1">
-                        <span>Sign up</span>
-                    </button>
-                </form>
-
-                <div class="newsletter-card__example js-newsletter-preview is-hidden">
-                @if(emailListing.exampleUrl.isDefined) {
-                    <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
-                        <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.identityName">
-                            <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
+                    <div class="signup-confirmation is-hidden js-signup-confirmation">
+                        <div class="signup-confirmation__success-headline-container">
+                            @fragments.inlineSvg("envelope", "icon")
+                            <h3 class="signup-confirmation--heading">@Html(emailListing.emailEmbed.successHeadline)</h3>
                         </div>
-                    </a>
-                }
+                        <div class="newsletter-card__content">
+                            <p class="signup-confirmation--description">@Html(emailListing.emailEmbed.successDescription)</p>
+                        </div>
+                    </div>
+
+                    <div class="signup-confirmation is-hidden js-signup-fail-message">
+                        <div class="signup-confirmation__success-headline-container">
+                            @fragments.inlineSvg("cross", "icon")
+                            <h3 class="signup-confirmation--heading">Sign up failed</h3>
+                        </div>
+                        <div class="newsletter-card__content">
+                            <p class="signup-confirmation--description">Please try again or contact <a href="mailto:customer.help@@theguardian.com" target="_blank">customer.help@@theguardian.com</a></p>
+                        </div>
+                    </div>
+
+                    <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.identityName">
+                        @if(EmailSignupRecaptcha.isSwitchedOn) {
+                            @fragments.email.signup.recaptchaContainer()
+                        }
+                        @helper.CSRF.formField
+                        <label aria-hidden="true">
+                            <input tabindex="-1" class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
+                        </label>
+                        <label>
+                            <span class="u-h">email address</span>
+                            <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
+                        </label>
+                        <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" aria-hidden="true"/>
+
+                        <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.identityName" type="submit" value="@emailListing.listIdV1">
+                            <span>Sign up</span>
+                        </button>
+                    </form>
+
+                    <div class="newsletter-card__example js-newsletter-preview is-hidden">
+                    @if(emailListing.exampleUrl.isDefined) {
+                        <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
+                            <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.identityName">
+                                <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
+                            </div>
+                        </a>
+                    }
+                    </div>
                 </div>
             </div>
-        </div>
+        }
     }
     </div>
 }


### PR DESCRIPTION
## What does this change?

Prevents a newsletter with a specific id number being rendered on the /email-newsletters page.

This is  temporary change - a newsletter with this number needs to be set up in advance but not rendered on /email-newsletters or https://manage.theguardian.com/email-prefs (will be addressed on another PR) until the journalism it refers to is published. At that point, this change can be reverted.

The change is on the page template rather than at the data layer since we need the underlying data about the new newsletter to be in place so the sign-up features can be operational.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Allows us to prevent the all newsletters page pre-empting a scheduled announcement, without delaying the launch of the newsletter.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
