### PR TITLE
feat: Removes the hasNoThrashers FaciaPicker check.

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -152,12 +152,6 @@ object FrontChecks {
     !faciaPage.collections.exists(collection => containsUnsupportedSnapLink(collection))
   }
 
-  //  We should add these to the `SUPPORTED_COLLECTIONS` above when they are supported
-  //  This is predominantly for assess how much more coverage each of these containers would give us
-  def hasNoThrashers(faciaPage: PressedPage): Boolean = {
-    !faciaPage.collections.map(_.collectionType).contains("fixed/thrasher")
-  }
-
   def hasNoDynamicPackage(faciaPage: PressedPage): Boolean = {
     !faciaPage.collections.map(_.collectionType).contains("dynamic/package")
   }
@@ -180,7 +174,6 @@ object FaciaPicker extends GuLogging {
       ("hasNoPaidCards", FrontChecks.hasNoPaidCards(faciaPage)),
       ("hasNoRegionalAusTargetedContainers", FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage)),
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
-      ("hasNoThrashers", FrontChecks.hasNoThrashers(faciaPage)),
       ("hasNoDynamicPackage", FrontChecks.hasNoDynamicPackage(faciaPage)),
       ("hasNoFixedVideo", FrontChecks.hasNoFixedVideo(faciaPage)),
     )


### PR DESCRIPTION
## What does this change?

We added `fixed/thrasher` to the list of supported collections in https://github.com/guardian/frontend/pull/26128 but we didn't realize there was a 2nd check that was stopping thrashers from being included in the test.

