### PR TITLE
Update contribution epics test parameters

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -2,10 +2,12 @@ import type { ABTest } from '@guardian/ab-core';
 import { getUrlVars } from 'lib/url';
 import { isInABTestSynchronous } from '../experiments/ab';
 import { integrateIma } from '../experiments/tests/integrate-ima';
+import { removeBusinessLiveblogEpics } from '../experiments/tests/remove-business-liveblog-epics';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
 	integrateIma,
+	removeBusinessLiveblogEpics,
 ];
 
 /**

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-business-liveblog-epics.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-business-liveblog-epics.ts
@@ -8,11 +8,11 @@ export const removeBusinessLiveblogEpics: ABTest = {
 	author: '@commercial-dev',
 	description:
 		'Test the commercial impact of removing contribution epics on business liveblogs',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
-	audienceCriteria: 'Opt in',
+	audience: 20 / 100,
+	audienceOffset: 20 / 100,
+	audienceCriteria: 'Business liveblogs',
 	successMeasure: 'Ad revenue increases on business liveblogs',
-	canRun: () => true,
+	canRun: () => !!(window.guardian.config.page.contentType === 'LiveBlog'),
 	variants: [
 		{ id: 'control', test: () => noop },
 		{ id: 'variant', test: () => noop },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-business-liveblog-epics.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-business-liveblog-epics.ts
@@ -12,7 +12,9 @@ export const removeBusinessLiveblogEpics: ABTest = {
 	audienceOffset: 20 / 100,
 	audienceCriteria: 'Business liveblogs',
 	successMeasure: 'Ad revenue increases on business liveblogs',
-	canRun: () => window.guardian.config.page.contentType === 'LiveBlog',
+	canRun: () =>
+		window.guardian.config.page.contentType === 'LiveBlog' &&
+		window.guardian.config.page.section === 'business',
 	variants: [
 		{ id: 'control', test: () => noop },
 		{ id: 'variant', test: () => noop },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-business-liveblog-epics.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-business-liveblog-epics.ts
@@ -12,7 +12,7 @@ export const removeBusinessLiveblogEpics: ABTest = {
 	audienceOffset: 20 / 100,
 	audienceCriteria: 'Business liveblogs',
 	successMeasure: 'Ad revenue increases on business liveblogs',
-	canRun: () => !!(window.guardian.config.page.contentType === 'LiveBlog'),
+	canRun: () => window.guardian.config.page.contentType === 'LiveBlog',
 	variants: [
 		{ id: 'control', test: () => noop },
 		{ id: 'variant', test: () => noop },


### PR DESCRIPTION
## What does this change?
Following the AB test scoping, the test details have been updated as follows:

- Add the test participation and audience offset percentages
- Add a canrun function so that the test will only run on liveblogs
- Record commercial metrics for the test
