### PR TITLE
chore(AbTests): update expiry for ab-elements-manager a/b test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -71,7 +71,7 @@ trait ABTestSwitches {
     "Test serving GEM assets in ad slots on page",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 6, 30)),
+    sellByDate = Some(LocalDate.of(2023, 7, 7)),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?

I've updated this to the end of the week to get the build green again. I'll leave it to @guardian/commercial-dev to decide what to do with it after that's working again.