### PR TITLE
Video card redesign

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -58,7 +58,7 @@
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
                 @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
                     <span class="video-overlay__duration">
-                    <span>@media.formattedDuration</span>
+                        <span>@media.formattedDuration</span>
                     </span>
                 }
                 <div class="video-overlay">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -109,7 +109,7 @@
                                 }
                             }
                         }
-                        <button class="youtube-media-atom__play-button vjs-control-text" style="border: none;">
+                        <button class="youtube-media-atom__play-button vjs-control-text centered-button" style="border: none;">
                             Play Video @fragments.inlineSvg("play", "icon")
                         </button>
                         @for(duration <- media.formattedDuration.filter(_ => displayDuration)) {

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -58,7 +58,7 @@
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
                 @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
                     <span class="video-overlay__duration">
-                    @media.formattedDuration
+                    <span>@media.formattedDuration</span>
                     </span>
                 }
                 <div class="video-overlay">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -52,25 +52,31 @@
             *@
             <div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
 
+            @*
+              Below is only rendered on video cards within the video container
+            *@
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
+                @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
+                    <span class="video-overlay__duration">
+                    @media.formattedDuration
+                    </span>
+                }
                 <div class="video-overlay">
                     <div class="video-overlay__headline">
 
                     @for(f <- faciaHeaderProperties) {
-                        @title(f.header, 0, 0, "u-faux-block-link__cta", None, isPaidFor)
+                        @title(f.header, 0, 0, "u-faux-block-link__cta", None, isPaidFor, isLink = false)
                         @if(f.showByline) {
                             <div class="fc-item__byline">@f.byline</div>
                         }
+                    }
 
                     </div>
-                        @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
-                            <span class="video-overlay__duration">
-                                @media.formattedDuration
-                            </span>
-                        }
-                    </div>
-                    <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1" aria-hidden="true"></a>
-                }
+
+                </div>
+                    @for(f <- faciaHeaderProperties) {
+                        <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1" aria-hidden="true"></a>
+                    }
             }
         }
         @defining(posterImageOverride orElse media.posterImage) { bestPosterImage =>

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -1,4 +1,4 @@
-@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false, isAction: Boolean = false)(implicit request: RequestHeader)
+@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false, isAction: Boolean = false, isLink: Boolean = true)(implicit request: RequestHeader)
 
 @import views.html.fragments.items.elements.facia_cards.itemHeader
 @import views.support._
@@ -17,7 +17,12 @@
 
 
 @articleLink(html: Html) = {
-    <a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>
+  @if(isLink) {
+      <a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>
+  } else {
+      <span href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</span>
+  }
+
 }
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -444,6 +444,8 @@ const initYoutubePlayerForElem = (el) => {
             return;
         }
 
+        iframe.style.display = 'block'
+
         /**
          * Note:
          * This element id must be unique!

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -362,11 +362,17 @@ const onPlayerReady = (
     };
 
     const iFrameBehaviourConfig = getIFrameBehaviourConfig(iframe);
+    console.log("iFrameBehaviourConfig: ");
+    console.log(iFrameBehaviourConfig);
     const iFrameBehaviour = getIFrameBehaviour(iFrameBehaviourConfig);
+    console.log("iFrameBehaviour: ");
+    console.log(iFrameBehaviour);
     if (iFrameBehaviour.mutedOnStart) {
+        console.log("muted on start");
         youtubePlayer.mute();
     }
     if (iFrameBehaviour.autoplay) {
+        console.log("playing the video");
         youtubePlayer.playVideo();
     }
 
@@ -376,10 +382,12 @@ const onPlayerReady = (
         if (
             !!config.get('page.section') &&
             isBreakpoint({
-                min: 'desktop',
+                min: 'mobile',
             })
         ) {
             const endSlate = getEndSlate(overlay);
+            console.log("endSlate: ");
+            console.log(endSlate);
 
             if (endSlate) {
                 players[uniqueAtomId].endSlate = endSlate;

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -288,7 +288,6 @@ const getIFrameBehaviour = (
         autoplay:
             ((isVideoArticle && isInternalReferrer && isMainVideo) ||
                 isFront) &&
-            !isAutoplayBlockingPlatform &&
             flashingElementsAllowed,
         mutedOnStart: false,
     };

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -362,17 +362,15 @@ const onPlayerReady = (
     };
 
     const iFrameBehaviourConfig = getIFrameBehaviourConfig(iframe);
-    console.log("iFrameBehaviourConfig: ");
-    console.log(iFrameBehaviourConfig);
     const iFrameBehaviour = getIFrameBehaviour(iFrameBehaviourConfig);
-    console.log("iFrameBehaviour: ");
-    console.log(iFrameBehaviour);
     if (iFrameBehaviour.mutedOnStart) {
-        console.log("muted on start");
         youtubePlayer.mute();
     }
     if (iFrameBehaviour.autoplay) {
-        console.log("playing the video");
+        // On IOS autoplay doesn't work unless video is muted
+        if (isIOS()) {
+            youtubePlayer.mute();
+        }
         youtubePlayer.playVideo();
     }
 
@@ -386,8 +384,6 @@ const onPlayerReady = (
             })
         ) {
             const endSlate = getEndSlate(overlay);
-            console.log("endSlate: ");
-            console.log(endSlate);
 
             if (endSlate) {
                 players[uniqueAtomId].endSlate = endSlate;

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -60,7 +60,7 @@ const reducers = {
         const makeYouTubeNonPlayableAtSmallBreakpoint = state => {
             if (
                 isBreakpoint({
-                    max: 'desktop',
+                    max: 'mobile',
                 })
             ) {
                 const youTubeIframes = Array.from(

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -57,41 +57,6 @@ const reducers = {
     },
 
     INIT: function init(previousState) {
-        const makeYouTubeNonPlayableAtSmallBreakpoint = state => {
-            if (
-                isBreakpoint({
-                    max: 'mobile',
-                })
-            ) {
-                const youTubeIframes = Array.from(
-                    state.container.querySelectorAll(
-                        '.youtube-media-atom iframe'
-                    )
-                );
-                youTubeIframes.forEach(el => {
-                    el.remove();
-                });
-                const overlayLinks = Array.from(
-                    state.container.querySelectorAll(
-                        '.video-container-overlay-link'
-                    )
-                );
-                overlayLinks.forEach(el => {
-                    el.classList.add('u-faux-block-link__overlay');
-                    // make visible to screen readers / keyboard users
-                    el.removeAttribute('tabindex');
-                    el.removeAttribute('aria-hidden');
-                });
-
-                const atomWrapper = Array.from(
-                    state.container.querySelectorAll('.youtube-media-atom')
-                );
-                atomWrapper.forEach(el => {
-                    el.classList.add('no-player');
-                });
-            }
-        };
-
         fastdom.measure(() => {
             // Lazy load images on scroll for mobile
             $('.js-video-playlist-image', previousState.container).each(el => {

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -91,7 +91,6 @@ const reducers = {
                 });
             }
         };
-        makeYouTubeNonPlayableAtSmallBreakpoint(previousState);
 
         fastdom.measure(() => {
             // Lazy load images on scroll for mobile

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -129,6 +129,10 @@
     @include hide;
 }
 
+.video-playlist__item .youtube-media-atom__iframe.youtube__video-started ~ .video-overlay {
+    @include hide;
+}
+
 .youtube-media-atom__iframe.youtube__video-started:not(.youtube__video-ended) ~ .youtube-media-atom__overlay {
     @include fade-out;
     transition-delay: 500ms;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -133,6 +133,10 @@
     @include hide;
 }
 
+.video-playlist__item .youtube-media-atom__iframe.youtube__video-started ~ .video-overlay__duration {
+    @include hide;
+}
+
 .youtube-media-atom__iframe.youtube__video-started:not(.youtube__video-ended) ~ .youtube-media-atom__overlay {
     @include fade-out;
     transition-delay: 500ms;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -35,7 +35,7 @@
 
 .video-playlist__item .youtube-media-atom iframe,
 .video-playlist__item .youtube-media-atom .vjs-big-play-button {
-    @include mq($until: desktop) {
+    @include mq($until: mobile) {
         bottom: 0;
         height: auto;
     }
@@ -183,6 +183,7 @@ youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.yout
     bottom: 44%;
     left: 40%;
     background-color: rgba(18, 18, 18, .6);
+    z-index: 3;
 }
 
 .no-player .youtube-media-atom__play-button.vjs-control-text {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -180,6 +180,12 @@ youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.yout
     opacity: 1;
 }
 
+.youtube-media-atom__play-button.vjs-control-text.centered-button {
+    bottom: 44%;
+    left: 40%;
+    background-color: rgba(18, 18, 18, .6);
+}
+
 .no-player .youtube-media-atom__play-button.vjs-control-text {
     transition: none;
 }

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -36,7 +36,6 @@
 .video-playlist__item .youtube-media-atom iframe,
 .video-playlist__item .youtube-media-atom .vjs-big-play-button {
     @include mq($until: desktop) {
-        top: gs-height(3) - (get-line-height(textSans, 3) + 4px);
         bottom: 0;
         height: auto;
     }

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -33,14 +33,6 @@
     }
 }
 
-.video-playlist__item .youtube-media-atom iframe,
-.video-playlist__item .youtube-media-atom .vjs-big-play-button {
-    @include mq($until: mobile) {
-        bottom: 0;
-        height: auto;
-    }
-}
-
 .video-playlist__item--active .youtube-media-atom {
     opacity: 1;
 }

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -259,7 +259,7 @@ $video-width-desktop: 700px;
     position: relative;
     display: inline-block;
     vertical-align: top;
-    width: 70%;
+    width: 90%;
     background-color: $brightness-7;
     margin-left: $gs-gutter / 2;
     margin-bottom: $gs-baseline;
@@ -408,10 +408,12 @@ $video-width-desktop: 700px;
     z-index: 2;
     white-space: normal;
     padding: 2.5rem $gs-gutter/4 $gs-baseline * 2;
+    padding-top: 0;
+    padding-bottom: 0;
     box-sizing: border-box;
     color: #ffffff;
     background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .7) 25%);
-    min-height: gs-height(3);
+    //min-height: gs-height(3);
     pointer-events: auto;
     width: 100%;
     bottom: 0;
@@ -443,6 +445,8 @@ $video-width-desktop: 700px;
         .fc-item__headline {
             color: #ffffff;
         }
+
+        padding-bottom: 0;
     }
 
     .inline-icon svg {
@@ -477,8 +481,9 @@ $video-width-desktop: 700px;
 .video-overlay__duration {
     @include fs-textSans(3);
     position: absolute;
-    bottom: 2px;
+    right: 4px;
     color: $brightness-86;
+    z-index: 2;
 }
 
 .fc-item__video-container {

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -404,26 +404,21 @@ $video-width-desktop: 700px;
 }
 
 .video-overlay {
-    position: relative;
+    position: absolute;
     z-index: 2;
     white-space: normal;
-    padding: 0 $gs-gutter/4 $gs-baseline * 2;
+    padding: 2.5rem $gs-gutter/4 $gs-baseline * 2;
     box-sizing: border-box;
-    border-top: 1px solid $highlight-main;
     color: #ffffff;
-    background-color: rgba(0, 0, 0, .9);
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .7) 25%);
     min-height: gs-height(3);
-    margin-bottom: -(get-line-height(textSans, 3) + 4px);
     pointer-events: auto;
+    width: 100%;
+    bottom: 0;
+
     @include mq(desktop, leftCol) {
         opacity: 0;
         transition: opacity .4s ease-out;
-    }
-    @include mq(desktop) {
-        position: absolute;
-        top: $gs-baseline;
-        left: $gs-gutter;
-        width: gs-span(3);
     }
 
     .video-playlist__item .vjs-playing ~ & {

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -413,7 +413,6 @@ $video-width-desktop: 700px;
     box-sizing: border-box;
     color: #ffffff;
     background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .7) 25%);
-    //min-height: gs-height(3);
     pointer-events: auto;
     width: 100%;
     bottom: 0;

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -479,11 +479,26 @@ $video-width-desktop: 700px;
 }
 
 .video-overlay__duration {
-    @include fs-textSans(3);
+    @include fs-textSans(2);
     position: absolute;
     right: 4px;
-    color: $brightness-86;
     z-index: 2;
+
+    border: 2px solid #000000;
+    border-radius: 500px;
+    background-color: #000000;
+    width: 57px;
+    height: 28px;
+    margin-top: 6px;
+    margin-right: 6px;
+    font-weight: 700;
+    color: #ffffff;
+    display: flex;
+    justify-content: center;
+
+    span {
+        padding-top: 4px;
+    }
 }
 
 .fc-item__video-container {

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -247,10 +247,6 @@ $pillars: (
         fill: map-get($palette, invertedKicker);
     }
 
-    &.video-playlist__item .video-overlay__duration {
-        color: map-get($palette, invertedKicker);
-    }
-
     &.fc-item--type-media,
     &.fc-item--type-interview {
         .inline-video-icon,


### PR DESCRIPTION
## What does this change?
This PR is doing the following:
- Change design for the video cards within video container
- Make video cards within the video container playable on fronts on smaller breakpoints.

## Limitation:
We can not autoplay video on IOS device unless video is muted. So we either need to let user play the video and then unmute it, or let the user click on play two times. Android seems to work fine. 

[youtube documentation explains this](https://developers.google.com/youtube/iframe_api_reference#Autoplay_and_scripted_playback) so we probably  need to re-visit UX for this unless we find a hacky way to work around this issue (I haven't unfortunately managed to find a solution for this). 






| Before      | 
|-------------|
| ![image](https://github.com/guardian/frontend/assets/15894063/f22c6a33-3544-48c8-9fde-3203c3e77050) |

| After      | 
|-------------|
| ![image](https://github.com/guardian/frontend/assets/15894063/272b9ef1-286c-4d1e-970b-0d13d38b2bec) |

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/15894063/618fa755-b93c-450a-a7b1-29f0f182f324) | ![image](https://github.com/guardian/frontend/assets/15894063/bf11a534-ce32-4f73-b1d1-aaa61aa6a5c7) |






## video on desktop machine  :
https://github.com/guardian/frontend/assets/15894063/80689752-1dc4-4da2-a315-c8ac9a8015b2

## video on ios device:
https://github.com/guardian/frontend/assets/15894063/e3e4a90e-1084-4fa3-bea3-cd9befa03760



## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
We want to enable users to play videos on our front pages

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
