### PR TITLE
Show Search Jobs in nav and footer for au edition

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -174,6 +174,7 @@ object FooterLinks {
     FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
     FooterLink("Advertise with us", "https://advertising.theguardian.com/", "au : footer : advertise with us"),
     cookiePolicy,
+    FooterLink("Search jobs", "https://jobs.theguardian.com", "au : footer : jobs"),
   )
 
   val intListThree = List(

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -109,10 +109,6 @@ object UrlHelpers {
     Url.parse(url.toString).toString
   }
 
-  def getJobUrl(editionId: String): String =
-    if (editionId == "au") {
-      "https://jobs.theguardian.com/landingpage/2868291/jobs-australia-html"
-    } else {
-      s"https://jobs.theguardian.com"
-    }
+  def getJobUrl(): String = s"https://jobs.theguardian.com"
+
 }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -51,17 +51,17 @@
                     </a>
                 </div>
 
-                @if(editionId != "au" || editionId == "uk") {
+
                 <div class="top-bar__commercial-items">
                     <span class="top-bar__item__seperator hide-until-desktop"></span>
                     <a class="top-bar__item hide-until-desktop"
                        data-link-name="nav2 : job-cta"
                        data-edition="@{editionId}"
-                       href="@getJobUrl(editionId)">
+                       href="@getJobUrl()">
                         Search jobs
                     </a>
                 </div>
-                }
+
 
                 @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
                 @fragments.nav.userAccountDropdown()

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -89,15 +89,15 @@
                     </ul>
                 </div>
 
-                @if(editionId != "au") {
+
                 <div class="header-top-nav__item">
                     <span class="header-top-nav__item--separator hide-until-desktop"></span>
                     <a class="top-bar__item hide-until-desktop" data-link-name="nav3 : job-cta"
-                        data-edition="@{editionId}" href="@getJobUrl(editionId)">
+                        data-edition="@{editionId}" href="@getJobUrl()">
                         Search jobs
                     </a>
                 </div>
-                }
+
 
 
                 <div class="header-top-nav__item">


### PR DESCRIPTION
## What does this change?
Continuing from this https://github.com/guardian/frontend/pull/26038, this PR adds the `Search Jobs` links in the navbar and footer of the Australian edition. This was a request by marketing so that Australian readers can see our global English speaking job opportunities like we have for the other versions of the site.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes. Only for footer. DCR AU edition already shows `Search Jobs` in the navbar. 

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1413" alt="image" src="https://user-images.githubusercontent.com/19683595/231111684-b78dc292-2923-4a60-8f89-89f35c858bc8.png"> | <img width="1469" alt="image" src="https://user-images.githubusercontent.com/19683595/231112383-176c7b8f-9f1e-4846-8f3a-7f848fbc59eb.png"> |
| <img width="1531" alt="image" src="https://user-images.githubusercontent.com/19683595/231111761-81c3d27e-46a6-4dac-bd7b-676883c52e63.png"> | TODO |


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
