### PR TITLE
braze-components v13

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^4.0.0",
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/braze-components": "^12.1.0",
+		"@guardian/braze-components": "^13.0.0",
 		"@guardian/commercial-bundle": "2.1.3",
 		"@guardian/commercial-core": "^6.0.0",
 		"@guardian/consent-management-platform": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,10 +2238,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-12.1.0.tgz#41ddcf08e374c36c5d80e7c9141e508ae630fff6"
-  integrity sha512-NvjmamSUypaPoK3plyRpSWWmeMvmnhhOeWNNKielP2/4Je0AjkezIA8Fj2CnOD3Nkv5/aCc+/avWyAFj9md3yQ==
+"@guardian/braze-components@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
+  integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
 "@guardian/commercial-bundle@2.1.3":
   version "2.1.3"


### PR DESCRIPTION
This version prepares braze-components for react 18 - https://github.com/guardian/braze-components/pull/408

Tested in CODE:
<img width="867" alt="Screenshot 2023-04-13 at 11 44 39" src="https://user-images.githubusercontent.com/1513454/231735680-18fad6ea-1ba4-4b0e-bac0-66bc12d7d4ec.png">
