### PR TITLE
Fix percentage logging for DCR fronts dashboard

### DIFF
--- a/common/app/experiments/ParticipationGroups.scala
+++ b/common/app/experiments/ParticipationGroups.scala
@@ -8,6 +8,7 @@ sealed abstract class ParticipationGroup(val headerName: String) extends EnumEnt
 
   val percentage = headerName match {
     case s"X-GU-Experiment-${percNo}perc-${_}" => percNo
+    case s"X-GU-Experiment-${percNo}perc"      => percNo
     case _                                     => "unknown"
   }
 }


### PR DESCRIPTION
## What does this change?

Updates the string pattern matching to cover the 50 percent group. It currently shows as "unknown" in our dashboards:
<img width="980" alt="image" src="https://user-images.githubusercontent.com/9575458/235951154-52c8050d-4921-4726-8683-c3d06bbab7c5.png">


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
