### PR TITLE
disable the action card kicker label design

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -31,20 +31,13 @@
         @header.kicker match {
             case Some(kicker) => {
                 @articleLink {
+                    <div class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</div>
+                    @headline()
                     @if(isAction && ActiveExperiments.isParticipating(ActionCardRedesign)) {
-                      <div class="fc-item__action-kicker-wrapper @kicker.linkClasses.mkString(" ")">
-                          <span class="fc-item__action-kicker-label">@Html(kicker.kickerHtml)</span>
-                      </div>
-                        @headline()
-
-
                         <button class="fc-item__action-tell-us-btn">
                             <span>Tell us</span>
                             @fragments.inlineSvg("arrow-right", "icon")
                         </button>
-                    } else {
-                        <div class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</div>
-                        @headline()
                     }
                 }
             }


### PR DESCRIPTION
## What does this change?

This PR is removing the recent design that had been added for the kicker of the action cards (cards that have tag `tone/callout`). 

The implementation of the design is not yet removed, because there's still discussion going on about it and it's not yet confirmed if we want to stay with this design or improve it.

The action card button `Tell us` will be left and we are going to continue to AB test the callout cards with this button.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)


## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/15894063/101c71b6-1518-4b40-ada0-0e2d49973789) | ![image](https://github.com/guardian/frontend/assets/15894063/8ef6e62c-595c-4260-836b-df52d91b4834) |

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/15894063/101c71b6-1518-4b40-ada0-0e2d49973789) | ![image](https://github.com/guardian/frontend/assets/15894063/8ef6e62c-595c-4260-836b-df52d91b4834) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
