### PR TITLE
Revert "Dblatcher/route for sign up many"

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -61,6 +61,9 @@
                         @fragments.email.signup.recaptchaContainer()
                     }
                     @helper.CSRF.formField
+                    <label aria-hidden="true">
+                        <input tabindex="-1" class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
+                    </label>
                     <label>
                         <span class="u-h">email address</span>
                         <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -41,7 +41,6 @@ GET        /email/$result<invalid|error>                                        
 ## Submission endpoints
 POST       /email/footer                                                        controllers.EmailSignupController.submitFooter()
 POST       /email                                                               controllers.EmailSignupController.submit()
-POST       /email/many                                                          controllers.EmailSignupController.submitMany()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()
 
 GET        /index/subjects                                                      controllers.TagIndexController.keywords()

--- a/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
@@ -22,6 +22,9 @@
             <div class="email-sub__inline-label">
                 <input class="email-sub__text-input" type="email" name="email" id="@inputId" required />
                 <label class="email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))Email address</label>
+                <label aria-hidden="true">
+                    <input tabindex="-1" class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" />
+                </label>
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
                 <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -48,6 +48,9 @@
 
                 <input class="email-sub__text-input" type="email" name="email" id="@inputId" required />
                 <label class="email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))Enter your email address</label>
+                <label aria-hidden="true">
+                    <input tabindex="-1" class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" placeholder="Name" />
+                </label>
 
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
                 <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />

--- a/common/app/views/fragments/email/signup/subscription/thrasherEmailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/thrasherEmailSignUp.scala.html
@@ -25,6 +25,9 @@
                 </button>
             </div>
 
+            <label aria-hidden="true">
+                <input tabindex="-1" class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="thrasher-embed-email-sub-input-name" placeholder="Name" />
+            </label>
             <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
             <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
             <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -43,7 +43,6 @@ GET        /email/$result<invalid|error>                                        
 ## Submission endpoints
 POST       /email/footer                                                        controllers.EmailSignupController.submitFooter()
 POST       /email                                                               controllers.EmailSignupController.submit()
-POST       /email/many                                                          controllers.EmailSignupController.submitMany()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()
 
 # Business data

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -26,6 +26,7 @@ const trackingEvents = {
 
 const inputs = {
 	email: 'email',
+	dummy: 'name',
 };
 
 let lastEventDataSent = undefined;
@@ -174,6 +175,9 @@ const modifyLinkNamesForSignedInUser = (el) =>
 const submitForm = (form, buttonEl) => {
 	buttonEl.setAttribute('disabled', 'true');
 
+	const dummyEmail = encodeURIComponent(
+		$(`input[name="${inputs.dummy}"]`, form).val(),
+	); // Used as a 'bot-bait', see https://stackoverflow.com/a/34623588/2823715
 	const email = encodeURIComponent(
 		$(`input[name="${inputs.email}"]`, form).val(),
 	);
@@ -194,6 +198,7 @@ const submitForm = (form, buttonEl) => {
 	formQueryString += `&listName=${listName}`;
 	formQueryString += `&ref=${ref}`;
 	formQueryString += `&refViewId=${refViewId}`;
+	formQueryString += `&${inputs.dummy}=${dummyEmail}`;
 	if (window.guardian.config.switches.emailSignupRecaptcha) {
 		formQueryString += `&g-recaptcha-response=${googleRecaptchaResponse}`;
 	}


### PR DESCRIPTION
Reverts guardian/frontend#26225

signing up for newsletters on https://www.theguardian.com/email-newsletters is currently failing - the controller is reporting 400 responses from the identity API - should revert this PR an d investigate further.