### PR TITLE
add button for action cards with or without kicker

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -33,12 +33,6 @@
                 @articleLink {
                     <div class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</div>
                     @headline()
-                    @if(isAction && ActiveExperiments.isParticipating(ActionCardRedesign)) {
-                        <button class="fc-item__action-tell-us-btn">
-                            <span>Tell us</span>
-                            @fragments.inlineSvg("arrow-right", "icon")
-                        </button>
-                    }
                 }
             }
             case _ => {
@@ -46,6 +40,12 @@
                     @headline()
                 }
             }
+        }
+        @if(isAction && ActiveExperiments.isParticipating(ActionCardRedesign)) {
+            <button class="fc-item__action-tell-us-btn">
+                <span>Tell us</span>
+                @fragments.inlineSvg("arrow-right", "icon")
+            </button>
         }
     }
 }


### PR DESCRIPTION
## What does this change?
This PR is fixing a bug where the `Tell us` button was showing up on the action cards only when the card had a kicker. But we want it to appear no matter if there's a kicker or not. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/15894063/98db0a86-6e97-4bed-a78d-b6a08fc03618) | ![image](https://github.com/guardian/frontend/assets/15894063/e8fad361-de5a-42df-bfa4-8f5fc36977fb) |

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
