### PR TITLE
accessibility: fronts email link mark-up

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -25,9 +25,10 @@
     @row(Seq("headline")) {
         <a @Html(card.header.url.hrefWithRel) class="fc-link">
             @card.header.kicker.map { kicker =>
-                <div class="fc__kicker">@Html(kicker.kickerHtml) </div>
+                <span class="fc__kicker">@Html(kicker.kickerHtml) </span>
+                &nbsp;
+                <br role="presentation"/>
             }
-
             @if(card.header.quoted) {
                 @card.pillar.map( pillar => {
                     pillar.name match {


### PR DESCRIPTION
## What does this change?

Revises the markup used in the fronts email template separate the "kicker" text from the headline inside links using a line break instead of a `<div>` element. The aim is to address an issue reported via user help by screen-reader users(recent example) :

**Morning. A user with a screen reader is having trouble with some of our newsletters e.g.Guardian Headlines US edition. "I use a screen reader. Recently the Guardian has changed the format and makes some stories impossible to access via keyboard.
_In today's news:
How US universities are ‘colonized’ by the fossil fuel industry
Capitol attack Marjorie Taylor Greene led delegation to visit
defendants in jail Population World ‘population bomb’ may never go off
as feared, finds study. I wanted to read the article on the population study. 
_  I cannot access
it via keyboard. There is no link to the story. There is no clue as to how it can be accessed.  I am using System Access by Serotek. The problem is a recent one--a change of format causes the stories to no longer have a direct link to the articles."**


Although the problem is not reproduced on the HTML output (https://www.theguardian.com/email/us/daily), I think it may be coming from the combination of a screen reader and the user's mail client. Older versions of MS Outlook do not correctly render block-level elements inside an `<a>` element, so this was likely causing the screen reader to treat the link  as inaccessible.

 Simplified revised markup for the link with added comments:
```
<a>
    @if(has kicker) {
        <span class="fc__kicker">@Html(kicker.kickerHtml) </span>
        &nbsp;  
        <!-- include a space between the kicker and the headline so the accessibility tree doesn't run the last and first words together  -->
    } 

    <br role="presentation"/> 
    <!-- marked linebreak as presentation so not announced by screen reader as having semantic significance-->
    @if(card.header.quoted) {<img src=@quoteSymbolUrl}/>
    @RemoveOuterParaHtml(card.header.headline)
</a>
```

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
<img width="1603" alt="Screenshot 2023-03-29 at 17 01 03" src="https://user-images.githubusercontent.com/30567854/228598518-db93adb8-81f9-404a-893e-c7f86323b851.png">



## What is the value of this and can you measure success?
Issue reported to user help should be resolved, with no visual difference in the rendered html.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

