### PR TITLE
Australia state switcher/picker supported in DCR

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -123,19 +123,6 @@ object FrontChecks {
     !faciaPage.isPaid(Edition(request));
   }
 
-  def hasNoRegionalAusTargetedContainers(faciaPage: PressedPage): Boolean = {
-    // We don't support the Aus region selector component
-    // https://github.com/guardian/dotcom-rendering/issues/6234
-    !faciaPage.collections.exists(collection =>
-      collection.targetedTerritory.exists(_.id match {
-        case "AU-VIC" => true
-        case "AU-QLD" => true
-        case "AU-NSW" => true
-        case _        => false
-      }),
-    )
-  }
-
   def hasNoUnsupportedSnapLinkCards(faciaPage: PressedPage): Boolean = {
     def containsUnsupportedSnapLink(collection: PressedCollection) = {
       collection.curated.exists(card =>
@@ -175,7 +162,6 @@ object FaciaPicker extends GuLogging {
       ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
       ("isNotPaidFront", FrontChecks.isNotPaidFront(faciaPage)),
-      ("hasNoRegionalAusTargetedContainers", FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage)),
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
       ("hasNoDynamicPackage", FrontChecks.hasNoDynamicPackage(faciaPage)),
       ("hasNoFixedVideo", FrontChecks.hasNoFixedVideo(faciaPage)),

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -89,16 +89,6 @@ import org.scalatestplus.mockito.MockitoSugar
     tier should be(LocalRender)
   }
 
-  "Facia Picker hasNoRegionalAusTargetedContainers" should "return false if there is a container with targetedTerritory set to an AU region" in {
-    val unsupportedPressedCollection =
-      List(
-        PressedCollectionBuilder.mkPressedCollection(targetedTerritory = Some(AUQueenslandTerritory)),
-      )
-
-    val faciaPage = FixtureBuilder.mkPressedPage(unsupportedPressedCollection)
-    FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage) should be(false)
-  }
-
   val linkSnap = FixtureBuilder.mkPressedLinkSnap(1).asInstanceOf[LinkSnap]
   val supportedThrasher = PressedCollectionBuilder.mkPressedCollection(curated =
     List(


### PR DESCRIPTION

## What does this change?

Allow containers targetting territories to be rendered by DCR, which are used on the [Australian network](https://www.theguardian.com/au#new-south-wales).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/7984

## Screenshots

| Before (frontend)| After (DCR)|
|------------------|------------|
| ![before][]      | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/7d371249-0584-4f3f-96d3-06dcd4d52d07
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/b5991372-f4d5-4453-9d25-9235f767c596

## What is the value of this and can you measure success?

This feature is supported in dotcom-rendering Fronts and therefore should not longer be a deciding factor in which rendering tier should be used.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
