### PR TITLE
Rename edition picker toggler and most popular Ophan components

### DIFF
--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -10,7 +10,7 @@
 @import model.Pillar.RichPillar
 
 @defining(popular.size > 1){ isTabbed =>
-    <div id="popular-trails" class="fc-slice fc-slice--popular" data-link-name="most popular Test" data-test-id="popular-in">
+    <div id="popular-trails" class="fc-slice fc-slice--popular" data-link-name="most popular" data-test-id="popular-in">
         @if(isTabbed) {
             <div class="tabs tabs--mostpop u-cf @if(isAdFree(containerDefinition) && isFront){tabs--mostpop--without-mpu}">
                 <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">

--- a/common/app/views/fragments/nav/editionPickerDropdown.scala.html
+++ b/common/app/views/fragments/nav/editionPickerDropdown.scala.html
@@ -21,7 +21,7 @@
         id="edition-picker-toggle"
         aria-controls="edition-dropdown-menu"
         class="u-h dropdown-menu-fallback js-enhance-checkbox"
-        data-link-name="nav2 : topbar : edition-picker: toggle"
+        data-link-name="nav3 : topbar : edition-picker: toggle"
         tabindex="-1">
 
         <ul class="dropdown-menu js-edition-dropdown-menu"
@@ -35,7 +35,7 @@
 
     <label for="edition-picker-toggle"
             class="top-bar__item popup__toggle js-edition-picker-trigger"
-            data-link-name="nav2 : topnav : edition-picker: toggle"
+            data-link-name="nav3 : topnav : edition-picker: toggle"
             data-display-name="@Edition(request).displayName"
             tabindex="0">
 


### PR DESCRIPTION
Addresses some of the issues here: https://github.com/guardian/dotcom-rendering/issues/4692

## What does this change?
Changes a few `data-link-name` values to achieve parity with DCR

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No. These are already the values in DCR.
- [ ] Yes (please indicate your plans for DCR Implementation)



<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
