### PR TITLE
Don't add automatic tag links for paid content

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -233,7 +233,10 @@ object DotcomRenderingUtils {
       )
       .filter(PageElement.isSupported)
 
-    val withTagLinks = TextCleaner.tagLinks(elems, article.content.tags, article.content.showInRelated, edition)
+    val withTagLinks =
+      if (article.content.isPaidContent) elems
+      else TextCleaner.tagLinks(elems, article.content.tags, article.content.showInRelated, edition)
+
     addDisclaimer(withTagLinks, capiElems, affiliateLinks)
   }
 


### PR DESCRIPTION
## What does this change?

We don't want to include auto tag-links on pages which are paid content

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - This change directly impacts the data sent to DCR, so all good :)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/235944730-3e4d448c-4df7-4846-8200-90666b24277e.png
[after]: https://user-images.githubusercontent.com/9575458/235944690-750bcbc2-3d93-4ec7-80af-41d4d9a4a854.png

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
