### PR TITLE
Bump commercial bundle and add merchandising slot ad label styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial-bundle": "5.0.0",
+		"@guardian/commercial-bundle": "^5.0.1-beta.1",
 		"@guardian/commercial-core": "^7.0.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial-bundle": "^5.0.1-beta.3",
+		"@guardian/commercial-bundle": "^5.0.1",
 		"@guardian/commercial-core": "^7.0.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial-bundle": "^5.0.1-beta.1",
+		"@guardian/commercial-bundle": "^5.0.1-beta.2",
 		"@guardian/commercial-core": "^7.0.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial-bundle": "^5.0.1-beta.2",
+		"@guardian/commercial-bundle": "^5.0.1-beta.3",
 		"@guardian/commercial-core": "^7.0.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -643,24 +643,21 @@
 }
 
 .ad-slot--merchandising[data-label-show='true']::before, .ad-slot--merchandising-high[data-label-show='true']::before {
-    content: 'Advertisement';
+    @include font-size(12, 20);
+    content: attr(ad-label-text);
     display: block;
     visibility: visible;
+    position: relative;
     height: $mpu-ad-label-height;
-    background-color: transparent;
+    background-color: $brightness-97;
     padding: 0 ($gs-baseline/3)*2;
-    border: 0;
-    max-width: 970px;
-    margin: auto;
-    border-top: 1px solid $brightness-20;
-    color: $brightness-86;
+    border-top: 1px solid $brightness-86;
+    color: $brightness-46;
     text-align: left;
     box-sizing: border-box;
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    right: 0px;
+    max-width: 970px;
+    margin: auto;
 }
 
 .ad-slot__adtest-cookie-clear-link {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -591,7 +591,7 @@
     visibility: hidden;
 }
 
-.ad-slot[data-label-show='true']:not(.ad-slot--dark):not(.ad-slot--interscroller)::before {
+.ad-slot[data-label-show='true']:not(.ad-slot--dark):not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
     @include font-size(12, 20);
     content: attr(ad-label-text);
     display: block;
@@ -631,6 +631,27 @@
     background-color: transparent;
     padding: 0 ($gs-baseline/3)*2;
     border: 0;
+    border-top: 1px solid $brightness-20;
+    color: $brightness-86;
+    text-align: left;
+    box-sizing: border-box;
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    right: 0px;
+}
+
+.ad-slot--merchandising[data-label-show='true']::before, .ad-slot--merchandising-high[data-label-show='true']::before {
+    content: 'Advertisement';
+    display: block;
+    visibility: visible;
+    height: $mpu-ad-label-height;
+    background-color: transparent;
+    padding: 0 ($gs-baseline/3)*2;
+    border: 0;
+    max-width: 970px;
+    margin: auto;
     border-top: 1px solid $brightness-20;
     color: $brightness-86;
     text-align: left;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,10 +1349,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial-bundle@^5.0.1-beta.2":
-  version "5.0.1-beta.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.1-beta.2.tgz#e471c1aea82e0d458c2c9cf01d318f6dc7fc42ac"
-  integrity sha512-tsFn0oSNyPkVASxFTNZ+hQ91tMQzBmg+KHf746iDOb0LrSzEHyoLECx3Svf8csBclUv+Wh1bQm/c7gM8d3Excg==
+"@guardian/commercial-bundle@^5.0.1-beta.3":
+  version "5.0.1-beta.3"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.1-beta.3.tgz#b6e0833e8486413b863e5b29f18ee9243ef8de36"
+  integrity sha512-5Q+oLaicTCM3ETgqdSI6wopM8ahOOy4/5AMbNJAquspqYUMtBqm7QJDuZgTOVNJXnvPvCD24MDhU/0ZgLZIwgg==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,10 +1349,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial-bundle@^5.0.1-beta.3":
-  version "5.0.1-beta.3"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.1-beta.3.tgz#b6e0833e8486413b863e5b29f18ee9243ef8de36"
-  integrity sha512-5Q+oLaicTCM3ETgqdSI6wopM8ahOOy4/5AMbNJAquspqYUMtBqm7QJDuZgTOVNJXnvPvCD24MDhU/0ZgLZIwgg==
+"@guardian/commercial-bundle@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.1.tgz#b579787aae37d1301887b33d795d4738d7b95c60"
+  integrity sha512-eCHA37HJos9BPMhmAB34rpNeZlQ+KYoclvd40pplj5kQdDKfxpEJctCKyRd8axChR1/W75sk091hVS0e1fi1Kg==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,10 +1349,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial-bundle@^5.0.1-beta.1":
-  version "5.0.1-beta.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.1-beta.1.tgz#3595f3103050011c08563d1f272dc3dc2b0429ed"
-  integrity sha512-bBwUFVjOBMzuLWH2cUU1woIRnQH94d07/PSehTBfoaTHdb+YteTY8SMeb6PEcI1Ck1JCcl/LSeyOmURUwk2ubw==
+"@guardian/commercial-bundle@^5.0.1-beta.2":
+  version "5.0.1-beta.2"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.1-beta.2.tgz#e471c1aea82e0d458c2c9cf01d318f6dc7fc42ac"
+  integrity sha512-tsFn0oSNyPkVASxFTNZ+hQ91tMQzBmg+KHf746iDOb0LrSzEHyoLECx3Svf8csBclUv+Wh1bQm/c7gM8d3Excg==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,10 +1349,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial-bundle@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.0.tgz#94da5021ddda4f282423872f90c1637ede74225f"
-  integrity sha512-cODN1V4ScZcBfyMUiRWfgyNrXAs+LwEY6OqITiCDTseOmKcUkp1i48+u1k/e00okhODNvnONnrJlr622vGsbCA==
+"@guardian/commercial-bundle@^5.0.1-beta.1":
+  version "5.0.1-beta.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.0.1-beta.1.tgz#3595f3103050011c08563d1f272dc3dc2b0429ed"
+  integrity sha512-bBwUFVjOBMzuLWH2cUU1woIRnQH94d07/PSehTBfoaTHdb+YteTY8SMeb6PEcI1Ck1JCcl/LSeyOmURUwk2ubw==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/commercial-core" "^7.0.0"


### PR DESCRIPTION
## What does this change?
- Bumps the commercial bundle so that consentless ads in merchandising slots will now be labelled
- Adds specific label styles to the slots so that they look neater

## Screenshots

Before bumping commercial:
<img width="1247" alt="Screenshot 2023-05-16 at 17 50 31" src="https://github.com/guardian/frontend/assets/108270776/05187639-0392-4b7f-be8d-ca3f15c0f4d4">

Before specific label styling is added:
<img width="1247" alt="Screenshot 2023-05-17 at 10 10 17" src="https://github.com/guardian/frontend/assets/108270776/0b528e60-3497-4b3f-a0da-1c6f497fbf61">

With specific styling:
<img width="1064" alt="Screenshot 2023-05-17 at 10 09 50" src="https://github.com/guardian/frontend/assets/108270776/204b7fa6-4d41-4081-9dd2-96e90f42be00">


### Tested

- [ ] Locally
- [X] On CODE (optional)
