### PR TITLE
Remove football-interactive-atom from FaciaPicker

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -62,7 +62,6 @@ object FrontChecks {
   val UNSUPPORTED_THRASHERS: Set[String] =
     Set(
       "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/04/australian-election/default",
-      "https://content.guardianapis.com/atom/interactive/interactives/2022/11/20/football-interactive-atom/knockout-full",
     )
 
   def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {


### PR DESCRIPTION
## What does this change?

Removes `football-interactive-atom/knockout-full` from FaciaPicker.

As this competition is no longer running I've manually edited the CSS & JS of this thrasher to get it working correctly in DCR.

## Screenshots

<img width="1307" alt="image" src="https://github.com/guardian/frontend/assets/21217225/896d2c15-ef82-457c-8069-6890d2b54337">

