### PR TITLE
Exclude commercial dist from terser to preserve sourcemap comments

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -42,6 +42,7 @@ module.exports = webpackMerge.smart(config, {
 	optimization: {
 		minimizer: [
 			new TerserPlugin({
+				exclude: /graun.*commercial.js/,
 				parallel: true,
 				terserOptions: {
 					sourceMap: true,


### PR DESCRIPTION
## What does this change?

Commercial's (already minified) dist files get copied out of `@guardian/commercial-bundle` and run through Frontend's Webpack build and minification via Terser. This removes the sourcemap comments and hence breaks sourcemaps for commercial JS.

This PR excludes commercial JS from Frontends Terser minification.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)



