### PR TITLE
Add a switch for a new inline-merchandising AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -84,4 +84,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2023, 6, 5)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-limit-inline-merch",
+    "Test the impact of limiting the eligibility of inline merchandising ad slots",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 9, 1)),
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
## What does this change

Add a switch for controlling a new client-side AB test, where we'll assess the impact of limiting how often we render the inline merchandising slot.

**What about the test definition?**

This test will only run on DCR-rendered articles, so we can omit the actual client-side AB test definition here.