### PR TITLE
Extend ab-sign-in-gate-copy-test-jan-2023 to the 2nd oct

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "Test the impact of changing the copy in the sign in gate",
     owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 7, 3)),
+    sellByDate = Some(LocalDate.of(2023, 10, 2)),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?
Extend ab-sign-in-gate-copy-test-jan-2023 to the 2nd oct

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
