### PR TITLE
Point australia edition news pillar nav to bar to aus podcasts

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -291,7 +291,7 @@ object NavLinks {
       auBusiness,
       science,
       tech,
-      podcasts,
+      podcastsAU,
     ),
   )
   val usNewsPillar = ukNewsPillar.copy(children =

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1958,7 +1958,7 @@
                 },
                 {
                     "title": "Podcasts",
-                    "url": "/podcasts",
+                    "url": "/australia-podcasts",
                     "children": [],
                     "classList": []
                 }


### PR DESCRIPTION
## What does this change?

- Point australia edition news pillar nav to bar to aus podcasts
- fixes https://github.com/guardian/dotcom-rendering/issues/7815

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

