### PR TITLE
Include overlay changes

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -89,7 +89,7 @@
                         <div class='gs-container'>
                             <div class='content__main-column'>
                                 <button class='youtube-media-atom__immersive-interface' style="border: none;">
-                                    <div class="youtube-media-atom__play-button vjs-control-text centred-button">
+                                    <div class="youtube-media-atom__play-button vjs-control-text">
                                         Play Video
                                         @fragments.inlineSvg("play", "icon")
                                     </div>

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -89,7 +89,7 @@
                         <div class='gs-container'>
                             <div class='content__main-column'>
                                 <button class='youtube-media-atom__immersive-interface' style="border: none;">
-                                    <div class="youtube-media-atom__play-button vjs-control-text">
+                                    <div class="youtube-media-atom__play-button vjs-control-text centred-button">
                                         Play Video
                                         @fragments.inlineSvg("play", "icon")
                                     </div>

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -32,6 +32,9 @@
                 }
             </video>
             @if(showOverlay){
+            <span class="video-overlay__duration">
+                @player.video.videos.formattedDuration
+            </span>
             <div class="video-overlay">
                 @seriesTag.map { series =>
                     <div class="video-overlay__series-label">
@@ -50,9 +53,6 @@
                         <h1 class="video-overlay__title">@player.title</h1>
                     }
                 </div>
-                <span class="video-overlay__duration">
-                    @player.video.videos.formattedDuration
-                </span>
             </div>
             }
         </div>

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -33,15 +33,6 @@
     }
 }
 
-.video-playlist__item .youtube-media-atom iframe,
-.video-playlist__item .youtube-media-atom .vjs-big-play-button {
-    @include mq($until: desktop) {
-        top: gs-height(3) - (get-line-height(textSans, 3) + 4px);
-        bottom: 0;
-        height: auto;
-    }
-}
-
 .video-playlist__item--active .youtube-media-atom {
     opacity: 1;
 }
@@ -130,6 +121,14 @@
     @include hide;
 }
 
+.video-playlist__item .youtube-media-atom__iframe.youtube__video-started ~ .video-overlay {
+    @include hide;
+}
+
+.video-playlist__item .youtube-media-atom__iframe.youtube__video-started ~ .video-overlay__duration {
+    @include hide;
+}
+
 .youtube-media-atom__iframe.youtube__video-started:not(.youtube__video-ended) ~ .youtube-media-atom__overlay {
     @include fade-out;
     transition-delay: 500ms;
@@ -182,6 +181,13 @@ youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.yout
 
 .no-player .youtube-media-atom__play-button.vjs-control-text {
     transition: none;
+}
+
+.youtube-media-atom__play-button.vjs-control-text.centered-button {
+    bottom: 44%;
+    left: 40%;
+    background-color: rgba(18, 18, 18, .6);
+    z-index: 3;
 }
 
 

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -183,13 +183,6 @@ youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.yout
     transition: none;
 }
 
-.youtube-media-atom__play-button.vjs-control-text.centered-button {
-    bottom: 44%;
-    left: 40%;
-    background-color: rgba(18, 18, 18, .6);
-    z-index: 3;
-}
-
 
 .youtube-media-atom__bottom-bar__duration {
     @include font($f-sans-serif-text, bold, 13, 16);

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -257,7 +257,7 @@ $video-width-desktop: 700px;
     position: relative;
     display: inline-block;
     vertical-align: top;
-    width: 70%;
+    width: 90%;
     background-color: $brightness-7;
     margin-left: $gs-gutter / 2;
     margin-bottom: $gs-baseline;
@@ -400,26 +400,22 @@ $video-width-desktop: 700px;
 }
 
 .video-overlay {
-    position: relative;
+    position: absolute;
     z-index: 2;
     white-space: normal;
-    padding: 0 $gs-gutter/4 $gs-baseline * 2;
+    padding: 2.5rem $gs-gutter/4 $gs-baseline * 2;
+    padding-top: 0;
+    padding-bottom: 0;
     box-sizing: border-box;
-    border-top: 1px solid $highlight-main;
     color: #ffffff;
-    background-color: rgba(0, 0, 0, .9);
-    min-height: gs-height(3);
-    margin-bottom: -(get-line-height(textSans, 3) + 4px);
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, .7) 25%);
     pointer-events: auto;
+    width: 100%;
+    bottom: 0;
+
     @include mq(desktop, leftCol) {
         opacity: 0;
         transition: opacity .4s ease-out;
-    }
-    @include mq(desktop) {
-        position: absolute;
-        top: $gs-baseline;
-        left: $gs-gutter;
-        width: gs-span(3);
     }
 
     .video-playlist__item .vjs-playing ~ & {
@@ -432,6 +428,7 @@ $video-width-desktop: 700px;
     .video-overlay__headline {
         @include fs-headline(2);
         font-weight: 400;
+        padding-bottom: 0;
         @include mq(mobileLandscape) {
             @include fs-headline(3);
             font-weight: 400;

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -233,6 +233,8 @@ $video-width-desktop: 700px;
 
 .video-playlist__icon {
     position: absolute;
+    top: 0;
+    bottom: 0;
     width: 30px;
     height: 30px;
     margin: auto;


### PR DESCRIPTION
## What does this change?
This cherrypicks the overlay changes from https://github.com/guardian/frontend/pull/26193. Initially we wanted the videos to play on small screens, but now it just updates the video overlay.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)
- https://github.com/guardian/dotcom-rendering/pull/7972

## Screenshots


| Before      | After      |
|-------------|------------|
| <img width="718" alt="image" src="https://github.com/guardian/frontend/assets/26366706/6768af5e-e995-4112-ba1a-1147d623848f"> | ![image](https://github.com/guardian/frontend/assets/26366706/ca10310a-807a-4826-84f6-902b91299e4d) |

