### PR TITLE
Add tracking to slideshow

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -183,7 +183,7 @@ data-test-id="facia-card"
             case Some(InlineSlideshow(imageElements)) => {
                 @defining(imageElements.take(5)) { slides =>
                     <div class="fc-item__media-wrapper">
-                        <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@slides.size">
+                        <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@slides.size" id="@item.id">
                             @slides.headOption.map { imageElement =>
                                 @captionedImage(
                                     classes = Seq("responsive-img "),

--- a/static/src/javascripts/bootstraps/enhanced/facia.js
+++ b/static/src/javascripts/bootstraps/enhanced/facia.js
@@ -118,8 +118,16 @@ const trackSlideshowDuration = (slideshow) => {
                 const timeTaken = slideshowTiming.end();
                 if (timeTaken) {
                     const timeTakenInSeconds = timeTaken/1000;
-                    console.log('*** timeTakenInSeconds', timeTakenInSeconds);
-                    ophan.record(componentEvent(slideshowId, 'VIEW', {value: timeTakenInSeconds.toString()}));
+                    ophan.record({
+                        componentEvent: {
+                            component: {
+                                componentType: 'SLIDESHOW',
+                                id: slideshowId,
+                            },
+                            action: 'VIEW',
+                            value: timeTakenInSeconds.toString(),
+                        }
+                    });
                 }
             }
         }, {


### PR DESCRIPTION
## What does this change?
This adds tracking to the slideshow component, so that we know how long it is in view for on the screen.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Tracking event being sent to ophan
<img width="884" alt="image" src="https://user-images.githubusercontent.com/26366706/233410864-c5c0e793-4e32-429d-ade2-66060823a5fe.png">

## What is the value of this and can you measure success?
This tracking is being added as part of our investigations into slideshows. Editorial have used 10 images in the slideshow for the queens funeral, and want to do so again for the kings coronation. Knowing how long a slideshow is in view for, will help us determine how many users are actually seeing each image in a slideshow.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
