### PR TITLE
bump `http4s-core` to fix a vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,6 +155,7 @@ val identity = application("identity")
     libraryDependencies ++= Seq(
       filters,
       identityAuthPlay,
+      http4sCore,
       slf4jExt,
       libPhoneNumber,
       supportInternationalisation,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,6 +36,7 @@ object Dependencies {
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % identityLibVersion
+  val http4sCore = "org.http4s" %% "http4s-core" % "0.21.29"
   val mockWs = "de.leanovate.play-mockws" %% "play-mockws" % "2.6.2" % Test
   val jodaTime = "joda-time" % "joda-time" % "2.9.9"
   val jodaConvert = "org.joda" % "joda-convert" % "1.8.3"


### PR DESCRIPTION
## What does this change?

- Adds `org.http4s:http4s-core` as an explicit dependency, to evict the vulnerable version. `http4s-core` is a transitive dependency used by the `identity` application
- Version `0.21.29` should evict `0.21.27`