### PR TITLE
Rewrite discussion profile comment filter

### DIFF
--- a/identity/app/services/DiscussionApiService.scala
+++ b/identity/app/services/DiscussionApiService.scala
@@ -12,13 +12,13 @@ class DiscussionApiService(discussionClient: DiscussionClient)(implicit executio
 
     val discussionProfileResponseF: Future[Option[DiscussionProfileResponse]] =
       discussionClient.findDiscussionUser(userId)
-    val discussionStatsF: Future[Option[DiscussionProfileStats]] = discussionClient.findProfileStats(userId)
+    val profileHasAtLeastOneCommentF = discussionClient.profileHasAtLeastOneComment(userId)
 
     for {
       discussionProfileResponse <- discussionProfileResponseF
-      discussionStats <- discussionStatsF
-    } yield (discussionProfileResponse, discussionStats) match {
-      case (Some(user), Some(stats)) if stats.comments > 0 =>
+      profileHasAtLeastOneComment <- profileHasAtLeastOneCommentF
+    } yield (discussionProfileResponse, profileHasAtLeastOneComment) match {
+      case (Some(user), true) =>
         Some(user.userProfile)
       case _ =>
         None

--- a/identity/test/services/DiscussionApiServiceTest.scala
+++ b/identity/test/services/DiscussionApiServiceTest.scala
@@ -24,7 +24,7 @@ class DiscussionApiServiceTest extends AsyncFlatSpec with MockitoSugar {
     import fixtures._
 
     when(discussionClient.findDiscussionUser(userId)) thenReturn Future.successful(Some(discussionProfileResponse))
-    when(discussionClient.findProfileStats(userId)) thenReturn Future.successful(Some(profileStats))
+    when(discussionClient.profileHasAtLeastOneComment(userId)) thenReturn Future.successful(true)
 
     val discussionApiService = new DiscussionApiService(discussionClient)
     discussionApiService.findDiscussionUserFilterCommented(userId).map(_ shouldBe Some(discussionProfile))
@@ -35,7 +35,7 @@ class DiscussionApiServiceTest extends AsyncFlatSpec with MockitoSugar {
     import fixtures._
 
     when(discussionClient.findDiscussionUser(userId)) thenReturn Future.successful(Some(discussionProfileResponse))
-    when(discussionClient.findProfileStats(userId)) thenReturn Future.successful(Some(profileStats.copy(comments = 0)))
+    when(discussionClient.profileHasAtLeastOneComment(userId)) thenReturn Future.successful(false)
 
     val discussionApiService = new DiscussionApiService(discussionClient)
     discussionApiService.findDiscussionUserFilterCommented(userId).map(_ shouldBe None)
@@ -46,7 +46,7 @@ class DiscussionApiServiceTest extends AsyncFlatSpec with MockitoSugar {
     import fixtures._
 
     when(discussionClient.findDiscussionUser(userId)) thenReturn Future.successful(None)
-    when(discussionClient.findProfileStats(userId)) thenReturn Future.successful(None)
+    when(discussionClient.profileHasAtLeastOneComment(userId)) thenReturn Future.successful(false)
 
     val discussionApiService = new DiscussionApiService(discussionClient)
     discussionApiService.findDiscussionUserFilterCommented(userId).map(_ shouldBe None)


### PR DESCRIPTION
## What does this change?

User Help have been receiving reports from some users with a very large number of comments whose public profile pages (`https://profile.theguardian.com/user/id/<id>`) fail to load with a 404 or 500 error. Identity investigated and determined that the problem lay in a call Frontend makes to Discussion API's `/discussion-api/profile/<id>/stats` endpoint, which performs a number of expensive `COUNT` queries for which the Discussion database is very much not optimized. The check is required because, before we show a public profile, we need to know if that profile has any publicly visible comments, and only show profiles that _do_ have comments.

We resolved the issue by replacing the expensive stats call with a cheap call to `/discussion-api/profile/<id>/comments` with `page` set to `1` and a `pageSize` of `1`. If a comment comes back, the profile has visible comments and can be shown.

This allows us to keep the Discussion API `/stats` endpoint untouched, lowers load on the database, and should speed up the loading of all public discussion profile pages considerably.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

In PROD, two known profiles with a large number of comments should begin to load again, and all profile pages should load faster across the board.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
