### PR TITLE
Don't server side render the `exclusion` ad slot

### DIFF
--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -3,20 +3,6 @@
 @import views.support.Commercial.topAboveNavSlot
 
 <div class="@topAboveNavSlot.cssClasses(page.metadata)">
-    @{ /*
-        This is a special type of ad which, when filled, blocks
-        all other ads on the page. This allows us to run "exclusion
-        campaigns" against certain breaking news pages. Exclusion
-        ads are used for consentless advertising only. They are
-        ignored by GAM, which has a different mechanism to achieve
-        the same thing.
-    */ }
-    @fragments.commercial.standardAd(
-        "exclusion",
-        Seq.empty[String],
-        Map(),
-        showLabel=false
-    )
     @fragments.commercial.standardAd(
         "top-above-nav",
         topAboveNavSlot.slotCssClasses,


### PR DESCRIPTION
## What does this change?

Stop SSRing the `exclusion` ad slot.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - https://github.com/guardian/dotcom-rendering/pull/7551

## What is the value of this and can you measure success?

Opt Out has a special slot called the `exclusion` which can be used to remotely disable advertising for entire pages in the Opt Out dashboard. It does not serve any actual advertising, and has to be ignored by Google Ad Manager.

We currently render an exclusion slot on every page, regardless of ad server we're using. We can avoid this by only inserting the slot client-side once we know we'll be serving Opt Out advertising.

### Tested

- [X] Locally
- [ ] On CODE (optional)