### PR TITLE
IntegrateIma test to 5%

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -8,8 +8,8 @@ export const integrateIma: ABTest = {
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',
-	audience: 0,
-	audienceOffset: 0,
+	audience: 5 / 100,
+	audienceOffset: 10 / 100,
 	audienceCriteria: 'Opt in',
 	successMeasure:
 		'IMA integration works as expected without adversely affecting pages with videos',


### PR DESCRIPTION
## What does this change?

IntegrateIma test to 5%

## Why?

Commercial want to run the YouTube Integrated Media Ads (IMA) ab test again but with updated targeting to assist reporting in Google Ad Manager.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/7708

