### PR TITLE
Commercial bundle bump workflow fix

### DIFF
--- a/.github/workflows/commercial-bundle-bump.yml
+++ b/.github/workflows/commercial-bundle-bump.yml
@@ -42,7 +42,7 @@ jobs:
         runs-on: ubuntu-latest
         needs: check
         # if there's no existing PR, and there's a new version available create a PR
-        if: ${{ needs.check.outputs.PR_EXISTS == false && needs.check.outputs.CURRENT_VERSION != needs.check.outputs.LATEST_VERSION }}
+        if: ${{ needs.check.outputs.PR_EXISTS == 'false' && needs.check.outputs.CURRENT_VERSION != needs.check.outputs.LATEST_VERSION }}
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/commercial-bundle-bump.yml
+++ b/.github/workflows/commercial-bundle-bump.yml
@@ -52,6 +52,8 @@ jobs:
 
             - run: yarn add @guardian/commercial-bundle@${{ needs.check.outputs.LATEST_VERSION }}
 
+            - run: sed -ri 's/"(prebid\.js@)(github:)(guardian\/prebid\.js#\w{7})"/\1\3/g' yarn.lock
+
             - name: Create branch and commit
               run: |
                   git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -59,7 +61,6 @@ jobs:
                   git checkout -b bump/commercial-bundle-v${{ needs.check.outputs.LATEST_VERSION }}
                   git add package.json yarn.lock
                   # there's a bug in yarn where it doesn't update the yarn.lock file correctly for prebid.js, so we need to do this fix
-                  sed -ri 's/"(prebid\.js@)(github:)(guardian\/prebid\.js#\w{7})"/\1\3/g' yarn.lock
                   git commit -m "Bump @guardian/commercial-bundle to ${{ needs.check.outputs.LATEST_VERSION }}"
                   git push --set-upstream origin bump/commercial-bundle-v${{ needs.check.outputs.LATEST_VERSION }}
 


### PR DESCRIPTION
## What does this change?
It's not detecting existing PR due to boolean/string typo

Also moved the `sed` to before the `git add` command, as it's not going to make it into the commit in its current position 🙃