### PR TITLE
Update paid content picker logic as we now support labs containers

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -95,7 +95,6 @@ class ArticleController(
   private def getDCRJson(article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): String = {
     val pageType: PageType = PageType(article, request, context)
     val newsletter = newsletterService.getNewsletterForArticle(article)
-    val edition = Edition(request)
 
     DotcomRenderingDataModel.toJson(
       DotcomRenderingDataModel

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -117,11 +117,11 @@ object FrontChecks {
     !faciaPage.metadata.hasPageSkin(request)
   }
 
-  def isPaidFront(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
+  def isNotPaidFront(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
     // We don't support paid fronts
     // See: https://github.com/guardian/dotcom-rendering/issues/5945
 
-    faciaPage.isPaid(Edition(request));
+    !faciaPage.isPaid(Edition(request));
   }
 
   def hasNoRegionalAusTargetedContainers(faciaPage: PressedPage): Boolean = {
@@ -175,7 +175,7 @@ object FaciaPicker extends GuLogging {
       ("hasNoWeatherWidget", FrontChecks.hasNoWeatherWidget(faciaPage)),
       ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
-      ("isPaidFront", FrontChecks.isPaidFront(faciaPage)),
+      ("isNotPaidFront", FrontChecks.isNotPaidFront(faciaPage)),
       ("hasNoRegionalAusTargetedContainers", FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage)),
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
       ("hasNoDynamicPackage", FrontChecks.hasNoDynamicPackage(faciaPage)),

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -1,11 +1,11 @@
 package services.dotcomrendering
 
-import common.GuLogging
+import common.{Edition, GuLogging}
 import conf.switches.Switches.DCRFronts
 import implicits.Requests._
 import model.PressedPage
 import model.facia.PressedCollection
-import model.pressed.{LinkSnap}
+import model.pressed.LinkSnap
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 
@@ -117,12 +117,11 @@ object FrontChecks {
     !faciaPage.metadata.hasPageSkin(request)
   }
 
-  def hasNoPaidCards(faciaPage: PressedPage): Boolean = {
-    // We don't support paid content
+  def isPaidFront(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
+    // We don't support paid fronts
     // See: https://github.com/guardian/dotcom-rendering/issues/5945
-    // See: https://github.com/guardian/dotcom-rendering/issues/5150
 
-    !faciaPage.collections.exists(_.curated.exists(card => card.isPaidFor))
+    faciaPage.isPaid(Edition(request));
   }
 
   def hasNoRegionalAusTargetedContainers(faciaPage: PressedPage): Boolean = {
@@ -176,7 +175,7 @@ object FaciaPicker extends GuLogging {
       ("hasNoWeatherWidget", FrontChecks.hasNoWeatherWidget(faciaPage)),
       ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
-      ("hasNoPaidCards", FrontChecks.hasNoPaidCards(faciaPage)),
+      ("isPaidFront", FrontChecks.isPaidFront(faciaPage)),
       ("hasNoRegionalAusTargetedContainers", FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage)),
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
       ("hasNoDynamicPackage", FrontChecks.hasNoDynamicPackage(faciaPage)),


### PR DESCRIPTION
## What does this change?

Updates the logic for filtering out paid content as we now support labs containers and paid for cards. 
Keeping the logic that checks for paid fronts, as we still don't support these yet. 

This will change the log string so the [grafana dashboard](https://metrics.gutools.co.uk/d/pCbViPIVk/front-migration?orgId=1) will need to be updated. 
