### PR TITLE
Support gradual rollout for Network Fronts based on test percentage

### DIFF
--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -38,10 +38,20 @@ import org.scalatestplus.mockito.MockitoSugar
     val isRSS = false
     val forceDCROff = true
     val forceDCR = false
-    val participatingInTest = true
+    val dcrSwitchEnabled = true
     val dcrCouldRender = true
+    val isNetworkFront = false
+    val isInNetworkFrontTest = false
 
-    val tier = FaciaPicker.decideTier(isRSS, forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(
+      isRSS,
+      forceDCROff,
+      forceDCR,
+      dcrSwitchEnabled,
+      dcrCouldRender,
+      isNetworkFront,
+      isInNetworkFrontTest,
+    )
     tier should be(LocalRender)
   }
 
@@ -51,8 +61,18 @@ import org.scalatestplus.mockito.MockitoSugar
     val forceDCR = true
     val dcrSwitchEnabled = false
     val dcrCouldRender = false
+    val isNetworkFront = false
+    val isInNetworkFrontTest = false
 
-    val tier = FaciaPicker.decideTier(isRSS, forceDCROff, forceDCR, dcrSwitchEnabled, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(
+      isRSS,
+      forceDCROff,
+      forceDCR,
+      dcrSwitchEnabled,
+      dcrCouldRender,
+      isNetworkFront,
+      isInNetworkFrontTest,
+    )
     tier should be(RemoteRender)
   }
 
@@ -62,8 +82,18 @@ import org.scalatestplus.mockito.MockitoSugar
     val forceDCR = false
     val dcrSwitchEnabled = false
     val dcrCouldRender = true
+    val isNetworkFront = false
+    val isInNetworkFrontTest = false
 
-    val tier = FaciaPicker.decideTier(isRSS, forceDCROff, forceDCR, dcrSwitchEnabled, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(
+      isRSS,
+      forceDCROff,
+      forceDCR,
+      dcrSwitchEnabled,
+      dcrCouldRender,
+      isNetworkFront,
+      isInNetworkFrontTest,
+    )
     tier should be(LocalRender)
   }
 
@@ -73,8 +103,18 @@ import org.scalatestplus.mockito.MockitoSugar
     val forceDCR = false
     val dcrSwitchEnabled = true
     val dcrCouldRender = true
+    val isNetworkFront = false
+    val isInNetworkFrontTest = false
 
-    val tier = FaciaPicker.decideTier(isRSS, forceDCROff, forceDCR, dcrSwitchEnabled, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(
+      isRSS,
+      forceDCROff,
+      forceDCR,
+      dcrSwitchEnabled,
+      dcrCouldRender,
+      isNetworkFront,
+      isInNetworkFrontTest,
+    )
     tier should be(RemoteRender)
   }
 
@@ -82,11 +122,63 @@ import org.scalatestplus.mockito.MockitoSugar
     val isRSS = true
     val forceDCROff = false
     val forceDCR = false
-    val participatingInTest = true
+    val dcrSwitchEnabled = true
     val dcrCouldRender = true
+    val isNetworkFront = false
+    val isInNetworkFrontTest = false
 
-    val tier = FaciaPicker.decideTier(isRSS, forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(
+      isRSS,
+      forceDCROff,
+      forceDCR,
+      dcrSwitchEnabled,
+      dcrCouldRender,
+      isNetworkFront,
+      isInNetworkFrontTest,
+    )
     tier should be(LocalRender)
+  }
+
+  it should "return LocalRender if a Network front is not in the test" in {
+    val isRSS = false
+    val forceDCROff = false
+    val forceDCR = false
+    val dcrSwitchEnabled = true
+    val dcrCouldRender = true
+    val isNetworkFront = true
+    val isInNetworkFrontTest = false
+
+    val tier = FaciaPicker.decideTier(
+      isRSS,
+      forceDCROff,
+      forceDCR,
+      dcrSwitchEnabled,
+      dcrCouldRender,
+      isNetworkFront,
+      isInNetworkFrontTest,
+    )
+    tier should be(LocalRender)
+  }
+
+  it should "return RemoteRender if a Network front is in the test" in {
+    val isRSS = false
+    val forceDCROff = false
+    val forceDCR = false
+    val dcrSwitchEnabled = true
+    val dcrCouldRender = true
+    val isNetworkFront = true
+    val isInNetworkFrontTest = true
+
+    val tier = FaciaPicker.decideTier(
+      isRSS,
+      forceDCROff,
+      forceDCR,
+      dcrSwitchEnabled,
+      dcrCouldRender,
+      isNetworkFront,
+      isInNetworkFrontTest,
+    )
+    tier should be(RemoteRender)
   }
 
   val linkSnap = FixtureBuilder.mkPressedLinkSnap(1).asInstanceOf[LinkSnap]


### PR DESCRIPTION
## What does this change?

Fixes: https://github.com/guardian/dotcom-rendering/issues/7481
Implements a rollout strategy for network fronts, even if they have can be rendered by DCR (`dcrCanRender`) so we can monitor impact.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No (but we need to squash bugs 🐛)
- [ ] Yes 

## Screenshots

N/A

## What is the value of this and can you measure success?

Part of https://github.com/guardian/dotcom-rendering/issues/7481

If there is anything that we thought we supported in DCR but in fact did not, this should help smooth things out.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

N/A

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
