### PR TITLE
fix: Update switch states prior to saving new switches

### DIFF
--- a/admin/app/controllers/admin/SwitchboardController.scala
+++ b/admin/app/controllers/admin/SwitchboardController.scala
@@ -25,14 +25,9 @@ class SwitchboardController(akkaAsync: AkkaAsync, val controllerComponents: Cont
 
       Future { Store.getSwitchesWithLastModified } map { switchesWithLastModified =>
         val configuration = switchesWithLastModified.map(_._1)
-        val nextStateLookup = Properties(configuration getOrElse "")
+        val switchStates = Properties(configuration getOrElse "")
 
-        Switches.all foreach { switch =>
-          nextStateLookup.get(switch.name) foreach {
-            case "on" => switch.switchOn()
-            case _    => switch.switchOff()
-          }
-        }
+        Switches.updateStates(switchStates)
 
         val lastModified = switchesWithLastModified.map(_._2).map(_.getMillis).getOrElse(System.currentTimeMillis)
         NoCache(Ok(views.html.switchboard(lastModified)))
@@ -44,9 +39,14 @@ class SwitchboardController(akkaAsync: AkkaAsync, val controllerComponents: Cont
       val form = request.body.asFormUrlEncoded
 
       val localLastModified = form.get("lastModified").head.toLong
-      val remoteLastModified = Store.getSwitchesLastModified
+      val switchesWithLastModified = Store.getSwitchesWithLastModified
 
-      if (remoteLastModified.exists(_.getMillis > localLastModified)) {
+      // Ensure the current state of the switches are up-to-date
+      val configuration = switchesWithLastModified.map(_._1)
+      val switchStates = Properties(configuration getOrElse "")
+      Switches.updateStates(switchStates)
+
+      if (switchesWithLastModified.exists(_._2.getMillis > localLastModified)) {
         Future {
           NoCache(
             Redirect(routes.SwitchboardController.renderSwitchboard())

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -187,4 +187,13 @@ object Switches
     val sortedSwitches = all.groupBy(_.group).map { case (key, value) => (key, value.sortBy(_.name)) }
     sortedSwitches.toList.sortBy(_._1.name)
   }
+
+  def updateStates(switchStates: Map[String, String]): Unit = {
+    Switches.all foreach { switch =>
+      switchStates.get(switch.name) foreach {
+        case "on" => switch.switchOn()
+        case _    => switch.switchOff()
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What does this change?

This fixes an issue where if there are multiple 'admin' servers running, the current state of the switches can become out-of-date on the servers, and the logging of updates becomes incorrect.

The previous behaviour involved the switch-state being updated on the next render of the switchboard. When one server rendered the switchboard & another received the 'save' request, if that server had an out-of-date version of the switchboard, then the logs would not correctly reflect the changes being made.

This unblocks https://github.com/guardian/frontend/pull/25590

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
