### PR TITLE
Add Lightbox to Active Experiments

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -4,21 +4,24 @@ import conf.switches.Owner
 import experiments.ParticipationGroups._
 import java.time.LocalDate
 
+/*
+ * This list of active experiments is sorted by participation group, rather than sell-by date.
+ */
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      FrontsBannerAds,
-      DCRNetworkFronts,
+      VerticalVideoContainer,
+      Lightbox,
       ServerSideLiveblogInlineAds,
       EuropeNetworkFront,
-      OfferHttp3,
       Okta,
+      DCRNetworkFronts,
       HeaderTopBarSearchCapi,
       BorkFCP,
       BorkFID,
+      OfferHttp3,
+      FrontsBannerAds,
       ActionCardRedesign,
-      VerticalVideoContainer,
-      Lightbox,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,7 +5,7 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 /*
- * This list of active experiments is sorted by participation group.
+ * This list of active experiments is sorted by participation group. 
  */
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,7 +5,7 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 /*
- * This list of active experiments is sorted by participation group.  
+ * This list of active experiments is sorted by participation group.
  */
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,7 +5,7 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 /*
- * This list of active experiments is sorted by participation group, rather than sell-by date.
+ * This list of active experiments is sorted by participation group.
  */
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,7 +5,7 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 /*
- * This list of active experiments is sorted by participation group. 
+ * This list of active experiments is sorted by participation group.  
  */
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -29,7 +29,7 @@ object Lightbox
       description = "Testing the impact lightbox might have on our CWVs",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 9, 29),
-      participationGroup = Perc0A,
+      participationGroup = Perc0B,
     )
 
 object ServerSideLiveblogInlineAds

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -23,6 +23,15 @@ object ActiveExperiments extends ExperimentsDefinition {
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
 
+object VerticalVideoContainer
+    extends Experiment(
+      name = "vertical-video-container",
+      description = "When ON, Vertical Video Container is displayed",
+      owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
+      sellByDate = LocalDate.of(2023, 7, 31),
+      participationGroup = Perc0A,
+    )
+
 object Lightbox
     extends Experiment(
       name = "lightbox",
@@ -131,13 +140,4 @@ object ActionCardRedesign
       owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
       sellByDate = LocalDate.of(2023, 9, 8),
       participationGroup = Perc20A,
-    )
-
-object VerticalVideoContainer
-    extends Experiment(
-      name = "vertical-video-container",
-      description = "When ON, Vertical Video Container is displayed",
-      owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
-      sellByDate = LocalDate.of(2023, 7, 31),
-      participationGroup = Perc0A,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -18,6 +18,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       BorkFID,
       ActionCardRedesign,
       VerticalVideoContainer,
+      Lightbox,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }


### PR DESCRIPTION
## What does this change?

Adds Lightbox to Active Experiments - see https://github.com/guardian/dotcom-rendering/pull/7129#discussion_r1249599057 in #7129

Edit: The TC build was failing, because Lightbox shared the same participation group (perc0A) with VerticalVideoContainer - ~~Lightbox or VerticalVideoContainer need to have their participation group changed to perc0B (EdX merged their VerticalVideoContainer PR 2 days ago and we haven't merged our Lightbox PR yet, so I propose out of courtesy, we change Lightbox's participation group from perc0A to perc0B)~~ (I have now implemented this proposal)

Edit 2: The TC build was failing, because of expired AB tests: ~~https://github.com/guardian/frontend/blob/0bf69f55a803edb3ffd004e2cd820a83e2320806/common/app/conf/switches/ABTestSwitches.scala)~~ - fixed by: https://github.com/guardian/frontend/pull/26271

Edit 3: The Scala code has been re-formatted to meet ScalaFMT's requirements 

Edit 4: Another A/B test failure - fixed by: https://github.com/guardian/frontend/pull/26273

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
