### PR TITLE
Fix prebid.js lockfile entry again

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10511,7 +10511,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-"prebid.js@github:guardian/prebid.js":
+"prebid.js@guardian/prebid.js":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?

Manually remove the github prefix for prebid.js in the lockfile.

Sadly #26256 didn't fix the issue.

The snyk job passed on the branch but not on the merge commit.

Will continue to investigate

