### PR TITLE
Euro 2024 started on the 23rd of march, not the 25th

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -217,7 +217,7 @@ object CompetitionsProvider {
       "Internationals",
       showInTeamsList = true,
       tableDividers = List(2),
-      startDate = Some(LocalDate.of(2023, 3, 25)),
+      startDate = Some(LocalDate.of(2023, 3, 23)),
     ),
     Competition(
       "701",


### PR DESCRIPTION
## What does this change?

Updates the start date of the tournament

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/227506714-35a557bb-7108-457c-9440-29aa1b7a7629.png
[after]: https://user-images.githubusercontent.com/9575458/227506784-26cffce5-e9fc-4051-907f-91794a2ae5c3.png

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
