### PR TITLE
Remove table divider for Euro qualifying

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -216,7 +216,6 @@ object CompetitionsProvider {
       "Euro 2024 qualifying",
       "Internationals",
       showInTeamsList = true,
-      tableDividers = List(2),
       startDate = Some(LocalDate.of(2023, 3, 23)),
     ),
     Competition(

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -6,6 +6,12 @@ import pa.MatchDayTeam
 import java.awt.Color
 import java.time.LocalDate
 
+/**
+  * @param tableDividers divides the league table into zones for promotion/relegation, or for qualification to another competition.
+  *                       Only add a table divider where the boundaries for progression are clear, e.g do not add
+  *                       a divider in Euro group stages as there are complicated rules which means some (but not all)
+  *                       teams finishing third could qualify
+  */
 case class Competition(
     id: String,
     url: String,


### PR DESCRIPTION
## What does this change?

 This removes the table divider at 3rd place for the Euro qualifying competition. James Dart (digital sports editor) says regarding the Euro qualifiers that "I think we shouldn't have any segments (super complicated due to certain teams advancing to playoffs as highest non-automatic qualifiers and so on)".

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/102960825/232449719-0d400b92-6d84-4a67-b10e-a7367d5f55d8.png
[after]: https://user-images.githubusercontent.com/102960825/232449742-b2ea861c-bb58-4b64-80db-c2cb63fe45ab.png

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [x] Apps [I am raising a PR to make the same change on apps]
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
