### PR TITLE
feat: render videos in 9:16

### DIFF
--- a/common/app/model/PressedCardHeader.scala
+++ b/common/app/model/PressedCardHeader.scala
@@ -15,7 +15,6 @@ final case class PressedCardHeader(
     headline: String,
     url: String,
     hasMainVideoElement: Option[Boolean],
-    isVerticalVideo: Option[Boolean]
 )
 
 object PressedCardHeader {
@@ -34,15 +33,6 @@ object PressedCardHeader {
       hasMainVideoElement = Some(
         capiContent.flatMap(_.elements).exists(_.exists(e => e.`type` == ElementType.Video && e.relation == "main")),
       ),
-      isVerticalVideo = capiContent.flatMap(item => fapiutils.ItemKicker.seriesOrBlogKicker(item).map((item) => {
-
-        val tagKicker = ItemKicker.makeTagKicker(item)
-println(tagKicker)
-       val resp = tagKicker.id == "info/series/vertical-video"
-        println("resp", resp)
-        resp
-      }
-      ))
     )
   }
 }

--- a/common/app/model/PressedCardHeader.scala
+++ b/common/app/model/PressedCardHeader.scala
@@ -15,6 +15,7 @@ final case class PressedCardHeader(
     headline: String,
     url: String,
     hasMainVideoElement: Option[Boolean],
+    isVerticalVideo: Option[Boolean]
 )
 
 object PressedCardHeader {
@@ -33,6 +34,15 @@ object PressedCardHeader {
       hasMainVideoElement = Some(
         capiContent.flatMap(_.elements).exists(_.exists(e => e.`type` == ElementType.Video && e.relation == "main")),
       ),
+      isVerticalVideo = capiContent.flatMap(item => fapiutils.ItemKicker.seriesOrBlogKicker(item).map((item) => {
+
+        val tagKicker = ItemKicker.makeTagKicker(item)
+println(tagKicker)
+       val resp = tagKicker.id == "info/series/vertical-video"
+        println("resp", resp)
+        resp
+      }
+      ))
     )
   }
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -870,6 +870,10 @@ final case class Tags(tags: List[Tag]) {
     tags.find(tag => tag.showSeriesInMeta && (tag.isBlog || tag.isSeries))
   }
 
+  lazy val isVerticalVideo: Boolean = {
+    tags.exists(t => t.id == "media/series/vertical-video")
+  }
+
   def javascriptConfig: Map[String, JsValue] =
     Map(
       (

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -20,7 +20,9 @@
     faciaHeaderProperties: Option[VideoFaciaProperties] = None,
     isPaidFor: Boolean = false,
     pressedContent: Option[PressedContent] = None,
+    verticalVideo: Boolean = false,
 )(implicit request: RequestHeader)
+
 
 @videoJsError() = @{
     <div class="vjs-error-display vjs-modal-dialog">
@@ -40,7 +42,7 @@
                 ("youtube-media-atom", true),
                 ("no-player", !playable || expired ),
                 ("youtube-related-videos", true),
-                ("vertical-video", true)
+                ("vertical-video", verticalVideo)
             )) " data-channel-id="@channelId">
         }
     }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -51,7 +51,7 @@
                 This fixes the scenario when there are muliple instances of the same assetId i.e. the same video on the page.
                 This is most likely to occur in a liveblog where the video can be in a main media position and in a block.
             *@
-            <div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
+            <div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe vertical-iframe"></div>
 
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
                 <div class="video-overlay">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -53,7 +53,11 @@
                 This fixes the scenario when there are muliple instances of the same assetId i.e. the same video on the page.
                 This is most likely to occur in a liveblog where the video can be in a main media position and in a block.
             *@
-            <div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe vertical-iframe"></div>
+          @if(verticalVideo) {
+              <div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe vertical-iframe"></div>
+          } else {
+              <div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
+            }
 
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
                 <div class="video-overlay">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -19,7 +19,7 @@
     mediaWrapper: Option[MediaWrapper] = None,
     faciaHeaderProperties: Option[VideoFaciaProperties] = None,
     isPaidFor: Boolean = false,
-    pressedContent: Option[PressedContent] = None
+    pressedContent: Option[PressedContent] = None,
 )(implicit request: RequestHeader)
 
 @videoJsError() = @{
@@ -39,8 +39,9 @@
                 ("u-responsive-ratio--hd", sixteenByNine),
                 ("youtube-media-atom", true),
                 ("no-player", !playable || expired ),
-                ("youtube-related-videos", true)
-            ))" data-channel-id="@channelId">
+                ("youtube-related-videos", true),
+                ("vertical-video", true)
+            )) " data-channel-id="@channelId">
         }
     }
 

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -42,8 +42,6 @@
            <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first} fc-item--pillar-@item.maybePillar.nameOrDefault @if(item.isPaidFor) { video-playlist__item--paid-for }">
                 @item.properties.maybeContent.map { content =>
                     @defining(content.elements.mediaAtoms.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube))) { youTubeAtom =>
-                        @println(Some(item))
-
                         @youTubeAtom.map { youTubeAtom =>
                             @youtube(media = youTubeAtom,
                                 displayCaption = false,
@@ -53,7 +51,7 @@
                                     showByline = item.properties.showByline, item.properties.byline)),
                                 isPaidFor = item.isPaidFor,
                                 pressedContent = Some(item),
-                                verticalVideo = item.header.isVerticalVideo
+                                verticalVideo = content.tags.isVerticalVideo
                             )
                         }
                     }

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -68,7 +68,7 @@
                         )) { player =>
                         <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
                             <div class="fc-item__video-container">
-<!--                            @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)-->
+                            @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)
                             </div>
                         </div>
                         <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -38,11 +38,12 @@
         <li class="video-playlist__item video-title video-title--leftcol fc-container__header__title">
             @treats(containerDefinition, frontProperties)
         </li>
-
         @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo).zipWithIndex.map { case (item, index) =>
            <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first} fc-item--pillar-@item.maybePillar.nameOrDefault @if(item.isPaidFor) { video-playlist__item--paid-for }">
                 @item.properties.maybeContent.map { content =>
                     @defining(content.elements.mediaAtoms.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube))) { youTubeAtom =>
+                        @println(Some(item))
+
                         @youTubeAtom.map { youTubeAtom =>
                             @youtube(media = youTubeAtom,
                                 displayCaption = false,
@@ -51,7 +52,9 @@
                                 faciaHeaderProperties = Some(VideoFaciaProperties(header = FaciaCardHeader.fromTrail(item, None),
                                     showByline = item.properties.showByline, item.properties.byline)),
                                 isPaidFor = item.isPaidFor,
-                                pressedContent = Some(item))
+                                pressedContent = Some(item),
+                                verticalVideo = item.header.isVerticalVideo
+                            )
                         }
                     }
 
@@ -67,7 +70,7 @@
                         )) { player =>
                         <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
                             <div class="fc-item__video-container">
-                            @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)
+<!--                            @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)-->
                             </div>
                         </div>
                         <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -144,13 +144,15 @@ data-test-id="facia-card"
             case Some(media@InlineYouTubeMediaAtom(_,_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__video-container">
-                    @youtube(
+                   @youtube(
                         media = media.youTubeAtom,
                         displayCaption = false,
                         displayDuration = false,
                         playable = item.cardTypes.showYouTubeMediaAtomPlayer,
                         posterImageOverride = media.posterImageOverride,
-                        cardStyle = Some(item.cardStyle))
+                        cardStyle = Some(item.cardStyle),
+                       verticalVideo = item.properties.map(p => p.maybeContent.map(c => c.tags.isVerticalVideo))
+                   )
                     </div>
                 </div>
             }

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -148,7 +148,7 @@
  */
 
 .u-responsive-ratio {
-    @include fix-aspect-ratio(5, 3); // 1
+    @include fix-aspect-ratio(9, 16); // 1
 
     img,
     object,

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -148,7 +148,7 @@
  */
 
 .u-responsive-ratio {
-    @include fix-aspect-ratio(9, 16); // 1
+    @include fix-aspect-ratio(5, 3); // 1
 
     img,
     object,
@@ -162,6 +162,11 @@
         top: 0;
         left: 0;
     }
+}
+
+u-responsive-ratio vertical-video {
+    @include fix-aspect-ratio(9, 16); // 1
+
 }
 
 .u-responsive-aligner {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -33,7 +33,7 @@
     }
 }
 
-.video-playlist__item .youtube-media-atom iframe,
+.video-playlist__item .youtube-media-atom:not(.vertical-iframe) iframe,
 .video-playlist__item .youtube-media-atom .vjs-big-play-button {
     @include mq($until: desktop) {
         top: gs-height(3) - (get-line-height(textSans, 3) + 4px);
@@ -41,6 +41,15 @@
         height: auto;
     }
 }
+
+.vertical-iframe {
+    @include mq($until: desktop) {
+        top: 0;
+        bottom: 0;
+        height: 100%;
+    }
+}
+
 
 .video-playlist__item--active .youtube-media-atom {
     opacity: 1;

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -92,6 +92,10 @@ $video-width-desktop: 700px;
     }
 }
 
+.vertical-video {
+    aspect-ratio: 9/16;
+    width: 100%;
+}
 .fc-container--video-no-fill-sides {
     background-color: transparent;
 }


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
