### PR TITLE
Add support for section (`s`) in `im` targeting

### DIFF
--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -13,6 +13,7 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[Gu
         keywords = soFar.keywords ++ lineItem.inlineMerchandisingTargetedKeywords,
         series = soFar.series ++ lineItem.inlineMerchandisingTargetedSeries,
         contributors = soFar.contributors ++ lineItem.inlineMerchandisingTargetedContributors,
+        sections = soFar.sections ++ lineItem.inlineMerchandisingTargetedSections,
       )
     }
   }

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -14,6 +14,7 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[Gu
         series = soFar.series ++ lineItem.inlineMerchandisingTargetedSeries,
         contributors = soFar.contributors ++ lineItem.inlineMerchandisingTargetedContributors,
         sections = soFar.sections ++ lineItem.inlineMerchandisingTargetedSections,
+        tones = soFar.tones ++ lineItem.inlineMerchandisingTargetedTones,
       )
     }
   }

--- a/admin/app/tools/DfpLink.scala
+++ b/admin/app/tools/DfpLink.scala
@@ -39,4 +39,6 @@ object CapiLink {
   def seriesPage(series: String): String = tagPage("series", series)
 
   def sectionPage(section: String): String = tagPage("section", section)
+
+  def tonePage(tone: String): String = tagPage("tone", tone)
 }

--- a/admin/app/tools/DfpLink.scala
+++ b/admin/app/tools/DfpLink.scala
@@ -37,4 +37,6 @@ object CapiLink {
   def keywordPage(keyword: String): String = tagPage("keyword", keyword)
 
   def seriesPage(series: String): String = tagPage("series", series)
+
+  def sectionPage(section: String): String = tagPage("section", section)
 }

--- a/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
@@ -19,6 +19,7 @@
                 <li>keyword: <em>k</em></li>
                 <li>series: <em>se</em></li>
                 <li>contributor: <em>co</em></li>
+                <li>section: <em>s</em></li>
             </ul>
         </li>
     </ol>
@@ -46,6 +47,15 @@
         <ol>
         @for(contributor <- report.targetedTags.contributors) {
             <li style="font-size : large"><a href="@SiteLink.contributorTagPage(contributor)">@contributor</a></li>
+        }
+        </ol>
+    }
+
+    <h2>Targeted Sections</h2>
+    @if(report.targetedTags.sections.isEmpty) {<p>None</p>} else {
+        <ol>
+        @for(section <- report.targetedTags.sections) {
+            <li style="font-size : large"><a href="@CapiLink.sectionPage(section)">@section</a></li>
         }
         </ol>
     }

--- a/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
@@ -20,6 +20,7 @@
                 <li>series: <em>se</em></li>
                 <li>contributor: <em>co</em></li>
                 <li>section: <em>s</em></li>
+                <li>tone: <em>tn</em></li>
             </ul>
         </li>
     </ol>
@@ -60,4 +61,12 @@
         </ol>
     }
 
+    <h2>Targeted Tones</h2>
+    @if(report.targetedTags.tones.isEmpty) {<p>None</p>} else {
+        <ol>
+        @for(tone <- report.targetedTags.tones) {
+            <li style="font-size : large"><a href="@CapiLink.tonePage(tone)">@tone</a></li>
+        }
+        </ol>
+    }
 }

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -90,6 +90,7 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
   val isContributorTag = isPositive("co")
   val isEditionTag = isPositive("edition")
   val isSectionTag = isPositive("s")
+  val isToneTag = isPositive("tn")
 }
 
 object CustomTarget {
@@ -110,6 +111,7 @@ case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
   val inlineMerchandisingTargetedSeries = filterTags(tag => tag.isSeriesTag)(_.isInlineMerchandisingSlot)
   val inlineMerchandisingTargetedContributors = filterTags(tag => tag.isContributorTag)(_.isInlineMerchandisingSlot)
   val inlineMerchandisingTargetedSections = filterTags(tag => tag.isSectionTag)(_.isInlineMerchandisingSlot)
+  val inlineMerchandisingTargetedTones = filterTags(tag => tag.isToneTag)(_.isInlineMerchandisingSlot)
 
   val highMerchandisingTargets =
     filterTags(tag => tag.isKeywordTag || tag.isSeriesTag || tag.isContributorTag)(_.isHighMerchandisingSlot)
@@ -256,6 +258,8 @@ case class GuLineItem(
     targeting.customTargetSets.flatMap(_.inlineMerchandisingTargetedContributors).distinct
   val inlineMerchandisingTargetedSections: Seq[String] =
     targeting.customTargetSets.flatMap(_.inlineMerchandisingTargetedSections).distinct
+  val inlineMerchandisingTargetedTones: Seq[String] =
+    targeting.customTargetSets.flatMap(_.inlineMerchandisingTargetedTones).distinct
 
   val highMerchandisingTargets: Seq[String] = targeting.customTargetSets.flatMap(_.highMerchandisingTargets).distinct
 

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -89,6 +89,7 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
   val isSeriesTag = isPositive("se")
   val isContributorTag = isPositive("co")
   val isEditionTag = isPositive("edition")
+  val isSectionTag = isPositive("s")
 }
 
 object CustomTarget {
@@ -108,6 +109,7 @@ case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
   val inlineMerchandisingTargetedKeywords = filterTags(tag => tag.isKeywordTag)(_.isInlineMerchandisingSlot)
   val inlineMerchandisingTargetedSeries = filterTags(tag => tag.isSeriesTag)(_.isInlineMerchandisingSlot)
   val inlineMerchandisingTargetedContributors = filterTags(tag => tag.isContributorTag)(_.isInlineMerchandisingSlot)
+  val inlineMerchandisingTargetedSections = filterTags(tag => tag.isSectionTag)(_.isInlineMerchandisingSlot)
 
   val highMerchandisingTargets =
     filterTags(tag => tag.isKeywordTag || tag.isSeriesTag || tag.isContributorTag)(_.isHighMerchandisingSlot)
@@ -252,6 +254,8 @@ case class GuLineItem(
     targeting.customTargetSets.flatMap(_.inlineMerchandisingTargetedSeries).distinct
   val inlineMerchandisingTargetedContributors: Seq[String] =
     targeting.customTargetSets.flatMap(_.inlineMerchandisingTargetedContributors).distinct
+  val inlineMerchandisingTargetedSections: Seq[String] =
+    targeting.customTargetSets.flatMap(_.inlineMerchandisingTargetedSections).distinct
 
   val highMerchandisingTargets: Seq[String] = targeting.customTargetSets.flatMap(_.highMerchandisingTargets).distinct
 

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -14,6 +14,7 @@ object InlineMerchandisingTagSet {
         "series" -> tagSet.series,
         "contributors" -> tagSet.contributors,
         "sections" -> tagSet.sections,
+        "tones" -> tagSet.tones,
       )
     }
   }
@@ -25,6 +26,7 @@ case class InlineMerchandisingTagSet(
     series: Set[String] = Set.empty,
     contributors: Set[String] = Set.empty,
     sections: Set[String] = Set.empty,
+    tones: Set[String] = Set.empty,
 ) {
 
   private def hasTagId(tags: Set[String], tagId: String): Boolean =
@@ -38,10 +40,12 @@ case class InlineMerchandisingTagSet(
       case "Series"      => hasTagId(series, tag.id)
       case "Contributor" => hasTagId(contributors, tag.id)
       case "Section"     => hasTagId(sections, tag.id)
+      case "Tone"        => hasTagId(tones, tag.id)
       case _             => false
     }
 
-  def nonEmpty: Boolean = keywords.nonEmpty || series.nonEmpty || contributors.nonEmpty || sections.nonEmpty
+  def nonEmpty: Boolean =
+    keywords.nonEmpty || series.nonEmpty || contributors.nonEmpty || sections.nonEmpty || tones.nonEmpty
 }
 
 object InlineMerchandisingTargetedTagsReport {

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -13,6 +13,7 @@ object InlineMerchandisingTagSet {
         "keywords" -> tagSet.keywords,
         "series" -> tagSet.series,
         "contributors" -> tagSet.contributors,
+        "sections" -> tagSet.sections,
       )
     }
   }
@@ -23,6 +24,7 @@ case class InlineMerchandisingTagSet(
     keywords: Set[String] = Set.empty,
     series: Set[String] = Set.empty,
     contributors: Set[String] = Set.empty,
+    sections: Set[String] = Set.empty,
 ) {
 
   private def hasTagId(tags: Set[String], tagId: String): Boolean =
@@ -35,10 +37,11 @@ case class InlineMerchandisingTagSet(
       case "Keyword"     => hasTagId(keywords, tag.id)
       case "Series"      => hasTagId(series, tag.id)
       case "Contributor" => hasTagId(contributors, tag.id)
+      case "Section"     => hasTagId(sections, tag.id)
       case _             => false
     }
 
-  def nonEmpty: Boolean = keywords.nonEmpty || series.nonEmpty || contributors.nonEmpty
+  def nonEmpty: Boolean = keywords.nonEmpty || series.nonEmpty || contributors.nonEmpty || sections.nonEmpty
 }
 
 object InlineMerchandisingTargetedTagsReport {


### PR DESCRIPTION
## What does this change?

This PR attempts to add:

```
section (s)
```

to the list of targeting values considered when calculating `hasInlineMerchandise`. This is in addition to:

```
keyword (k)
series (se)
contributor (co)
```

See this PR for more information about how `hasInlineMerchandise` is calculated: https://github.com/guardian/frontend/pull/25959

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

I set up this dummy line item for testing:

https://admanager.google.com/59666047#delivery/line_item/detail/line_item_id=6256737297&order_id=3175718530

It uses `adtest` targeting to prevent it ever being accidentally shown.

| Before      | After      |
|-------------|------------|
| ![screencapture-frontend-code-dev-gutools-co-uk-commercial-inline-merchandising-2023-03-27-10_02_28](https://user-images.githubusercontent.com/7423751/227894803-42654d62-b04a-4bfe-a2ba-02cf53765a99.png) | ![screencapture-frontend-code-dev-gutools-co-uk-commercial-inline-merchandising-2023-03-27-10_02_34](https://user-images.githubusercontent.com/7423751/227894794-8727b453-7cab-4505-8b2b-3b1ed9a6ce5b.png) |

Currently the writing part (pulling from GAM and writing to `inline-merchandising-tags-v3.json`, and displaying on [admin](https://frontend.gutools.co.uk/commercial/inline-merchandising)) seems to be working but the reading part (using this to correctly calculate `hasInlineMerchandise`) is not.

This might be a caching thing because we noticed `hasInlineMerchandise` doesn't update when the test line item is paused/unpaused. 

## What is the value of this and can you measure success?

Allows adops to target inline merch ads by `section`.

### Tested

- [ ] Locally
- [x] On CODE (optional)
