### PR TITLE
Revert "Editionalise links on DCR Navbar"

### DIFF
--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -1,14 +1,14 @@
 package navigation
 
-import common.{Edition, LinkTo}
+import common.Edition
 import model.Page
 import navigation.ReaderRevenueSite.{
-  PrintCTA,
-  PrintCTAWeekly,
   Support,
   SupportContribute,
   SupportSubscribe,
   SupporterCTA,
+  PrintCTA,
+  PrintCTAWeekly,
 }
 import navigation.UrlHelpers._
 import play.api.libs.json.{Json, Writes}
@@ -100,43 +100,16 @@ object Nav {
 
   implicit val writes = Json.writes[Nav]
 
-  private def recursiveEditionalise(links: Seq[NavLink], edition: Edition, depth: Int = 0): Seq[NavLink] = {
-    // This recursive function will exit naturally once the 'links' Seq is empty
-    // but this depth check prevents any kind of accidental circular structure from
-    // hanging the application / request.
-    if (depth > 5) links
-    else
-      links.map(link =>
-        link.copy(
-          url = LinkTo.processUrl(link.url, edition).url,
-          children = recursiveEditionalise(link.children, edition, depth + 1),
-        ),
-      )
-  }
-
-  private def editionaliseSubNav(subNav: Subnav, edition: Edition): Subnav =
-    subNav match {
-      case ParentSubnav(parent, links) =>
-        ParentSubnav(
-          parent.copy(
-            url = LinkTo.processUrl(parent.url, edition).url,
-            children = recursiveEditionalise(parent.children, edition),
-          ),
-          recursiveEditionalise(links, edition),
-        )
-      case FlatSubnav(links) => FlatSubnav(recursiveEditionalise(links, edition))
-    }
-
   def apply(page: Page, edition: Edition): Nav = {
     val navMenu = NavMenu(page, edition)
     Nav(
       currentUrl = navMenu.currentUrl,
-      pillars = recursiveEditionalise(navMenu.pillars, edition),
-      otherLinks = recursiveEditionalise(navMenu.otherLinks, edition),
+      pillars = navMenu.pillars,
+      otherLinks = navMenu.otherLinks,
       brandExtensions = navMenu.brandExtensions,
       currentNavLinkTitle = navMenu.currentNavLink.map(NavLink.id),
       currentPillarTitle = navMenu.currentPillar.map(NavLink.id),
-      subNavSections = navMenu.subNavSections.map(editionaliseSubNav(_, edition)),
+      subNavSections = navMenu.subNavSections,
       readerRevenueLinks = ReaderRevenueLinks.all,
     )
   }


### PR DESCRIPTION
Reverts guardian/frontend#26093

This is causing the data-link-name of subnav links to have the full URL of the link. This is causing our cypress tests to fail.

We're not entirely sure what the ramifications of the full URL being in the data-link-name so we've opted to raise a revert PR.

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/21217225/234918195-017f6c6a-2d5a-4936-aeea-cee0f44f3040.png">
