### PR TITLE
Degrade web vitals for 1% of users

### DIFF
--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -62,14 +62,4 @@ trait JournalismSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
-
-  val BorkWebVitals = Switch(
-    SwitchGroup.Journalism,
-    "bork-web-vitals",
-    "Enables borking (synthetic delay) of web vitals",
-    owners = Seq(Owner.withName("Open Journalism")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,6 +14,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       HeaderTopBarSearchCapi,
       ServerSideLiveblogInlineAds,
       FrontsBannerAds,
+      BorkWebVitals,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -80,4 +81,13 @@ object FrontsBannerAds
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
       sellByDate = LocalDate.of(2023, 9, 6),
       participationGroup = Perc0A,
+    )
+
+object BorkWebVitals
+    extends Experiment(
+      name = "bork-web-vitals",
+      description = "Enables borking (synthetic delay) of web vitals",
+      owners = Seq(Owner.withName("Open Journalism")),
+      sellByDate = LocalDate.of(2023, 6, 1),
+      participationGroup = Perc1C,
     )


### PR DESCRIPTION
## What does this change?

Subscribe 1% of our users to a test where we degrade/[“bork”](https://en.wiktionary.org/wiki/bork#Verb_2) web vitals to measure their impact on engagement.

## What about dotcom-rendering ?

https://github.com/guardian/dotcom-rendering/pull/7711
