### PR TITLE
SpecialReportAlt improvements / visual bug fixes

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -347,6 +347,36 @@ $pillars: (
     }
 }
 
+section.fc-container--has-palette {
+    .fc-item--type-comment.fc-item--pillar-news.fc-item--has-cutout  {
+        &.fc-item--type-comment {
+            .fc-item__avatar {
+                background-color: transparent;
+            }
+
+            &:hover {
+                .fc-item__avatar {
+                    background-color: transparent;
+                }
+
+                .fc-item__timestamp,
+                .fc-trail__count--commentcount {
+                    background-color: transparent;
+                }
+            }
+        }
+    }
+}
+
+section.fc-container--has-palette.fc-container--special-report-alt-palette {
+    .fc-item.fc-item--type-comment.fc-item--pillar-news {
+        &.fc-item--type-comment {
+            .fc-item__container.u-faux-block-link--hover {
+                background-color: darken($special-report-alt-pastel, 5%);
+            }
+        }
+    }
+}
 
 
 .fc-item--pillar-special-report,

--- a/static/src/stylesheets/module/facia-garnett/_sublinks.scss
+++ b/static/src/stylesheets/module/facia-garnett/_sublinks.scss
@@ -42,6 +42,16 @@
     }
 }
 
+section.fc-container--special-report-alt-palette {
+    .fc-sublinks {
+        .fc-sublink__title {
+            &:before {
+                border-top: 1px solid rgba(118, 118, 118, .3);
+            }
+        }
+    }
+}
+
 .fc-sublink__title.fc-sublink--pillar-special-report-alt {
     @include fs-headline(1);
     color: $brightness-7;


### PR DESCRIPTION
## What does this change?
Fixes a couple of visual bugs for SpecialReportAlt. See comments for screenshots.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No. DCR as it has storybook so these bugs were never introduced. See [relevant PR](https://github.com/guardian/dotcom-rendering/pull/6335).
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
