### PR TITLE
feat: add disable-amp-test

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -309,6 +309,16 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
+  val DisableAmpTest = Switch(
+    SwitchGroup.Feature,
+    "disable-amp-test",
+    "If this switch is on, we will disable the amphtml link on articles for a cohort of readers",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
   val R2PagePressServiceSwitch = Switch(
     SwitchGroup.Feature,
     "r2-page-press-service",


### PR DESCRIPTION
Part of https://github.com/guardian/dotcom-rendering/issues/7486

Creates a switch we can use to turn off the above test if we need to in haste.

<img width="335" alt="Screenshot 2023-03-29 at 10 53 44" src="https://user-images.githubusercontent.com/31692/228497926-9d653cbc-bf57-47de-a33a-3ca1a1807f2a.png">
