### PR TITLE
fix: do not use DCR for showcase containers

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -16,6 +16,9 @@ object FrontChecks {
   def hasNoEmailCollections(faciaPage: PressedPage) =
     !faciaPage.collections.exists(collection => EmailLayouts.all.contains(collection.collectionType))
 
+  def hasNoShowcaseCollections(faciaPage: PressedPage) =
+    !faciaPage.collections.exists(collection => collection.collectionType == "fixed/showcase")
+
   /*
    * This list contains JSON.HTML thrashers that DCR allows. These thrashers should not actually be rendered by DCR
    * but instead have an alternate way of being rendered on DCR.
@@ -63,6 +66,7 @@ object FaciaPicker extends GuLogging {
     Map(
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
       ("hasNoEmailCollections", FrontChecks.hasNoEmailCollections(faciaPage)),
+      ("hasNoShowcaseCollections", FrontChecks.hasNoShowcaseCollections(faciaPage)),
     )
   }
 


### PR DESCRIPTION
## What does this change?
Adds `showcase` containers to the unsupported list.

While this might not be a sustainable way to do things, it fixes the immediate problem of not rendering the [showcase HTML](https://www.theguardian.com/uk-showcase?dcr=false).


## before
<img width="1325" alt="Screenshot 2023-06-27 at 09 17 27" src="https://github.com/guardian/frontend/assets/31692/596783c6-3e44-484b-bb03-681dc0e5b640">

## after
<img width="1313" alt="Screenshot 2023-06-27 at 09 17 19" src="https://github.com/guardian/frontend/assets/31692/5930b97a-b643-4a5b-9296-22f523684865">
