### PR TITLE
Revert "fix local commercial bundle"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial": "8.0.1",
+		"@guardian/commercial": "8.0.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -9,4 +9,17 @@ module.exports = webpackMerge.smart(config, {
         filename: `graun.[name].js`,
         chunkFilename: `graun.[name].js`,
     },
+    plugins: [
+        // Copy the commercial bundle dist to Frontend's static output location:
+        // static/target/javascripts/commercial
+        // In development mode the hashed directory structure is discarded and all files are copied to '/commercial'
+        new CopyPlugin({
+            patterns: [
+              {
+                  from: "node_modules/@guardian/commercial/dist/bundle",
+                  to: "commercial/[name].[ext]"
+              },
+            ],
+        }),
+    ],
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -158,16 +158,6 @@ module.exports = {
             // add errors to webpack instead of warnings
             failOnError: true,
         }),
-        // Copy the commercial bundle dist to Frontend's static output location:
-		// static/target/javascripts/commercial
-		new CopyPlugin({
-			patterns: [
-				{
-					from: 'node_modules/@guardian/commercial/dist/bundle',
-					to: 'commercial',
-				},
-			],
-		}),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         }),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -15,6 +15,16 @@ module.exports = webpackMerge.smart(config, {
 	},
 	devtool: 'source-map',
 	plugins: [
+		// Copy the commercial bundle dist to Frontend's static output location:
+		// static/target/javascripts/commercial
+		new CopyPlugin({
+			patterns: [
+				{
+					from: 'node_modules/@guardian/commercial/dist/bundle',
+					to: 'commercial',
+				},
+			],
+		}),
 		new webpack.optimize.AggressiveMergingPlugin({
 			// delicate number: stops enhanced-no-commercial and enhanced
 			// being merged into one

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,10 +1349,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial@8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-8.0.1.tgz#d6ce1886c6f12901b5260006e8e8d5e257d8813f"
-  integrity sha512-5admQMBOxue5L2vuxYWFugP4QyXpHbfCT+6fRuqaZY3oR/KMLxWUJ5YkvU0qVoKhabIjexutTDDk96A4NvIX7Q==
+"@guardian/commercial@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-8.0.0.tgz#e6d5e16d1cd2534ee2c15bfc1da45445f2b7f2aa"
+  integrity sha512-VcOf3WCnT5Gxj1UWHTobRH6J08dasPzeYbiY1+xsSFhHVBA4D/0kcKJ/p4ZBwnBFCrlzlf/6/tVZLybmQ/CHLQ==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
     "@guardian/consent-management-platform" "^13.0.2"


### PR DESCRIPTION
Reverts guardian/frontend#26178

This appears to have removed the hash in the commercial bundle URL for some reason!