### PR TITLE
chore(🥞): Simplify unit of measurement

### DIFF
--- a/docs/99-archives/crepes.md
+++ b/docs/99-archives/crepes.md
@@ -9,7 +9,7 @@ Quantities are in metric system, because science.
 - 100 g sugar
 - a pinch of salt
 - 3 eggs
-- ½ L of milk (a pint, for you bloody Brits)
+- 500ml of milk (a pint, for you bloody Brits)
 
 ## Steps
 


### PR DESCRIPTION
## What does this change?
`500ml` is easier to understand than `1/2 L`, ~particularly as a [US litre and a UK litre are different volumes of measurement](https://www.thedonutwhole.com/are-us-liters-the-same-as-uk-litres/#Are_American_Litres_different_to_UK_Litres).~

Fractions of ingredients require multiple steps:
  - What's the starting point
  - Perform some maths
  - Ah, finally, I have the answer

And if the answer isn't a whole number, you have to decide what to do. Round up/down, and hope? Buy a set of precision scales?

Whereas now we have the answer straight away, improving UX.

Is it a minor, pedantic change? Am I exaggerating? Yes, absolutely!

## Tested
Sadly, I've not tested the before and after locally, yet. Happy to help taste test though!