### PR TITLE
Network fronts are supported

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -43,13 +43,6 @@ object FrontChecks {
     !faciaPage.metadata.hasPageSkin(request)
   }
 
-  def isNotPaidFront(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
-    // We don't support paid fronts
-    // See: https://github.com/guardian/dotcom-rendering/issues/5945
-
-    !faciaPage.isPaid(Edition(request));
-  }
-
   def hasNoUnsupportedSnapLinkCards(faciaPage: PressedPage): Boolean = {
     def containsUnsupportedSnapLink(collection: PressedCollection) = {
       collection.curated.exists(card =>
@@ -78,7 +71,6 @@ object FaciaPicker extends GuLogging {
     Map(
       ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
-      ("isNotPaidFront", FrontChecks.isNotPaidFront(faciaPage)),
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
     )
   }

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -9,8 +9,12 @@ import model.pressed.LinkSnap
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 import experiments.{ActiveExperiments, DCRNetworkFronts}
+import layout.slices.EmailLayouts
 
 object FrontChecks {
+
+  def hasNoEmailCollections(faciaPage: PressedPage) =
+    !faciaPage.collections.exists(collection => EmailLayouts.all.contains(collection.collectionType))
 
   /*
    * This list contains JSON.HTML thrashers that DCR allows. These thrashers should not actually be rendered by DCR
@@ -58,6 +62,7 @@ object FaciaPicker extends GuLogging {
   def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
     Map(
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
+      ("hasNoEmailCollections", FrontChecks.hasNoEmailCollections(faciaPage)),
     )
   }
 

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -96,10 +96,13 @@ object FaciaPicker extends GuLogging {
     if (isRss) LocalRender
     else if (forceDCROff) LocalRender
     else if (forceDCR) RemoteRender
-    else if (isNetworkFront)
-      if (dcrCouldRender && isInNetworkFrontTest) RemoteRender else LocalRender
-    else if (dcrCouldRender && dcrSwitchEnabled) RemoteRender
-    else LocalRender
+    else if (dcrCouldRender && dcrSwitchEnabled) {
+      isNetworkFront match {
+        case false                        => RemoteRender
+        case true if isInNetworkFrontTest => RemoteRender
+        case _                            => LocalRender
+      }
+    } else LocalRender
   }
 
   private def logTier(

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -13,14 +13,14 @@ import experiments.{ActiveExperiments, DCRNetworkFronts}
 object FrontChecks {
 
   /*
-   * This list contains JSON.HTML thrashers that DCR Supports. These thrashers should not actually be rendered by DCR
+   * This list contains JSON.HTML thrashers that DCR allows. These thrashers should not actually be rendered by DCR
    * but instead have an alternate way of being rendered on DCR.
    *
    * Right now this is limited to just treats as we now configure treats in DCR instead of relying on a thrasher.
    *
    * In theory once 100% of the page views for these fronts are rendered by DCR then the thrashers can be deleted.
    */
-  val SUPPORTED_JSON_HTML_THRASHERS: Set[String] =
+  val ALLOWED_JSON_HTML_THRASHERS: Set[String] =
     Set(
       "https://interactive.guim.co.uk/thrashers/qatar-beyond-the-football/source.json",
       "https://interactive.guim.co.uk/thrashers/newsletters-2020-election-nugget/source.json",
@@ -58,7 +58,7 @@ object FrontChecks {
           case card: LinkSnap if card.properties.embedType.contains("interactive") =>
             card.properties.embedUri.exists(UNSUPPORTED_THRASHERS.contains)
           case card: LinkSnap if card.properties.embedType.contains("json.html") =>
-            card.properties.embedUri.exists(uri => !SUPPORTED_JSON_HTML_THRASHERS.contains(uri))
+            card.properties.embedUri.exists(uri => !ALLOWED_JSON_HTML_THRASHERS.contains(uri))
           // Because embedType is typed as Option[String] it's hard to know whether we've
           // identified all possible embedTypes. If it's an unidentified embedType then
           // assume we can't render it.

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -37,12 +37,6 @@ object FrontChecks {
     !Commercial.isAdFree(request)
   }
 
-  def hasNoPageSkin(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
-    // We don't support page skin ads
-    // See: https://github.com/guardian/dotcom-rendering/issues/5490
-    !faciaPage.metadata.hasPageSkin(request)
-  }
-
   def hasNoUnsupportedSnapLinkCards(faciaPage: PressedPage): Boolean = {
     def containsUnsupportedSnapLink(collection: PressedCollection) = {
       collection.curated.exists(card =>
@@ -70,7 +64,6 @@ object FaciaPicker extends GuLogging {
   def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
     Map(
       ("isNotAdFree", FrontChecks.isNotAdFree()),
-      ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
     )
   }

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -31,11 +31,6 @@ object FrontChecks {
       "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/04/australian-election/default",
     )
 
-  /** See: https://github.com/guardian/dotcom-rendering/issues/6378 */
-  def hasNoWeatherWidget(faciaPage: PressedPage): Boolean = {
-    !faciaPage.isNetworkFront
-  }
-
   def isNotAdFree()(implicit request: RequestHeader): Boolean = {
     // We don't support the signed in experience
     // See: https://github.com/guardian/dotcom-rendering/issues/5926
@@ -85,7 +80,6 @@ object FaciaPicker extends GuLogging {
 
   def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
     Map(
-      ("hasNoWeatherWidget", FrontChecks.hasNoWeatherWidget(faciaPage)),
       ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
       ("isNotPaidFront", FrontChecks.isNotPaidFront(faciaPage)),

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -70,10 +70,6 @@ object FrontChecks {
     !faciaPage.collections.exists(collection => containsUnsupportedSnapLink(collection))
   }
 
-  def hasNoDynamicPackage(faciaPage: PressedPage): Boolean = {
-    !faciaPage.collections.map(_.collectionType).contains("dynamic/package")
-  }
-
 }
 
 object FaciaPicker extends GuLogging {

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -20,11 +20,7 @@ object FrontChecks {
       // We partly support thrashers. They will be fully supported after this is completed: https://github.com/guardian/dotcom-rendering/issues/7319
       "fixed/thrasher",
       "dynamic/package",
-      /*
-      "fixed/video"
-      pending https://github.com/guardian/dotcom-rendering/issues/5149
-       */
-
+      "fixed/video",
       "dynamic/slow-mpu",
       "fixed/small/slow-V-mpu",
       "fixed/medium/slow-XII-mpu",
@@ -117,10 +113,6 @@ object FrontChecks {
     !faciaPage.collections.map(_.collectionType).contains("dynamic/package")
   }
 
-  def hasNoFixedVideo(faciaPage: PressedPage): Boolean = {
-    !faciaPage.collections.map(_.collectionType).contains("fixed/video")
-  }
-
 }
 
 object FaciaPicker extends GuLogging {
@@ -133,7 +125,6 @@ object FaciaPicker extends GuLogging {
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
       ("isNotPaidFront", FrontChecks.isNotPaidFront(faciaPage)),
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
-      ("hasNoFixedVideo", FrontChecks.hasNoFixedVideo(faciaPage)),
     )
   }
 

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -31,12 +31,6 @@ object FrontChecks {
       "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/04/australian-election/default",
     )
 
-  def isNotAdFree()(implicit request: RequestHeader): Boolean = {
-    // We don't support the signed in experience
-    // See: https://github.com/guardian/dotcom-rendering/issues/5926
-    !Commercial.isAdFree(request)
-  }
-
   def hasNoUnsupportedSnapLinkCards(faciaPage: PressedPage): Boolean = {
     def containsUnsupportedSnapLink(collection: PressedCollection) = {
       collection.curated.exists(card =>
@@ -63,7 +57,6 @@ object FaciaPicker extends GuLogging {
 
   def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
     Map(
-      ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
     )
   }

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -12,36 +12,6 @@ import experiments.{ActiveExperiments, DCRNetworkFronts}
 
 object FrontChecks {
 
-  // To check which collections are supported by DCR and update this set please check:
-  // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/lib/DecideContainer.tsx
-  // and https://github.com/guardian/dotcom-rendering/issues/4720
-  val SUPPORTED_COLLECTIONS: Set[String] =
-    Set(
-      // We partly support thrashers. They will be fully supported after this is completed: https://github.com/guardian/dotcom-rendering/issues/7319
-      "fixed/thrasher",
-      "dynamic/package",
-      "fixed/video",
-      "dynamic/slow-mpu",
-      "fixed/small/slow-V-mpu",
-      "fixed/medium/slow-XII-mpu",
-      "dynamic/slow",
-      "dynamic/fast",
-      "fixed/small/slow-I",
-      "fixed/small/slow-III",
-      "fixed/small/slow-IV",
-      "fixed/small/slow-V-third",
-      "fixed/small/slow-V-half",
-      "fixed/small/fast-VIII",
-      "fixed/medium/slow-VI",
-      "fixed/medium/slow-VII",
-      "fixed/medium/fast-XII",
-      "fixed/medium/fast-XI",
-      "fixed/large/slow-XIV",
-      "nav/list",
-      "nav/media-list",
-      "news/most-popular",
-    )
-
   /*
    * This list contains JSON.HTML thrashers that DCR Supports. These thrashers should not actually be rendered by DCR
    * but instead have an alternate way of being rendered on DCR.
@@ -60,10 +30,6 @@ object FrontChecks {
     Set(
       "https://content.guardianapis.com/atom/interactive/interactives/thrashers/2022/04/australian-election/default",
     )
-
-  def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {
-    faciaPage.collections.forall(collection => SUPPORTED_COLLECTIONS.contains(collection.collectionType))
-  }
 
   /** See: https://github.com/guardian/dotcom-rendering/issues/6378 */
   def hasNoWeatherWidget(faciaPage: PressedPage): Boolean = {
@@ -119,7 +85,6 @@ object FaciaPicker extends GuLogging {
 
   def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
     Map(
-      ("allCollectionsAreSupported", FrontChecks.allCollectionsAreSupported(faciaPage)),
       ("hasNoWeatherWidget", FrontChecks.hasNoWeatherWidget(faciaPage)),
       ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -157,6 +157,27 @@ import org.scalatestplus.mockito.MockitoSugar
     tier should be(RemoteRender)
   }
 
+  it should "return LocalRender for a Network front is the switch is off even if in test" in {
+    val isRSS = false
+    val forceDCROff = false
+    val forceDCR = false
+    val dcrSwitchEnabled = false
+    val dcrCouldRender = true
+    val isNetworkFront = true
+    val isInNetworkFrontTest = true
+
+    val tier = FaciaPicker.decideTier(
+      isRSS,
+      forceDCROff,
+      forceDCR,
+      dcrSwitchEnabled,
+      dcrCouldRender,
+      isNetworkFront,
+      isInNetworkFrontTest,
+    )
+    tier should be(LocalRender)
+  }
+
   val linkSnap = FixtureBuilder.mkPressedLinkSnap(1).asInstanceOf[LinkSnap]
   val supportedThrasher = PressedCollectionBuilder.mkPressedCollection(curated =
     List(

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -10,30 +10,6 @@ import org.scalatestplus.mockito.MockitoSugar
 
 @DoNotDiscover class FaciaPickerTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
-  "Facia Picker allCollectionsAreSupported" should "return false if at least one collection type of the faciaPage collections is not supported" in {
-    val unsupportedPressedCollection =
-      List(
-        PressedCollectionBuilder.mkPressedCollection(collectionType = FrontChecks.SUPPORTED_COLLECTIONS.head),
-        PressedCollectionBuilder.mkPressedCollection(collectionType = "non-supported-collection-type"),
-      )
-
-    val faciaPage = FixtureBuilder.mkPressedPage(unsupportedPressedCollection)
-    FrontChecks.allCollectionsAreSupported(faciaPage) should be(false)
-  }
-
-  it should "return true if all collection types of a facia page are supported" in {
-    val supportedTypes = FrontChecks.SUPPORTED_COLLECTIONS.take(3).toList
-    val supportedPressedCollection =
-      List(
-        PressedCollectionBuilder.mkPressedCollection(collectionType = supportedTypes(0)),
-        PressedCollectionBuilder.mkPressedCollection(collectionType = supportedTypes(1)),
-        PressedCollectionBuilder.mkPressedCollection(collectionType = supportedTypes(2)),
-      )
-
-    val faciaPage = FixtureBuilder.mkPressedPage(supportedPressedCollection)
-    FrontChecks.allCollectionsAreSupported(faciaPage) should be(true)
-  }
-
   "Facia Picker decideTier" should "return LocalRender if dcr=false" in {
     val isRSS = false
     val forceDCROff = true
@@ -203,8 +179,6 @@ import org.scalatestplus.mockito.MockitoSugar
 
     val faciaPage = FixtureBuilder.mkPressedPage(
       List(
-        PressedCollectionBuilder
-          .mkPressedCollection(collectionType = FrontChecks.SUPPORTED_COLLECTIONS.take(1).toList.head),
         unsupportedThrasher,
         supportedThrasher,
       ),
@@ -216,8 +190,6 @@ import org.scalatestplus.mockito.MockitoSugar
   it should "return true if all thrashers in a front are supported" in {
     val faciaPage = FixtureBuilder.mkPressedPage(
       List(
-        PressedCollectionBuilder
-          .mkPressedCollection(collectionType = FrontChecks.SUPPORTED_COLLECTIONS.take(1).toList.head),
         supportedThrasher,
         supportedThrasher,
       ),


### PR DESCRIPTION
## What does this change?

Stop checking for support before sending Network Fronts to DCR (`RemoteRenderer`)

- `fixed/video`: https://github.com/guardian/dotcom-rendering/issues/5149
- weather widget: https://github.com/guardian/dotcom-rendering/issues/6378
- paid fronts: https://github.com/guardian/dotcom-rendering/issues/5945
- page skins: https://github.com/guardian/dotcom-rendering/issues/5490
- ad free: https://github.com/guardian/dotcom-rendering/issues/6379
- all collections (no single ticket can encapsulate the mahoosiveness of this)

And small health refactors…

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No – support is good enough for now
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/76776/251cbecf-cd35-4173-8582-16986441997f
[after]: https://github.com/guardian/frontend/assets/76776/323bce12-8981-4af4-a697-b88f82d6f693


## What is the value of this and can you measure success?

Enable us to start serving actual DCR Network Fronts to users.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
