### PR TITLE
Extend Europe experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -63,7 +63,7 @@ object EuropeNetworkFront
       name = "europe-network-front",
       description = "Test new europe network front",
       owners = Seq(Owner.withGithub("rowannekabalan")),
-      sellByDate = LocalDate.of(2023, 5, 31),
+      sellByDate = LocalDate.of(2023, 9, 30),
       participationGroup = Perc0D,
     )
 


### PR DESCRIPTION
## What does this change?

Extends the Europe experiment until end of September. We will explore putting the conditional logic behind a switch in order to free up this 0% experiment.

## Does this change need to be reproduced in dotcom-rendering ?

- [ X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

