### PR TITLE
Remove Europe edition test to save on A/B testing groups

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -6,7 +6,6 @@ import java.util.Locale
 import org.joda.time.DateTimeZone
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import experiments.{ActiveExperiments, EuropeNetworkFront}
 
 import java.time.ZoneId
 

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -48,8 +48,10 @@ object Edition {
 
   lazy val defaultEdition: Edition = editions.Uk
   def editionsByRequest(implicit request: RequestHeader): List[Edition] = {
-    val participatingInTest = ActiveExperiments.isParticipating(EuropeNetworkFront)
-    if (!participatingInTest) all else allWithBetaEditions
+    // We don't have a 0% test slot available, for the time being europe edition is disabled
+    val participatingInEuropeTest =
+      /* ActiveExperiments.isParticipating(EuropeNetworkFront) */ false
+    if (!participatingInEuropeTest) all else allWithBetaEditions
   }
   def editionsSupportingSection(sectionId: String): Seq[Edition] =
     allWithBetaEditions.filter(_.isEditionalised(sectionId))

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -8,7 +8,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       OfferHttp3,
-      EuropeNetworkFront,
+//      EuropeNetworkFront,
       DCRJavascriptBundle,
       HeaderTopBarSearchCapi,
       ServerSideLiveblogInlineAds,
@@ -48,14 +48,16 @@ object OfferHttp3
       participationGroup = Perc0B,
     )
 
-object EuropeNetworkFront
-    extends Experiment(
-      name = "europe-network-front",
-      description = "Test new europe network front",
-      owners = Seq(Owner.withGithub("rowannekabalan")),
-      sellByDate = LocalDate.of(2023, 8, 31),
-      participationGroup = Perc0D,
-    )
+// We know the Europe edition won't be launched for some time
+// so we've removed it in order to save 0% groups for other tests.
+//object EuropeNetworkFront
+//    extends Experiment(
+//      name = "europe-network-front",
+//      description = "Test new europe network front",
+//      owners = Seq(Owner.withGithub("rowannekabalan")),
+//      sellByDate = LocalDate.of(2023, 8, 31),
+//      participationGroup = Perc0D,
+//    )
 
 object HeaderTopBarSearchCapi
     extends Experiment(

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -175,10 +175,14 @@ trait FaciaController
 
   import PressedPage.pressedPageFormat
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader): Future[Result] = {
-    val participatingInTest = ActiveExperiments.isParticipating(EuropeNetworkFront)
-    if (path == "europe" && !participatingInTest) {
+    // We don't have a 0% test slot available, for the time being europe edition is disabled
+    val participatingInEuropeTest =
+      /* ActiveExperiments.isParticipating(EuropeNetworkFront) */ false
+
+    if (path == "europe" && !participatingInEuropeTest) {
       return successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
     }
+
     val futureFaciaPage: Future[Option[(PressedPage, Boolean)]] = frontJsonFapi.get(path, liteRequestType).flatMap {
       case Some(faciaPage: PressedPage) =>
         val pageContainsTargetedCollections = TargetedCollections.pageContainsTargetedCollections(faciaPage)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -26,7 +26,6 @@ import contentapi.ContentApiClient
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
-import experiments.{ActiveExperiments, EuropeNetworkFront}
 import play.api.http.ContentTypes.JSON
 import services.dotcomrendering.{FaciaPicker, RemoteRender}
 import services.fronts.{FrontJsonFapi, FrontJsonFapiLive}


### PR DESCRIPTION
## What does this change?

Removes the A/B test for the Europe edition to save on testing groups.

This PR can be reverted when we need the Europe edition to be in a test again

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - DCRs server-side-test checks are untyped, so they'll always return false without any errors
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist
### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
