### PR TITLE
Use github-script for PR exists check in commercial bundle check workflow

### DIFF
--- a/.github/workflows/commercial-bundle-bump.yml
+++ b/.github/workflows/commercial-bundle-bump.yml
@@ -1,4 +1,4 @@
-name: Bump @guardian/commercial-bundle
+name: Check for new @guardian/commercial-bundle version
 
 on:
     schedule:
@@ -32,10 +32,18 @@ jobs:
             - name: Check for existing pull request
               id: pr-exists
               if: ${{ steps.latest-version.outputs.result != steps.current-version.outputs.result }}
-              run: |
-                  gh pr list --head "bump/commercial-bundle-v${{ steps.latest-version.outputs.result }}" --repo guardian/frontend --json number --limit 1 | node -e "console.log(JSON.parse(require('fs').readFileSync(0, 'utf8')).length > 0)"
-              env:
-                  GH_TOKEN: ${{ github.token }}
+              uses: actions/github-script@v6
+              with:
+                  result-encoding: string
+                  github-token: ${{ github.token }}
+                  script: |
+                      const prs = await github.rest.pulls.list({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        head: 'guardian:bump/commercial-bundle-v${{ steps.latest-version.outputs.result }}',
+                      });
+                      console.log(prs.data.length > 0);
+                      return String(prs.data.length > 0);
 
     pr:
         name: Create pull request


### PR DESCRIPTION
## What does this change?
Use github-script for the PR exists check in commercial bundle check workflow

## Why
When writing plain `run` commands the return value is not accessible without loading it into the `$GITHUB_OUTPUT` environment variable ([docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)), with simple commands it's not so difficult, but when there's a few levels of quotes it gets complicated, like we have here.

Using github-script lets you use the return value by default, it's also more readable.