### PR TITLE
Don't amplify if an article has quiz atoms

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -94,7 +94,10 @@ final case class Content(
         AmpLiveBlogSwitch.isSwitchedOn
       } else if (tags.isArticle) {
         val hasBodyBlocks: Boolean = fields.blocks.exists(b => b.body.nonEmpty)
-        AmpArticleSwitch.isSwitchedOn && hasBodyBlocks && !tags.isQuiz
+        // Some Labs pages have quiz atoms but are not tagged as quizzes
+        val hasQuizAtoms: Boolean = atoms.exists(a => a.quizzes.nonEmpty)
+
+        AmpArticleSwitch.isSwitchedOn && hasBodyBlocks && !tags.isQuiz && !hasQuizAtoms
       } else {
         false
       }


### PR DESCRIPTION
## What does this change?

Adds a check for quiz atoms in `shouldAmplify`. If quiz atoms are included in the CAPI response, frontend should not render the AMP version of this article.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

See also: guardian/dotcom-rendering#7889

## What is the value of this and can you measure success?

Quizzes are not supported on AMP and are caught by the `!tags.isQuiz` check in `shouldAmplify`. However this check depends on the article having the `quizzes` tag. Labs quizzes don't receive this tag as they shouldn't appear in the `/tone/quizzes` front.

Checking for the presence of quiz atoms catches this omission.

This issue was identified when a member of the Labs team noticed that a quiz they had shared was not appearing when the article was rendered in the LinkedIn app. This is because the LinkedIn app renders AMP pages for shared articles.