### PR TITLE
Adding fight for democracy to us home front

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -64,7 +64,7 @@ object NavLinks {
   val careers = NavLink("Careers", "/money/work-and-careers")
   val obituaries = NavLink("Obituaries", "/obituaries")
   val greenLight = NavLink("Green light", "/environment/series/green-light")
-  val fightToVote = NavLink("Fight to vote", "/us-news/series/the-fight-to-vote")
+  val fightForDemocracy = NavLink("Fight for democracy", "/us-news/series/the-fight-for-democracy")
   val ukNews = NavLink(
     "UK",
     "/uk-news",
@@ -305,7 +305,7 @@ object NavLinks {
       tech,
       science,
       newsletters.copy(url = s"${newsletters.url}"),
-      fightToVote,
+      fightForDemocracy,
     ),
   )
   val intNewsPillar = ukNewsPillar.copy(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1003,8 +1003,8 @@
                 "children" : [ ],
                 "classList" : [ ]
             }, {
-                "title" : "Fight to vote",
-                "url" : "/us-news/series/the-fight-to-vote",
+                "title" : "Fight for democracy",
+                "url" : "/us-news/series/the-fight-for-democracy",
                 "children" : [ ],
                 "classList" : [ ]
             } ],


### PR DESCRIPTION
## What does this change?
Updates nav links on us home front, as requested by CP. We're replacing 'fight to vote' with 'fight for democracy'.
## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/110032454/ccf07a68-5a54-41d5-b4fe-fd7181f00e57
[after]: https://github.com/guardian/frontend/assets/110032454/0ce70912-fecf-4fd6-b81c-3982088e1c31



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
