### PR TITLE
Remove `most-relevant-container` endpoint and code

### DIFF
--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -78,16 +78,6 @@ object ConfigAgent extends GuLogging {
     }).toSeq
   }
 
-  def getCanonicalIdForFront(frontId: String): Option[String] = {
-    val config = configAgent.get()
-    val canonicalCollectionMap =
-      config
-        .map(_.fronts.mapV(front => front.canonical.orElse(front.collections.headOption)))
-        .getOrElse(Map.empty)
-
-    canonicalCollectionMap.get(frontId).flatten
-  }
-
   def getConfig(id: String): Option[CollectionConfig] =
     configAgent.get().flatMap(_.collections.get(id).map(CollectionConfig.make))
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -403,7 +403,6 @@ GET            /*path.emailjson                                                 
 GET            /*path.emailtxt                                                                                                   controllers.FaciaController.renderFrontJson(path)
 GET            /container/use-layout/*id.json                                                                                    controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
 GET            /container/*id.json                                                                                               controllers.FaciaController.renderContainerJson(id)
-GET            /most-relevant-container/*path.json                                                                               controllers.FaciaController.renderMostRelevantContainerJson(path)
 GET            /*path/show-more/*id.json                                                controllers.FaciaController.renderShowMore(path, id)
 
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -316,23 +316,6 @@ trait FaciaController
       renderContainerView(id, preserveLayout)
     }
 
-  def renderMostRelevantContainerJson(path: String): Action[AnyContent] =
-    Action.async { implicit request =>
-      val canonicalId = ConfigAgent
-        .getCanonicalIdForFront(path)
-        .orElse(
-          alternativeEndpoints(path).map(ConfigAgent.getCanonicalIdForFront).headOption.flatten,
-        )
-
-      canonicalId
-        .map { collectionId =>
-          renderContainerView(collectionId)
-        }
-        .getOrElse(successful(NotFound))
-    }
-
-  def alternativeEndpoints(path: String): Seq[String] = path.split("/").toList.take(2).reverse
-
   private def renderContainerView(collectionId: String, preserveLayout: Boolean = false)(implicit
       request: RequestHeader,
   ): Future[Result] = {

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -27,7 +27,6 @@ GET        /collection/*id/rss                                                  
 GET        /container/use-layout/*id.json                                           controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
 GET        /container/data/*id.json                                                 controllers.FaciaController.renderContainerDataJson(id)
 GET        /container/*id.json                                                     controllers.FaciaController.renderContainerJson(id)
-GET        /most-relevant-container/*path.json                                      controllers.FaciaController.renderMostRelevantContainerJson(path)
 
 # Editionalised pages
 GET        /*path/show-more/*id.json                                                controllers.FaciaController.renderShowMore(path, id)

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -181,12 +181,6 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
     header("Location", redirectToInternational).head should endWith("/uk/commentisfree")
   }
 
-  it should "list the alterative options for a path by section and edition" in {
-    faciaController.alternativeEndpoints("uk/lifeandstyle") should be(List("lifeandstyle", "uk"))
-    faciaController.alternativeEndpoints("uk") should be(List("uk"))
-    faciaController.alternativeEndpoints("uk/business/stock-markets") should be(List("business", "uk"))
-  }
-
   it should "render correct amount of fronts in mf2 format (no section or edition provided)" in {
     val count = 2
     val request = FakeRequest("GET", s"/container/count/$count/offset/0/mf2.json")


### PR DESCRIPTION
As far as I can tell these routes have not been used for some time. It looks like they were added in #9971 for an ab test, and then the test was removed shortly afterwards in #10162. I haven't found [any logs for this endpoint in the last 2 weeks](https://logs.gutools.co.uk/s/dotcom/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15d,to:now))&_a=(columns:!(),filters:!(),index:'50201630-bd0f-11e9-92b3-f10623802d36',interval:auto,query:(language:kuery,query:%22most-relevant-container%22),sort:!(!('@timestamp',desc)))), and I can't find any other reference to these endpoints in the Frontend codebase or other Guardian repos.


The facia controller and `configAgent` methods were only used for this endpoint so I have removed those too.