### PR TITLE
Include json in path when internally redirecting to applications

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -50,7 +50,10 @@ trait FaciaController
   implicit val context: ApplicationContext
 
   def applicationsRedirect(path: String)(implicit request: RequestHeader): Future[Result] = {
-    successful(InternalRedirect.internalRedirect("applications", path, request.rawQueryStringOption.map("?" + _)))
+    val redirectPath = if (request.isJson) s"$path.json" else path
+    successful(
+      InternalRedirect.internalRedirect("applications", redirectPath, request.rawQueryStringOption.map("?" + _)),
+    )
   }
 
   def rssRedirect(path: String)(implicit request: RequestHeader): Future[Result] = {


### PR DESCRIPTION
## What does this change?

Currently, trying to access the DCR JSON version of a tag front, (e.g https://www.theguardian.com/profile/josh-halliday.json?dcr), you will get a 500.

Despite this, if I was to run `main` locally, start up the `applications` app & make the same request, it would work fine. So what's going wrong?

<details>
  <summary>**Internal Redirects**</summary>
  
Frontend is powered by `router` - an application (outside this repo) that is responsible for looking at any incoming request to www.theguardian.com & picking a frontend server to send the request to. 

The problem? Some requests are just impossible to predict with the path alone - to solve this, we make a best guess at the router level, and when a request comes into an app in Frontend and it determines it doesn't have content for the given path, it can chose to run an 'internal redirect' to another application.
</details>

Internal redirects are required for tag fronts - a request will first go to the `facia` app, and when it discovers it doesn't have a pressed front for the path, it will be sent on to `applications`. 

If we look at the logs for our request to the tag front mentioned above, we see an issue:
<img width="920" alt="image" src="https://github.com/guardian/frontend/assets/9575458/bb9682fd-778e-4506-a453-c8402798ee74">


The `.json` suffix is stripped in our internal redirect, likely because the `path` parameter we receive from play does not include it. We can see why this happens in our `routes` file:

<img width="1408" alt="image" src="https://github.com/guardian/frontend/assets/9575458/681f066f-13ea-4b52-bb88-4ca063646f4b">

Therefor, the `applications` app receives a request for `/josh-halliday?dcr` which currently fails, as the DCR endpoint does not yet exist.

This PR should resolve this issue by adding back in the `.json` to the path given to the internal redirect - though it should be noted this issue is likely more widely spread, and it could be worth looking at a fix within the `InternalRedirect` class itself. I didn't for this PR since I don't have a good understand of where else this might have an impact.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [x] On CODE 
<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
