### PR TITLE
We render *almost* all Fronts

### DIFF
--- a/common/test/helpers/FaciaTestData.scala
+++ b/common/test/helpers/FaciaTestData.scala
@@ -144,8 +144,8 @@ trait FaciaTestData extends ModelHelper {
   )
 
   val auFaciaPage: PressedPage = PressedPage(
-    id = "us",
-    SeoData.fromPath("us"),
+    id = "au",
+    SeoData.fromPath("au"),
     FrontProperties.empty,
     collections = List(
       PressedCollection(

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -48,6 +48,9 @@ object FrontChecks {
   def hasOnlySupportedCollections(faciaPage: PressedPage) =
     faciaPage.collections.forall(collection => SUPPORTED_COLLECTIONS.contains(collection.collectionType))
 
+  /** Required until we fully support the Labs container & finish the vertical video test */
+  def isNotAustralianFront(faciaPage: PressedPage) = faciaPage.id != "au"
+
   /*
    * This list contains JSON.HTML thrashers that DCR allows. These thrashers should not actually be rendered by DCR
    * but instead have an alternate way of being rendered on DCR.
@@ -95,6 +98,7 @@ object FaciaPicker extends GuLogging {
     Map(
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
       ("hasOnlySupportedCollections", FrontChecks.hasOnlySupportedCollections(faciaPage)),
+      ("isNotAustralianFront", FrontChecks.isNotAustralianFront(faciaPage)),
     )
   }
 

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -13,11 +13,40 @@ import layout.slices.EmailLayouts
 
 object FrontChecks {
 
-  def hasNoEmailCollections(faciaPage: PressedPage) =
-    !faciaPage.collections.exists(collection => EmailLayouts.all.contains(collection.collectionType))
+  /**
+    * This is the list that DCR will accept, otherwise the validation fails, resulting in an error.
+    *
+    * **It must be kept in sync manually.**
+    *
+    * @see https://github.com/guardian/dotcom-rendering/blob/07b8f29decc1/dotcom-rendering/src/types/front.ts#L61-L83 */
+  val SUPPORTED_COLLECTIONS: Set[String] =
+    Set(
+      "dynamic/fast",
+      "dynamic/package",
+      "dynamic/slow",
+      "dynamic/slow-mpu",
+      "fixed/large/slow-XIV",
+      "fixed/medium/fast-XI",
+      "fixed/medium/fast-XII",
+      "fixed/medium/slow-VI",
+      "fixed/medium/slow-VII",
+      "fixed/medium/slow-XII-mpu",
+      "fixed/small/fast-VIII",
+      "fixed/small/slow-I",
+      "fixed/small/slow-III",
+      "fixed/small/slow-IV",
+      "fixed/small/slow-V-half",
+      "fixed/small/slow-V-mpu",
+      "fixed/small/slow-V-third",
+      "fixed/thrasher",
+      "fixed/video",
+      "nav/list",
+      "nav/media-list",
+      "news/most-popular",
+    )
 
-  def hasNoShowcaseCollections(faciaPage: PressedPage) =
-    !faciaPage.collections.exists(collection => collection.collectionType == "fixed/showcase")
+  def hasOnlySupportedCollections(faciaPage: PressedPage) =
+    faciaPage.collections.forall(collection => SUPPORTED_COLLECTIONS.contains(collection.collectionType))
 
   /*
    * This list contains JSON.HTML thrashers that DCR allows. These thrashers should not actually be rendered by DCR
@@ -65,8 +94,7 @@ object FaciaPicker extends GuLogging {
   def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
     Map(
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
-      ("hasNoEmailCollections", FrontChecks.hasNoEmailCollections(faciaPage)),
-      ("hasNoShowcaseCollections", FrontChecks.hasNoShowcaseCollections(faciaPage)),
+      ("hasOnlySupportedCollections", FrontChecks.hasOnlySupportedCollections(faciaPage)),
     )
   }
 

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -7,10 +7,12 @@ import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import helpers.FaciaTestData
+import test.FaciaControllerTest
 import model.facia.PressedCollection
 import layout.slices.EmailLayouts
 
-@DoNotDiscover class FaciaPickerTest extends AnyFlatSpec with Matchers with MockitoSugar {
+@DoNotDiscover class FaciaPickerTest extends AnyFlatSpec with FaciaTestData with Matchers with MockitoSugar {
 
   "Facia Picker decideTier" should "return LocalRender if dcr=false" in {
     val isRSS = false
@@ -269,5 +271,15 @@ import layout.slices.EmailLayouts
     )
 
     FrontChecks.hasOnlySupportedCollections(faciaPage) should be(false)
+  }
+
+  it should "Should not render the Australian front" in {
+    FrontChecks.isNotAustralianFront(auFaciaPage) should be(false)
+  }
+
+  it should "Should render the UK, US and International fronts" in {
+    FrontChecks.isNotAustralianFront(ukFaciaPage) should be(true)
+    FrontChecks.isNotAustralianFront(usFaciaPage) should be(true)
+    FrontChecks.isNotAustralianFront(internationalFaciaPageWithTargetedTerritories) should be(true)
   }
 }

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -7,6 +7,8 @@ import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import model.facia.PressedCollection
+import layout.slices.EmailLayouts
 
 @DoNotDiscover class FaciaPickerTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
@@ -217,5 +219,55 @@ import org.scalatestplus.mockito.MockitoSugar
     )
 
     FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage) should be(true)
+  }
+
+  it should "Should render supported collections" in {
+    val faciaPage = FixtureBuilder.mkPressedPage(
+      List(
+        PressedCollectionBuilder.mkPressedCollection("dynamic/fast"),
+        PressedCollectionBuilder.mkPressedCollection("dynamic/package"),
+        PressedCollectionBuilder.mkPressedCollection("dynamic/slow"),
+        PressedCollectionBuilder.mkPressedCollection("dynamic/slow-mpu"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/large/slow-XIV"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/medium/fast-XI"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/medium/fast-XII"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/medium/slow-VI"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/medium/slow-VII"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/medium/slow-XII-mpu"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/small/fast-VIII"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-I"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-III"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-IV"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-V-half"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-V-mpu"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-V-third"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/thrasher"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/video"),
+        PressedCollectionBuilder.mkPressedCollection("nav/list"),
+        PressedCollectionBuilder.mkPressedCollection("nav/media-list"),
+        PressedCollectionBuilder.mkPressedCollection("news/most-popular"),
+      ),
+    )
+
+    FrontChecks.hasOnlySupportedCollections(faciaPage) should be(true)
+  }
+
+  it should "Should not render Email layouts" in {
+    val supported = EmailLayouts.all.keySet.exists(collectionType => {
+      val faciaPage = FixtureBuilder.mkPressedPage(
+        List(PressedCollectionBuilder.mkPressedCollection(collectionType)),
+      )
+      FrontChecks.hasOnlySupportedCollections(faciaPage)
+    })
+
+    supported should be(false)
+  }
+
+  it should "Should not render Showcase" in {
+    val faciaPage = FixtureBuilder.mkPressedPage(
+      List(PressedCollectionBuilder.mkPressedCollection("fixed/showcase")),
+    )
+
+    FrontChecks.hasOnlySupportedCollections(faciaPage) should be(false)
   }
 }


### PR DESCRIPTION
## What does this change?

Add a few checks before sending a Front request to DCR in `FaciaPicker`:
- Is it the AU Front?
- Does it only contain supported collection types?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

Follow-up on #26249, after we discovered one more edge case in #26252

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
