### PR TITLE
Add 0% AB test for Fronts Banner ads

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       DCRJavascriptBundle,
       HeaderTopBarSearchCapi,
       ServerSideLiveblogInlineAds,
+      FrontsBannerAds,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -70,4 +71,13 @@ object ServerSideLiveblogInlineAds
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
       sellByDate = LocalDate.of(2023, 6, 1),
       participationGroup = Perc5A,
+    )
+
+object FrontsBannerAds
+    extends Experiment(
+      name = "fronts-banner-ads",
+      description = "Creates a new ad experience on fronts pages",
+      owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
+      sellByDate = LocalDate.of(2023, 9, 6),
+      participationGroup = Perc0A,
     )


### PR DESCRIPTION
## What does this change?

Creates a 0% AB test for Fronts Banner ads. The commercial team will be working on a new ad strategy for network fronts pages this quarter and this work needs to be hidden behind a feature switch.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
