### PR TITLE
Document renderFrontJsonLite

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -397,7 +397,7 @@ GET            /$path<(lifeandstyle/love-and-sex|lifeandstyle/home-and-garden|wo
 GET            /rss                                                                                                              controllers.FaciaController.renderRootFrontRss()
 GET            /$path<(uk|au|us|international)(/(culture|sport|commentisfree|business|money|travel|rss))?>                       controllers.FaciaController.renderFrontPress(path)
 GET            /$path<email/.*>                                                                                                  controllers.FaciaController.renderFrontPress(path)
-GET            /*path/lite.json                                                                                                  controllers.FaciaController.renderFrontJsonLite(path)
+GET            /*path/lite.json                                                                                                  controllers.FaciaController.renderFrontJsonMinimal(path)
 GET            /*path/headline.txt                                                                                               controllers.FaciaController.renderFrontHeadline(path)
 GET            /*path.emailjson                                                                                                  controllers.FaciaController.renderFrontJson(path)
 GET            /*path.emailtxt                                                                                                   controllers.FaciaController.renderFrontJson(path)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -155,6 +155,11 @@ trait FaciaController
       Cached(CacheTime.Facia)(WithoutRevalidationResult(Found(LinkTo(s"/$path$params"))))
     }
 
+  // Returns a 'lite' version of the 'lite' version of a PressedPage.
+  // i.e. it fetches the 'lite' version of the PressedPage from S3 and then returns
+  // a subset of the properties found in S3.
+  // It's used by a number of services, including the 'pressreader' edition feed,
+  // see https://github.com/guardian/pressreader
   def renderFrontJsonLite(path: String): Action[AnyContent] =
     Action.async { implicit request =>
       frontJsonFapi.get(path, liteRequestType).map { resp =>

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -155,16 +155,17 @@ trait FaciaController
       Cached(CacheTime.Facia)(WithoutRevalidationResult(Found(LinkTo(s"/$path$params"))))
     }
 
-  // Returns a 'lite' version of the 'lite' version of a PressedPage.
-  // i.e. it fetches the 'lite' version of the PressedPage from S3 and then returns
-  // a subset of the properties found in S3.
+  // Returns a stripped-down 'minimal' version of the 'lite' version of a PressedPage.
+  // The minimal version of a Front contains only the `webTitle` and `collections`
+  // from that Front. Some content items are filtered out (e.g. LinkSnaps) and some fields
+  // are renamed.
   // It's used by a number of services, including the 'pressreader' edition feed,
   // see https://github.com/guardian/pressreader
-  def renderFrontJsonLite(path: String): Action[AnyContent] =
+  def renderFrontJsonMinimal(path: String): Action[AnyContent] =
     Action.async { implicit request =>
       frontJsonFapi.get(path, liteRequestType).map { resp =>
         Cached(CacheTime.Facia)(JsonComponent.fromWritable(resp match {
-          case Some(pressedPage) => FapiFrontJsonLite.get(pressedPage)
+          case Some(pressedPage) => FapiFrontJsonMinimal.get(pressedPage)
           case None              => JsObject(Nil)
         }))
       }

--- a/facia/app/controllers/front/FapiFrontJsonMinimal.scala
+++ b/facia/app/controllers/front/FapiFrontJsonMinimal.scala
@@ -5,7 +5,7 @@ import model.facia.PressedCollection
 import model.pressed._
 import play.api.libs.json._
 
-trait FapiFrontJsonLite {
+trait FapiFrontJsonMinimal {
   def get(pressedPage: PressedPage): JsObject = {
     Json.obj("webTitle" -> pressedPage.seoData.webTitle, "collections" -> getCollections(pressedPage))
   }
@@ -58,4 +58,4 @@ trait FapiFrontJsonLite {
     }
 }
 
-object FapiFrontJsonLite extends FapiFrontJsonLite
+object FapiFrontJsonMinimal extends FapiFrontJsonMinimal

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -32,7 +32,7 @@ GET        /container/*id.json                                                  
 GET        /*path/show-more/*id.json                                                controllers.FaciaController.renderShowMore(path, id)
 GET        /rss                                                                     controllers.FaciaController.renderRootFrontRss()
 GET        /*path/rss                                                               controllers.FaciaController.renderFrontRss(path)
-GET        /*path/lite.json                                                         controllers.FaciaController.renderFrontJsonLite(path)
+GET        /*path/lite.json                                                         controllers.FaciaController.renderFrontJsonMinimal(path)
 GET        /*path.emailjson                                                         controllers.FaciaController.renderFrontJson(path)
 GET        /*path.emailtxt                                                          controllers.FaciaController.renderFrontJson(path)
 GET        /*path.json                                                              controllers.FaciaController.renderFrontJson(path)

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -133,7 +133,7 @@ GET        /rss                                                                 
 GET        /$path<.+>/show-more/*id.json                                                       controllers.FaciaDraftController.renderShowMore(path, id)
 GET        /$path<(culture|sport|commentisfree|business|money|rss)>                            controllers.FaciaDraftController.renderFront(path)
 GET        /$path<(\w\w)(/[\w\d-]+)?>/rss                                                      controllers.FaciaDraftController.renderFrontRss(path)
-GET        /$path<.+>/lite.json                                                                controllers.FaciaDraftController.renderFrontJsonLite(path)
+GET        /$path<.+>/lite.json                                                                controllers.FaciaDraftController.renderFrontJsonMinimal(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                       controllers.FaciaDraftController.renderFrontJson(path)
 
 GET        /container/*id.json                                                                 controllers.FaciaDraftController.renderContainerJson(id)


### PR DESCRIPTION
## What does this change?

Adds a comment to (hopefully!) disambiguate the use of 'lite' in the `renderFrontJsonLite` function, and also to point towards one of the internal services that makes use of this function, via the `{path}.lite.json` endpoint.

For example, http://api.nextgen.guardianapps.co.uk/au/lite.json

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


