### PR TITLE
Load commercial bundle in ad-free

### DIFF
--- a/common/app/views/fragments/page/head/stylesheets/styles.scala.html
+++ b/common/app/views/fragments/page/head/stylesheets/styles.scala.html
@@ -60,9 +60,5 @@
 @styles.criticalCss
 @styles.linkCss
 <!--<![endif]-->
-<style class="js-loggable">
-    @if(isAdFree(request)) {
-        @Html(common.Assets.css.adFree)
-    }
-</style>
+
 <link rel="stylesheet" media="print" type="text/css" href="@Static("stylesheets/print.css")" />

--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -77,9 +77,4 @@
 @fragments.stylesheetLink(common.Assets.css.projectCss(projectName), isCrossword)
 
 <!--<![endif]-->
-<style class="js-loggable">
-    @if(isAdFree(request)) {
-        @Html(common.Assets.css.adFree)
-    }
-</style>
 <link rel="stylesheet" media="print" type="text/css" href="@Static("stylesheets/print.css")" />

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -158,8 +158,7 @@ const go = () => {
 				Promise.resolve({ bootCommercial: () => {} });
 
 			if (
-				!config.get('switches.commercial') ||
-				config.get('page.isAdFree', false)
+				!config.get('switches.commercial')
 			) {
 				return noop();
 			}

--- a/static/src/stylesheets/head.ad-free.scss
+++ b/static/src/stylesheets/head.ad-free.scss
@@ -1,9 +1,0 @@
-// this is slightly kludgy way of clearing up the space left by ad slots in
-// ad-free. it used to be done in the commercial JS, but that's not loaded in
-// ad-free now. ideally we'd not render the slots in the first place, but the
-// ad-free path is slightly labyrinthine, and soon DCR will handle fronts
-// anyway.
-
-.ad-slot, .top-banner-ad-container {
-    display: none !important;
-}


### PR DESCRIPTION
## What does this change?
Loads the commercial bundle if a user is ad free, and removes the code added to collapse empty slots, effectively reversing the change made here: https://github.com/guardian/frontend/pull/25909/files

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes - see https://github.com/guardian/dotcom-rendering/pull/7538

## What is the value of this and can you measure success?
The commercial bundle contains essential code even for ad free users, including code that controls the collapsing of empty ad slots, and code to manage the ad free cookie. At the moment, if a user who had opted out of cookies changed their mind and decided to opt back in, adverts still wouldn't show, because the code to remove the ad free cookie on consent change would not have been loaded.

## Next steps
We would really like to improve performance for ad free users, so we'll be looking at the following improvements so that we keep some of the performance boost for ad free users:
- Decide server-side whether to supply a commercial bundle or an ad-free bundle, trying to minimise the amount of JS supplied to ad-free users in this new bundle.
- More effective code splitting in the commercial bundle - so ad-free users receive a minimal commercial bundle. This could have a performance impact on commercial users, since they’d have to make subsequent requests for additional bundles.
- Shake out as much JS as possible from the commercial bundle.
