### PR TITLE
Support more thrashers

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -65,20 +65,8 @@ object FrontChecks {
 
   val UNSUPPORTED_THRASHERS: Set[String] =
     Set(
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/12/wordiply/default",
       "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/04/australian-election/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/07/full-story/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/10/saved-for-later/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/12/documentaries-signup-thrasher/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/12/100-best-footballers/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/01/football-weekly-thrasher/thrasher",
       "https://content.guardianapis.com/atom/interactive/interactives/2022/11/20/football-interactive-atom/knockout-full",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/07/pegasus/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/07/lakeside/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/07/support-guardian-thrasher/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/02/pw-uk/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/11/comfort-eating-grace-dent-thrasher-no-logo/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/02/weekend-podcast-2022/default",
     )
 
   def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {


### PR DESCRIPTION
## What does this change?

Supports more thrashers:

| Thrasher | Front |
|----------|-------|
| 2022/12/wordiply/default | all network fronts + `/lifeandstyle` |
| 2022/12/documentaries-signup-thrasher/default | `/documentaries` |
| 2022/12/pw-uk/default | `/politics` |
| 2022/11/comfort-eating-grace-dent-thrasher-no-logo/default | `/lifeandstyle` |
| 2022/02/weekend-podcast-2022/default | `/lifeandstyle` |
| 2021/10/saved-for-later/default | `/culture/series/saved-for-later` |
| 2021/07/full-story/default | `/australia-podcasts` |
| 2021/12/100-best-footballers/default | `/football` |
| 2021/01/football-weekly-thrasher/thrasher | `/football` |
| 2021/07/pegasus/default | `/news/series/pegasus-project` |
| 2022/07/lakeside/default | `/news/series/uber-files` |
| 2022/07/support-guardian-thrasher/default | `/news/series/uber-files` |


We won't render `/documentaries` and `/australia-podcasts` yet even though we are now supporting these thrashers because they also contain `json.html` thrashers which we don't support. Check [here](https://docs.google.com/spreadsheets/d/14TluXezib-u1lhBRkMav4mjW3PNnlkMW_rmqdqKcP8E/edit#gid=2012745450) to track progress on the `json.html` thrashers.

