### PR TITLE
Rename `topnav` to `topbar`

### DIFF
--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -118,7 +118,7 @@
 
                     <input type="checkbox" id="edition-picker-toggle" aria-controls="edition-dropdown-menu"
                         class="u-h dropdown-menu-fallback js-enhance-checkbox"
-                        data-link-name="nav2 : topbar : edition-picker: toggle" tabindex="-1">
+                        data-link-name="nav3 : topbar : edition-picker: toggle" tabindex="-1">
 
                     <ul class="dropdown-menu js-edition-dropdown-menu" id="edition-dropdown-menu" aria-hidden="true">
 
@@ -128,7 +128,7 @@
                     </ul>
 
                     <label for="edition-picker-toggle" class="top-bar__item popup__toggle js-edition-picker-trigger"
-                        data-link-name="nav2 : topnav : edition-picker: toggle"
+                        data-link-name="nav3 : topbar : edition-picker: toggle"
                         data-display-name="@Edition(request).displayName" tabindex="0">
 
                         <span class="u-h">current edition: </span>

--- a/common/app/views/fragments/nav/editionPickerDropdown.scala.html
+++ b/common/app/views/fragments/nav/editionPickerDropdown.scala.html
@@ -35,7 +35,7 @@
 
     <label for="edition-picker-toggle"
             class="top-bar__item popup__toggle js-edition-picker-trigger"
-            data-link-name="nav3 : topnav : edition-picker: toggle"
+            data-link-name="nav3 : topbar : edition-picker: toggle"
             data-display-name="@Edition(request).displayName"
             tabindex="0">
 


### PR DESCRIPTION
## What does this change?
Edition Picker Dropdown was introduced in https://github.com/guardian/frontend/pull/17996
The [button's `data-link-name`](https://github.com/guardian/frontend/blob/main/common/app/views/fragments/nav/editionPickerDropdown.scala.html#L24) is `nav3 : topbar : edition-picker: toggle`. This PR is to make the label consistent with the button.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
