### PR TITLE
Adding deeply read trails to dcr fronts model 

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -532,4 +532,14 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
+  val DeeplyReadSwitch = Switch(
+    SwitchGroup.Feature,
+    "deeply-read-switch",
+    "When ON, shows the new most popular component containing mode viewed and deeply read articles",
+    owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
 }

--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -30,6 +30,7 @@ case class DotcomFrontsRenderingDataModel(
     mostViewed: Seq[Trail],
     mostCommented: Option[Trail],
     mostShared: Option[Trail],
+    deeplyRead: Option[Seq[Trail]],
 )
 
 object DotcomFrontsRenderingDataModel {
@@ -42,6 +43,7 @@ object DotcomFrontsRenderingDataModel {
       mostViewed: Seq[RelatedContentItem],
       mostCommented: Option[Content],
       mostShared: Option[Content],
+      deeplyRead: Option[Seq[Trail]],
   ): DotcomFrontsRenderingDataModel = {
     val edition = Edition.edition(request)
     val nav = Nav(page, edition)
@@ -88,6 +90,7 @@ object DotcomFrontsRenderingDataModel {
       mostViewed = mostViewed.map(content => Trail.pressedContentToTrail(content.faciaContent)(request)),
       mostCommented = mostCommented.flatMap(ContentCard.fromApiContent).flatMap(Trail.contentCardToTrail),
       mostShared = mostShared.flatMap(ContentCard.fromApiContent).flatMap(Trail.contentCardToTrail),
+      deeplyRead = deeplyRead,
     )
   }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -29,6 +29,7 @@ import model.dotcomrendering.{
   DotcomNewslettersPageRenderingDataModel,
   DotcomRenderingDataModel,
   PageType,
+  Trail,
 }
 import services.NewsletterData
 import services.newsletters.model.NewsletterResponse
@@ -265,6 +266,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       mostViewed: Seq[RelatedContentItem],
       mostCommented: Option[Content],
       mostShared: Option[Content],
+      deeplyRead: Option[Seq[Trail]],
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomFrontsRenderingDataModel(
       page,
@@ -273,6 +275,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       mostViewed,
       mostCommented,
       mostShared,
+      deeplyRead,
     )
 
     val json = DotcomFrontsRenderingDataModel.toJson(dataModel)

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import agents.MostViewedAgent
+import agents.{DeeplyReadAgent, MostViewedAgent}
 import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
@@ -47,6 +47,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   lazy val ophanApi = wire[OphanApi]
   lazy val logbackOperationsPool = wire[LogbackOperationsPool]
   lazy val mostViewedAgent = wire[MostViewedAgent]
+  lazy val deeplyReadAgent = wire[DeeplyReadAgent]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -22,6 +22,7 @@ import implicits.GUHeaders
 import pages.{FrontEmailHtmlPage, FrontHtmlPage}
 import utils.TargetedCollections
 import conf.Configuration
+import conf.switches.Switches
 import contentapi.ContentApiClient
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
@@ -202,7 +203,9 @@ trait FaciaController
     }
 
     val networkFrontEdition = Edition.allWithBetaEditions.find(_.networkFrontId == path)
-    val deeplyRead = networkFrontEdition.map(deeplyReadAgent.getTrails)
+    val deeplyRead = if (Switches.DeeplyReadSwitch.isSwitchedOn) {
+      networkFrontEdition.map(deeplyReadAgent.getTrails)
+    } else None
 
     val futureResult = futureFaciaPage.flatMap {
       case Some((faciaPage, _)) if nonHtmlEmail(request) =>

--- a/facia/app/controllers/FaciaControllers.scala
+++ b/facia/app/controllers/FaciaControllers.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import agents.MostViewedAgent
+import agents.{MostViewedAgent, DeeplyReadAgent}
 import com.softwaremill.macwire._
 import model.ApplicationContext
 import play.api.libs.ws.WSClient
@@ -12,6 +12,7 @@ trait FaciaControllers {
   def controllerComponents: ControllerComponents
   def wsClient: WSClient
   def mostViewedAgent: MostViewedAgent
+  def deeplyReadAgent: DeeplyReadAgent
   implicit def appContext: ApplicationContext
   lazy val faciaController = wire[FaciaControllerImpl]
 }

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -1,6 +1,6 @@
 package test
 
-import agents.MostViewedAgent
+import agents.{DeeplyReadAgent, MostViewedAgent}
 import akka.actor.ActorSystem
 import com.fasterxml.jackson.core.JsonParseException
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
@@ -46,6 +46,7 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
     play.api.test.Helpers.stubControllerComponents(),
     wsClient,
     new MostViewedAgent(testContentApiClient, new OphanApi(wsClient), wsClient),
+    new DeeplyReadAgent(testContentApiClient, new OphanApi(wsClient)),
   )
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"
   val callbackName = "aFunction"

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -1,6 +1,6 @@
 package metadata
 
-import agents.MostViewedAgent
+import agents.{DeeplyReadAgent, MostViewedAgent}
 import akka.actor.ActorSystem
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import concurrent.BlockingOperations
@@ -50,6 +50,7 @@ import test._
     play.api.test.Helpers.stubControllerComponents(),
     wsClient,
     new MostViewedAgent(testContentApiClient, new OphanApi(wsClient), wsClient),
+    new DeeplyReadAgent(testContentApiClient, new OphanApi(wsClient)),
   )
   val frontPath = "music"
 

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import agents.MostViewedAgent
+import agents.{DeeplyReadAgent, MostViewedAgent}
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common.TrailsToShowcase
 import contentapi.{ContentApiClient, SectionsLookUp}
@@ -20,6 +20,7 @@ class FaciaDraftController(
     val controllerComponents: ControllerComponents,
     val ws: WSClient,
     val mostViewedAgent: MostViewedAgent,
+    val deeplyReadAgent: DeeplyReadAgent,
 )(implicit val context: ApplicationContext)
     extends FaciaController
     with RendersItemResponse {


### PR DESCRIPTION
## What does this change?
This PR is updating the DCR fronts rendering model to include the deeply read trails data. We will then be using this data in DCR to render the new `Most popular` section that contains the existing `Most viewed` articles & the new `Deeply read` articles.

This feature is behind a switch `deeply-read-switch` in switch board and is also exposed to client side with name `deeplyReadSwitch`. When switch is disabled, no data is send through to DCR. 

The DCR PR can be seen https://github.com/guardian/dotcom-rendering/pull/7829  

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/15894063/75ccec81-0833-44e3-8026-ad1b953e61ac) | ![image](https://github.com/guardian/frontend/assets/15894063/471f7a90-7963-4881-9704-8e90f0420847) |


<!-- Please use the following table template to make image comparison easier to parse:


[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
