### PR TITLE
Add CloudWatch metrics for the DFP API

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -96,6 +96,10 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
 
   lazy val appIdentity = ApplicationIdentity("admin")
 
+  override lazy val appMetrics = ApplicationMetrics(
+    DfpApiMetrics.DfpSessionErrors,
+  )
+
   def actorSystem: ActorSystem
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[AdminHttpErrorHandler]

--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -98,6 +98,7 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
 
   override lazy val appMetrics = ApplicationMetrics(
     DfpApiMetrics.DfpSessionErrors,
+    DfpApiMetrics.DfpApiErrors,
   )
 
   def actorSystem: ActorSystem

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -5,6 +5,7 @@ import com.google.api.ads.admanager.axis.v202208._
 import common.GuLogging
 
 import scala.util.control.NonFatal
+import common.DfpApiMetrics
 
 private[dfp] object SessionLogger extends GuLogging {
 
@@ -82,10 +83,12 @@ private[dfp] object SessionLogger extends GuLogging {
       Some(result)
     } catch {
       case e: ApiException =>
-        logApiException(e, msgPrefix)
+        logApiException(e, msgPrefix);
+        DfpApiMetrics.DfpApiErrors.increment();
         None
       case NonFatal(e) =>
-        log.error(s"$msgPrefix failed", e)
+        log.error(s"$msgPrefix failed", e);
+        DfpApiMetrics.DfpApiErrors.increment();
         None
     }
   }

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -5,7 +5,7 @@ import com.google.api.ads.admanager.axis.v202208._
 import common.GuLogging
 
 import scala.util.control.NonFatal
-import common.DfpApiMetrics
+import common.DfpApiMetrics.DfpApiErrors
 
 private[dfp] object SessionLogger extends GuLogging {
 
@@ -84,11 +84,11 @@ private[dfp] object SessionLogger extends GuLogging {
     } catch {
       case e: ApiException =>
         logApiException(e, msgPrefix);
-        DfpApiMetrics.DfpApiErrors.increment();
+        DfpApiErrors.increment();
         None
       case NonFatal(e) =>
         log.error(s"$msgPrefix failed", e);
-        DfpApiMetrics.DfpApiErrors.increment();
+        DfpApiErrors.increment();
         None
     }
   }

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -13,6 +13,7 @@ import dfp.SessionLogger.{logAroundCreate, logAroundPerform, logAroundRead, logA
 import scala.jdk.CollectionConverters._
 
 import scala.util.control.NonFatal
+import common.DfpApiMetrics.DfpSessionErrors
 
 private[dfp] class SessionWrapper(dfpSession: AdManagerSession) {
 
@@ -225,6 +226,7 @@ object SessionWrapper extends GuLogging {
       } catch {
         case NonFatal(e) =>
           log.error(s"Building DFP session failed.", e)
+          DfpSessionErrors.increment();
           None
       }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -143,6 +143,11 @@ object DfpApiMetrics {
     "dfp-session-errors",
     "Number of times the app failed to build a DFP session",
   )
+
+  val DfpApiErrors = CountMetric(
+    "dfp-api-errors",
+    "Number of times a request to the DFP API results in an error",
+  )
 }
 
 object FaciaPressMetrics {

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -138,6 +138,13 @@ object ContentApiMetrics {
 
 }
 
+object DfpApiMetrics {
+  val DfpSessionErrors = CountMetric(
+    "dfp-session-errors",
+    "Number of times the app failed to build a DFP session",
+  )
+}
+
 object FaciaPressMetrics {
   val FrontPressCronSuccess = CountMetric(
     "front-press-cron-success",
@@ -240,7 +247,7 @@ class CloudWatchMetricsLifecycle(
 
   override def start(): Unit = {
     jobs.deschedule("ApplicationSystemMetricsJob")
-    //run every minute, 36 seconds after the minute
+    // Run every minute, 36 seconds after the minute
     jobs.schedule("ApplicationSystemMetricsJob", "36 * * * * ?") {
       report()
     }


### PR DESCRIPTION
## What does this change?

This PR adds two additional metrics that we log to CloudWatch:

- `dfp-session-errors` - Increment a count every time we failed to _build_ a DFP session. These errors are indicative of invalid / expired credentials being pulled from Parameter Store.
- `dfp-api-errors` - Increment a count every time the DFP API client code raises an exception. These errors could be indicative of a number of issues, but in the past we've seen this occur when we have to upgrade the API in line with the [deprecation schedule](https://developers.google.com/ad-manager/api/deprecation).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The DFP API is required to enable a few key parts of the Commercial experience:
- Detect whether to insert inline merch slots on certain articles.
- Run Pageskin takeovers.
- Do not refresh sponsorship level line items.

Historically we've had a number of issues with the DFP API silently failing. For example:

- The API has a [deprecation schedule](https://developers.google.com/ad-manager/api/deprecation), which can cause requests to 404 after a given date. We've encountered this before, and had to diagnose the issue and upgrade the API (see https://github.com/guardian/frontend/pull/25586).
- On a number of occasions credentials have been unable to refresh. This can occur due to someone leaving the org, where the credentials are associated with their Google account.

Sending these additional metrics to CloudWatch will enable us to set alarms when the counts cross certain thresholds, so we can be notified in the event of a DFP outage. This should enable us to respond faster, rather than waiting for a report of an error from someone else.

### Tested

- [X] Locally
- [X] On CODE (*)

(*) To test this, I temporarily allowed the collection of CloudWatch metrics from CODE as well as PROD.

Then, I intentionally broke two aspects of the DFP API to check for the two errors:
- Use intentionally invalid credentials in parameter store for CODE. This triggered the errors shown in the screenshot below.
- Revert to using a deprecated version of the DFP API, to trigger DFP API error metrics. 

It was then simple to setup a graph showing the errors, as well as an example alarm for the session errors, which is shown below:

![Screenshot 2023-06-05 at 15 47 58](https://github.com/guardian/frontend/assets/8000415/f1e0b465-354a-439d-9d95-3326e2e878ca)

