### PR TITLE
build(deps): evict `jackson-databind` version used by the Play SBT plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,14 @@ val rss = application("rss")
   .aggregate(common)
 
 val main = root()
+// This evicts the version of
+// "com.fasterxml.jackson.core:jackson-databind"
+// used by "com.typesafe.play:sbt-plugin"
+  .settings(
+    libraryDependencies ++= Seq(
+      jacksonDatabind,
+    ),
+  )
   .aggregate(
     common,
     facia,


### PR DESCRIPTION
## What does this change?

- Evicts the version of `com.fasterxml.jackson.core:jackson-databind` used by `com.typesafe.play:sbt-plugin` to fix a vulnerability

### Tested

- [ ] Locally
- [x] On CODE (optional)
  - [RiffRaff deploy](https://riffraff.gutools.co.uk/deployment/view/b3365be7-0012-45d9-a57f-76f7b63fb415)
