### PR TITLE
Make `request` mandatory in request logging

### DIFF
--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -7,7 +7,7 @@ import play.api.routing.Router
 
 import scala.util.Random
 
-case class RequestLoggerFields(request: Option[RequestHeader], response: Option[Result], stopWatch: Option[StopWatch]) {
+case class RequestLoggerFields(request: RequestHeader, response: Option[Result], stopWatch: Option[StopWatch]) {
 
   private lazy val requestHeadersFields: List[LogField] = {
     val allowListedHeaderNames = Set(
@@ -27,7 +27,7 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
       "Accept-Encoding", // TODO remove if seen after 2021/09/03
     )
 
-    val allHeadersFields = request.map(_.headers.toMap.mapV(_.mkString(","))).getOrElse(Map.empty)
+    val allHeadersFields = request.headers.toMap.mapV(_.mkString(","))
 
     val allowListedHeaders = (for {
       headerName <- allowListedHeaderNames
@@ -42,15 +42,11 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
     }
   }
   private lazy val customFields: List[LogField] = {
-    val requestHeaders: List[LogField] = request
-      .map { r: RequestHeader =>
-        List[LogField](
-          "req.method" -> r.method,
-          "req.url" -> r.uri,
-          "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString,
-        )
-      }
-      .getOrElse(Nil)
+    val requestHeaders: List[LogField] = List[LogField](
+      "req.method" -> request.method,
+      "req.url" -> request.uri,
+      "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString,
+    )
 
     val responseHeaders: List[LogField] = response
       .map { r: Result =>
@@ -70,15 +66,13 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
       }
       .getOrElse(Nil)
 
-    val actionInfo: List[LogField] = request
-      .map { r: RequestHeader =>
-        val handlerDefOpt = r.attrs.get(Router.Attrs.HandlerDef)
-        List[LogField](
-          "action.controller" -> handlerDefOpt.map(_.controller).getOrElse("unknown"),
-          "action.method" -> handlerDefOpt.map(_.method).getOrElse("unknown"),
-        )
-      }
-      .getOrElse(Nil)
+    val actionInfo: List[LogField] = {
+      val handlerDefOpt = request.attrs.get(Router.Attrs.HandlerDef)
+      List[LogField](
+        "action.controller" -> handlerDefOpt.map(_.controller).getOrElse("unknown"),
+        "action.method" -> handlerDefOpt.map(_.method).getOrElse("unknown"),
+      )
+    }
 
     requestHeaders ++ responseHeaders ++ stopWatchHeaders ++ actionInfo
   }
@@ -86,21 +80,13 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
   def toList: List[LogField] = customFields ++ requestHeadersFields
 }
 
-case class RequestLogger(request: Option[RequestHeader], response: Option[Result], stopWatch: Option[StopWatch])
+case class RequestLogger(request: RequestHeader, response: Option[Result], stopWatch: Option[StopWatch])
     extends GuLogging {
 
   private def allFields: List[LogField] = RequestLoggerFields(request, response, stopWatch).toList
 
-  def withRequestHeaders(rh: RequestHeader): RequestLogger = {
-    copy(Some(rh), response, stopWatch)
-  }
-
   def withResponse(resp: Result): RequestLogger = {
     copy(request, Some(resp), stopWatch)
-  }
-
-  def withStopWatch(sw: StopWatch): RequestLogger = {
-    copy(request, response, Some(sw))
   }
 
   def info(message: String): Unit = {
@@ -112,8 +98,4 @@ case class RequestLogger(request: Option[RequestHeader], response: Option[Result
   def error(message: String, error: Throwable): Unit = {
     logErrorWithCustomFields(message, error, allFields)
   }
-}
-
-object RequestLogger {
-  def apply(): RequestLogger = RequestLogger(None, None, None)
 }

--- a/common/app/http/RequestLoggingFilter.scala
+++ b/common/app/http/RequestLoggingFilter.scala
@@ -15,7 +15,7 @@ class RequestLoggingFilter(implicit val mat: Materializer, executionContext: Exe
 
     val stopWatch = new StopWatch
     val result = next(rh)
-    val requestLogger = RequestLogger().withRequestHeaders(rh).withStopWatch(stopWatch)
+    val requestLogger = RequestLogger(rh, response = None, Some(stopWatch))
     result onComplete {
       case Success(response) =>
         val additionalInfo =


### PR DESCRIPTION
It looks like this field (`RequestLoggerFields.request`) was introduced as optional (in https://github.com/guardian/frontend/pull/14637) to make writing tests slightly easier, but in actual use, a request always *is*  present, and the implementation of `RequestLoggerFields` was being complicated unnecessarily by having to deal with the `Option` (as seen recently in https://github.com/guardian/frontend/pull/26090).

The tests can cope with having to supply a little FakeRequest, it does them no harm!