### PR TITLE
Fix request logging to be case-insensitive

### DIFF
--- a/common/test/common/RequestLoggerTest.scala
+++ b/common/test/common/RequestLoggerTest.scala
@@ -7,6 +7,8 @@ import play.api.test.FakeRequest
 
 class RequestLoggerTest extends AnyFlatSpec with Matchers {
 
+  private val baseRequest: FakeRequest[_] = FakeRequest("GET", "/some/path")
+
   "RequestLogger with no request, response or stopwatch" should "have no fields" in {
     val fields = RequestLoggerFields(request = None, response = None, stopWatch = None)
     fields.toList should be(empty)
@@ -25,7 +27,7 @@ class RequestLoggerTest extends AnyFlatSpec with Matchers {
       ("Referer", "someReferer"),
       ("NotSupported", "value"),
     )
-    val req = FakeRequest("GET", "/some/path").withHeaders(headers: _*)
+    val req = baseRequest.withHeaders(headers: _*)
     val fields = RequestLoggerFields(request = Some(req), response = None, stopWatch = None)
     val expectedFields: List[LogField] = List(
       "req.method" -> "GET",
@@ -42,11 +44,33 @@ class RequestLoggerTest extends AnyFlatSpec with Matchers {
     notExpectedFields.forall(fields.toList.contains) should be(false)
   }
 
+  "RequestLogger with request" should "tolerate case-insensitive HTTP headers names, outputting standard case regardless" in {
+    def loggedFieldsFor(headers: (String, String)*) =
+      RequestLoggerFields(
+        request = Some(baseRequest.withHeaders(headers: _*)),
+        response = None,
+        stopWatch = None,
+      ).toList
+
+    // It's crucial that the Kibana field is named with consistent case, otherwise it will become many fields!
+    val logfieldWithStandardCase = LogFieldString("req.header.User-Agent", "Example-UA")
+    loggedFieldsFor("User-Agent" -> "Example-UA") should contain(logfieldWithStandardCase)
+    loggedFieldsFor("User-agent" -> "Example-UA") should contain(logfieldWithStandardCase)
+    loggedFieldsFor("user-agent" -> "Example-UA") should contain(logfieldWithStandardCase)
+    loggedFieldsFor("USER-AGENT" -> "Example-UA") should contain(logfieldWithStandardCase)
+  }
+
   "RequestLogger with response" should "log expected fields" in {
     val fields = RequestLoggerFields(request = None, response = Some(Ok), stopWatch = None)
     val expectedFields: List[LogField] = List(
       "resp.status" -> 200,
     )
     expectedFields.forall(fields.toList.contains) should be(true)
+  }
+
+  "RequestLogger with response" should "tolerate case-insensitive HTTP headers names" in {
+    val fields =
+      RequestLoggerFields(request = None, response = Some(Ok.withHeaders("vary" -> "example")), stopWatch = None)
+    fields.toList should contain(LogFieldString("resp.Vary", "example"))
   }
 }


### PR DESCRIPTION
## What does this change?
After deploying Fastly WAF at the Edge we noticed that the `User-Agent` request header was no longer available at the origin. See [graph and more detailed description of the issue here](https://github.com/guardian/fastly-edge-cache/pull/990#issuecomment-1516585960). 

After discussion with Matej Svirk, our Sales Engineer contact for Fastly WAF, he commented:

> Is your logging case-sensitive? Specifically for the user-agent field, in case the configuration can be field-specific.
> In case of the edge deployment option, the golang wrapper used for our compute deployments also converts header names to lower case.

Respecting case-insensitivity is also compliant with the [HTTP headers standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers).

It's worth mentioning we have only noticed the loss of `User-Agent` request header from our ELK logs and not any other header, although according to Mateij the edge deployment converts all header names to lower case

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
