### PR TITLE
Play videos on small breakpoints

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -57,7 +57,7 @@
                     <div class="video-overlay__headline">
 
                     @for(f <- faciaHeaderProperties) {
-                        @title(f.header, 0, 0, "u-faux-block-link__cta", None, isPaidFor)
+                        @title(f.header, 0, 0, "u-faux-block-link__cta", None, isPaidFor, isLink = false)
                         @if(f.showByline) {
                             <div class="fc-item__byline">@f.byline</div>
                         }

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -1,4 +1,4 @@
-@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false, isAction: Boolean = false)(implicit request: RequestHeader, isLink: Boolean = true)
+@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false, isAction: Boolean = false, isLink: Boolean = true)(implicit request: RequestHeader)
 
 @import views.html.fragments.items.elements.facia_cards.itemHeader
 @import views.support._

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -1,4 +1,4 @@
-@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false, isAction: Boolean = false)(implicit request: RequestHeader)
+@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false, isAction: Boolean = false)(implicit request: RequestHeader, isLink: Boolean = true)
 
 @import views.html.fragments.items.elements.facia_cards.itemHeader
 @import views.support._
@@ -17,7 +17,11 @@
 
 
 @articleLink(html: Html) = {
-    <a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>
+    @if(isLink) {
+        <a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>
+    } else {
+        <span href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</span>
+    }
 }
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -364,6 +364,10 @@ const onPlayerReady = (
         youtubePlayer.mute();
     }
     if (iFrameBehaviour.autoplay) {
+        // On IOS autoplay doesn't work unless video is muted
+        if (isIOS()) {
+            youtubePlayer.mute();
+        }
         youtubePlayer.playVideo();
     }
 
@@ -373,7 +377,7 @@ const onPlayerReady = (
         if (
             !!config.get('page.section') &&
             isBreakpoint({
-                min: 'desktop',
+                min: 'mobile',
             })
         ) {
             const endSlate = getEndSlate(overlay);
@@ -440,6 +444,8 @@ const initYoutubePlayerForElem = (el) => {
         if (!iframe) {
             return;
         }
+
+        iframe.style.display = 'block'
 
         /**
          * Note:

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -221,7 +221,6 @@ const STATES = {
 const getIFrameBehaviourConfig = (
     iframe
 ) => {
-    const isAutoplayBlockingPlatform = isIOS() || isAndroid();
 
     const isInternalReferrer = (() => {
         if (config.get('page.isDev')) {
@@ -247,7 +246,6 @@ const getIFrameBehaviourConfig = (
     const isPaidContent = config.get('page.isPaidContent');
 
     return {
-        isAutoplayBlockingPlatform,
         isInternalReferrer,
         isMainVideo,
         flashingElementsAllowed,
@@ -262,7 +260,6 @@ const getIFrameBehaviour = (
     iframeConfig
 ) => {
     const {
-        isAutoplayBlockingPlatform,
         isInternalReferrer,
         isMainVideo,
         flashingElementsAllowed,
@@ -288,7 +285,6 @@ const getIFrameBehaviour = (
         autoplay:
             ((isVideoArticle && isInternalReferrer && isMainVideo) ||
                 isFront) &&
-            !isAutoplayBlockingPlatform &&
             flashingElementsAllowed,
         mutedOnStart: false,
     };

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.spec.js
@@ -10,7 +10,7 @@ const isIOS = _isIOS;
 const accessibilityIsOn = _isOn;
 
 jest.mock('lib/detect', () => {
-    
+
     const original = jest.requireActual('lib/detect');
     return {
         ...original,
@@ -20,7 +20,7 @@ jest.mock('lib/detect', () => {
 });
 
 jest.mock('common/modules/accessibility/main', () => {
-    
+
     const original = jest.requireActual('common/modules/accessibility/main');
     return {
         ...original,
@@ -80,7 +80,6 @@ describe('youtube', () => {
         it('autoplays muted US paid content videos on Android', () => {
             isAndroid.mockReturnValue(true);
             const iFrameBehaviourConfig = {
-                isAutoplayBlockingPlatform: true,
                 isInternalReferrer: true,
                 isMainVideo: true,
                 flashingElementsAllowed: true,
@@ -98,7 +97,6 @@ describe('youtube', () => {
         it("doesn't mute US paid content videos on desktop", () => {
             isAndroid.mockReturnValue(false);
             const iFrameBehaviourConfig = {
-                isAutoplayBlockingPlatform: false,
                 isInternalReferrer: true,
                 isMainVideo: true,
                 flashingElementsAllowed: true,
@@ -116,7 +114,6 @@ describe('youtube', () => {
         it("doesn't mute autoplaying videos on desktop fronts", () => {
             isAndroid.mockReturnValue(false);
             const iFrameBehaviourConfig = {
-                isAutoplayBlockingPlatform: false,
                 isInternalReferrer: false,
                 isMainVideo: false,
                 flashingElementsAllowed: true,
@@ -134,7 +131,6 @@ describe('youtube', () => {
         it("doesn't autoplay videos when flashing elements are disallowed", () => {
             isAndroid.mockReturnValue(false);
             const iFrameBehaviourConfig = {
-                isAutoplayBlockingPlatform: false,
                 isInternalReferrer: false,
                 isMainVideo: false,
                 flashingElementsAllowed: false,
@@ -176,29 +172,15 @@ describe('youtube', () => {
             )));
         });
 
-        it('is Autoplay blocking platform if isAndroid', () => {
-            isAndroid.mockReturnValue(true);
-            isIOS.mockReturnValue(false);
-            const iFrameBehaviourConfig = getIFrameBehaviourConfig(iframe);
-            expect(iFrameBehaviourConfig.isAutoplayBlockingPlatform).toBe(true);
-        });
-
-        it('is Autoplay blocking platform if isIOS', () => {
-            isAndroid.mockReturnValue(false);
-            isIOS.mockReturnValue(true);
-            const iFrameBehaviourConfig = getIFrameBehaviourConfig(iframe);
-            expect(iFrameBehaviourConfig.isAutoplayBlockingPlatform).toBe(true);
-        });
-
         it('correctly identifies Internal Referrer', () => {
-            
+
             jest.spyOn(global.document, 'referrer', 'get').mockReturnValueOnce(
                 'https://www.theguardian.com'
             );
             expect(getIFrameBehaviourConfig(iframe).isInternalReferrer).toBe(
                 true
             );
-            
+
             jest.spyOn(global.document, 'referrer', 'get').mockReturnValueOnce(
                 'https://www.garbage-site.com'
             );

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -60,7 +60,7 @@ const reducers = {
         const makeYouTubeNonPlayableAtSmallBreakpoint = state => {
             if (
                 isBreakpoint({
-                    max: 'desktop',
+                    max: 'mobile',
                 })
             ) {
                 const youTubeIframes = Array.from(

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -36,9 +36,7 @@
 .video-playlist__item .youtube-media-atom iframe,
 .video-playlist__item .youtube-media-atom .vjs-big-play-button {
     @include mq($until: desktop) {
-        top: gs-height(3) - (get-line-height(textSans, 3) + 4px);
         bottom: 0;
-        height: auto;
     }
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -276,6 +276,10 @@ $video-width-desktop: 700px;
             z-index: 3;
         }
     }
+
+    @include mq($until: mobileLandscape ) {
+        width: 80%;
+    }
 }
 
 .video-playlist__item--first {
@@ -426,6 +430,15 @@ $video-width-desktop: 700px;
         width: gs-span(3);
     }
 
+    @include mq($until: mobileLandscape)   {
+        position: absolute;
+        padding: 2.5rem $gs-gutter/4 $gs-baseline * 2;
+        min-height: gs-height(2);
+        padding-top: 0;
+        padding-bottom: 0;
+        background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .7) 25%);
+    }
+
     .video-playlist__item .vjs-playing ~ & {
         @include mq(desktop) {
             visibility: hidden;
@@ -484,6 +497,10 @@ $video-width-desktop: 700px;
     position: absolute;
     bottom: 2px;
     color: $brightness-86;
+
+    @include mq($until: mobileLandscape)   {
+        right: 0;
+    }
 }
 
 .fc-item__video-container {

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -277,7 +277,7 @@ $video-width-desktop: 700px;
         }
     }
 
-    @include mq($until: mobileLandscape ) {
+    @include mq($until: mobileLandscape) {
         width: 80%;
     }
 }


### PR DESCRIPTION
## What does this change?

- Makes video cards within the video container playable on fronts on smaller breakpoints.
- Contains a few style changes for cards on breakpoints smaller than mobileLandscape. These changes were necessary to size the card appropriately for the video player.

**Note:** We can not autoplay video on IOS device unless video is muted. So we either need to let user play the video and then unmute it, or let the user click on play two times. Muting was determined to be the preferred option. This doesn't affect android. [The youtube documentation explains this](https://developers.google.com/youtube/iframe_api_reference#Autoplay_and_scripted_playback)

## Screenshots


|      | Difference | Before      | After      |
|-------------|-------------|-------------|------------|
| Medium size video card | No change | <img width="872" alt="image" src="https://github.com/guardian/frontend/assets/26366706/14b444c2-64cb-45bc-bc2d-ef84fb2cae14"> | <img width="872" alt="image" src="https://github.com/guardian/frontend/assets/26366706/b36279dc-2fa0-44f8-a00f-39b7849a6a16"> |
| Medium size video card (video playing) | Video now plays on front | Video didn't play, instead it linked to the video page | <img width="872" alt="image" src="https://github.com/guardian/frontend/assets/26366706/7ad1861a-7800-4f29-af84-026221fb0c57"> |
| Large video card | No change | <img width="1482" alt="image" src="https://github.com/guardian/frontend/assets/26366706/37bd5d7a-2e62-458a-9ead-a128d37c50d7"> | <img width="1482" alt="image" src="https://github.com/guardian/frontend/assets/26366706/07de6fe6-7615-4b00-8c17-e51cdf18ea62"> |
| Large video cards (playing) | No change | <img width="1482" alt="image" src="https://github.com/guardian/frontend/assets/26366706/8920ac30-4694-4cd0-b143-7bbd2aafc72a"> |  <img width="1497" alt="image" src="https://github.com/guardian/frontend/assets/26366706/a0c96afd-4a95-4768-8709-1e1a823e5cda"> |
| Mobile video cards | Overlay text is transparent and over the image, so that the player can be the correct size. Duration has moved to right of card to avoid looking squashed with the play button|  <img width="416" alt="image" src="https://github.com/guardian/frontend/assets/26366706/6a207009-fd33-4626-a248-015ff660b041">|  <img width="416" alt="image" src="https://github.com/guardian/frontend/assets/26366706/2ca42654-5f05-4af2-8501-6104a4c299af"> |
|Mobile video cards (playing) | Video now plays on front | Video didn't play, instead it linked to the video page |  <img width="416" alt="image" src="https://github.com/guardian/frontend/assets/26366706/9f00d9d0-4ae3-46b8-b35b-76eabc697e08"> |




## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
We want to enable users to play videos on our front pages, as once the vertical video work is implemented this will be consistent.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
