### PR TITLE
Hide UK network front merch slots in fronts test

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -860,9 +860,14 @@ case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boole
         slot <- adSlot
       } {
         container.after(slot)
-        slot.wrap("""<div class="fc-container fc-container--commercial"></div>""")
+        if (ActiveExperiments.isParticipating(FrontsBannerAds)) {
+          slot.wrap(
+            """<div class="fc-container fc-container--commercial fc-container--commercial--hide-desktop"></div>""",
+          )
+        } else {
+          slot.wrap("""<div class="fc-container fc-container--commercial"></div>""")
+        }
       }
-
     }
     document
   }

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -3,6 +3,7 @@
 @import views.support.RenderClasses
 @import views.support.Commercial.container.isFirstNonThrasherContainer
 @import implicits.Requests._
+@import experiments.{ActiveExperiments, FrontsBannerAds}
 
 @(faciaPage: model.PressedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
@@ -55,9 +56,11 @@
                 @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
 
                 @if(!isPaid) {
-                    <div class="fc-container fc-container--commercial">
-                    @fragments.commercial.commercialComponent()
-                    </div>
+                    @if(ActiveExperiments.isParticipating(FrontsBannerAds)) {
+                        <div class="fc-container fc-container--commercial js-container--commercial fc-container--commercial--hide-desktop">@fragments.commercial.commercialComponent()</div>
+                    } else {
+                        <div class="fc-container fc-container--commercial js-container--commercial">@fragments.commercial.commercialComponent()</div>
+                    }
                 }
             </div>
         </div>

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -28,6 +28,13 @@ $header-image-size-desktop: 100px;
     padding-bottom: 0;
 }
 
+// For the Fronts OKR test May 2023
+@include mq(desktop) {
+    .facia-page[data-link-name='Front | /uk'] .fc-container--commercial--hide-desktop {
+        display: none;
+    }
+}
+
 .fc-container__inner,
 .facia-container__inner {
     padding-top: $gs-baseline / 4;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -22,6 +22,13 @@ $header-image-size-desktop: 100px;
     padding-bottom: 0;
 }
 
+// For the Fronts OKR test May 2023
+@include mq(desktop) {
+    .facia-page[data-link-name='Front | /uk'] .fc-container--commercial--hide-desktop {
+        display: none;
+    }
+}
+
 .fc-container__inner,
 .facia-container__inner {
     padding-top: $gs-baseline / 4;


### PR DESCRIPTION
## What does this change?
When a user is in the server side fronts banner test, merchandising slots on the desktop UK network front will be hidden. This change will not affect the appearance of fronts on mobile.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1272" alt="Screenshot 2023-05-23 at 10 20 21" src="https://github.com/guardian/frontend/assets/108270776/e686afe3-2fc9-4dc3-a18c-9847cc65c845"> | <img width="1282" alt="Screenshot 2023-05-23 at 10 12 09" src="https://github.com/guardian/frontend/assets/108270776/a974d4b3-05e6-4842-bdec-17e928345863"> |
| <img width="280" alt="Screenshot 2023-05-23 at 11 03 50" src="https://github.com/guardian/frontend/assets/108270776/5239c371-5624-4657-938c-1a65f8441708"> | <img width="340" alt="Screenshot 2023-05-23 at 10 29 26" src="https://github.com/guardian/frontend/assets/108270776/757271b1-7cf0-46f9-94d9-4bee4e052c96"> |


### Tested

- [X] Locally
- [X] On CODE (optional)
