### PR TITLE
removed bold css

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -74,9 +74,9 @@ $block-height: 58px; // Note: duplicated from _item.scss
 }
 
 .fc-container--story-package {
-    
+
     .fc-container__header {
-        z-index: 1;   
+        z-index: 1;
     }
 
     .fc-container__body {
@@ -140,10 +140,6 @@ $block-height: 58px; // Note: duplicated from _item.scss
             text-decoration: none;
             border-bottom: #ffffff;
         }
-    }
-
-    .fc-item__title {
-        font-weight: 800;
     }
 
     .fc-item__standfirst-wrapper {
@@ -455,8 +451,6 @@ $block-height: 58px; // Note: duplicated from _item.scss
 
             .fc-sublink__title,
             &.fc-item--type-live.fc-item--pillar-news .fc-sublink__link {
-                font-weight: 800;
-
                 &:before {
                     width: 100%;
                 }


### PR DESCRIPTION
## What does this change?
Removed bold headlines from Dynamo containers. This was previously removed from the palette thrasher and DCR but missed removing from dynamic containers
## Does this change need to be reproduced in dotcom-rendering ?
This has been done in DCR already
- [X ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1483" alt="image" src="https://user-images.githubusercontent.com/20658471/234563733-f9665400-d091-421f-b397-a1137db3dcc2.png"> | <img width="1479" alt="image" src="https://user-images.githubusercontent.com/20658471/234563658-cdd4cc5f-75ac-4d67-9972-2b830b33dbe1.png"> |

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
