### PR TITLE
Add Okta 0% experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -17,6 +17,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       BorkFCP,
       BorkFID,
       ActionCardRedesign,
+      Okta,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -110,4 +111,13 @@ object ActionCardRedesign
       owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
       sellByDate = LocalDate.of(2023, 6, 9),
       participationGroup = Perc20A,
+    )
+
+object Okta
+    extends Experiment(
+      name = "okta",
+      description = "Use Okta for authentication",
+      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
+      sellByDate = LocalDate.of(2023, 7, 24),
+      participationGroup = Perc0E,
     )


### PR DESCRIPTION
## What does this change?

- Adds a 0% test for the Okta work

## Does this change need to be reproduced in dotcom-rendering?

- [ ] No
- [x] Sort of. We should put Okta work behind this switch, starting with https://github.com/guardian/dotcom-rendering/pull/7643

