### PR TITLE
Add 0% test to remove epics on business liveblogs

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -94,4 +94,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2023, 9, 1)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-remove-business-liveblog-epics",
+    "Test the commercial impact of removing contribution epics on business liveblogs",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 7, 10)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -5,6 +5,7 @@ import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer'
 import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
+import { removeBusinessLiveblogEpics } from './tests/remove-business-liveblog-epics';
 import { signInGateCopyTestJan2023 } from './tests/sign-in-gate-copy-test-variant';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -21,4 +22,5 @@ export const concurrentTests: readonly ABTest[] = [
 	integrateIma,
 	billboardsInMerch,
 	elementsManager,
+	removeBusinessLiveblogEpics,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-business-liveblog-epics.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-business-liveblog-epics.ts
@@ -1,0 +1,20 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const removeBusinessLiveblogEpics: ABTest = {
+	id: 'RemoveBusinessLiveblogEpics',
+	start: '2022-05-24',
+	expiry: '2023-07-10',
+	author: '@commercial-dev',
+	description:
+		'Test the commercial impact of removing contribution epics on business liveblogs',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in',
+	successMeasure: 'Ad revenue increases on business liveblogs',
+	canRun: () => true,
+	variants: [
+		{ id: 'control', test: () => noop },
+		{ id: 'variant', test: () => noop },
+	],
+};


### PR DESCRIPTION
## What does this change?
Adds a 0% test to remove contribution epics on business liveblogs. This is so that we can test the effect of removing the contribution epics on our ad revenue and metrics.
