### PR TITLE
use correct blocks when key event filtered is on

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -292,7 +292,7 @@ object DotcomRenderingDataModel {
       )
     })
 
-    val bodyBlocks = blocksForLiveblogPage(page, blocks).map(ensureSummaryTitle)
+    val bodyBlocks = blocksForLiveblogPage(page, blocks, filterKeyEvents).map(ensureSummaryTitle)
 
     val allTimelineBlocks = blocks.body match {
       case Some(allBlocks) if allBlocks.nonEmpty =>

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -140,19 +140,39 @@ object DotcomRenderingUtils {
       .getOrElse("news")
   }
 
+  def getKeyEventsIfFiltered(filterKeyEvents: Boolean, blocks: APIBlocks): Option[List[APIBlock]] = {
+    if (filterKeyEvents) {
+      blocks.requestedBodyBlocks.flatMap { requested =>
+        for {
+          keyEvents <- requested.get(CanonicalLiveBlog.timeline)
+          summaries <- requested.get(CanonicalLiveBlog.summary)
+        } yield {
+          val res: Seq[APIBlock] = (keyEvents.toSeq ++ summaries.toSeq)
+          orderBlocks(res).toList
+        }
+      }
+    } else None
+  }
+
+  def getLast60Blocks(blocks: APIBlocks): Option[List[APIBlock]] = {
+    blocks.requestedBodyBlocks.flatMap(_.get(CanonicalLiveBlog.firstPage).map(_.toList))
+  }
+
   def blocksForLiveblogPage(
       liveblog: LiveBlogPage,
       blocks: APIBlocks,
+      filterKeyEvents: Boolean,
   ): Seq[APIBlock] = {
-    val last60 = blocks.requestedBodyBlocks
-      .getOrElse(Map.empty[String, Seq[APIBlock]])
-      .getOrElse(CanonicalLiveBlog.firstPage, Seq.empty[APIBlock])
-      .toList
+    // When the key events filter is on, we'd need all of the key events rather than just the last 60 blocks
+    val allBlocks =
+      getKeyEventsIfFiltered(filterKeyEvents, blocks)
+        .orElse(getLast60Blocks(blocks))
+        .getOrElse(List.empty)
 
     // For the newest page, the last 60 blocks are requested, but for other page,
     // all of the blocks have been requested and returned in the blocks.body bit
     // of the response so we use those
-    val relevantBlocks = if (last60.isEmpty) blocks.body.getOrElse(Nil) else last60
+    val relevantBlocks = if (allBlocks.isEmpty) blocks.body.getOrElse(Nil) else allBlocks
 
     val ids = liveblog.currentPage.currentPage.blocks.map(_.id).toSet
     relevantBlocks.filter(block => ids(block.id))

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -154,7 +154,7 @@ object DotcomRenderingUtils {
     } else None
   }
 
-  def getLast60Blocks(blocks: APIBlocks): Option[List[APIBlock]] = {
+  def getLatest60Blocks(blocks: APIBlocks): Option[List[APIBlock]] = {
     blocks.requestedBodyBlocks.flatMap(_.get(CanonicalLiveBlog.firstPage).map(_.toList))
   }
 
@@ -163,13 +163,13 @@ object DotcomRenderingUtils {
       blocks: APIBlocks,
       filterKeyEvents: Boolean,
   ): Seq[APIBlock] = {
-    // When the key events filter is on, we'd need all of the key events rather than just the last 60 blocks
+    // When the key events filter is on, we'd need all of the key events rather than just the latest 60 blocks
     val allBlocks =
       getKeyEventsIfFiltered(filterKeyEvents, blocks)
-        .orElse(getLast60Blocks(blocks))
+        .orElse(getLatest60Blocks(blocks))
         .getOrElse(List.empty)
 
-    // For the newest page, the last 60 blocks are requested, but for other page,
+    // For the newest page, the latest 60 blocks are requested, but for other page,
     // all of the blocks have been requested and returned in the blocks.body bit
     // of the response so we use those
     val relevantBlocks = if (allBlocks.isEmpty) blocks.body.getOrElse(Nil) else allBlocks

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -164,7 +164,7 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
     val requested = getRequestedBlocks(
       keyEvents = Seq(1, 2, 4, 6, 7),
       summaries = Seq(3, 5, 8),
-      last60 = Seq(6, 7, 8, 9, 10),
+      latest60 = Seq(6, 7, 8, 9, 10),
     )
     when(testCapiBlocks.requestedBodyBlocks) thenReturn (Some(requested))
 
@@ -175,11 +175,11 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
     result.map(_.id) should equal(Seq("8", "7", "6", "5", "4", "3"))
   }
 
-  it should "return blocks from the last 60 that are included in the page, keeping the order of last60, given keye events filter is off" in {
+  it should "return blocks from the latest 60 that are included in the page, keeping the order of latest60, given key events filter is off" in {
     val requested = getRequestedBlocks(
       keyEvents = Seq(1, 2, 4, 6, 7),
       summaries = Seq(3, 5, 8),
-      last60 = Seq(6, 7, 8, 9, 10),
+      latest60 = Seq(6, 7, 8, 9, 10),
     )
     when(testCapiBlocks.requestedBodyBlocks) thenReturn (Some(requested))
 
@@ -206,18 +206,18 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
     )
   }
 
-  def getRequestedBlocks(keyEvents: Seq[Int], summaries: Seq[Int], last60: Seq[Int] = Seq.empty) = {
+  def getRequestedBlocks(keyEvents: Seq[Int], summaries: Seq[Int], latest60: Seq[Int] = Seq.empty) = {
     val offsetDate = jodaToJavaInstant(DateTime.now).atOffset(ZoneOffset.UTC)
     val keyEventBlocks =
       keyEvents.toSeq.map(digit => getApiBlockWithId(digit, offsetDate.plusMinutes(digit).toCapiDateTime))
     val summarieBlocks =
       summaries.toSeq.map(digit => getApiBlockWithId(digit, offsetDate.plusMinutes(digit).toCapiDateTime))
 
-    val last60Blocks =
-      last60.toSeq.map(digit => getApiBlockWithId(digit, offsetDate.plusMinutes(digit).toCapiDateTime))
+    val latest60Blocks =
+      latest60.toSeq.map(digit => getApiBlockWithId(digit, offsetDate.plusMinutes(digit).toCapiDateTime))
 
     val requested: Map[String, Seq[Block]] =
-      Map("body:key-events" -> keyEventBlocks, "body:summary" -> summarieBlocks, "body:latest:60" -> last60Blocks)
+      Map("body:key-events" -> keyEventBlocks, "body:summary" -> summarieBlocks, "body:latest:60" -> latest60Blocks)
 
     requested
   }


### PR DESCRIPTION
## What does this change?
This PR fixes a bug when some of the key events or summary blocks are missed when the filter key events is on. 

This issue only occurs on a blog that has a key event or summary block that happened before the last 60 blocks. For every request, we are querying CAPI with specific block ranges. e.g. for first page, we query the last 60 blocks or for key events, we query all the key events. 

The list of blocks that frontend passes on to DCR for the CanonicalLiveBlog, was only being retrieved from the last 60 blocks. Therefore, when the `filter key events` switch is enabled, only the key events or summary blocks that were included in the last 60 blocks were used. And all of the older blocks were missed. 

This PR, checks if the `filterKeyEvents` is true, and as a result uses the list of key events and summaries from the capi `requestedBodyBlocks`, otherwise, the last 60 blocks are used.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
