### PR TITLE
Forward Link request from DCR for apps requests

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -112,9 +112,12 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
             .withHeaders("X-GU-Dotcomponents" -> "true")
 
           response.header("Link") match {
-            // DCR Returns a Link header for apps requests, this is used for offline reading
-            case Some(linkValue) => cachedRequest.withHeaders("Link" -> linkValue)
-            // For any other requests, we return the default link header with preconnect urls
+            case Some(linkValue) =>
+              cachedRequest
+              // Send both the prefetch header for offline reading, and the usual preconnect URLs
+                .withHeaders("Link" -> linkValue)
+                .withPreconnect(HttpPreconnections.defaultUrls)
+            // For any other requests, we return just the default link header with preconnect urls
             case _ => cachedRequest.withPreconnect(HttpPreconnections.defaultUrls)
 
           }


### PR DESCRIPTION
## What does this change?

Offline reading in Android uses the 'Link' header in-order to know which scripts are required. DCR already sends this header for apps requests, so this PR simply forwards that header on.

We also add on the regular preconnect headers which Frontend typically sends. I'm not 100% sure if these will provide value to the apps requests.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - DCR already sends this header
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/233133907-18a36224-9fed-4bd3-9ee5-7cc6c895ced2.png
[after]: https://user-images.githubusercontent.com/9575458/233133768-e92745bf-371c-41ac-bb5a-6d6581dc5859.png



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
