### PR TITLE
Add list of unsupported thrashers in `FaciaPicker`

### DIFF
--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -7,7 +7,7 @@ import model.ContentFormat
 
 object FixtureBuilder {
 
-  def mkContent(id: Int): PressedContent = FixtureBuilder.mkPressedContent(id)
+  def mkContent(id: Int): PressedContent = FixtureBuilder.mkPressedCuratedContent(id)
 
   def mkPressedCollection(
       id: String,
@@ -47,86 +47,99 @@ object FixtureBuilder {
     )
   }
 
-  def mkPressedContent(id: Int, kicker: Option[ItemKicker] = None): PressedContent = {
+  def mkProperties(id: Int): PressedProperties =
+    PressedProperties(
+      isBreaking = false,
+      showMainVideo = false,
+      showKickerTag = false,
+      showByline = false,
+      imageSlideshowReplace = false,
+      maybeContent = None,
+      maybeContentId = Some(id.toString),
+      isLiveBlog = false,
+      isCrossword = false,
+      byline = None,
+      image = None,
+      webTitle = s"webTitle $id",
+      linkText = None,
+      embedType = None,
+      embedCss = None,
+      embedUri = None,
+      maybeFrontPublicationDate = None,
+      href = None,
+      webUrl = None,
+      editionBrandings = None,
+      atomId = None,
+    )
 
-    def mkProperties(): PressedProperties =
-      PressedProperties(
-        isBreaking = false,
-        showMainVideo = false,
-        showKickerTag = false,
-        showByline = false,
-        imageSlideshowReplace = false,
-        maybeContent = None,
-        maybeContentId = Some(id.toString),
-        isLiveBlog = false,
-        isCrossword = false,
-        byline = None,
-        image = None,
-        webTitle = s"webTitle $id",
-        linkText = None,
-        embedType = None,
-        embedCss = None,
-        embedUri = None,
-        maybeFrontPublicationDate = None,
-        href = None,
-        webUrl = None,
-        editionBrandings = None,
-        atomId = None,
-      )
+  def mkHeader(id: Int, kicker: Option[ItemKicker] = None): PressedCardHeader =
+    PressedCardHeader(
+      isVideo = false,
+      isComment = false,
+      isGallery = false,
+      isAudio = false,
+      kicker,
+      seriesOrBlogKicker = None,
+      headline = "",
+      url = id.toString,
+      hasMainVideoElement = None,
+    )
 
-    def mkHeader(): PressedCardHeader =
-      PressedCardHeader(
-        isVideo = false,
-        isComment = false,
-        isGallery = false,
-        isAudio = false,
-        kicker,
-        seriesOrBlogKicker = None,
-        headline = "",
-        url = id.toString,
-        hasMainVideoElement = None,
-      )
+  def mkCard(id: Int): PressedCard =
+    PressedCard(
+      id.toString,
+      cardStyle = DefaultCardstyle,
+      webPublicationDateOption = None,
+      lastModifiedOption = None,
+      trailText = Some("trail text"),
+      mediaType = None,
+      starRating = None,
+      shortUrlPath = None,
+      shortUrl = "",
+      group = "0",
+      isLive = false,
+    )
 
-    def mkCard(): PressedCard =
-      PressedCard(
-        id.toString,
-        cardStyle = DefaultCardstyle,
-        webPublicationDateOption = None,
-        lastModifiedOption = None,
-        trailText = Some("trail text"),
-        mediaType = None,
-        starRating = None,
-        shortUrlPath = None,
-        shortUrl = "",
-        group = "0",
-        isLive = false,
-      )
+  def mkDiscussion(): PressedDiscussionSettings =
+    PressedDiscussionSettings(
+      isCommentable = false,
+      isClosedForComments = false,
+      discussionId = None,
+    )
 
-    def mkDiscussion(): PressedDiscussionSettings =
-      PressedDiscussionSettings(
-        isCommentable = false,
-        isClosedForComments = false,
-        discussionId = None,
-      )
+  def mkDisplay(): PressedDisplaySettings =
+    PressedDisplaySettings(
+      isBoosted = false,
+      showBoostedHeadline = false,
+      showQuotedHeadline = false,
+      imageHide = false,
+      showLivePlayable = false,
+    )
 
-    def mkDisplay(): PressedDisplaySettings =
-      PressedDisplaySettings(
-        isBoosted = false,
-        showBoostedHeadline = false,
-        showQuotedHeadline = false,
-        imageHide = false,
-        showLivePlayable = false,
-      )
+  def mkPressedCuratedContent(id: Int, kicker: Option[ItemKicker] = None): PressedContent = {
 
     CuratedContent(
-      properties = mkProperties(),
-      header = mkHeader(),
-      card = mkCard(),
+      properties = mkProperties(id),
+      header = mkHeader(id, kicker),
+      card = mkCard(id),
       discussion = mkDiscussion(),
       display = mkDisplay(),
       enriched = None,
       supportingContent = Nil,
       cardStyle = DefaultCardstyle,
+      format = Some(ContentFormat.defaultContentFormat),
+    )
+  }
+
+  def mkPressedLinkSnap(id: Int, kicker: Option[ItemKicker] = None): PressedContent = {
+
+    LinkSnap(
+      properties = mkProperties(id),
+      header = mkHeader(id, kicker),
+      card = mkCard(id),
+      discussion = mkDiscussion(),
+      display = mkDisplay(),
+      enriched = None,
       format = Some(ContentFormat.defaultContentFormat),
     )
   }

--- a/common/test/common/facia/PressedCollectionBuilder.scala
+++ b/common/test/common/facia/PressedCollectionBuilder.scala
@@ -1,13 +1,13 @@
 package common.facia
 
-import FixtureBuilder.mkPressedContent
+import FixtureBuilder.mkPressedCuratedContent
 import com.gu.facia.client.models.TargetedTerritory
 import model.facia.PressedCollection
 import model.pressed.{CollectionConfig, PressedContent}
 
 object PressedCollectionBuilder {
-  private val defaultCurated = List(mkPressedContent(1), mkPressedContent(2), mkPressedContent(3))
-  private val defaultBackfill = List(mkPressedContent(4), mkPressedContent(5))
+  private val defaultCurated = List(mkPressedCuratedContent(1), mkPressedCuratedContent(2), mkPressedCuratedContent(3))
+  private val defaultBackfill = List(mkPressedCuratedContent(4), mkPressedCuratedContent(5))
 
   def mkPressedCollection(
       collectionType: String = "collectionType",

--- a/common/test/layout/PaidCardTest.scala
+++ b/common/test/layout/PaidCardTest.scala
@@ -1,6 +1,6 @@
 package layout
 
-import common.facia.FixtureBuilder.mkPressedContent
+import common.facia.FixtureBuilder.mkPressedCuratedContent
 import model.pressed.{FreeHtmlKicker, ItemKicker, KickerProperties}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.OptionValues
@@ -15,7 +15,7 @@ class PaidCardTest extends AnyFlatSpec with Matchers with OptionValues {
     )
 
   "fromPressedContent" should "populate kicker" in {
-    val pressedContent = mkPressedContent(1, kicker = Some(mkKicker()))
+    val pressedContent = mkPressedCuratedContent(1, kicker = Some(mkKicker()))
     val card = PaidCard.fromPressedContent(pressedContent)
     card.kicker.value shouldBe "kicker!!!"
   }

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -67,7 +67,7 @@ object FrontChecks {
       "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/02/pw-uk/default",
       "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/11/comfort-eating-grace-dent-thrasher-no-logo/default",
       "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/02/weekend-podcast-2022/default",
-      // We can support those once we support full width for thrashers: https://github.com/guardian/dotcom-rendering/issues/7678
+      // We can support the following thrashers once we support full width: https://github.com/guardian/dotcom-rendering/issues/7678
       "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/default-fronts-default",
       "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/david-olusoga-front-default",
       "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/cassandra-gooptar-front-default",
@@ -82,6 +82,7 @@ object FrontChecks {
       "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/johny-pitts-photo-essay-front-default",
       "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2021/09/pandora-header/default",
       "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2023/04/cost-of-crown/default",
+      // End of list of full-width thrashers
     )
 
   def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -51,6 +51,39 @@ object FrontChecks {
       "news/most-popular",
     )
 
+  val UNSUPPORTED_THRASHERS: Set[String] =
+    Set(
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/12/wordiply/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/04/australian-election/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2021/07/full-story/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2021/10/saved-for-later/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/12/documentaries-signup-thrasher/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2021/12/100-best-footballers/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2021/01/football-weekly-thrasher/thrasher",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/11/20/football-interactive-atom/knockout-full",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2021/07/pegasus/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/07/lakeside/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/07/support-guardian-thrasher/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/02/pw-uk/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/11/comfort-eating-grace-dent-thrasher-no-logo/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2022/02/weekend-podcast-2022/default",
+      // We can support those once we support full width for thrashers: https://github.com/guardian/dotcom-rendering/issues/7678
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/default-fronts-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/david-olusoga-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/cassandra-gooptar-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/gary-younge-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/deneen-l-brown-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/the-enslaved-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/olivette-otele-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/interactives-front--globe",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/michael-taylor-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/lanre-bakare-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/hidden-figures-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/2022/10/tr/johny-pitts-photo-essay-front-default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2021/09/pandora-header/default",
+      "https: //content.guardianapis.com/atom/interactive/interactives/thrashers/2023/04/cost-of-crown/default",
+    )
+
   def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {
     faciaPage.collections.forall(collection => SUPPORTED_COLLECTIONS.contains(collection.collectionType))
   }
@@ -106,8 +139,8 @@ object FrontChecks {
       collection.curated.exists(card =>
         card match {
           case card: LinkSnap if card.properties.embedType.contains("link") => false
-          // We don't support interactive embeds yet
-          case card: LinkSnap if card.properties.embedType.contains("interactive") => true
+          case card: LinkSnap if card.properties.embedType.contains("interactive") =>
+            card.properties.embedUri.exists(UNSUPPORTED_THRASHERS.contains)
           // We don't support json.html embeds yet
           case card: LinkSnap if card.properties.embedType.contains("json.html") => true
           // Because embedType is typed as Option[String] it's hard to know whether we've


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/7330

## What does this change?
This PR adds a set in `FaciaPicker` of interactive `SnapLinks` that are currently unsupported by DCR and their CSS needs modification. We concluded to this list by running [this script](https://gist.github.com/AshCorr/a5057dc2857f13385450b67b959e16bc#file-thrasheteer-ts) to get a list of fronts where `interactive` `LinkSnaps` appear and by comparing how they look in frontend and DCR. We are working with design in order to fix those. Once they get fixed, they can be removed from the set.

We chose to create a list if unsupported thrashers and not supported ones because we actually support more than we thought!

There is also another ticket in progress in order to support [`json.html` `SnapLinks`](https://github.com/guardian/dotcom-rendering/issues/7326).

This PR also refactors slightly `FixtureBuilder.scala` so that we can unit test the `hasNoUnsupportedSnapLinkCards` method.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
