### PR TITLE
Bump @guardian/commercial-bundle@5.0.0 for consentless advertising

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial-bundle": "4.0.0",
+		"@guardian/commercial-bundle": "5.0.0",
 		"@guardian/commercial-core": "^7.0.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,10 +1349,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial-bundle@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-4.0.0.tgz#637d632cca1de8bd78201bcac789287a1f2a95c5"
-  integrity sha512-x4BjR6P0ACfoG8iEHSii54MV2rI8CrI0e5lFEY30lhfpyjXYKabGloAZtoWHRkH2qQTqInWHUZJIqeJUo1SqGA==
+"@guardian/commercial-bundle@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.0.tgz#94da5021ddda4f282423872f90c1637ede74225f"
+  integrity sha512-cODN1V4ScZcBfyMUiRWfgyNrXAs+LwEY6OqITiCDTseOmKcUkp1i48+u1k/e00okhODNvnONnrJlr622vGsbCA==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^7.0.0"


### PR DESCRIPTION
## What does this change?

Bump @guardian/commercial-bundle for:

https://github.com/guardian/commercial/releases/tag/%40guardian%2Fcommercial-bundle-v5.0.0
https://github.com/guardian/commercial/releases/tag/%40guardian%2Fcommercial-bundle-v4.2.0
https://github.com/guardian/commercial/releases/tag/%40guardian%2Fcommercial-bundle-v4.1.0

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [x] On CODE (optional)
