### PR TITLE
Helps with adding Prout to DCR

### DIFF
--- a/admin/app/controllers/admin/DeploysController.scala
+++ b/admin/app/controllers/admin/DeploysController.scala
@@ -6,15 +6,25 @@ import model.NoCache
 import model.deploys.{ApiResults, RiffRaffService, _}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
+import renderers.DotcomRenderingService
 
 trait DeploysController extends BaseController with GuLogging with Requests with ImplicitControllerExecutionContext {
 
   val riffRaff: RiffRaffService
+  val remoteRenderer: DotcomRenderingService = DotcomRenderingService()
+  val ws: WSClient
 
   def getDeploys(stage: Option[String], pageSize: Option[Int] = None): Action[AnyContent] =
     Action.async {
       riffRaff.getRiffRaffDeploys(Some("dotcom:all"), stage, pageSize, Some("Completed")).map(ApiResults(_))
     }
+
+  def getDCRProut()
+  Action.async { implicit request =>
+    {
+      remoteRenderer.getProut(ws)(request)
+    }
+  }
 
   def deploy(stage: String, build: Int): Action[AnyContent] =
     Action {

--- a/admin/app/http/AdminFilters.scala
+++ b/admin/app/http/AdminFilters.scala
@@ -18,6 +18,7 @@ class AdminFilters(httpConfiguration: HttpConfiguration)(implicit
   val filterExemptions = FilterExemptions(
     "/deploys", //not authenticated so it can be accessed by Prout to determine which builds have been deployed
     "/deploy", //not authenticated so it can be accessed by Riff-Raff to notify about a new build being deployed
+    "/prout-dcr", //not authenticated so it can be accessed by Prout to determine which builds have been deployed in DCR
   )
   val adminAuthFilter = new AuthFilterWithExemptions(filterExemptions.loginExemption, filterExemptions.exemptions)(
     mat,

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -111,6 +111,7 @@ GET         /metrics/webpack-bundle-analyzer                                    
 # Used by Prout to know which builds/commits have been deployed in PROD
 GET         /deploys                                                                                controllers.admin.DeploysController.getDeploys(stage: Option[String], pageSize: Option[Int])
 POST        /deploy                                                                                 controllers.admin.DeploysController.deploy(stage: String, build: Int)
+GET         /prout-dcr                                                                                controllers.admin.DeploysController.getDCRProut()
 
 # Redirects
 GET         /redirects                                                                              controllers.admin.RedirectController.redirect()


### PR DESCRIPTION
Co-authored by: Olly Namey <olly.namey@theguardian.com>

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
