### PR TITLE
Bump commercial bundle version and tweak ad test label styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^11.0.0",
-		"@guardian/commercial-bundle": "1.9.0",
+		"@guardian/commercial-bundle": "^1.10.0",
 		"@guardian/commercial-core": "^5.4.5",
 		"@guardian/consent-management-platform": "^11.0.0",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -647,8 +647,9 @@
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
     text-align: left;
     position: absolute;
-    right: 3px;
-    top: -22px;
+    left: 268px;
+    top: 1px;
     padding: 0;
     border: 0;
+    z-index: 1030;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,10 +2243,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-11.0.0.tgz#2800fd98aefbea532799c5df158710980e9f7596"
   integrity sha512-xEaYvsSvfs9J5mxibS6FUD4AqqjVS89m/KSI/652uWf7MfT6qJvxIedFGg3vkompXhF7oNXMLQSL8eNiKUqW7g==
 
-"@guardian/commercial-bundle@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.9.0.tgz#e6d23e89e398838fc492743fedce76460fdf993c"
-  integrity sha512-sVJeS5/rXHB73RV7wxB5tMhjnQcyqPByaP1fReJE9gHmtO0O2UEl+A++YnBTGUH3WymiBo5nYl0WbGtMY5f2qg==
+"@guardian/commercial-bundle@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-1.10.0.tgz#fbc0bebce0feb01e0bc153d27df653b92d2e3e52"
+  integrity sha512-TDV0ef/h7fzpp+HHYLt++Hgiz9cUcCOaSMIZV3jXzoInSYmLlZ9Gjt7WJozxh/K8UagNZNYEY+FhoZSMlGRulw==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^5.4.4"


### PR DESCRIPTION
## What does this change?
Bumps the commercial bundle version to update how the ad test labels are rendered. Updates the styling of the ad test labels on pages rendered by frontend.

commercial-bundle-v1.10.0:
https://github.com/guardian/commercial/releases/tag/%40guardian%2Fcommercial-bundle-v1.10.0

### Tested

- [X] Locally
- [X] On CODE (optional)

