### PR TITLE
Rename some Ophan components

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -42,7 +42,7 @@
             @if(FlagshipFrontContainer.displayFlagshipContainer()) {
                 <section id="@componentName"
                     class="@GetClasses.forContainerDefinition(containerDefinition)"
-                    data-link-name="container-@{containerDefinition.index + 1} | @componentName"
+                    data-link-name="container-@{containerDefinition.index} | @componentName"
                     data-id="@containerDefinition.dataId"
                     data-component="@componentName"
                     aria-expanded="true">
@@ -57,7 +57,7 @@
         case _ => {
             <section id="@componentName"
                  class="@GetClasses.forContainerDefinition(containerDefinition) @GetClasses.forFrontId(frontId)"
-                 data-link-name="container-@{containerDefinition.index + 1} | @componentName"
+                 data-link-name="container-@{containerDefinition.index} | @componentName"
                  data-id="@containerDefinition.dataId"
                  data-component="@componentName"
                  aria-expanded="true">

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -37,7 +37,7 @@
                     <span class="header-top-nav__item--separator hide-until-desktop"></span>
                     @defining(if (editionId == "uk") getReaderRevenueUrl(PrintCTA,
                     Header) else getReaderRevenueUrl(PrintCTAWeekly, Header)) { href =>
-                    <a class="top-bar__item hide-until-desktop yellow" data-link-name="nav3 : print-cta"
+                    <a class="top-bar__item hide-until-desktop yellow" data-link-name="nav3 : topbar : printsubs"
                         data-edition="@{editionId}" href="@href">
                         @fragments.inlineSvg("newspaper", "icon", List("top-bar__item__icon"))
                         Print subscriptions
@@ -56,15 +56,16 @@
                     </a>
 
                     <input type="checkbox" id="my-account-toggle" aria-controls="my-account-dropdown"
-                        class="dropdown-menu-fallback js-enhance-checkbox" data-link-name="nav3 : topbar: my account"
+                        class="dropdown-menu-fallback js-enhance-checkbox" data-link-name="nav3 : topbar : my account"
                         tabindex="-1" />
 
                     <label
                         class="top-bar__item popup__toggle js-navigation-account-actions js-user-account-trigger is-hidden"
-                        for="my-account-toggle" data-link-name="nav3 : topbar: my account" tabindex="0">
+                        for="my-account-toggle" data-link-name="nav3 : topbar : my account" tabindex="0">
                         @fragments.inlineSvg("profile", "icon", List("top-bar__item__icon"))
                         My account
-                        <span class="top-bar__user-account-notification-badge js-user-account-notification-badge is-hidden"></span>
+                        <span
+                            class="top-bar__user-account-notification-badge js-user-account-notification-badge is-hidden"></span>
                     </label>
                     <div class="my-account__overlay"></div>
 
@@ -154,7 +155,7 @@
             if(editionId == "uk") {
             fragments.inlineSvg("guardian-best-newspaper-logo", "logo")
             } else if(editionId == "au") {
-                fragments.inlineSvg("guardian-australia-decade-logo", "logo")
+            fragments.inlineSvg("guardian-australia-decade-logo", "logo")
             } else {
             fragments.inlineSvg("the-guardian-logo", "logo")
             }

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -5,7 +5,7 @@
 
 <li class="menu-item js-navigation-item">
     <button class="menu-item__title js-navigation-toggle"
-            data-link-name="nav2 : edition picker"
+            data-link-name="nav3 : edition picker"
             aria-haspopup="true"
             aria-expanded="true">
         <i class="menu-item__toggle"></i>
@@ -16,7 +16,7 @@
         @Edition.editionsByRequest.map { edition =>
              @if(edition != Edition(request)) {
                  <li class="menu-item">
-                     <a data-link-name="nav2 : edition-picker: @edition.id"
+                     <a data-link-name="nav3 : topbar : edition-picker: @edition.id"
                      href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")"
                      class="menu-item__title">
                          <span class="u-h">switch to the </span>


### PR DESCRIPTION
## What does this change?

Rename and refactor some of the Ophan components / `data-link-names` to be more consistent.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/7893

## What is the value of this and can you measure success?

There are some inconsistencies that make parity with DCR harder to achieve.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
