### PR TITLE
Sets server-side ads on liveblog pages AB test to 0%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -70,7 +70,7 @@ object ServerSideLiveblogInlineAds
         "Test whether we can load liveblog inline ads server-side without negative effects on user experience or revenue",
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
       sellByDate = LocalDate.of(2023, 6, 1),
-      participationGroup = Perc5A,
+      participationGroup = Perc0C,
     )
 
 object FrontsBannerAds


### PR DESCRIPTION
## What does this change?

Sets the server-side liveblog ads AB test from 5% to 0%.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The AB test has reached the required amount of data.