### PR TITLE
chore: bump capiVersion for Cost of the crown special report

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.2.1"
+  val capiVersion = "19.2.3"
   val faciaVersion = "4.0.5"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?
Bumps CAPI client to [support cost of the crown as a special report](https://github.com/guardian/content-api-scala-client/pull/384).


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/31692/230106958-cb7a5ca0-e8ef-42d9-8e14-6b421f0e40c6.png

[after]: https://user-images.githubusercontent.com/31692/230106991-4b8e7bcc-7c96-4265-960d-7bddc89841b4.png

