### PR TITLE
feat: add lightbox 0 percent test to help measure any impact on CWVs

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -20,6 +20,16 @@ object ActiveExperiments extends ExperimentsDefinition {
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
+
+object Lightbox
+    extends Experiment(
+      name = "lightbox",
+      description = "Testing the impact lightbox might have on our CWVs",
+      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
+      sellByDate = LocalDate.of(2023, 9, 29),
+      participationGroup = Perc0A,
+    )
+
 object ServerSideLiveblogInlineAds
     extends Experiment(
       name = "server-side-liveblog-inline-ads",


### PR DESCRIPTION
## What does this change?
Adds the 0 percent experiment to allow us to release the [amazing Lightbox PR](https://github.com/guardian/dotcom-rendering/pull/7129) submitted by @oliverlloyd.

We will measure any impact it might have on CWVs and other core KPIs.
