### PR TITLE
Editionalise links on DCR Navbar

### DIFF
--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -101,6 +101,9 @@ object Nav {
   implicit val writes = Json.writes[Nav]
 
   private def recursiveEditionalise(links: Seq[NavLink], edition: Edition, depth: Int = 0): Seq[NavLink] = {
+    // This recursive function will exit naturally once the 'links' Seq is empty
+    // but this depth check prevents any kind of accidental circular structure from
+    // hanging the application / request.
     if (depth > 5) links
     else
       links.map(link =>

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -100,13 +100,16 @@ object Nav {
 
   implicit val writes = Json.writes[Nav]
 
-  private def recursiveEditionalise(links: Seq[NavLink], edition: Edition): Seq[NavLink] =
-    links.map(link =>
-      link.copy(
-        url = LinkTo.processUrl(link.url, edition).url,
-        children = recursiveEditionalise(link.children, edition),
-      ),
-    )
+  private def recursiveEditionalise(links: Seq[NavLink], edition: Edition, depth: Int = 0): Seq[NavLink] = {
+    if (depth > 5) links
+    else
+      links.map(link =>
+        link.copy(
+          url = LinkTo.processUrl(link.url, edition).url,
+          children = recursiveEditionalise(link.children, edition, depth + 1),
+        ),
+      )
+  }
 
   private def editionaliseSubNav(subNav: Subnav, edition: Edition): Subnav =
     subNav match {


### PR DESCRIPTION
## What does this change?

In Frontend, the links on the site nav are 'editionalised' where appropriate (e.g /commentisfree turns into /uk/commentisfree). This happens in the LinkTo.scala file, which is used to process URLs before rendering.

However, this 'editionalising' doesn't happen for the links sent to DCR, because of this, the nav includes the base links, /commentisfree, /sport, etc. 

The impact of this is an extra request for users, first going to /commentisfree, where they will then receive a 302 (uncached) redirect:

<img width="353" alt="image" src="https://user-images.githubusercontent.com/9575458/234235555-288468c8-5fda-4361-93b7-884ef17a2967.png">

This costs us both in terms of origin traffic, and adds extra network requests to our users. 

**How do we fix it?**

We had a couple of options from copying the LinkTo class in DCR, updating the nav schema to include the editionalised URLs there, but we chose to try and editionalise the links while constructing the DCR nav data. This has the advantage that the existing logic is re-used, and the source of truth for which URLs should be editionalised remains in a single place.

Our PR adds functions which recursively crawl through the navlinks in the navbar, editionalising the URLs for all levels of the nav. The data-model supports an infinite depth of nav-links, though in practice high depths are not used, the recursive function will stop at a max depth of 5.

Issue: https://github.com/guardian/dotcom-rendering/issues/7610

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - DCR just consumes the new editionalised nav URLS
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE - TODO

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
