### PR TITLE
Downgrade DFP API to test alarm

### DIFF
--- a/admin/app/dfp/AdUnitAgent.scala
+++ b/admin/app/dfp/AdUnitAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
 import common.dfp.GuAdUnit
 import conf.Configuration
 import ApiHelper.toSeq

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202108._
 import common.GuLogging
 import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
 

--- a/admin/app/dfp/CustomFieldAgent.scala
+++ b/admin/app/dfp/CustomFieldAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.v202208.{CustomFieldValue, LineItem, TextValue}
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
+import com.google.api.ads.admanager.axis.v202108.{CustomFieldValue, LineItem, TextValue}
 import common.dfp.GuCustomField
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/CustomTargetingAgent.scala
+++ b/admin/app/dfp/CustomTargetingAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.v202208.{CustomTargetingKey, CustomTargetingValue}
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
+import com.google.api.ads.admanager.axis.v202108.{CustomTargetingKey, CustomTargetingValue}
 import common.GuLogging
 import common.dfp.{GuCustomTargeting, GuCustomTargetingValue}
 import concurrent.BlockingOperations

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202108._
 import common.dfp._
 import dfp.ApiHelper.{isPageSkin, optJavaInt, toJodaTime, toSeq}
 

--- a/admin/app/dfp/DataValidation.scala
+++ b/admin/app/dfp/DataValidation.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202108._
 import common.dfp._
 import dfp.ApiHelper.toSeq
 

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -2,8 +2,8 @@ package dfp
 
 // StatementBuilder query language is PQL defined here:
 // https://developers.google.com/ad-manager/api/pqlreference
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
+import com.google.api.ads.admanager.axis.v202108._
 import com.madgag.scala.collection.decorators.MapDecorator
 import common.GuLogging
 import common.dfp._

--- a/admin/app/dfp/PlacementAgent.scala
+++ b/admin/app/dfp/PlacementAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
 import common.dfp.GuAdUnit
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/Reader.scala
+++ b/admin/app/dfp/Reader.scala
@@ -1,8 +1,8 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder.SUGGESTED_PAGE_LIMIT
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder.SUGGESTED_PAGE_LIMIT
+import com.google.api.ads.admanager.axis.v202108._
 
 import scala.annotation.tailrec
 

--- a/admin/app/dfp/ServicesWrapper.scala
+++ b/admin/app/dfp/ServicesWrapper.scala
@@ -1,7 +1,7 @@
 package dfp
 
 import com.google.api.ads.admanager.axis.factory.AdManagerServices
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202108._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 
 private[dfp] class ServicesWrapper(session: AdManagerSession) {

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
+import com.google.api.ads.admanager.axis.v202108._
 import common.GuLogging
 
 import scala.util.control.NonFatal

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -2,8 +2,8 @@ package dfp
 
 import com.google.api.ads.common.lib.auth.OfflineCredentials
 import com.google.api.ads.common.lib.auth.OfflineCredentials.Api
-import com.google.api.ads.admanager.axis.utils.v202208.{ReportDownloader, StatementBuilder}
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.utils.v202108.{ReportDownloader, StatementBuilder}
+import com.google.api.ads.admanager.axis.v202108._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 import com.google.common.io.CharSource
 import common.GuLogging
@@ -226,6 +226,7 @@ object SessionWrapper extends GuLogging {
       } catch {
         case NonFatal(e) =>
           log.error(s"Building DFP session failed.", e)
+          println(s"Building DFP session failed.", e)
           DfpSessionErrors.increment();
           None
       }

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -3,10 +3,10 @@ package jobs
 import java.time.{LocalDate, LocalDateTime}
 
 import app.LifecycleComponent
-import com.google.api.ads.admanager.axis.v202208.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
-import com.google.api.ads.admanager.axis.v202208.DateRangeType.CUSTOM_DATE
-import com.google.api.ads.admanager.axis.v202208.Dimension.{CUSTOM_CRITERIA, DATE}
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202108.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
+import com.google.api.ads.admanager.axis.v202108.DateRangeType.CUSTOM_DATE
+import com.google.api.ads.admanager.axis.v202108.Dimension.{CUSTOM_CRITERIA, DATE}
+import com.google.api.ads.admanager.axis.v202108._
 import common.{AkkaAsync, Box, JobScheduler, GuLogging}
 import dfp.DfpApi
 import play.api.inject.ApplicationLifecycle

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -2,7 +2,7 @@ package dfp
 
 import concurrent.BlockingOperations
 import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202108._
 import org.joda.time.DateTime
 import akka.actor.ActorSystem
 import org.scalatest.flatspec.AnyFlatSpec

--- a/admin/test/dfp/ReaderTest.scala
+++ b/admin/test/dfp/ReaderTest.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
 import dfp.Reader.read
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.5"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "4.20.0"
+  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "4.15.1"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play27" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion


### PR DESCRIPTION
## What does this change?

This PR intentionally downgrades the DFP API to a version we know is deprecated, and therefore will raise exceptions in the DFP client.

**This PR will cause the DFP API to error in production. We're doing this intentionally, in order to check that an alarm is triggered in such an instance. Once we have detected this has happened, we'll merge a revert of this.**

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this?

We want to check that the CloudWatch metrics that are used to count DFP API errors will correctly trigger an alarm.

These metrics were introduced in #26191.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
