### PR TITLE
Support Cost of the crown thrasher

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -79,7 +79,7 @@ object FrontChecks {
       "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/02/pw-uk/default",
       "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/11/comfort-eating-grace-dent-thrasher-no-logo/default",
       "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/02/weekend-podcast-2022/default",
-      // We can support the following thrashers once we support full width: https://github.com/guardian/dotcom-rendering/issues/7678
+      // We can support the Cotton Capital thrashers once this is completed: https://github.com/guardian/dotcom-rendering/issues/7748
       "https://content.guardianapis.com/atom/interactive/interactives/2022/10/tr/default-fronts-default",
       "https://content.guardianapis.com/atom/interactive/interactives/2022/10/tr/david-olusoga-front-default",
       "https://content.guardianapis.com/atom/interactive/interactives/2022/10/tr/cassandra-gooptar-front-default",
@@ -92,8 +92,7 @@ object FrontChecks {
       "https://content.guardianapis.com/atom/interactive/interactives/2022/10/tr/lanre-bakare-front-default",
       "https://content.guardianapis.com/atom/interactive/interactives/2022/10/tr/hidden-figures-front-default",
       "https://content.guardianapis.com/atom/interactive/interactives/2022/10/tr/johny-pitts-photo-essay-front-default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2023/04/cost-of-crown/default",
-      // End of list of full-width thrashers
+      // End of list of Cotton Capital thrashers
     )
 
   def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {


### PR DESCRIPTION
## What does this change?
Supports Cost of the crown thrasher.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No. We can merge the current PR and render https://www.theguardian.com/uk-news/series/cost-of-the-crown via DCR 
after this https://github.com/guardian/dotcom-rendering/pull/7891 gets merged 
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
