### PR TITLE
feat: add Switch to enable borking web vitals

### DIFF
--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -62,4 +62,14 @@ trait JournalismSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
+
+  val BorkWebVitals = Switch(
+    SwitchGroup.Journalism,
+    "bork-web-vitals",
+    "Enables borking (synthetic delay) of web vitals",
+    owners = Seq(Owner.withName("Open Journalism")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
## What does this change?

Adds a new Switch to control whether to run the “borking” experiment in which we synthetically slow down some web vitals.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No – but https://github.com/guardian/dotcom-rendering/pull/7639 & https://github.com/guardian/dotcom-rendering/pull/7641 should use it
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We can turn off our experiment quickly in case anything goes wrong.

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)