### PR TITLE
Update Ozone user sync URL

### DIFF
--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -6,7 +6,7 @@
 			height="1"
 			sandbox="allow-scripts allow-same-origin"
 			frameborder="0"
-			src="https://elb.the-ozone-project.com/static/load-cookie.html"
+			src="https://elb.the-ozone-project.com/static/load-cookie-with-consent.html"
 			id="ozone-load-cookie"
 		></iframe>
 		<iframe


### PR DESCRIPTION
## What does this change?

Update the URL used by the Ozone user sync iframe on AMP.

## Why

Ozone have reviewed the user sync and requested a change of URL.