### PR TITLE
Re-enable `TagPagesTest` (after 9 years!)

### DIFF
--- a/admin/app/indexes/TagPages.scala
+++ b/admin/app/indexes/TagPages.scala
@@ -8,7 +8,7 @@ import model.{TagDefinition, TagIndex}
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
-object TagPages {
+object TagPages extends GuLogging {
 
   /** To be curated by Peter Martin */
   val validSections = Map(
@@ -81,9 +81,6 @@ object TagPages {
     ("theguardian", "The Guardian"),
     ("theobserver", "The Observer"),
   )
-}
-
-class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
 
   def alphaIndexKey(s: String): String = {
     val badCharacters = """[^a-z0-9]+""".r
@@ -95,6 +92,18 @@ class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
     }
 
     maybeFirstChar.filterNot(_.isDigit).map(_.toString).getOrElse("1-9")
+  }
+
+  def alphaIndexKeyForContributor(tag: Tag): String = {
+
+    /**
+      * The alphaIndexKey function looks at the first alphanumeric character in the string passed to it.
+      * Concatenating these three strings therefore allows us to use firstName and webTitle as fallbacks
+      * if lastName is None or "".
+      * */
+    val indexString =
+      tag.lastName.getOrElse("").trim.concat(tag.firstName.getOrElse("").trim).concat(tag.webTitle)
+    alphaIndexKey(indexString)
   }
 
   def tagHeadKey(id: String): Option[String] = {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -352,7 +352,7 @@ case class MetaData(
   val sectionId = section map (_.value) getOrElse ""
   lazy val neilsenApid: String = Nielsen.apidFromString(sectionId)
 
-  private val fullAdUnitPath = AdUnitMaker.make(id, adUnitSuffix)
+  private lazy val fullAdUnitPath = AdUnitMaker.make(id, adUnitSuffix)
 
   def hasPageSkin(request: RequestHeader): Boolean =
     DfpAgent.hasPageSkin(fullAdUnitPath, this, request)


### PR DESCRIPTION
These tests were disabled (perhaps [_unintentionally_](https://github.com/guardian/frontend/pull/6028#issuecomment-56163278)) with a `@DoNotDiscover` annotation in September 2014 by PR https://github.com/guardian/frontend/pull/6028.

This change re-enables the tests and adds a few more test cases, which would have caught https://github.com/guardian/frontend/issues/25785 if they'd been enabled back then! With the tests enabled, I've also made a few small tweaks to the implementation of `alphaIndexKey()` (last updated in https://github.com/guardian/frontend/pull/25834), and introduced `alphaIndexKeyForContributor()` to make testing easier.

An example of a resulting page is https://www.theguardian.com/index/contributors/1-9 - but this PR won't change those pages, it's just a refactor and enabling the tests.

![image](https://github.com/guardian/frontend/assets/52038/43beeda8-e919-4f97-8add-4b5df0ce5cd2)
