### PR TITLE
Pass `Format` in `LatestSnaps`

### DIFF
--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -162,7 +162,7 @@ object LatestSnap {
       card = PressedCard.make(content),
       discussion = PressedDiscussionSettings.make(content),
       display = PressedDisplaySettings.make(content),
-      format = None,
+      format = Some(ContentFormat.fromFapiContentFormat(content.format)),
     )
   }
 }


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/6447

## What does this change?

Passes CAPI format to `LatestSnaps` in `facia-press` because we want to be able to consume it in the platform. This change will fix the `Contributors` page in DCR which currently does not respect format in the cards: https://www.theguardian.com/index/contributors?dcr. `Format` goes through this pass and at the moment `facia-press` is the link missing for `LatestSnaps`:

```mermaid
flowchart LR;
    CAPI --> FAPI-client --> facia-press --> S3 --> facia --> DCR;
```

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No. DCR already [knows how to consume format in cards](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/model/enhanceCards.ts#L170-L176). However, if format is not present as in the case of `LatestSnaps`, it uses the default format:
```
{
    design: 'ArticleDesign',
    theme: 'NewsPillar',
    display: 'StandardDisplay',
}
```

- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| frontend      | DCR Before      | DCR After deploying this change in CODE and re-pressing |
|-------------|------------|------------|
| ![Screenshot 2023-04-24 at 11 40 34](https://user-images.githubusercontent.com/19683595/233986882-6ef637bc-88ce-4e8e-b05e-0471ecd5acdb.png) | ![image](https://user-images.githubusercontent.com/19683595/233986511-8bd3ac4b-12c1-4f9f-b7c6-eac89e310033.png) | ![Screenshot 2023-04-24 at 11 40 11](https://user-images.githubusercontent.com/19683595/233986816-83c1b9c9-6c92-4b1a-bc35-1dad92235818.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
