### PR TITLE
Extend expiring tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "Test the impact of changing the copy in the sign in gate",
     owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 6, 5)),
+    sellByDate = Some(LocalDate.of(2023, 7, 3)),
     exposeClientSide = true,
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,7 +51,7 @@ trait ABTestSwitches {
     "Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos",
     owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 6, 6)),
+    sellByDate = Some(LocalDate.of(2023, 7, 10)),
     exposeClientSide = true,
   )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -44,7 +44,7 @@ object OfferHttp3
       name = "offer-http3",
       description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
       owners = Seq(Owner.withGithub("paulmr")),
-      sellByDate = LocalDate.of(2023, 6, 5),
+      sellByDate = LocalDate.of(2023, 7, 3),
       participationGroup = Perc0B,
     )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -4,7 +4,7 @@ import { noop } from '../../../../../lib/noop';
 export const integrateIma: ABTest = {
 	id: 'IntegrateIma',
 	start: '2022-07-14',
-	expiry: '2023-07-03',
+	expiry: '2023-07-10',
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
@@ -1,7 +1,7 @@
 export const signInGateCopyTestJan2023 = {
 	id: 'SignInGateCopyTestJan2023',
 	start: '2023-01-23',
-	expiry: '2023-06-05',
+	expiry: '2023-07-03',
 	author: 'Lindsey Dew',
 	description: 'Test varying the copy in the call to action for sign in gate',
 	audience: 0.0,


### PR DESCRIPTION
## What does this change?

Extend:
- `integrate-ima` switch and test
- `offer-http3` switch
- `sign-in-gate-copy-test-jan-2023` switch and test

