### PR TITLE
Hide inline ads on uk network front if in fronts OKR test

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -22,6 +22,7 @@ import play.api.mvc.RequestHeader
 import services.SkimLinksCache
 import views.html.fragments.affiliateLinksDisclaimer
 import views.support.Commercial.isAdFree
+import experiments.{ActiveExperiments, FrontsBannerAds}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
@@ -817,6 +818,9 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
     val slices: List[Element] = document.getElementsByClass("fc-slice__item--mpu-candidate").asScala.toList
 
     for (slice <- slices) {
+      if (ActiveExperiments.isParticipating(FrontsBannerAds)) {
+        slice.addClass("fc-slice__item--mpu-candidate--hide-desktop")
+      }
       slice.append(s"${sliceSlot(slices.indexOf(slice) + 1)}")
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_items.scss
+++ b/static/src/stylesheets/module/facia-garnett/_items.scss
@@ -66,7 +66,7 @@
 
 // For the Fronts OKR test May 2023
 @include mq(desktop) {
-    .facia-page[data-link-name='Front | /uk'] .fc-slice__item--mpu-candidate {
+    .facia-page[data-link-name='Front | /uk'] .fc-slice__item--mpu-candidate.fc-slice__item--mpu-candidate--hide-desktop {
         display: none;
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_items.scss
+++ b/static/src/stylesheets/module/facia-garnett/_items.scss
@@ -63,6 +63,14 @@
 @import 'item-types/_fc-item--type-comment';
 @import 'item-types/_fc-item--type-immersive';
 
+
+// For the Fronts OKR test May 2023
+@include mq(desktop) {
+    .facia-page[data-link-name='Front | /uk'] .fc-slice__item--mpu-candidate {
+        display: none;
+    }
+}
+
 .fc-slice__item {
     width: 100%;
     position: relative;

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -21,7 +21,7 @@
 
 // For the Fronts OKR test May 2023
 @include mq(desktop) {
-    .facia-page[data-link-name='Front | /uk'] .fc-slice__item--mpu-candidate {
+    .facia-page[data-link-name='Front | /uk'] .fc-slice__item--mpu-candidate.fc-slice__item--mpu-candidate--hide-desktop {
         display: none;
     }
 }

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -19,6 +19,13 @@
 @import 'item-layouts/fc-item--full-media-100';
 @import 'item-layouts/fc-item--fluid';
 
+// For the Fronts OKR test May 2023
+@include mq(desktop) {
+    .facia-page[data-link-name='Front | /uk'] .fc-slice__item--mpu-candidate {
+        display: none;
+    }
+}
+
 // overrides of current slices
 
 .fc-slice__item {


### PR DESCRIPTION
## What does this change?
Hides inline MPUs on the UK Network Front on Desktop when in the Fronts OKR Server side test

I've tested it works on CODE.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/1731150/7d6bee44-ed11-4510-b9da-4d537703e7f8
[after]: https://github.com/guardian/frontend/assets/1731150/fc7a96f1-2c85-49a0-ba9e-a3c8524df623

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
