### PR TITLE
Bump @guardian/commercial@10.1.1 for potential snyk prebid.js fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial": "10.1.0",
+		"@guardian/commercial": "10.1.1",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial@10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.1.0.tgz#1a1fd256bbf6fc6bd9d1271816a119f27ecf879e"
-  integrity sha512-natr/bIH+8Jc0dqC3NrjP7OCgE9hm4XSJQ7ThyJqgcPxHmh6uWGOQTiOAgM30yYvQuETQo+rCRf4NNklHtiFcA==
+"@guardian/commercial@10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.1.1.tgz#0a6820613fd7ecfa91adf438daf33ee397b16d8d"
+  integrity sha512-vq8jPbAnZcc7mhQz0TDIAq0/Qy18SXQ0K5XOc7ZQxUaSDfIrOm9zNLaLggFDqJ4PppSz+AcgN53+2CimU+S55w==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"
@@ -1577,7 +1577,7 @@
     fastdom "^1.0.11"
     lodash-es "^4.17.21"
     ophan-tracker-js "^1.4.0"
-    prebid.js guardian/prebid.js#2e3b96d
+    prebid.js guardian/prebid.js
     process "^0.11.10"
     raven-js "^3.27.2"
     tslib "^2.5.3"
@@ -10511,7 +10511,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js#2e3b96d:
+"prebid.js@github:guardian/prebid.js":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?

Bump @guardian/commercial@10.1.1 for potential snyk prebid.js fix

More details here: https://github.com/guardian/commercial/pull/919

