### PR TITLE
Bump commercial to 9.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial": "9.2.0",
+		"@guardian/commercial": "9.3.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,6 +1519,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-4.0.0.tgz#50c1fc076437e594b367f6e8d9469a3d9b97a78e"
   integrity sha512-l6Ot/anisLKyoLZOp8koW7Ia5JFOtmZkB0sfgdWajv5+N0w0UScUVoImEdPlFstM1anSd3FvV8D3UgYkRzAang==
 
+"@guardian/ab-core@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-5.0.0.tgz#cce32ff4cdfb6b24c013723bf352dcd61135d34d"
+  integrity sha512-Td5gtK2sARl+fXj1Qe6RuFqf/zxuZjW1q2Jck09zXPIfMgU+sJoTi549zbNeC1cldCBhPWy/qPQ0r+8klfF7jg==
+
 "@guardian/atom-renderer@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-2.0.0.tgz#cf51feb97421829c7e6b9106c8478e049bc97478"
@@ -1556,17 +1561,17 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial@9.2.0":
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-9.2.0.tgz#36250e7f14d526b85cad8a2d2b6bb5da5fa19c5b"
-  integrity sha512-NekjB+Ca3CD09Av3hq6bg+hxOu33zBTH3nD65v/YUbhCWbGsRxu0MBwwU6J7gG9vpvjdOzjoHIEhUptWrCQwZw==
+"@guardian/commercial@9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-9.3.0.tgz#34068ff451d53b06e7d4a551d9d539b94aef5cf7"
+  integrity sha512-OwYq3omttgGm8sUPQDo7liHvnEsle174XEyU5XhpVy9OaUGtI/7LLL5XNhmSByp+TSUy369N126oCoI3jNPUcw==
   dependencies:
     "@changesets/cli" "^2.26.1"
-    "@guardian/ab-core" "^4.0.0"
+    "@guardian/ab-core" "^5.0.0"
     "@guardian/consent-management-platform" "^13.2.0"
-    "@guardian/core-web-vitals" "^4.0.0"
-    "@guardian/libs" "^14.0.0"
-    "@guardian/source-foundations" "^10.0.1"
+    "@guardian/core-web-vitals" "^5.0.0"
+    "@guardian/libs" "^15.0.0"
+    "@guardian/source-foundations" "^12.0.0"
     "@guardian/support-dotcom-components" "^1.0.7"
     "@octokit/core" "^4.0.5"
     fastdom "^1.0.11"
@@ -1575,8 +1580,8 @@
     prebid.js guardian/prebid.js#2e3b96d
     process "^0.11.10"
     raven-js "^3.27.2"
-    tslib "^2.4.1"
-    web-vitals "^2.1.2"
+    tslib "^2.5.3"
+    web-vitals "^3.3.2"
     wolfy87-eventemitter "^5.2.9"
 
 "@guardian/consent-management-platform@^13.0.2":
@@ -1593,6 +1598,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-4.0.0.tgz#e09bf40ee896ae92c0223fa57399b1b0b5f9bdb2"
   integrity sha512-LDXnDhsNApO9v8LrXPK1AHMZYoa457tYjqjHnXNSxleHHoyeS3ehB4qohdDMpWv76F8DLUVMXBTZ/8EbQce3sA==
+
+"@guardian/core-web-vitals@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-5.0.0.tgz#ab74da6001427f3414a84d15f57bac1a888a140a"
+  integrity sha512-Mq3v8Y/YJGs7p/8NWmYHFKdVqRThjDJSfpoo1zSb6DgpQ1Ko8RjvOa2Q9P9ABWfKJCaDp0kcGK3dk0AjDSi/Qw==
 
 "@guardian/eslint-config-typescript@^0.7.0":
   version "0.7.0"
@@ -1623,6 +1633,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.0.0.tgz#07022b652430a1c5d6b16f8aa105ae3d73da4e7c"
   integrity sha512-rB4h4FlD3EcoCY66f3xjO7alnXiimPOynL9znvX/xP2nAVpG4UyedJnIpupw4KPqJuB0lZMih6EeXq0a1XnI3w==
 
+"@guardian/libs@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.0.0.tgz#c3fbb1d7fdafaefe156232b7088f43e2ff4cd18b"
+  integrity sha512-UnNxcJHYDfpElrxc7sbfwSJ82erH3mjdKsALAgevggsbhOSAkE9yoCn+XMBPN7iQ14bEHZPYyOMt0y1hNCItyg==
+
 "@guardian/prettier@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-3.0.0.tgz#7a313372b7e6919298999dc801a23f5b69f008f0"
@@ -1635,10 +1650,17 @@
   dependencies:
     tslib "^2.0.0"
 
-"@guardian/source-foundations@^10.0.0", "@guardian/source-foundations@^10.0.1":
+"@guardian/source-foundations@^10.0.0":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-10.0.1.tgz#fe9d5d1bee9dd1b0d3d579d21a99f6051aa47649"
   integrity sha512-q7FHvQO2JN463SHRjLNKeywW8KUfjoao6oiULoyHssI07saol2rE0W8BdPCeD9337FNztiOxMGOmXWSBUIdYJw==
+  dependencies:
+    mini-svg-data-uri "1.4.4"
+
+"@guardian/source-foundations@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-12.0.0.tgz#3f75d5dd26dae0d3fe13fd93aabe1e837cf0ddbb"
+  integrity sha512-sq+htAsvPlaZBjfSZ8ISZZdAnFQwuZ7xeCrI/C369HA+MDl3pQ1dFWz3YmqCP/vkXS8Wr3qVlxXNqWGwKKrYrw==
   dependencies:
     mini-svg-data-uri "1.4.4"
 
@@ -12748,6 +12770,11 @@ tslib@^2.0.0, tslib@^2.4.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
+tslib@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
+
 tsml@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tsml/-/tsml-1.0.1.tgz#89f8218b9d9e257f47d7f6b56d01c5a4d2c68fc3"
@@ -13275,15 +13302,15 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-vitals@^2.1.2:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.4.tgz#76563175a475a5e835264d373704f9dde718290c"
-  integrity sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==
-
 web-vitals@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-3.3.1.tgz#f80e4fd01784476c023c8b2c4219075bbe96f64d"
   integrity sha512-LTfY5GjcY3ngFzNsYFSYL+AmVmlWrzPTUxSMDis2rZbf+SzT7HH3NH4Y/l45XOlrAIunOBeURN9qtBHkRskAiA==
+
+web-vitals@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-3.3.2.tgz#83e8dbd0f8fba43c5fe2e601573e804afc771790"
+  integrity sha512-qRkpmSeKfEWAzNhtX541xA8gCJ+pqCqBmUlDVkVDSCSYUvfvNqF+k9g8I+uyreRcDBdfiJrd0/aLbTy5ydo49Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/commercial` to `9.3.0`.

## Why

See [the changelog](https://github.com/guardian/commercial/releases/tag/v9.3.0).
