### PR TITLE
Create a new script for client-side AB tests

### DIFF
--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -82,6 +82,8 @@ object JavaScriptPage {
         .getOrElse(assetURL("javascripts/commercial/graun.standalone.commercial.js")),
     )
 
+    val abScriptUrl = JsString(assetURL("javascripts/graun.ab.js"))
+
     javascriptConfig ++ config ++ commercialMetaData ++ journalismMetaData ++ Map(
       ("edition", JsString(edition.id)),
       ("ajaxUrl", JsString(Configuration.ajax.url)),
@@ -102,6 +104,7 @@ object JavaScriptPage {
       ("ipsosTag", JsString(ipsos)),
       ("isAdFree", JsBoolean(isAdFree(request))),
       ("commercialBundleUrl", commercialBundleUrl),
+      ("abScriptUrl", abScriptUrl),
     )
   }.toMap
 }

--- a/static/src/javascripts/bootstraps/ab.ts
+++ b/static/src/javascripts/bootstraps/ab.ts
@@ -1,0 +1,11 @@
+import type { ABTest } from '@guardian/ab-core';
+import { log } from '@guardian/libs';
+import { concurrentTests } from 'common/modules/experiments/ab-tests';
+
+log('dotcom', 'Setting AB test stub');
+
+const clientSideExperiments = concurrentTests.reduce<
+	Record<string, ABTest | undefined>
+>((abTests, test) => ({ ...abTests, [test.id]: test }), {});
+
+window.guardian.config.clientSideExperiments = clientSideExperiments;

--- a/static/src/javascripts/bootstraps/ab.ts
+++ b/static/src/javascripts/bootstraps/ab.ts
@@ -1,8 +1,27 @@
 import type { ABTest } from '@guardian/ab-core';
 import { concurrentTests } from 'common/modules/experiments/ab-tests';
 
-const clientSideABTests = concurrentTests.reduce<
-	Record<string, ABTest | undefined>
->((abTests, test) => ({ ...abTests, [test.id]: test }), {});
+/**
+ * Take the set of currently running tests and attach them to the window
+ *
+ * DCR will load this script and then be able to pick up the test definitions
+ * from the window
+ *
+ */
+
+export type ABTestMap = Record<
+	string,
+	| ABTest
+	/**
+	 * Without having --noUncheckedIndexedAccess enabled it's safer for these to
+	 * be possibly defined
+	 */
+	| undefined
+>;
+
+const clientSideABTests = concurrentTests.reduce<ABTestMap>(
+	(abTests, test) => ({ ...abTests, [test.id]: test }),
+	{},
+);
 
 window.guardian.config.clientSideABTests = clientSideABTests;

--- a/static/src/javascripts/bootstraps/ab.ts
+++ b/static/src/javascripts/bootstraps/ab.ts
@@ -1,11 +1,8 @@
 import type { ABTest } from '@guardian/ab-core';
-import { log } from '@guardian/libs';
 import { concurrentTests } from 'common/modules/experiments/ab-tests';
 
-log('dotcom', 'Setting AB test stub');
-
-const clientSideExperiments = concurrentTests.reduce<
+const clientSideABTests = concurrentTests.reduce<
 	Record<string, ABTest | undefined>
 >((abTests, test) => ({ ...abTests, [test.id]: test }), {});
 
-window.guardian.config.clientSideExperiments = clientSideExperiments;
+window.guardian.config.clientSideABTests = clientSideABTests;

--- a/static/src/javascripts/bootstraps/ab.ts
+++ b/static/src/javascripts/bootstraps/ab.ts
@@ -4,8 +4,7 @@ import { concurrentTests } from 'common/modules/experiments/ab-tests';
 /**
  * Take the set of currently running tests and attach them to the window
  *
- * DCR will load this script and then be able to pick up the test definitions
- * from the window
+ * DCR will load this script to pick up the test definitions
  *
  */
 

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -112,7 +112,7 @@ interface Config {
 		};
 		timingEvents?: GoogleTimingEvent[];
 	};
-	clientSideExperiments?: Record<
+	clientSideABTests?: Record<
 		string,
 		// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- import this way so this file is treated as ambient declarations
 		import('@guardian/ab-core').ABTest | undefined

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -1,3 +1,5 @@
+import type { ABTest } from '@guardian/ab-core';
+
 type ServerSideABTest = `${string}${'Variant' | 'Control'}`;
 
 declare const twttr: {
@@ -112,6 +114,7 @@ interface Config {
 		};
 		timingEvents?: GoogleTimingEvent[];
 	};
+	clientSideExperiments?: Record<string, ABTest | undefined>;
 }
 
 type Edition = string; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L79

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -1,5 +1,3 @@
-import type { ABTest } from '@guardian/ab-core';
-
 type ServerSideABTest = `${string}${'Variant' | 'Control'}`;
 
 declare const twttr: {
@@ -114,7 +112,11 @@ interface Config {
 		};
 		timingEvents?: GoogleTimingEvent[];
 	};
-	clientSideExperiments?: Record<string, ABTest | undefined>;
+	clientSideExperiments?: Record<
+		string,
+		// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- import this way so this file is treated as ambient declarations
+		import('@guardian/ab-core').ABTest | undefined
+	>;
 }
 
 type Edition = string; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L79

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -112,11 +112,8 @@ interface Config {
 		};
 		timingEvents?: GoogleTimingEvent[];
 	};
-	clientSideABTests?: Record<
-		string,
-		// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- import this way so this file is treated as ambient declarations
-		import('@guardian/ab-core').ABTest | undefined
-	>;
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- import this way so this file is treated as ambient declarations
+	clientSideABTests?: import('../bootstraps/ab').ABTestMap;
 }
 
 type Edition = string; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L79

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
             'bootstraps',
             'youtube-embed.ts'
         ),
+        'ab': path.join(__dirname, 'static', 'src', 'javascripts', 'bootstraps', 'ab'),
     },
     output: {
         path: path.join(__dirname, 'static', 'target', 'javascripts'),


### PR DESCRIPTION
_See also https://github.com/guardian/frontend/issues/26132._

## What does this change?

This PR creates a new bundle `graun.ab.js` that contains the full set of **client-side AB tests** defined in Frontend.

This new script is currently a simple stub, and is responsible for:

1. Importing the set of concurrent tests definitions from Frontend
2. Assembling these into an object, keyed by test id, that is then attached to the window under `clientSideABTests`.

A production bundle of this script will look something like:

![Screenshot 2023-05-09 at 15 59 39](https://github.com/guardian/frontend/assets/8000415/bda85bae-deaf-4c97-b8ac-8eded7877be4)

And have a URL like this CODE example:

```https://assets-code.guim.co.uk/javascripts/b3ae0a49d01c33a5de54/graun.ab.js```

We pass the URL for this script onto the page via a property `abScriptURL`, which can be referenced via:

```typescript
window.guardian.config.page.abScriptUrl;
```

Note:
- Frontend does not load the AB tests from this script. It may do eventually, but for now this is to experiment with passing them along to DCR.
- DCR will load this script, but doesn't yet.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No - Although we will consume this script in DCR later.
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This PR is a first experimental step in avoiding having to duplicate test definitions across Frontend and DCR (and possibly even more places, such as the commercial code).

Having to duplicate test definitions is a continuing source of confusion and is prone to errors, such as:
- Not aligning each of their properties (e.g. forgetting to extend the expiry of one test).
- Forgetting to delete one after the test has completed.
- Forgetting to correctly bypass sampling metrics in one definition.

It also makes it much harder to provision improvements to the AB testing system, such as:
- Adding tests that check tests are valid (e.g. their expiries aren't in the past, for example). Everything that validates any given test is properly defined would have to be duplicated in every place.
- Having a view over all tests currently running within the platform (we have the Frontend dashboard, but this doesn't have any knowledge of tests in DCR and other places such as Commercial).

Instead, this PR proposes that AB tests are defined once (currently in Frontend), and then passed through to DCR via a new script. This script will then be used by DCR to boot the AB test framework.

### Tested

- [X] Locally
- [X] On CODE (optional)
