### PR TITLE
Add substituted by to match nav response for dcr calls

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -118,48 +118,6 @@ object NxAnswer {
     }
   }
 
-  def getListOfPlayerAndSubstitutes(lineUp: LineUpTeam, maybeMatchEvents: Option[MatchEvents]) = {
-    maybeMatchEvents map { matchEvents =>
-      val substitutionEvents = matchEvents.events filter { event =>
-        event.eventType == "substitution" && event.teamID.contains(lineUp.id)
-      }
-
-      val subs = substitutionEvents map { event =>
-        event.players.last.id -> event.players.head.id
-      }
-
-      subs.toMap
-    }
-  }
-
-  def getPlayerSubstitute(
-      optionalPlayerAndSubstituteList: Option[Map[String, String]],
-      allSubstitutes: Seq[LineUpPlayer],
-      player: LineUpPlayer,
-  ): Option[NxPlayer] = {
-    optionalPlayerAndSubstituteList flatMap { playerAndSubstituteList =>
-      for {
-        substituteId <- playerAndSubstituteList.get(player.id)
-        substitute <- allSubstitutes.find(_.id == substituteId)
-      } yield {
-        val events = substitute.events.filter(event => NsAnswer.reportedEventTypes.contains(event.eventType)).map {
-          event => EventAnswer(event.eventTime, event.eventType)
-        }
-
-        NxPlayer(
-          id = substitute.id,
-          name = substitute.name,
-          position = substitute.position,
-          lastName = substitute.lastName,
-          substitute = substitute.substitute,
-          timeOnPitch = substitute.timeOnPitch,
-          shirtNumber = substitute.shirtNumber,
-          events = events,
-        )
-      }
-    }
-  }
-
   def makeTeamAnswer(
       teamV1: MatchDayTeam,
       teamV2: LineUpTeam,
@@ -234,6 +192,48 @@ object NxAnswer {
       minByMinUrl = makeMinByMinUrl(request, theMatch, related),
       reportUrl = makeMatchReportUrl(request, theMatch, related),
     )
+  }
+
+  private def getListOfPlayerAndSubstitutes(lineUp: LineUpTeam, maybeMatchEvents: Option[MatchEvents]) = {
+    maybeMatchEvents map { matchEvents =>
+      val substitutionEvents = matchEvents.events filter { event =>
+        event.eventType == "substitution" && event.teamID.contains(lineUp.id)
+      }
+
+      val subs = substitutionEvents map { event =>
+        event.players.last.id -> event.players.head.id
+      }
+
+      subs.toMap
+    }
+  }
+
+  private def getPlayerSubstitute(
+      optionalPlayerAndSubstituteList: Option[Map[String, String]],
+      allSubstitutes: Seq[LineUpPlayer],
+      player: LineUpPlayer,
+  ): Option[NxPlayer] = {
+    optionalPlayerAndSubstituteList flatMap { playerAndSubstituteList =>
+      for {
+        substituteId <- playerAndSubstituteList.get(player.id)
+        substitute <- allSubstitutes.find(_.id == substituteId)
+      } yield {
+        val events = substitute.events.filter(event => NsAnswer.reportedEventTypes.contains(event.eventType)).map {
+          event => EventAnswer(event.eventTime, event.eventType)
+        }
+
+        NxPlayer(
+          id = substitute.id,
+          name = substitute.name,
+          position = substitute.position,
+          lastName = substitute.lastName,
+          substitute = substitute.substitute,
+          timeOnPitch = substitute.timeOnPitch,
+          shirtNumber = substitute.shirtNumber,
+          events = events,
+        )
+      }
+    }
   }
 
   implicit val EventAnswerWrites: Writes[NxEvent] = Json.writes[NxEvent]

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -357,6 +357,7 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
     extends Competitions
     with LiveMatches
     with Lineups
+    with feed.MatchEvents
     with GuLogging
     with implicits.Football {
 

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -23,6 +23,29 @@ trait Lineups extends GuLogging {
       .recover(footballClient.logErrorsWithMessage(s"Failed getting line-up for match ${theMatch.id}"))
 }
 
+trait MatchEvents extends GuLogging {
+  def footballClient: FootballClient
+  def teamNameBuilder: TeamNameBuilder
+
+  def getMatchEvents(
+      theMatch: FootballMatch,
+  )(implicit executionContext: ExecutionContext): Future[Option[pa.MatchEvents]] = {
+    footballClient
+      .matchEvents(theMatch.id)
+      .map { matbeMatchEvents =>
+        matbeMatchEvents.map { m =>
+          val homeTeam = m.homeTeam.copy(name = teamNameBuilder.withTeam(m.homeTeam))
+          val awayTeam = m.awayTeam.copy(name = teamNameBuilder.withTeam(m.awayTeam))
+          MatchEvents(homeTeam, awayTeam, m.events, m.isResult)
+        }
+
+        matbeMatchEvents
+      }
+      .recover(footballClient.logErrorsWithMessage(s"Failed getting match events for match ${theMatch.id}"))
+
+  }
+}
+
 trait LiveMatches extends GuLogging {
 
   def footballClient: FootballClient

--- a/sport/test/football/implicits/FootballTest.scala
+++ b/sport/test/football/implicits/FootballTest.scala
@@ -21,7 +21,7 @@ class FootballTest extends AnyFlatSpec with Matchers {
     result.get("3") should be("5")
   }
 
-  it should "not return the team substitutions" in {
+  it should "return an empty list given no substitution occured for the relevant team" in {
     val eventsList = List(
       getMatchEvent(eventType = "random", teamID = "homeTeamId", players = List("2", "4")),
     )
@@ -39,7 +39,7 @@ class FootballTest extends AnyFlatSpec with Matchers {
     result shouldBe None
   }
 
-  "RichLineUpTeam allSubstitutes" should "all substitutes players" in {
+  "RichLineUpTeam allSubstitutes" should "return all substitutes players" in {
     val home = makeLineUpTeam("homeTeamId", "team1", homePlayers)
 
     val result = home.allSubstitutes
@@ -49,7 +49,7 @@ class FootballTest extends AnyFlatSpec with Matchers {
     result(1).id should be("5")
   }
 
-  "Football getPlayerSubstitute" should "all substitutes players" in {
+  "Football getPlayerSubstitute" should "the substitute who replaced the given player" in {
     val playerAndSubstitute = Some(Map(("2", "5"), ("1", "4")))
     val substitutes = Seq(
       makeLineUpPlayer("4", "Alessandro", "Bastoni", true),

--- a/sport/test/football/implicits/FootballTest.scala
+++ b/sport/test/football/implicits/FootballTest.scala
@@ -1,0 +1,162 @@
+package football.implicits
+
+import pa.{LineUpEvent, LineUpPlayer, LineUpTeam, MatchEvent, MatchEvents, Official, Player, Team}
+import implicits.Football._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FootballTest extends AnyFlatSpec with Matchers {
+
+  "RichLineUpTeam getListOfPlayerAndSubstitutes" should "return the team substitutions" in {
+    val eventsList = List(
+      getMatchEvent(eventType = "substitution", teamID = "homeTeamId", players = List("4", "2")),
+      getMatchEvent(eventType = "substitution", teamID = "homeTeamId", players = List("5", "3")),
+    )
+    val home = makeLineUpTeam("homeTeamId", "team1", homePlayers)
+    val away = makeLineUpTeam("awayTeamId", "team2", awayPlayers)
+    val result = home.getListOfPlayerAndSubstitutes(getMatchEvents(home, away, eventsList))
+
+    result.get.size should be(2)
+    result.get("2") should be("4")
+    result.get("3") should be("5")
+  }
+
+  it should "not return the team substitutions" in {
+    val eventsList = List(
+      getMatchEvent(eventType = "random", teamID = "homeTeamId", players = List("2", "4")),
+    )
+    val home = makeLineUpTeam("homeTeamId", "team1", homePlayers)
+    val away = makeLineUpTeam("awayTeamId", "team2", awayPlayers)
+    val result = home.getListOfPlayerAndSubstitutes(getMatchEvents(home, away, eventsList))
+
+    result.get.size should be(0)
+  }
+
+  it should "return None given a None for match events" in {
+    val home = makeLineUpTeam("homeTeamId", "team1", homePlayers)
+    val result = home.getListOfPlayerAndSubstitutes(None)
+
+    result shouldBe None
+  }
+
+  "RichLineUpTeam allSubstitutes" should "all substitutes players" in {
+    val home = makeLineUpTeam("homeTeamId", "team1", homePlayers)
+
+    val result = home.allSubstitutes
+
+    result.length should be(2)
+    result(0).id should be("4")
+    result(1).id should be("5")
+  }
+
+  "Football getPlayerSubstitute" should "all substitutes players" in {
+    val playerAndSubstitute = Some(Map(("2", "5"), ("1", "4")))
+    val substitutes = Seq(
+      makeLineUpPlayer("4", "Alessandro", "Bastoni", true),
+      makeLineUpPlayer("5", "Denzel", "Dumfries", true),
+    )
+    val player = makeLineUpPlayer("1", "Andre", "Onana", false)
+
+    val result = getPlayerSubstitute(playerAndSubstitute, substitutes, player)
+
+    result.get shouldEqual (substitutes(0))
+  }
+
+  it should "return None given player was not substituted" in {
+    val playerAndSubstitute = Some(Map(("2", "5"), ("1", "4")))
+    val substitutes = Seq(
+      makeLineUpPlayer("4", "Alessandro", "Bastoni", true),
+      makeLineUpPlayer("5", "Denzel", "Dumfries", true),
+    )
+    val player = makeLineUpPlayer("3", "Francesco", "Acerbi", false)
+
+    val result = getPlayerSubstitute(playerAndSubstitute, substitutes, player)
+
+    result shouldBe None
+  }
+
+  it should "return None given player substitute is not found in the list of all substitutes" in {
+    val playerAndSubstitute = Some(Map(("2", "5"), ("1", "4")))
+    val substitutes = Seq(
+      makeLineUpPlayer("5", "Denzel", "Dumfries", true),
+    )
+    val player = makeLineUpPlayer("1", "Andre", "Onana", false)
+
+    val result = getPlayerSubstitute(playerAndSubstitute, substitutes, player)
+
+    result shouldBe None
+  }
+
+  val homePlayers = Seq(
+    makeLineUpPlayer("1", "Andre", "Onana", false),
+    makeLineUpPlayer("2", "Matteo", "Darmian", false),
+    makeLineUpPlayer("3", "Francesco", "Acerbi", false),
+    makeLineUpPlayer("4", "Alessandro", "Bastoni", true),
+    makeLineUpPlayer("5", "Denzel", "Dumfries", true),
+  )
+
+  val awayPlayers = Seq(
+    makeLineUpPlayer("1", "Nicolo", "Barella", false),
+    makeLineUpPlayer("2", "Hakan", "Calhanoglu", false),
+    makeLineUpPlayer("3", "Henrikh", "Mkhitaryan", false),
+    makeLineUpPlayer("4", "Marcelo", "Brozovic", true),
+    makeLineUpPlayer("5", "Federico", "Dimarco", true),
+  )
+
+  def getMatchEvents(home: LineUpTeam, away: LineUpTeam, events: List[MatchEvent]) = {
+    Some(MatchEvents(getTeam(home), getTeam(away), events, true))
+  }
+
+  def getTeam(lineUpTeam: LineUpTeam): Team = Team(lineUpTeam.id, lineUpTeam.name)
+
+  def getMatchEvent(eventType: String, teamID: String, players: List[String]) = {
+    MatchEvent(
+      id = Some("someId"),
+      teamID = Some(teamID),
+      eventType = eventType,
+      matchTime = None,
+      eventTime = None,
+      addedTime = None,
+      players = players.map(p => Player(id = p, teamID = "teamId", name = "playerName")),
+      reason = None,
+      how = None,
+      whereFrom = None,
+      whereTo = None,
+      distance = None,
+      outcome = None,
+    )
+  }
+
+  def makeLineUpTeam(id: String, name: String, players: Seq[LineUpPlayer]) = {
+    LineUpTeam(
+      id = id,
+      name = name,
+      teamColour = "blue",
+      manager = Official("officialId", "officialName"),
+      formation = "formation",
+      shotsOn = 1,
+      shotsOff = 1,
+      fouls = 1,
+      corners = 1,
+      offsides = 1,
+      bookings = 1,
+      dismissals = 1,
+      players = players,
+    )
+  }
+
+  def makeLineUpPlayer(id: String, firstName: String, lastName: String, substitute: Boolean = false) = {
+    LineUpPlayer(
+      id = id,
+      name = s"${firstName} ${lastName}",
+      firstName = firstName,
+      lastName = lastName,
+      shirtNumber = "1",
+      position = "position",
+      substitute = substitute,
+      rating = Some(1),
+      timeOnPitch = "20",
+      events = Seq[LineUpEvent](),
+    )
+  }
+}


### PR DESCRIPTION
## What does this change?

This change affects the following endpoints only if `dcr=true` query parameter exists. 
- `/football/api/match-nav/:year/:month/:day/:home/:away` 
- `/football/api/match-nav/:year/:month/:day/:home/:away.json` 

This means on football match articles or liveblogs rendered by DCR, the client makes a call to these endpoints to get the match stats. example pages:
**article**: https://www.theguardian.com/football/2023/may/16/internazionale-milan-champions-league-semi-final-second-leg-match-report
**liveblog**: https://www.theguardian.com/football/live/2023/may/15/leicester-city-v-liverpool-premier-league-live-score-updates

With this change, the player field in the response will include `substitutedBy` field if the player has been replaced by one of the substitutes, as shown below below in the right column. 

The `substituteBy` field is optional, so if the player hasn't been replaced throughout the game, the player data in the response wouldn't have the `substitutedBy` field as shown below in the left column.

| Player not being substituted      | Player being substituted      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/15894063/25729176-5c5d-41c5-8fbf-452a5496aba3) | ![image](https://github.com/guardian/frontend/assets/15894063/306f430c-b104-4757-9dc7-b00e11f3e579) |

## Why
This feature already exists in the App. 
James Dart, digital sports editor brought this to out attention as a web only issue: 

_"We get the live info re: substitutes, but only seem to be able to show who has come on and when, rather than showing who has been replaced by them (which would provide the complete picture and is what you would normally see elsewhere)."_ 

## Line in the sand
These 2 endpoints are both being called from the client to render the match stats. 

Yes, we are adding 1 extra API call (matchEvents) on top of the existing lineup call to PA. Before this change, in the current production code the PA lineup endpoint is called as part of the task of these endpoints, as shown here https://github.com/guardian/frontend/blob/main/sport/app/football/controllers/MoreOnMatchController.scala#L267

It's true that in the sport api there is competition agent that is used to store competition data in memory, but for lineup there is no agent setup and we've always been calling PA directly to get the lineup ([the client call](https://github.com/guardian/frontend/blob/main/sport/app/football/feed/agent.scala#L17)), this is most probably because of the size of this data which is dramatically bigger than the current competition related data.

I think because this call is made from the client, it is not interfering with the content delivery since content has already been delivered but I'm more than happy to hear any thoughts. 

Also the 2 calls to PA (lineup & matchEvents) are happening in parallel. Based on some manual testing I did, on average the duration of both these calls are similar and it can vary from 80ms to 300ms. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

The next stage would be to use this data in DCR

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
