### PR TITLE
Update kicker design for action front cards 

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -108,6 +108,6 @@ object ActionCardRedesign
       name = "action-card-redesign",
       description = "Creates a new action card design on fronts pages",
       owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
-      sellByDate = LocalDate.of(2023, 6, 10),
+      sellByDate = LocalDate.of(2023, 6, 9),
       participationGroup = Perc20A,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,6 +16,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       FrontsBannerAds,
       BorkFCP,
       BorkFID,
+      ActionCardRedesign,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -100,4 +101,13 @@ object BorkFID
       owners = Seq(Owner.withName("Open Journalism")),
       sellByDate = LocalDate.of(2023, 6, 1),
       participationGroup = Perc1D,
+    )
+
+object ActionCardRedesign
+    extends Experiment(
+      name = "action-card-redesign",
+      description = "Creates a new action card design on fronts pages",
+      owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
+      sellByDate = LocalDate.of(2023, 6, 10),
+      participationGroup = Perc20A,
     )

--- a/common/app/layout/FaciaCard.scala
+++ b/common/app/layout/FaciaCard.scala
@@ -249,6 +249,7 @@ case class PaidCard(
     targetUrl: String,
     cardTypes: Option[ItemClasses] = None,
     branding: Option[Branding],
+    isAction: Boolean = false,
 ) extends FaciaCard
 
 object PaidCard {
@@ -286,6 +287,7 @@ object PaidCard {
       },
       cardTypes = cardTypes,
       branding = content.branding(defaultEdition),
+      isAction = content.isActionCard,
     )
   }
 }

--- a/common/app/layout/FaciaCard.scala
+++ b/common/app/layout/FaciaCard.scala
@@ -70,6 +70,7 @@ object FaciaCard {
       faciaContent.card.group,
       branding = faciaContent.branding(defaultEdition),
       properties = Some(faciaContent.properties),
+      isAction = faciaContent.isActionCard,
     )
   }
 }
@@ -98,6 +99,7 @@ case class ContentCard(
     branding: Option[Branding],
     properties: Option[PressedProperties],
     fromShowMore: Boolean = false,
+    isAction: Boolean = false,
 ) extends FaciaCard {
 
   private lazy val storyContent: Option[PressedStory] = properties.flatMap(_.maybeContent)

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -34,12 +34,10 @@ sealed trait PressedContent {
       branding <- editionBranding.branding
     } yield branding
 
-  def isActionCard: Boolean = {
-    val test: Boolean = properties.maybeContent.exists { c =>
+  def isActionCard: Boolean =
+    properties.maybeContent.exists { c =>
       c.tags.tags.exists(_.id == "tone/callout")
     }
-    test
-  }
 
   // For DCR
   def ageWarning: Option[String] = {

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -34,6 +34,13 @@ sealed trait PressedContent {
       branding <- editionBranding.branding
     } yield branding
 
+  def isActionCard: Boolean = {
+    val test: Boolean = properties.maybeContent.exists { c =>
+      c.tags.tags.exists(_.id == "tone/callout")
+    }
+    test
+  }
+
   // For DCR
   def ageWarning: Option[String] = {
     properties.maybeContent

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -41,7 +41,7 @@
                                 @fragments.inlineSvg(s"number-${info.rowNum}", "numbers")
                             </span>
                             <div class="headline-list__text">
-                                @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body")
+                                @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body", isAction = trail.isActionCard)
                                 @trail.properties.maybeContent.map { content =>
                                     @if(content.tags.tags.exists(_.id == "tone/news") || content.tags.tags.exists(_.id == "tone/comment")) {
                                         @fragments.contentAgeNotice(ContentOldAgeDescriber(content))

--- a/common/app/views/fragments/collections/popularExtended.scala.html
+++ b/common/app/views/fragments/collections/popularExtended.scala.html
@@ -45,7 +45,7 @@
                             @fragments.inlineSvg(s"number-${info.rowNum}", "numbers")
                             </span>
                             <div class="most-popular__headline">
-                                @title(header, 2, 2, "headline-list__body")
+                                @title(header, 2, 2, "headline-list__body", isAction = trail.isActionCard)
                                 @trail.properties.maybeContent.map { content =>
                                     @if(content.tags.tags.exists(_.id == "tone/news") || content.tags.tags.exists(_.id == "tone/comment")) {
                                         @fragments.contentAgeNotice(ContentOldAgeDescriber(content))

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -29,7 +29,7 @@
         @header.kicker match {
             case Some(kicker) => {
                 @articleLink {
-                    @if(isAction) {
+                    @if(!isAction) {
                       <div class="fc-item__action-kicker-wrapper @kicker.linkClasses.mkString(" ")">
                           <span class="fc-item__action-kicker-label">@Html(kicker.kickerHtml)</span>
                       </div>

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -1,4 +1,4 @@
-@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false)(implicit request: RequestHeader)
+@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false, isAction: Boolean = false)(implicit request: RequestHeader)
 
 @import views.html.fragments.items.elements.facia_cards.itemHeader
 @import views.support._
@@ -29,6 +29,9 @@
         @header.kicker match {
             case Some(kicker) => {
                 @articleLink {
+                    @if(isAction) {
+                        <span>Marjan</span>
+                    }
                     <div class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</div>
                     @headline()
                 }

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -34,6 +34,12 @@
                           <span class="fc-item__action-kicker-label">@Html(kicker.kickerHtml)</span>
                       </div>
                         @headline()
+
+
+                        <button class="fc-item__action-tell-us-btn">
+                            <span>Tell us</span>
+                            @fragments.inlineSvg("arrow-right", "icon")
+                        </button>
                     } else {
                         <div class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</div>
                         @headline()

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -30,10 +30,14 @@
             case Some(kicker) => {
                 @articleLink {
                     @if(isAction) {
-                        <span>Marjan</span>
+                      <div class="fc-item__action-kicker-wrapper @kicker.linkClasses.mkString(" ")">
+                          <span class="fc-item__action-kicker-label">@Html(kicker.kickerHtml)</span>
+                      </div>
+                        @headline()
+                    } else {
+                        <div class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</div>
+                        @headline()
                     }
-                    <div class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</div>
-                    @headline()
                 }
             }
             case _ => {

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -4,6 +4,8 @@
 @import views.support._
 @import layout.FrontendLatestSnap
 @import implicits.ItemKickerImplicits._
+@import experiments.ActiveExperiments
+@import experiments.ActionCardRedesign
 
 @headline() = {
     <span class="@labelCssClasses fc-item__headline">
@@ -29,7 +31,7 @@
         @header.kicker match {
             case Some(kicker) => {
                 @articleLink {
-                    @if(isAction) {
+                    @if(isAction && ActiveExperiments.isParticipating(ActionCardRedesign)) {
                       <div class="fc-item__action-kicker-wrapper @kicker.linkClasses.mkString(" ")">
                           <span class="fc-item__action-kicker-label">@Html(kicker.kickerHtml)</span>
                       </div>

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -29,7 +29,7 @@
         @header.kicker match {
             case Some(kicker) => {
                 @articleLink {
-                    @if(!isAction) {
+                    @if(isAction) {
                       <div class="fc-item__action-kicker-wrapper @kicker.linkClasses.mkString(" ")">
                           <span class="fc-item__action-kicker-label">@Html(kicker.kickerHtml)</span>
                       </div>

--- a/common/app/views/fragments/items/facia_cards/audioFlagshipCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/audioFlagshipCard.scala.html
@@ -81,7 +81,7 @@ data-test-id="facia-card"
             <div class="fc-item__header">
 
 
-                @title(item.header.copy(kicker = getTagKicker()), index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+                @title(item.header.copy(kicker = getTagKicker()), index, containerIndex, snapType = item.snapStuff.map(_.snapType), isAction = item.isAction)
 
                 @item.bylineText.map { byline =>
                     <div class="fc-item__byline">@byline</div>

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -214,7 +214,7 @@ data-test-id="facia-card"
                 ("fc-item__header", true),
                 ("fc-item__header--inline-video", item.isVideo && item.displaySettings.isBoosted)
             ))">
-                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType), isAction = item.isAction)
 
                 @item.bylineText.map { byline =>
                     <div class="fc-item__byline">@byline</div>

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -272,6 +272,6 @@ data-test-id="facia-card"
             @meta(item)
         }
 
-@*        <a @Html(item.header.url.hrefWithRel) class="u-faux-block-link__overlay js-headline-text" data-link-name="article" tabindex="-1" aria-hidden="true">@RemoveOuterParaHtml(item.header.headline)</a>*@
+        <a @Html(item.header.url.hrefWithRel) class="u-faux-block-link__overlay js-headline-text" data-link-name="article" tabindex="-1" aria-hidden="true">@RemoveOuterParaHtml(item.header.headline)</a>
     </div>
 }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -272,6 +272,6 @@ data-test-id="facia-card"
             @meta(item)
         }
 
-        <a @Html(item.header.url.hrefWithRel) class="u-faux-block-link__overlay js-headline-text" data-link-name="article" tabindex="-1" aria-hidden="true">@RemoveOuterParaHtml(item.header.headline)</a>
+@*        <a @Html(item.header.url.hrefWithRel) class="u-faux-block-link__overlay js-headline-text" data-link-name="article" tabindex="-1" aria-hidden="true">@RemoveOuterParaHtml(item.header.headline)</a>*@
     </div>
 }

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -95,7 +95,7 @@ data-test-id="facia-card"
 
         <div class="fc-item__content fc-item__content--above">
             <div class="fc-item__header">
-                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType), isAction = item.isAction)
             </div>
 
             @if(item.isLive && item.displaySettings.showLivePlayable && !isList) {
@@ -220,7 +220,7 @@ data-test-id="facia-card"
                 ("fc-item__header--inline-video", item.isVideo && item.displaySettings.isBoosted)
             ))">
 
-                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType), isAction = item.isAction)
 
                 @item.bylineText.map { byline =>
                     <div class="fc-item__byline">@byline</div>

--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -19,7 +19,7 @@
         }
         <div class="fc-item__content">
             <div class="fc-item__header">
-                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType), isAction = item.isAction)
             </div>
 
             @item.trailText.filter(const(item.showStandfirst)).map { text =>

--- a/onward/app/views/mostPopular.scala.html
+++ b/onward/app/views/mostPopular.scala.html
@@ -23,7 +23,7 @@
 
 
                                 <div class="headline-list__text">
-                                    @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body") @trail.properties.maybeContent.map { content =>
+                                    @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body", isAction = trail.isActionCard) @trail.properties.maybeContent.map { content =>
                                         @if(content.tags.tags.exists(_.id == "tone/news") || content.tags.tags.exists(_.id == "tone/comment")) {
                                             @fragments.contentAgeNotice(ContentOldAgeDescriber(content))
                                         }

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -317,7 +317,7 @@
     .fc-item__action-kicker-label {
         @include action-kicker-font-size($size);
         @if ($size <= 2) {
-            padding: 1px 5px 2px;
+            padding: 0 3px 1px;
         }
 
         @else if ($size == 3) {
@@ -325,7 +325,7 @@
         }
 
         @else if ($size == 4) {
-            padding: 2px 5px;
+            padding: 1px 4px 2px;
         }
 
         @else if ($size >= 5) {
@@ -334,8 +334,8 @@
     }
 
     @if ($size <= 2) {
-        margin-bottom: 2px;
-        margin-top: 1px;
+        margin-bottom: 0;
+        margin-top: 0;
     }
 
     @else if ($size == 3) {
@@ -344,11 +344,12 @@
     }
 
     @else if ($size == 4) {
-        margin-top: 0;
+        margin-top: -2px;
         margin-bottom: 2px;
     }
 
     @else if ($size >= 5) {
+        margin-top: -2px;
         margin-bottom: 2px;
     }
 }

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -311,3 +311,45 @@
         margin-left: gs-span(3) + $gs-gutter;
     }
 }
+
+// action kicker appears on actionable cards (for now cards for tone/callout tags)
+@mixin fs-action-kicker($size) {
+    .fc-item__action-kicker-label {
+        @include action-kicker-font-size($size);
+        @if ($size <= 2) {
+            padding: 1px 5px 2px;
+        }
+
+        @else if ($size == 3) {
+            padding: 1px 4px 2px;
+        }
+
+        @else if ($size == 4) {
+            padding: 2px 5px;
+        }
+
+        @else if ($size >= 5) {
+            padding: 2px 5px 3px;
+        }
+    }
+
+    @if ($size <= 2) {
+        margin-bottom: 2px;
+        margin-top: 1px;
+    }
+
+    @else if ($size == 3) {
+        margin-top: -1px;
+        margin-bottom: 1px;
+    }
+
+    @else if ($size == 4) {
+        margin-top: 0;
+        margin-bottom: 2px;
+    }
+
+    @else if ($size >= 5) {
+        margin-bottom: 2px;
+    }
+}
+

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -26,46 +26,6 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-@mixin fs-action-kicker($size) {
-    .fc-item__action-kicker-label {
-        @include action-kicker-font-size($size);
-        @if ($size <= 2) {
-            padding: 1px 5px 2px;
-        }
-
-        @else if ($size == 3) {
-            padding: 1px 4px 2px;
-        }
-
-        @else if ($size == 4) {
-            padding: 2px 5px;
-        }
-
-        @else if ($size >= 5) {
-            padding: 2px 5px 3px;
-        }
-    }
-
-    @if ($size <= 2) {
-        margin-bottom: 2px;
-        margin-top: 1px;
-    }
-
-    @else if ($size == 3) {
-        margin-top: -1px;
-        margin-bottom: 1px;
-    }
-
-    @else if ($size == 4) {
-        margin-top: .5px;
-        margin-bottom: 2px;
-    }
-
-    @else if ($size >= 5) {
-        margin-bottom: 2px;
-    }
-}
-
 @mixin fc-item--horizontal($media-width, $media-align: right) {
 
     .fc-item__image-container {

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -26,6 +26,46 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
+@mixin fs-action-kicker($size) {
+    .fc-item__action-kicker-label {
+        @include action-kicker-font-size($size);
+        @if ($size <= 2) {
+            padding: 1px 5px 2px;
+        }
+
+        @else if ($size == 3) {
+            padding: 1px 4px 2px;
+        }
+
+        @else if ($size == 4) {
+            padding: 2px 5px;
+        }
+
+        @else if ($size >= 5) {
+            padding: 2px 5px 3px;
+        }
+    }
+
+    @if ($size <= 2) {
+        margin-bottom: 2px;
+        margin-top: 1px;
+    }
+
+    @else if ($size == 3) {
+        margin-top: -1px;
+        margin-bottom: 1px;
+    }
+
+    @else if ($size == 4) {
+        margin-top: .5px;
+        margin-bottom: 2px;
+    }
+
+    @else if ($size >= 5) {
+        margin-bottom: 2px;
+    }
+}
+
 @mixin fc-item--horizontal($media-width, $media-align: right) {
 
     .fc-item__image-container {

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -222,6 +222,35 @@ $fc-item-gutter: $gs-gutter / 4;
     font-weight: 700;
 }
 
+.fc-item__action-tell-us-btn {
+    @include fs-textSans(3);
+    font-size: 15px;
+    margin: 8px 0px;
+    display: flex;
+    color: $brightness-7;
+    box-sizing: border-box;
+    align-items: center;
+    background: transparent;
+    transition: .3s ease-in-out;
+    height: 24px;
+    min-height: 24px;
+    padding: 0 7px 1px 11px;
+    border-radius: 24px;
+    line-height: 1.35;
+    font-weight: 700;
+    border: 1px solid #000000;
+    svg {
+        color: #000000;
+        margin-right: -4px;
+        flex: 0 0 auto;
+        display: block;
+        fill: currentColor;
+        position: relative;
+        width: 27px;
+        height: auto;
+    }
+}
+
 .fc-item__byline {
     margin-bottom: 0;
     font-style: italic;

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -174,6 +174,10 @@ $fc-item-gutter: $gs-gutter / 4;
     @include fs-headline(3);
     @include fs-headline-quote(3);
 
+    .fc-item__action-kicker-wrapper {
+        @include fs-action-kicker(3);
+    }
+
     font-weight: 500;
     padding-bottom: .5em;
 

--- a/static/src/stylesheets/module/facia-garnett/_items.scss
+++ b/static/src/stylesheets/module/facia-garnett/_items.scss
@@ -133,6 +133,10 @@
                 @include fs-headline(2, true);
                 @include fs-headline-quote(2);
                 @include headline-boost(3);
+
+                .fc-item__action-kicker-wrapper {
+                    @include fs-action-kicker(2);
+                }
             }
         }
 
@@ -268,10 +272,18 @@
                 @include fs-headline-quote(4);
                 @include headline-boost(5);
 
+                .fc-item__action-kicker-wrapper {
+                    @include fs-action-kicker(4);
+                }
+
                 @include mq(desktop) {
                     @include fs-headline(6, true);
                     @include fs-headline-quote(6);
                     @include headline-boost(6);
+
+                    .fc-item__action-kicker-wrapper {
+                        @include fs-action-kicker(6);
+                    }
                 }
 
                 padding-right: gs-height(4.5);
@@ -318,10 +330,17 @@
                 @include fs-headline(3, true);
                 @include fs-headline-quote(3);
 
+                .fc-item__action-kicker-wrapper {
+                    @include fs-action-kicker(3);
+                }
+
                 @include mq(desktop) {
                     @include fs-headline(5, true);
                     @include fs-headline-quote(5);
                     @include headline-boost(6);
+                    .fc-item__action-kicker-wrapper {
+                        @include fs-action-kicker(5);
+                    }
                 }
             }
 
@@ -363,6 +382,10 @@
         .fc-item__header {
             @include fs-headline(5, true);
             @include fs-headline-quote(5);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(5);
+            }
         }
     }
 }
@@ -379,6 +402,10 @@
         .fc-item__header {
             @include fs-headline(3, true);
             @include fs-headline-quote(3);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(3);
+            }
         }
 
         &[class*='fc-item--has-sublinks'] {
@@ -392,6 +419,10 @@
         .fc-item__header {
             @include fs-headline(6, true);
             @include fs-headline-quote(6);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(6);
+            }
         }
 
         .fc-item__header,

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -148,6 +148,12 @@ $pillars: (
         color: map-get($palette, kicker);
     }
 
+    .fc-item__action-kicker-label {
+        background-color: map-get($palette, kicker);
+        color: #ffffff;
+        box-decoration-break: clone;
+    }
+
     &.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile {
         .fc-item__content {
             background-color: map-get($palette, kicker);

--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -75,6 +75,10 @@ Hence why a greater depth of selector specificity is needed.
         @include mq($until: tablet) {
             .fc-item__header {
                 @include fs-headline(3, true);
+
+                .fc-item__action-kicker-wrapper {
+                    @include fs-action-kicker(3);
+                }
             }
 
             .inline-garnett-quote__svg {
@@ -104,6 +108,10 @@ Hence why a greater depth of selector specificity is needed.
             .fc-item__header {
                 @include mq(tablet) {
                     @include fs-headline(2, true);
+
+                    .fc-item__action-kicker-wrapper {
+                        @include fs-action-kicker(2);
+                    }
                 }
             }
 

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--full-media-100.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--full-media-100.scss
@@ -22,16 +22,24 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
 */
 
 @mixin fc-item--full-media-100 {
-    
+
     .fc-item__header {
         @include fs-headline(4, true);
         @include fs-headline-quote(4);
         @include headline-boost(5);
 
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(4);
+        }
+
         @include mq(desktop) {
             @include fs-headline(6, true);
             @include fs-headline-quote(6);
             @include headline-boost(6);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(6);
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--half.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--half.scss
@@ -31,10 +31,18 @@ x x x x x x x x x x x x x x x x x x
         @include fs-headline-quote(4);
         @include headline-boost(5);
 
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(4);
+        }
+
         @include mq(tablet, desktop) {
             @include fs-headline(3, true);
             @include fs-headline-quote(3);
             @include headline-boost(4);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(3);
+            }
         }
     }
 
@@ -74,7 +82,7 @@ x x x x x x x x x x x x x x x x x x
         &[class*='fc-item--has-sublinks']:not(.fc-item--has-sublinks-1) {
             .fc-item__header {
                 padding-bottom: gs-height(2) + $gs-baseline * 2;
-    
+
                 @include mq(desktop) {
                     padding-bottom: gs-height(4.6);
                 }
@@ -83,8 +91,8 @@ x x x x x x x x x x x x x x x x x x
             &:not(.fc-item--type-comment) {
                 .fc-sublink {
                     margin-top: 0;
-        
-                    .fc-sublink__title {                
+
+                    .fc-sublink__title {
                         &:before {
                             width: auto;
                             left: 0 - $fc-item-gutter;

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list.scss
@@ -17,6 +17,10 @@ x x x x x x x x x x x x x x x x x x x x x x x x
         @include fs-headline(2, true);
         @include fs-headline-quote(2);
         @include headline-boost(3);
+
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(2);
+        }
     }
 
     &.fc-item--has-cutout {

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--three-quarters-tall.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--three-quarters-tall.scss
@@ -34,10 +34,18 @@ x x x x x x x x x x x x x x x x x x
         @include fs-headline-quote(3);
         @include headline-boost(4);
 
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(3);
+        }
+
         @include mq(desktop) {
             @include fs-headline(5, true);
             @include fs-headline-quote(5);
             @include headline-boost(6);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(5);
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--three-quarters.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--three-quarters.scss
@@ -28,6 +28,10 @@ Three quarter item. Looks like a wide standard, a bit like this:
             @include fs-headline(4, true);
             @include fs-headline-quote(4);
             @include headline-boost(5);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(4);
+            }
         }
     }
 
@@ -63,6 +67,10 @@ Three quarter item. Looks like a wide standard, a bit like this:
             @include headline-boost(6);
             padding-bottom: gs-height(3);
             margin-bottom: $gs-gutter * .25;
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(5);
+            }
 
             @include mq(desktop) {
                 padding-bottom: gs-height(4);

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-100.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-100.scss
@@ -36,9 +36,17 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
         @include fs-headline(4, true);
         @include headline-boost(5);
 
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(4);
+        }
+
         @include mq(desktop) {
             @include fs-headline(6, true);
             @include headline-boost(6);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(6);
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
@@ -23,9 +23,17 @@ Full item with 50% width media.
     .fc-item__header {
         @include fs-headline(3, true);
 
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(3);
+        }
+
         @include mq(desktop) {
             @include fs-headline(5, true);
             @include headline-boost(6);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(5);
+            }
         }
     }
 
@@ -74,9 +82,17 @@ Full item with 50% width media.
             @include fs-headline(4, true);
             @include headline-boost(5);
 
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(4);
+            }
+
             @include mq(desktop) {
                 @include fs-headline(6, true);
                 @include headline-boost(6);
+
+                .fc-item__action-kicker-wrapper {
+                    @include fs-action-kicker(6);
+                }
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
@@ -24,9 +24,17 @@ Full item with 75% width media.
     .fc-item__header {
         @include fs-headline(3, true);
 
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(3);
+        }
+
         @include mq(desktop) {
             @include fs-headline(5, true);
             @include headline-boost(6);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(5);
+            }
         }
     }
 
@@ -75,9 +83,17 @@ Full item with 75% width media.
             @include fs-headline(4, true);
             @include headline-boost(5);
 
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(4);
+            }
+
             @include mq(desktop) {
                 @include fs-headline(6, true);
                 @include headline-boost(6);
+
+                .fc-item__action-kicker-wrapper {
+                    @include fs-action-kicker(6);
+                }
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
@@ -31,9 +31,17 @@ x x x x x x x x x x x x x x x x x x
         @include fs-headline(4, true);
         @include headline-boost(5);
 
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(4);
+        }
+
         @include mq(tablet, desktop) {
             @include fs-headline(3, true);
             @include headline-boost(4);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(3);
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
@@ -72,6 +72,10 @@ Media list item. Looks a bit like this:
     .fc-item__header {
         @include fs-headline($headline-size, true);
         @include headline-boost($headline-size + 1);
+
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker($headline-size);
+        }
     }
 
     .fc-item__media-wrapper,

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
@@ -16,6 +16,10 @@ x x x x x x x x x x x x x x x x x x x x x x x x
     .fc-item__header {
         @include fs-headline(2, true);
         @include headline-boost(3);
+
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(2);
+        }
     }
 
     .fc-item__media-wrapper {

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters-tall.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters-tall.scss
@@ -39,9 +39,17 @@ x x x x x x x x x x x x x x x x x x
         @include fs-headline(3, true);
         @include headline-boost(4);
 
+        .fc-item__action-kicker-wrapper {
+            @include fs-action-kicker(3);
+        }
+
         @include mq(desktop) {
             @include fs-headline(5, true);
             @include headline-boost(6);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(5);
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
@@ -29,6 +29,10 @@ Three quarter item. Looks like a wide standard, a bit like this:
         @include mq(desktop) {
             @include fs-headline(4, true);
             @include headline-boost(5);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(4);
+            }
         }
     }
 
@@ -61,6 +65,10 @@ Three quarter item. Looks like a wide standard, a bit like this:
         .fc-item__header {
             @include fs-headline(5, true);
             @include headline-boost(6);
+
+            .fc-item__action-kicker-wrapper {
+                @include fs-action-kicker(5);
+            }
         }
 
         .fc-item__content {

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -98,47 +98,6 @@ $font-scale: (
     line-height: 115%;
 }
 
-@mixin fs-action-kicker($size) {
-    .fc-item__action-kicker-label {
-        @include action-kicker-font-size($size);
-        @if ($size <= 2) {
-            padding: 1px 5px 2px;
-        }
-
-        @else if ($size == 3) {
-            padding: 1px 4px 2px;
-        }
-
-        @else if ($size == 4) {
-            padding: 2px 5px;
-        }
-
-        @else if ($size >= 5) {
-            padding: 2px 5px 3px;
-        }
-    }
-
-    @if ($size <= 2) {
-        margin-bottom: 2px;
-        margin-top: 1px;
-    }
-
-    @else if ($size == 3) {
-        margin-top: -1px;
-        margin-bottom: 1px;
-    }
-
-    @else if ($size == 4) {
-        margin-top: .5px;
-        margin-bottom: 2px;
-    }
-
-    @else if ($size >= 5) {
-        margin-bottom: 2px;
-    }
-
-}
-
 @mixin f-bodyHeading {
     font-family: $f-serif-text;
     font-weight: bold;

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -102,19 +102,19 @@ $font-scale: (
     .fc-item__action-kicker-label {
         @include action-kicker-font-size($size);
         @if ($size <= 2) {
-            padding: 1px 5px 2px 5px;
+            padding: 1px 5px 2px;
         }
 
         @else if ($size == 3) {
-            padding: 1px 4px 2px 4px;
+            padding: 1px 4px 2px;
         }
 
         @else if ($size == 4) {
-            padding: 2px 5px 2px 5px;
+            padding: 2px 5px;
         }
 
         @else if ($size >= 5) {
-            padding: 2px 5px 3px 5px;
+            padding: 2px 5px 3px;
         }
     }
 
@@ -129,7 +129,7 @@ $font-scale: (
     }
 
     @else if ($size == 4) {
-        margin-top: 0.5px;
+        margin-top: .5px;
         margin-bottom: 2px;
     }
 

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -36,6 +36,17 @@ $font-scale: (
         4: (font-size: 14, line-height: 22),
         5: (font-size: 16, line-height: 22),
         6: (font-size: 18, line-height: 18),
+    ),
+    actionKicker: (
+        1: (font-size: 14),
+        2: (font-size: 14),
+        3: (font-size: 15),
+        4: (font-size: 17),
+        5: (font-size: 20),
+        6: (font-size: 20),
+        8: (font-size: 20),
+        9: (font-size: 20),
+        10: (font-size: 20),
     )
 );
 
@@ -80,6 +91,52 @@ $font-scale: (
     @if $size-only == false {
         @include f-headline;
     }
+}
+
+@mixin action-kicker-font-size($size) {
+    font-size: get-font-size(actionKicker, $size);
+    line-height: 115%;
+}
+
+@mixin fs-action-kicker($size) {
+    .fc-item__action-kicker-label {
+        @include action-kicker-font-size($size);
+        @if ($size <= 2) {
+            padding: 1px 5px 2px 5px;
+        }
+
+        @else if ($size == 3) {
+            padding: 1px 4px 2px 4px;
+        }
+
+        @else if ($size == 4) {
+            padding: 2px 5px 2px 5px;
+        }
+
+        @else if ($size >= 5) {
+            padding: 2px 5px 3px 5px;
+        }
+    }
+
+    @if ($size <= 2) {
+        margin-bottom: 2px;
+        margin-top: 1px;
+    }
+
+    @else if ($size == 3) {
+        margin-top: -1px;
+        margin-bottom: 1px;
+    }
+
+    @else if ($size == 4) {
+        margin-top: 0.5px;
+        margin-bottom: 2px;
+    }
+
+    @else if ($size >= 5) {
+        margin-bottom: 2px;
+    }
+
 }
 
 @mixin f-bodyHeading {


### PR DESCRIPTION
## What does this change?
This PR updates the design for actionable card where user can take an action by opening the article, e.g. filling in a callout form.

The kicker font size and its position in the card is related to the heading font size, and it has to be very accurate because these cards could be located next to a non-actionable card, therefore, the headings of these 2 cards should be **aligned**.

Also there has to be support for long kickers where it ends up in multiple lines. But obviously, when the kickers are multi-line, the card heading could be dis-aligned from the heading of the neighbouring card. This is acceptable as it's a rare case.

Also, in bigger cards, when the kicker is multi-line there could be a gap between the 2 lines. This is also acceptable (discussed with @benwuersching )

NOTE: AB test is added for this change and after release, 20% of users will see this change.

## Why?
Currently, there is not a very clear way of visually setting apart what is a "callout" article on fronts. Because of this, some of our users currently think callout articles are actual articles. This ambiguity could be having a negative impact on our users' experience. Additionally, we think that if we can make it clearer to our users that an article is a callout, we could drive user engagement in our callout campaigns.

<img width="964" alt="image" src="https://github.com/guardian/frontend/assets/15894063/90065b1a-4ef3-4d75-8fa7-64e3cb6464fc">

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/233143882-f772c62a-8567-492a-9143-3922318cb62d.png) | ![image](https://user-images.githubusercontent.com/15894063/233143972-99c87f7b-be7c-442a-82d8-a056304c237d.png) |

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/233144564-59b9bbfe-802a-4539-8ebe-c3a584a277a8.png) | ![image](https://user-images.githubusercontent.com/15894063/233144649-6446f962-18c0-4634-94ac-c47baf843eb6.png) |

<!-- Please use the following table template to make image comparison easier to parse:



[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
