### PR TITLE
Remove `fetchNonRefreshableLineItems` switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -541,16 +541,6 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
-  val fetchNonRefreshableLineItems: Switch = Switch(
-    group = Commercial,
-    name = "fetch-non-refreshable-line-items",
-    description = "Lazily fetch non-refreshable line item ids from an endpoint",
-    owners = group(Commercial),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val ampContentABTesting: Switch = Switch(
     group = Commercial,
     name = "amp-content-ab-testing",

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -6,7 +6,6 @@ import common.Edition
 import common.Maps.RichMap
 import common.commercial.EditionAdTargeting._
 import conf.Configuration.environment
-import conf.switches.Switches.fetchNonRefreshableLineItems
 import conf.{Configuration, DiscussionAsset}
 import model._
 import play.api.libs.json._
@@ -44,14 +43,6 @@ object JavaScriptPage {
       JsArray(ids map (id => JsNumber(id)))
     }
 
-    // Only attach the non-refreshable line items to the commercial config
-    // if the `fetchNonRefreshableLineItems` switch is off
-    val nonRefreshableConfig = if (fetchNonRefreshableLineItems.isSwitchedOff) {
-      Map("nonRefreshableLineItemIds" -> nonRefreshableLineItemIds)
-    } else {
-      Map()
-    }
-
     val commercialMetaData = Map(
       "dfpHost" -> JsString("pubads.g.doubleclick.net"),
       "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(request)),
@@ -63,7 +54,7 @@ object JavaScriptPage {
       "sharedAdTargeting" -> Json.toJson(toMap(metaData.commercial.map(_.adTargeting(edition)) getOrElse Set.empty)),
       "pbIndexSites" -> Json.toJson(metaData.commercial.flatMap(_.prebidIndexSites).getOrElse(Set.empty)),
       "isSensitive" -> JsBoolean(page.metadata.sensitive),
-    ) ++ sponsorshipType ++ nonRefreshableConfig
+    ) ++ sponsorshipType
 
     val journalismMetaData = Map(
       "calloutsUrl" -> JsString(Configuration.journalism.calloutsUrl),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^13.0.0",
-		"@guardian/commercial": "10.1.1",
+		"@guardian/commercial": "10.2.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -151,7 +151,6 @@ interface PageConfig extends CommercialPageConfig {
 	keywordIds: string;
 	keywords: string;
 	lightboxImages?: LightboxImages;
-	nonRefreshableLineItemIds?: number[];
 	pageId: string;
 	publication: string;
 	revisionNumber: string; // https://github.com/guardian/frontend/blob/1b6f41c3/common/app/model/meta.scala#L388

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
   integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
 
-"@guardian/commercial@10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.1.1.tgz#0a6820613fd7ecfa91adf438daf33ee397b16d8d"
-  integrity sha512-vq8jPbAnZcc7mhQz0TDIAq0/Qy18SXQ0K5XOc7ZQxUaSDfIrOm9zNLaLggFDqJ4PppSz+AcgN53+2CimU+S55w==
+"@guardian/commercial@10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.2.0.tgz#810692ad564359b1a2319e648ceb402231824ebe"
+  integrity sha512-pw5SK9hUS6yrXW4tBcE+XKosJRGy5nlu0nLGLh8IT3KPNcTAkBRzMTV/6PqT+VfnclNgBkSfTbM8IPi8HFzIjg==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"
@@ -10511,7 +10511,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-"prebid.js@guardian/prebid.js":
+"prebid.js@github:guardian/prebid.js":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?

This PR removes the switch that enables lazily fetching the array of _non refreshable line items_ from an endpoint.

We remove the logic that, when the switch is off, attaches the non refreshable line items to the window.

## What is the value of this and can you measure success?

[Some time ago](https://github.com/guardian/frontend/pull/24387) we start lazily loading non refreshable line items from an endpoint.

We left the original behaviour behind a switch so we could fallback to the old behaviour if there were any issues with the new endpoint (with caching, for example). The new method has been stable for a long time now, so it's safe to remove the switch and any logic associated with the old method. Further logic is removed in [this PR](https://github.com/guardian/commercial/pull/921).

### Tested

- [X] Locally
- [ ] On CODE (optional)