### PR TITLE
Bump commercial and update webpack path for commercial

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial": "9.3.0",
+		"@guardian/commercial": "10.0.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -8,6 +8,7 @@ module.exports = webpackMerge.smart(config, {
     output: {
         filename: `graun.[name].js`,
         chunkFilename: `graun.[name].js`,
+        clean: true,
     },
     plugins: [
         // Copy the commercial bundle dist to Frontend's static output location:
@@ -16,8 +17,8 @@ module.exports = webpackMerge.smart(config, {
         new CopyPlugin({
             patterns: [
               {
-                  from: "node_modules/@guardian/commercial/dist/bundle",
-                  to: "commercial/[name].[ext]"
+                  from: "node_modules/@guardian/commercial/dist/bundle/dev",
+                  to: "commercial"
               },
             ],
         }),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -12,6 +12,7 @@ module.exports = webpackMerge.smart(config, {
 	output: {
 		filename: `[chunkhash]/graun.[name].js`,
 		chunkFilename: `[chunkhash]/graun.[name].js`,
+        clean: true,
 	},
 	devtool: 'source-map',
 	plugins: [
@@ -20,7 +21,7 @@ module.exports = webpackMerge.smart(config, {
 		new CopyPlugin({
 			patterns: [
 				{
-					from: 'node_modules/@guardian/commercial/dist/bundle',
+					from: 'node_modules/@guardian/commercial/dist/bundle/prod',
 					to: 'commercial',
 				},
 			],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial@9.3.0":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-9.3.0.tgz#34068ff451d53b06e7d4a551d9d539b94aef5cf7"
-  integrity sha512-OwYq3omttgGm8sUPQDo7liHvnEsle174XEyU5XhpVy9OaUGtI/7LLL5XNhmSByp+TSUy369N126oCoI3jNPUcw==
+"@guardian/commercial@10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.0.0.tgz#5969ed132d31c0fb14f5dd8b2399083372499a16"
+  integrity sha512-ymKxtAuKmYJDKIbHPMpSHmjM1xATn9cq/t6g3G5GPPg4/f71g2H31elIfalPo9pes9dhgpXTyH+TzryF551F1w==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"
@@ -10516,7 +10516,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js#2e3b96d:
+"prebid.js@github:guardian/prebid.js#2e3b96d":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10516,7 +10516,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-"prebid.js@github:guardian/prebid.js#2e3b96d":
+prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?
The paths to the dev/prod commercial bundles have changed in 10.0.0 (https://github.com/guardian/commercial/pull/903)

Update webpack config to use the new paths.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
