### PR TITLE
feat: Add Golf to US Sport subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -410,6 +410,7 @@ object NavLinks {
       NBA,
       NHL,
       formulaOne,
+      golf,
     ),
   )
   val intSportPillar = ukSportPillar.copy(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1129,6 +1129,11 @@
                 "url" : "/sport/formulaone",
                 "children" : [ ],
                 "classList" : [ ]
+            }, {
+                "title" : "Golf",
+                "url" : "/sport/golf",
+                "children" : [ ],
+                "classList" : [ ]
             } ],
             "classList" : [ ]
         },


### PR DESCRIPTION
## What does this change?

Adds Golf to the US Sports subnav.

Closes https://github.com/guardian/dotcom-rendering/issues/7583

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/233611170-2e3de79a-e22b-47c1-b627-c341cc22bf70.png
[after]: https://user-images.githubusercontent.com/21217225/233610835-5e7e3155-beea-49c1-9501-9334224d52f9.png