### PR TITLE
evict vulnerable versions of `jackson-databind` for `sanity-tests`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,10 @@ val common = library("common")
 val commonWithTests = withTests(common)
 
 val sanityTest = application("sanity-tests")
+  .settings(
+    // Evict vulnerable versions of jackson-databind
+    libraryDependencies += jacksonDatabind,
+  )
 
 val facia = application("facia")
   .dependsOn(commonWithTests)


### PR DESCRIPTION
## What does this change?

- evicts `jackson-databind` for the `sanity-tests` project
  - whoops, I missed this in https://github.com/guardian/frontend/pull/26024