### PR TITLE
Remove google plus publisher links

### DIFF
--- a/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
@@ -75,7 +75,6 @@
     <link rel="shorturl" href="http://gu.com/p/3kft2" />
 
     <meta name="content-id" content="/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes"/>
-    <link rel="publisher" href="https://plus.google.com/113000071431138202574"/>
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@guardian">
     <meta name="twitter:app:name:iphone" content="The Guardian">

--- a/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
@@ -35,7 +35,6 @@
     <meta name="msapplication-TileImage" content="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/favicons/windows_tile_144_b.png">
     <link rel="shorturl" href="http://gu.com/p/3kft2">
     <meta name="content-id" content="/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
-    <link rel="publisher" href="https://plus.google.com/113000071431138202574">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@guardian">
     <meta name="twitter:app:name:iphone" content="The Guardian">

--- a/commercial/app/views/fragments/hostedContentsAMPMetaData.scala.html
+++ b/commercial/app/views/fragments/hostedContentsAMPMetaData.scala.html
@@ -51,9 +51,6 @@
     <meta name="apple-itunes-app" content="app-id=@Configuration.ios.ukAppId, app-argument=@page.metadata.webUrl, affiliate-data=ct=newsmartappbanner&pt=304191">
 }
 
-@* https://support.google.com/plus/answer/1713826 *@
-<link rel="publisher" href="https://plus.google.com/113000071431138202574" />
-
 @Page.getContent(page).map { content =>
     @content.tags.contributors.map { contributor =>
         <meta name="author" content="@contributor.name" />

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -81,9 +81,6 @@
     <meta name="apple-itunes-app" content="app-id=@Configuration.ios.ukAppId, app-argument=@page.metadata.webUrl, affiliate-data=ct=newsmartappbanner&pt=304191">
 }
 
-@* https://support.google.com/plus/answer/1713826 *@
-<link rel="publisher" href="https://plus.google.com/113000071431138202574" />
-
 @Page.getContent(page).map { content =>
     @content.tags.contributors.map { contributor =>
         <meta name="author" content="@contributor.name" />


### PR DESCRIPTION
## What does this change?

Remove google plus publisher links, they are not supported anymore and add bloat.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No, as we did not add them
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Remove bloat

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)
- [x] None 

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested
- [x] Can be merged without more testing
- [ ] Locally
- [ ] On CODE (optional)