### PR TITLE
Not remove the first block if it is pinned post

### DIFF
--- a/common/app/model/LiveBlogCurrentPage.scala
+++ b/common/app/model/LiveBlogCurrentPage.scala
@@ -74,7 +74,6 @@ object LiveBlogCurrentPage {
 
       val pinnedBlocks = blocks.requestedBodyBlocks.get(CanonicalLiveBlog.pinned)
       val pinnedBlock = pinnedBlocks.flatMap(_.headOption)
-      val blocksToDisplay = removeFirstBlockIfPinned(firstPageBlocks, pinnedBlock)
       val pinnedBlockRenamed = pinnedBlock.map(renamePinnedBlock)
 
       val pagination = {
@@ -91,7 +90,7 @@ object LiveBlogCurrentPage {
         else None
       }
 
-      LiveBlogCurrentPage(FirstPage(blocksToDisplay, filterKeyEvents, topicResult), pagination, pinnedBlockRenamed)
+      LiveBlogCurrentPage(FirstPage(firstPageBlocks, filterKeyEvents, topicResult), pagination, pinnedBlockRenamed)
     }
   }
 


### PR DESCRIPTION
## What does this change?
We were filtering out the first block if that block was also a pinned block, because we didn't want to repeat the block 2 times once in pinned post and once in the blocks. This change is removing this filtering, because it was requested by editorial that for this scenario, we want to show the first block, but instead not showing the pinned post. 

The DCR PR for this can be found [here](https://github.com/guardian/dotcom-rendering/pull/8079)

This was tested locally using a code liveblog. Below are screenshots of both DCR and frontend working together. This PR needs to go after DCR PR. 


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://github.com/guardian/frontend/assets/15894063/2ca3d607-ea6b-4bce-80ce-26534bbab3fe) | ![image](https://github.com/guardian/dotcom-rendering/assets/15894063/d6e06e33-eb57-4657-a375-6fa2596fce27) |

<!-- Please use the following table template to make image comparison easier to parse:



[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->
