### PR TITLE
Override the commercial bundle in development

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -180,6 +180,7 @@ class GuardianConfiguration extends GuLogging {
 
     lazy val isProd = stage.equalsIgnoreCase("prod")
     lazy val isCode = stage.equalsIgnoreCase("code")
+    lazy val isDev = stage.equalsIgnoreCase("dev")
     lazy val isDevInfra = stage.equalsIgnoreCase("devinfra")
     lazy val isNonProd = List("dev", "code", "gudev").contains(stage.toLowerCase)
     lazy val isNonDev = isProd || isCode || isDevInfra
@@ -543,6 +544,10 @@ class GuardianConfiguration extends GuLogging {
 
     lazy val prebidServerUrl =
       configuration.getStringProperty("commercial.prebid.server.url") getOrElse "http://localhost:8000"
+
+    lazy val overrideCommercialBundleUrl: Option[String] =
+      if (environment.isDev) configuration.getStringProperty("commercial.overrideCommercialBundleUrl")
+      else None
   }
 
   object journalism {

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -77,8 +77,10 @@ object JavaScriptPage {
 
     val ipsos = if (page.metadata.isFront) getScriptTag(page.metadata.id) else getScriptTag(page.metadata.sectionId)
 
-    val commercialBundleUrl: Map[String, JsString] =
-      Map("commercialBundleUrl" -> JsString(assetURL("javascripts/commercial/graun.standalone.commercial.js")))
+    val commercialBundleUrl = JsString(
+      Configuration.commercial.overrideCommercialBundleUrl
+        .getOrElse(assetURL("javascripts/commercial/graun.standalone.commercial.js")),
+    )
 
     javascriptConfig ++ config ++ commercialMetaData ++ journalismMetaData ++ Map(
       ("edition", JsString(edition.id)),
@@ -99,6 +101,7 @@ object JavaScriptPage {
       ("brazeApiKey", JsString(Configuration.braze.apiKey)),
       ("ipsosTag", JsString(ipsos)),
       ("isAdFree", JsBoolean(isAdFree(request))),
-    ) ++ commercialBundleUrl
+      ("commercialBundleUrl", commercialBundleUrl),
+    )
   }.toMap
 }


### PR DESCRIPTION
## What does this change?

This change adds the Frontend equivalent to [DCR #5572](https://github.com/guardian/dotcom-rendering/pull/5572). That is, to allow the typical static asset path for the commercial bundle to be overridden locally to point to a development server.

Whereas DCR uses an environment variable, the more idiomatic way to pass configuration in Frontend is via a file `~/.gu/frontend.conf`. So, if you were running a local development server using [`yarn serve`](https://github.com/guardian/commercial/blob/603aa4c/bundle/package.json#L20), you could have a configuration file that looks like:

```
devOverrides {
    commercial.overrideCommercialBundleUrl="http://localhost:3031/graun.standalone.commercial.js"
}
```

The `commercialBundleUrl` property across Frontend will then refer to a local dev server, rather than pre-built bundle.

(I'll update the documentation in [@guardian/commercial](https://github.com/guardian/commercial) once this has settled).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Allows you to run the commercial dev server against Frontend, as opposed to just DCR. Previously you'd have to `yarn link` in your local changes, which involves running full builds every time you make a change.

### Tested

- [X] Locally
- [x] On CODE (optional) - ~**TODO**~