### PR TITLE
Vertical video article pages should align to the designs

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -127,6 +127,7 @@
                                     }
                                         @fragments.contentMeta(media, page)
                                         @fragments.submeta(media)
+                                }
                                 </div>
                             </div>
                         </div>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -15,7 +15,8 @@
                 Map(
                     "content--has-body" -> media.fields.body.nonEmpty,
                     "content--paid-content paid-content" -> isPaidContent,
-                    "content--pillar-special-report" -> (toneClass(media) == "tone-special-report")
+                    "content--pillar-special-report" -> (toneClass(media) == "tone-special-report"),
+                    "vertical-video" -> page.media.tags.isVerticalVideo
                 ),
                 "content", "content--media", s"content--pillar-${media.metadata.pillar.nameOrDefault}", s"content--media--$mediaType", "tonal", "tonal--tone-media", s"tonal--${toneClass(media)}"
             )"
@@ -76,7 +77,7 @@
                                             }
 
                                             @video.mediaAtom.map { mediaAtom =>
-                                                @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, mediaWrapper = None, posterImageOverride = None)
+                                                @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, mediaWrapper = None, posterImageOverride = None, isVerticalVideo=page.media.tags.isVerticalVideo)
                                             }
 
                                             @video.elements.mainVideo.map { videoElement =>
@@ -98,18 +99,34 @@
                                 }
                                 </div>
 
-                                <div class="content__main-column__body" data-component="body">
+                                @if(!page.media.tags.isVerticalVideo) {
+                                    <div class="content__main-column__body" data-component="body">
+                                        @media match {
+                                            case v: Video => {
+                                                <div class="tonal__standfirst">
+                                                @fragments.standfirst(v)
+                                                </div>
+                                            }
+                                            case _ => {}
+                                        }
+
+                                        @fragments.contentMeta(media, page)
+                                        @fragments.submeta(media)
+                                    </div>
+                                }
+                                @if(page.media.tags.isVerticalVideo) {
                                     @media match {
                                         case v: Video => {
-                                            <div class="tonal__standfirst">
-                                            @fragments.standfirst(v)
+                                            <div class="content__main-column__body" data-component="body">
+                                                <div class="tonal__standfirst">
+                                                    @fragments.standfirst(v)
+                                                </div>
                                             </div>
                                         }
                                         case _ => {}
                                     }
-
-                                    @fragments.contentMeta(media, page)
-                                    @fragments.submeta(media)
+                                        @fragments.contentMeta(media, page)
+                                        @fragments.submeta(media)
                                 </div>
                             </div>
                         </div>

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -843,6 +843,10 @@ final case class Tags(tags: List[Tag]) {
     _.id == Tags.Interactive
   }
 
+  lazy val isVerticalVideo: Boolean = {
+    tags.exists(t => t.id == "tone/vertical-video")
+  }
+
   lazy val hasLargeContributorImage: Boolean =
     tagsOfType("Contributor").exists(_.properties.contributorLargeImagePath.nonEmpty)
 

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -6,7 +6,8 @@
     media: model.content.MediaAtom,
     displayCaption: Boolean,
     mediaWrapper: Option[MediaWrapper],
-    posterImageOverride: Option[ImageMedia] = None
+    posterImageOverride: Option[ImageMedia] = None,
+    isVerticalVideo: Boolean = false
 )(implicit request: RequestHeader)
 
 @{
@@ -19,7 +20,8 @@
                 displayCaption,
                 displayDuration = true,
                 mediaWrapper = mediaWrapper,
-                posterImageOverride = posterImageOverride
+                posterImageOverride = posterImageOverride,
+                verticalVideo = isVerticalVideo
             )
         case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, false)
         case _ =>

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -20,7 +20,7 @@
     faciaHeaderProperties: Option[VideoFaciaProperties] = None,
     isPaidFor: Boolean = false,
     pressedContent: Option[PressedContent] = None,
-    verticalVideo: Boolean = false,
+    verticalVideo: Boolean = false
 )(implicit request: RequestHeader)
 
 @videoJsError() = @{
@@ -57,13 +57,14 @@
             @*
             Below is only rendered on video cards within the video container and on the vertical video page
             *@
-            @if(mediaWrapper.contains(MediaWrapper.VideoContainer || verticalVideo)){
+            @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
               @if(verticalVideo) {
                   @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
                       <span class="vertical-video-overlay__duration">
                           <span>@media.formattedDuration</span>
                       </span>
                   }
+                }
               }
 
                 <div class="@if(verticalVideo) {vertical-video-overlay} else {video-overlay}">
@@ -89,7 +90,7 @@
                 <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1" aria-hidden="true"></a>
                 }
             }
-        }
+
         @defining(posterImageOverride orElse media.posterImage) { bestPosterImage =>
             @if(bestPosterImage.isEmpty && expired) {
                 <div class="youtube-media-atom__overlay">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -37,7 +37,8 @@
         @defining(media.channelId.getOrElse("")){ channelId: String =>
             <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
                 ("u-responsive-ratio", !isPaidFor),
-                ("u-responsive-ratio--hd", sixteenByNine),
+                ("u-responsive-ratio--hd", !verticalVideo),
+                ("u-responsive-ratio--vertical", verticalVideo),
                 ("youtube-media-atom", true),
                 ("no-player", !playable || expired ),
                 ("youtube-related-videos", true),
@@ -54,9 +55,9 @@
             *@
             <div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
             @*
-            Below is only rendered on video cards within the video container
+            Below is only rendered on video cards within the video container and on the vertical video page
             *@
-            @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
+            @if(mediaWrapper.contains(MediaWrapper.VideoContainer || verticalVideo)){
               @if(verticalVideo) {
                   @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
                       <span class="vertical-video-overlay__duration">

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -458,6 +458,8 @@ const initYoutubePlayerForElem = (el) => {
             return;
         }
 
+        iframe.style.display = 'block';
+
         /**
          * Note:
          * This element id must be unique!

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -174,6 +174,15 @@
     padding-bottom: aspect-ratio-height(16, 9);
 }
 
+.u-responsive-ratio--vertical {
+    @include mq($from: phablet) {
+        padding-bottom: aspect-ratio-height(9, 16);
+    }
+    @include mq($until: phablet) {
+        padding-bottom: aspect-ratio-height(9, 16, 85%);
+    }
+}
+
 .u-responsive-ratio--letterbox {
     padding-bottom: aspect-ratio-height(5, 2);
 }

--- a/static/src/stylesheets/module/content-garnett/_media-player.scss
+++ b/static/src/stylesheets/module/content-garnett/_media-player.scss
@@ -14,6 +14,22 @@ $ima-controls-height: 70px;
     text-align: center; // prevents poster from loading to left then centering
 }
 
+vertical-video .player {
+    @include mq($from: phablet) {
+        width: 40%;
+        display: inline-block;
+    }
+}
+.vertical-video .content__main-column__body {
+    @include mq($from: phablet) {
+        width: 60%;
+        float: right;
+        display: inline-block;
+        padding-left: 8px;
+        box-sizing: border-box;
+    }
+}
+
 .gu-media-wrapper {
     background: #000000;
     -webkit-transform: translateZ(0); // fixes iOS hover bug


### PR DESCRIPTION
## What does this change?
This updates the video pages, so if the vertical video tag is present, the video is rendered properly

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1453" alt="image" src="https://github.com/guardian/frontend/assets/26366706/2d7e90b8-86b7-41f3-a365-af4d276676fe"> | <img width="1474" alt="Screenshot 2023-06-13 at 08 41 36" src="https://github.com/guardian/frontend/assets/26366706/6635eaaa-7386-45d3-b84b-760054536901"> |


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
