### PR TITLE
Remove `MerchandisingHighSection` switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -268,16 +268,6 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val MerchandisingHighSection: Switch = Switch(
-    group = Commercial,
-    name = "merchandising-high-section",
-    description = "Move merchandising high section one section lower. This switch is only applied in the UK.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
   val commercialMetrics: Switch = Switch(
     group = Commercial,
     name = "commercial-metrics",

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -840,14 +840,10 @@ case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boole
     val minContainers = if (isPaidContent) 1 else 2
 
     if (containers.length >= minContainers) {
-
-      val merchHighCanBeMoved = MerchandisingHighSection.isSwitchedOn && edition.id.equals(Uk.id)
-
-      val containerIndex = (containers.length >= 4, isNetworkFront, merchHighCanBeMoved) match {
-        case (false, _, _)       => 0
-        case (true, false, _)    => 2
-        case (true, true, false) => 3
-        case (true, true, true)  => 4
+      val containerIndex = (containers.length >= 4, isNetworkFront) match {
+        case (false, _)    => 0
+        case (true, false) => 2
+        case (true, true)  => 3
       }
 
       val adSlotHtml = views.html.fragments.commercial.commercialComponentHigh(isPaidContent, hasPageSkin)


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/7616.

## What does this change?

Remove the switch `MerchandisingHighSection` and the switch that controls it.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - this functionality won't be reproduced in DCR, we're simply removing it here.
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This logic was first introduced in https://github.com/guardian/frontend/pull/23677. It was introduced to temporarily reposition the high merch unit, so that it didn't break up two Coronavirus containers that belonged together. This was always a temporary fix, and not destined for reproduction in DCR, so this functionality can now be removed from Frontend.

### Tested

- [x] Locally
- [ ] On CODE (optional)
