### PR TITLE
remove `@guardian/guardian-frontend-team` as reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,4 @@ updates:
       interval: 'daily'
     allow:
       - dependency-name: "@guardian/*"
-    reviewers:
-      - "@guardian/guardian-frontend-team"
     open-pull-requests-limit: 10


### PR DESCRIPTION
this team no longer exists. The CODEOWNERS file automatically assigns PRs to the correct team, `@guardian/dotcom-platform`