### PR TITLE
Hosted bundle - Remove unused modules and simplify

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -29,11 +29,20 @@ if (process.env.NODE_ENV !== 'production') {
 // kick off the app
 const go = () => {
     domready(async () => {
-        // 1. boot standard, always
+
+        /**
+         * Boot Standard
+         *
+         */
+
         markTime('standard boot');
         bootStandard();
 
-        // Start CMP
+        /**
+         * CMP
+         *
+         */
+
         // CCPA and TCFv2
         const browserId = getCookie('bwid') || undefined;
         const pageViewId = config.get('ophan.pageViewId');
@@ -127,10 +136,13 @@ const go = () => {
 
         cmp.init({ pubData, country: await getLocale() });
 
+        /**
+         * Handle Ad blockers
+         *
+         */
+
         detectAdBlockers()
 
-        // 2. once standard is done, next is commercial
-        // Handle ad blockers
         window.guardian.adBlockers.onDetect.push((adblockInUse) => {
             if (!adblockInUse) return;
 
@@ -151,15 +163,15 @@ const go = () => {
             }
         });
 
-        // Start downloading these ASAP
+        /**
+         * Commercial boot promise
+         *
+         */
 
 		const fetchCommercial = () => {
-			const noop = () =>
-				Promise.resolve({ bootCommercial: () => {} });
+			const noop = () => Promise.resolve({ bootCommercial: () => {} });
 
-			if (
-				!config.get('switches.commercial')
-			) {
+			if (!config.get('switches.commercial')) {
 				return noop();
 			}
 
@@ -175,11 +187,20 @@ const go = () => {
 			);
 		};
 
+        /**
+         * Enhanced boot promise
+         *
+         */
 
         const fetchEnhanced = window.guardian.isEnhanced
             ? (markTime('enhanced request'),
                 import(/* webpackChunkName: "enhanced" */ 'bootstraps/enhanced/main'))
             : Promise.resolve({ bootEnhanced: () => { } });
+
+        /**
+         * Boot commercial and enhanced
+         *
+         */
 
         Promise.all([
             fetchCommercial().then(({ bootCommercial }) => {

--- a/static/src/javascripts/bootstraps/commercial-hosted-legacy.ts
+++ b/static/src/javascripts/bootstraps/commercial-hosted-legacy.ts
@@ -1,71 +1,19 @@
 /**
- * This file is deprecated. Only used for “Hosted” pages
- * All other pages use the standalone bundle.
+ * This file is deprecated. Only used for legacy “Hosted” pages
  */
 
-import { EventTimer } from '@guardian/commercial-core';
-import { initAdblockAsk } from 'commercial/adblock-ask';
-import { init as initCommercialMetrics } from 'commercial/commercial-metrics';
-import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
-import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
-import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
-import { initCommentAdverts } from 'commercial/modules/comment-adverts';
-import { init as initComscore } from 'commercial/modules/comscore';
-import { init as prepareA9 } from 'commercial/modules/dfp/prepare-a9';
-import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
-import { initPermutive } from 'commercial/modules/dfp/prepare-permutive';
-import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
-import { init as initRedplanet } from 'commercial/modules/dfp/redplanet';
-import { init as initHighMerch } from 'commercial/modules/high-merch';
-import { init as initIpsosMori } from 'commercial/modules/ipsos-mori';
-import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
-import { manageAdFreeCookieOnConsentChange } from 'commercial/modules/manage-ad-free-cookie-on-consent-change';
-import { init as initMobileSticky } from 'commercial/modules/mobile-sticky';
-import { paidContainers } from 'commercial/modules/paid-containers';
-import { removeDisabledSlots as closeDisabledSlots } from 'commercial/modules/remove-slots';
-import { init as setAdTestCookie } from 'commercial/modules/set-adtest-cookie';
-import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
-import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { reportError } from 'lib/report-error';
 import { catchErrorsWithContext } from 'lib/robust';
 import type { Modules } from './types';
 
-const tags = {
+const errorTags = {
 	feature: 'commercial',
 	bundle: 'hosted',
 };
 
-const commercialModules: Modules = [
-	['cm-setAdTestCookie', setAdTestCookie],
-	['cm-manageAdFreeCookieOnConsentChange', manageAdFreeCookieOnConsentChange],
-	['cm-closeDisabledSlots', closeDisabledSlots],
-	['cm-comscore', initComscore],
-	['cm-ipsosmori', initIpsosMori],
-];
+const loadModules = async () => {
+	const modules: Modules = [];
 
-if (!commercialFeatures.adFree) {
-	commercialModules.push(
-		['cm-commercial-metrics', initCommercialMetrics], // In DCR, see App.tsx
-		['cm-prepare-prebid', preparePrebid],
-		['cm-prepare-a9', prepareA9],
-		['cm-thirdPartyTags', initThirdPartyTags],
-		// Permutive init code must run before google tag enableServices()
-		// The permutive lib however is loaded async with the third party tags
-		['cm-prepare-googletag', () => initPermutive().then(prepareGoogletag)],
-		['cm-redplanet', initRedplanet],
-		['cm-prepare-adverification', prepareAdVerification],
-		['cm-mobileSticky', initMobileSticky],
-		['cm-highMerch', initHighMerch],
-		['cm-articleAsideAdverts', initArticleAsideAdverts],
-		['cm-articleBodyAdverts', initArticleBodyAdverts],
-		['cm-liveblogAdverts', initLiveblogAdverts],
-		['cm-paidContainers', paidContainers],
-		['cm-commentAdverts', initCommentAdverts],
-		['rr-adblock-ask', initAdblockAsk],
-	);
-}
-
-const loadHostedModules = async () => {
 	if (!window.guardian.config.page.isHosted) return; // should never happen
 
 	const hostedAbout = await import(
@@ -89,7 +37,7 @@ const loadHostedModules = async () => {
 		'commercial/modules/hosted/onward'
 	);
 
-	commercialModules.push(
+	modules.push(
 		['cm-hostedAbout', hostedAbout.init],
 		['cm-hostedVideo', initHostedVideo.initHostedVideo],
 		['cm-hostedGallery', hostedGallery.init],
@@ -97,15 +45,10 @@ const loadHostedModules = async () => {
 		['cm-hostedOJCarousel', initHostedCarousel.initHostedCarousel],
 	);
 
-	return;
-};
-
-const loadModules = () => {
 	const modulePromises: Array<Promise<unknown>> = [];
 
-	commercialModules.forEach((module) => {
+	modules.forEach((module) => {
 		const [moduleName, moduleInit] = module;
-
 		catchErrorsWithContext(
 			[
 				[
@@ -116,52 +59,16 @@ const loadModules = () => {
 					},
 				],
 			],
-			tags,
+			errorTags,
 		);
 	});
 
 	return Promise.all(modulePromises);
 };
 
-export const bootCommercial = (): Promise<void> => {
-	// Init Commercial event timers
-	EventTimer.init();
-
-	catchErrorsWithContext(
-		[
-			[
-				'ga-user-timing-commercial-start',
-				function runTrackPerformance() {
-					EventTimer.get().trigger('commercialStart');
-				},
-			],
-		],
-		tags,
-	);
-
-	// Stub the command queue
-	// @ts-expect-error -- it’s a stub, not the whole Googletag object
-	window.googletag = {
-		cmd: [],
-	};
-
-	return loadHostedModules()
-		.then(loadModules)
-		.then(() => {
-			catchErrorsWithContext(
-				[
-					[
-						'ga-user-timing-commercial-end',
-						function runTrackPerformance(): void {
-							EventTimer.get().trigger('commercialEnd');
-						},
-					],
-				],
-				tags,
-			);
-		})
-		.catch((err) => {
-			// report async errors in bootCommercial to Sentry with the commercial feature tag
-			reportError(err, tags, false);
-		});
+export const bootCommercial = (): Promise<unknown> => {
+	return loadModules().catch((err) => {
+		// report async errors in bootCommercial to Sentry with the commercial feature tag
+		reportError(err, errorTags, false);
+	});
 };

--- a/static/src/javascripts/bootstraps/commercial-hosted-legacy.ts
+++ b/static/src/javascripts/bootstraps/commercial-hosted-legacy.ts
@@ -1,5 +1,5 @@
 /**
- * This file is deprecated. Only used for legacy “Hosted” pages
+ * Only used for Commercial legacy “Hosted” pages
  */
 
 import { reportError } from 'lib/report-error';


### PR DESCRIPTION
## What does this change?

The hosted bundle adds JS functionality to hosted content e.g.

https://www.theguardian.com/advertiser-content/visa-2020/why-digital-equity-is-fundamental-to-pandemic-recovery

It currently loads in a full set of commercial modules when it does not need to.

This PR removes unused modules and simplifies the hosted bundle. 

This will also allow help to untangle the hosted bundle from the deprecated commercial code in Frontend so we can deprecate it fully.

Tested with the following pages:

Custom video player:
https://www.theguardian.com/advertiser-content/visa-2020/why-digital-equity-is-fundamental-to-pandemic-recovery

YouTube player and onwards carousel:
https://www.theguardian.com/advertiser-content/we-are-still-in/driving-climate-action

Gallery:
https://www.theguardian.com/advertiser-content/microsoft-ai-for-earth/meet-the-changemakers

## Screenshots

Before:
![before][]

After:
![after][]

[before]: https://github.com/guardian/frontend/assets/7014230/da407ba9-9a71-4824-9092-9a117ba9a0d1
[after]: https://github.com/guardian/frontend/assets/7014230/5d546c6e-aa96-41e0-8f97-42e9de33eaee

~85% decrease in the hosted bundle size


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [x] On CODE (optional)
