### PR TITLE
add player substitute to relevant player data

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -10,7 +10,7 @@ import football.model.{FootballMatchTrail, GuTeamCodes}
 import implicits.{Football, Requests}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{Cached, Competition, Content, ContentType, TeamColours}
-import pa.{FootballMatch, LineUp, LineUpTeam, MatchDayTeam}
+import pa.{FootballMatch, LineUp, LineUpPlayer, LineUpTeam, MatchDayTeam, MatchEvents}
 import play.api.libs.json._
 import play.api.mvc._
 import play.twirl.api.Html
@@ -60,6 +60,7 @@ case class NxPlayer(
     timeOnPitch: String,
     shirtNumber: String,
     events: Seq[EventAnswer],
+    substitutedBy: Option[NxPlayer] = None,
 ) extends NxAnswer
 case class NxTeam(
     id: String,
@@ -92,11 +93,17 @@ case class NxMatchData(
 
 object NxAnswer {
   val reportedEventTypes = List("booking", "dismissal", "substitution")
-  def makePlayers(team: LineUpTeam): Seq[NxPlayer] = {
+  def makePlayers(team: LineUpTeam, matchEvents: Option[MatchEvents]): Seq[NxPlayer] = {
+    val substitutedBy: Option[Map[String, String]] = getListOfSubstitutes(team, matchEvents)
+    val subs: Seq[LineUpPlayer] = team.players.filter(_.substitute)
+
     team.players.map { player =>
       val events = player.events.filter(event => NsAnswer.reportedEventTypes.contains(event.eventType)).map { event =>
         EventAnswer(event.eventTime, event.eventType)
       }
+
+      val playerSub = getPlayerSub(substitutedBy, subs, player)
+
       NxPlayer(
         player.id,
         player.name,
@@ -106,11 +113,56 @@ object NxAnswer {
         player.timeOnPitch,
         player.shirtNumber,
         events,
+        playerSub,
       )
     }
   }
-  def makeTeamAnswer(teamV1: MatchDayTeam, teamV2: LineUpTeam, teamPossession: Int, teamColour: String): NxTeam = {
-    val players = makePlayers(teamV2)
+
+  def getListOfSubstitutes(lineUp: LineUpTeam, maybeMatchEvents: Option[MatchEvents]) = {
+    maybeMatchEvents map { matchEvents =>
+      val substitutionEvents = matchEvents.events filter { event =>
+        event.eventType == "substitution" && event.teamID.contains(lineUp.id)
+      }
+
+      val subs = substitutionEvents map { event =>
+        event.players.last.id -> event.players.head.id
+      }
+
+      subs.toMap
+    }
+  }
+
+  def getPlayerSub(substitutedBy: Option[Map[String, String]], subs: Seq[LineUpPlayer], player: LineUpPlayer) = {
+    substitutedBy flatMap { s =>
+      for {
+        subbedById <- s.get(player.id)
+        player <- subs.find(_.id == subbedById)
+      } yield {
+        val events = player.events.filter(event => NsAnswer.reportedEventTypes.contains(event.eventType)).map { event =>
+          EventAnswer(event.eventTime, event.eventType)
+        }
+        NxPlayer(
+          id = player.id,
+          name = player.name,
+          position = player.position,
+          lastName = player.lastName,
+          substitute = player.substitute,
+          timeOnPitch = player.timeOnPitch,
+          shirtNumber = player.shirtNumber,
+          events = events,
+        )
+      }
+    }
+  }
+
+  def makeTeamAnswer(
+      teamV1: MatchDayTeam,
+      teamV2: LineUpTeam,
+      matchEvents: Option[MatchEvents],
+      teamPossession: Int,
+      teamColour: String,
+  ): NxTeam = {
+    val players = makePlayers(teamV2, matchEvents)
     NxTeam(
       teamV1.id,
       cleanTeamNameNextGenApi(teamV1.name),
@@ -157,6 +209,7 @@ object NxAnswer {
       theMatch: FootballMatch,
       related: Seq[ContentType],
       lineUp: LineUp,
+      matchEvents: Option[MatchEvents],
       competition: Option[Competition],
       isResult: Boolean,
       isLive: Boolean,
@@ -165,8 +218,10 @@ object NxAnswer {
     NxMatchData(
       id = theMatch.id,
       isResult = isResult,
-      homeTeam = makeTeamAnswer(theMatch.homeTeam, lineUp.homeTeam, lineUp.homeTeamPossession, teamColours.home),
-      awayTeam = makeTeamAnswer(theMatch.awayTeam, lineUp.awayTeam, lineUp.awayTeamPossession, teamColours.away),
+      homeTeam =
+        makeTeamAnswer(theMatch.homeTeam, lineUp.homeTeam, matchEvents, lineUp.homeTeamPossession, teamColours.home),
+      awayTeam =
+        makeTeamAnswer(theMatch.awayTeam, lineUp.awayTeam, matchEvents, lineUp.awayTeamPossession, teamColours.away),
       competition = NxCompetition(competition.map(_.fullName)),
       isLive = isLive,
       venue = theMatch.venue.map(_.name).getOrElse(""),
@@ -265,6 +320,7 @@ class MoreOnMatchController(
           if (request.forceDCR) {
             for {
               lineup <- competitionsService.getLineup(theMatch)
+              matchEvents <- competitionsService.getMatchEvents(theMatch)
               filtered <- related map { _ filter hasExactlyTwoTeams }
             } yield {
               Cached(if (theMatch.isLive) 10 else 300) {
@@ -274,6 +330,7 @@ class MoreOnMatchController(
                     theMatch,
                     filtered,
                     lineup,
+                    matchEvents,
                     competition,
                     theMatch.isResult,
                     theMatch.isLive,

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -357,6 +357,7 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
     extends Competitions
     with LiveMatches
     with Lineups
+    with feed.MatchEvents
     with GuLogging
     with implicits.Football {
 

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -23,6 +23,29 @@ trait Lineups extends GuLogging {
       .recover(footballClient.logErrorsWithMessage(s"Failed getting line-up for match ${theMatch.id}"))
 }
 
+trait MatchEvents extends GuLogging {
+  def footballClient: FootballClient
+  def teamNameBuilder: TeamNameBuilder
+
+  def getMatchEvents(
+      theMatch: FootballMatch,
+  )(implicit executionContext: ExecutionContext): Future[Option[pa.MatchEvents]] = {
+    footballClient
+      .matchEvents(theMatch.id)
+      .map { matbeMatchEvents =>
+        matbeMatchEvents.map { m =>
+          val homeTeam = m.homeTeam.copy(name = teamNameBuilder.withTeam(m.homeTeam))
+          val awayTeam = m.awayTeam.copy(name = teamNameBuilder.withTeam(m.awayTeam))
+          MatchEvents(homeTeam, awayTeam, m.events, m.isResult)
+        }
+
+        matbeMatchEvents
+      }
+      .recover(footballClient.logErrorsWithMessage(s"Failed getting match events for match ${theMatch.id}"))
+
+  }
+}
+
 trait LiveMatches extends GuLogging {
 
   def footballClient: FootballClient

--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -8,7 +8,7 @@
 @import football.model.GuTeamCodes
 @(page: MatchPage)(implicit request: RequestHeader)
 
-@team(players: Seq[LineUpPlayer]) = {
+@team(players: Seq[LineUpPlayer], playerAndSubstituteList: Option[Map[String, LineUpPlayer]] = None) = {
     <ul class="match-stats__players u-unstyled">
         @players.map{ player =>
             <li class="match-stats__player">
@@ -21,6 +21,12 @@
                         case "substitution" => "(s " + event.eventTime + "')"
                         case _ =>  ""
                     }}
+                }
+                @playerAndSubstituteList.map { p =>
+                    @p.get(player.id).map { pp =>
+                        @fragments.inlineSvg("arrow-right", "icon")
+                        @pp.lastName
+                    }
                 }
             </li>
         }
@@ -107,7 +113,7 @@
                 <h4 class="match-stats__caption">@cleanTeamName(home.name)</h4>
                 @team(page.lineUp.homeTeam.players.filterNot {
                     _.substitute
-                })
+                }, page.homePlayerAndSubstitute)
                 <h4 class="match-stats__caption">Substitutes</h4>
                 @team(page.lineUp.homeTeam.players.filter {
                     _.substitute
@@ -117,7 +123,7 @@
                 <h4 class="match-stats__caption">@cleanTeamName(away.name)</h4>
                 @team(page.lineUp.awayTeam.players.filterNot {
                     _.substitute
-                })
+                }, page.awayPlayerAndSubstitute)
                 <h4 class="match-stats__caption">Substitutes</h4>
                 @team(page.lineUp.awayTeam.players.filter {
                     _.substitute


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
