### PR TITLE
Remove commercial feed switches

### DIFF
--- a/commercial/app/model/feeds/FeedMetaData.scala
+++ b/commercial/app/model/feeds/FeedMetaData.scala
@@ -11,19 +11,12 @@ sealed trait FeedMetaData {
   def url: String
   def parameters: Map[String, String] = Map.empty
   def timeout: Duration = 2.seconds
-
-  def fetchSwitch: Switch
-
-  def parseSwitch: Switch
   def responseEncoding: String = ResponseEncoding.default
 }
 
 case class JobsFeedMetaData(override val url: String) extends FeedMetaData {
 
   val name = "jobs"
-
-  override val fetchSwitch = Switches.JobsFeedFetchSwitch
-  override val parseSwitch = Switches.JobsFeedParseSwitch
 
   override val responseEncoding = utf8
 }
@@ -32,9 +25,6 @@ case class BestsellersFeedMetaData(domain: String) extends FeedMetaData {
 
   val name = "bestsellers"
   val url = s"https://$domain/bertrams/feed/independentsTop20"
-
-  override val fetchSwitch = Switches.GuBookshopFeedsSwitch
-  override val parseSwitch = Switches.GuBookshopFeedsSwitch
 
   override val responseEncoding = utf8
 }
@@ -54,9 +44,6 @@ case class EventsFeedMetaData(
   ) ++ additionalParameters
 
   override val timeout = 20.seconds
-
-  override val fetchSwitch = Switches.EventsFeedSwitch
-  override val parseSwitch = Switches.EventsFeedSwitch
 }
 
 case class TravelOffersFeedMetaData(url: String) extends FeedMetaData {
@@ -64,7 +51,4 @@ case class TravelOffersFeedMetaData(url: String) extends FeedMetaData {
   override def name: String = "travel-offers"
 
   override val timeout = 10.seconds
-
-  override val fetchSwitch = Switches.TravelFeedFetchSwitch
-  override val parseSwitch = Switches.TravelFeedParseSwitch
 }

--- a/commercial/app/model/merchandise/books/MagentoBestsellersFeed.scala
+++ b/commercial/app/model/merchandise/books/MagentoBestsellersFeed.scala
@@ -45,22 +45,14 @@ object MagentoBestsellersFeed extends GuLogging {
 
     val feedName = feedMetaData.name
 
-    feedMetaData.parseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
-      if (switchedOn) {
-        val start = currentTimeMillis
-        feedContent map { body =>
-          val parsed = parse(XML.loadString(body)).map { book =>
-            book.copy(jacketUrl = book.jacketUrl.map(_.stripPrefix("http:")))
-          }
-          Future(ParsedFeed(parsed, Duration(currentTimeMillis - start, MILLISECONDS)))
-        } getOrElse {
-          Future.failed(MissingFeedException(feedName))
-        }
-      } else {
-        Future.failed(SwitchOffException(feedMetaData.parseSwitch.name))
+    val start = currentTimeMillis
+    feedContent map { body =>
+      val parsed = parse(XML.loadString(body)).map { book =>
+        book.copy(jacketUrl = book.jacketUrl.map(_.stripPrefix("http:")))
       }
-    } recoverWith {
-      case NonFatal(e) => Future.failed(e)
+      Future(ParsedFeed(parsed, Duration(currentTimeMillis - start, MILLISECONDS)))
+    } getOrElse {
+      Future.failed(MissingFeedException(feedName))
     }
   }
 }

--- a/commercial/app/model/merchandise/events/Eventbrite.scala
+++ b/commercial/app/model/merchandise/events/Eventbrite.scala
@@ -106,22 +106,14 @@ object Eventbrite extends GuLogging {
       executionContext: ExecutionContext,
   ): Future[ParsedFeed[Event]] = {
 
-    feedMetaData.parseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
-      if (switchedOn) {
-        val start = currentTimeMillis
-        feedContent map { body =>
-          val responses = Json.parse(body).as[Seq[Response]]
-          val events = responses flatMap { _.events }
+    val start = currentTimeMillis
+    feedContent map { body =>
+      val responses = Json.parse(body).as[Seq[Response]]
+      val events = responses flatMap { _.events }
 
-          Future(ParsedFeed(events, Duration(currentTimeMillis - start, MILLISECONDS)))
-        } getOrElse {
-          Future.failed(MissingFeedException(feedMetaData.name))
-        }
-      } else {
-        Future.failed(SwitchOffException(feedMetaData.parseSwitch.name))
-      }
-    } recoverWith {
-      case NonFatal(e) => Future.failed(e)
+      Future(ParsedFeed(events, Duration(currentTimeMillis - start, MILLISECONDS)))
+    } getOrElse {
+      Future.failed(MissingFeedException(feedMetaData.name))
     }
   }
 

--- a/commercial/app/model/merchandise/travel/TravelOffersApi.scala
+++ b/commercial/app/model/merchandise/travel/TravelOffersApi.scala
@@ -21,21 +21,13 @@ object TravelOffersApi extends GuLogging {
   def parseOffers(feedMetaData: FeedMetaData, feedContent: => Option[String])(implicit
       executionContext: ExecutionContext,
   ): Future[ParsedFeed[TravelOffer]] = {
-    feedMetaData.parseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
-      if (switchedOn) {
-        val start = System.currentTimeMillis
-        feedContent map { body =>
-          val elems = XML.loadString(body)
-          val parsed = parse(elems)
-          Future(ParsedFeed(parsed, Duration(currentTimeMillis - start, MILLISECONDS)))
-        } getOrElse {
-          Future.failed(MissingFeedException(feedMetaData.name))
-        }
-      } else {
-        Future.failed(SwitchOffException(feedMetaData.parseSwitch.name))
-      }
-    } recoverWith {
-      case NonFatal(e) => Future.failed(e)
+    val start = System.currentTimeMillis
+    feedContent map { body =>
+      val elems = XML.loadString(body)
+      val parsed = parse(elems)
+      Future(ParsedFeed(parsed, Duration(currentTimeMillis - start, MILLISECONDS)))
+    } getOrElse {
+      Future.failed(MissingFeedException(feedMetaData.name))
     }
   }
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -136,66 +136,6 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val TravelFeedFetchSwitch = Switch(
-    SwitchGroup.CommercialFeeds,
-    "gu-travel-feed-fetch",
-    "If this switch is on, cached travel offers feed will be updated from external source.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
-  val TravelFeedParseSwitch = Switch(
-    SwitchGroup.CommercialFeeds,
-    "gu-travel-feed-parse",
-    "If this switch is on, commercial components will be fed by travel offers feed.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
-  val JobsFeedFetchSwitch = Switch(
-    SwitchGroup.CommercialFeeds,
-    "gu-jobs-feed-fetch",
-    "If this switch is on, jobs feed will be periodically updated from external source.",
-    owners = Owner.group(SwitchGroup.Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
-  val JobsFeedParseSwitch = Switch(
-    SwitchGroup.CommercialFeeds,
-    "gu-jobs-feed-parse",
-    "If this switch is on, commercial components will be fed by jobs feed.",
-    owners = Owner.group(SwitchGroup.Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
-  val EventsFeedSwitch = Switch(
-    SwitchGroup.CommercialFeeds,
-    "gu-events",
-    "If this switch is on, commercial components will be fed by masterclass and live-events feeds.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
-  val GuBookshopFeedsSwitch = Switch(
-    SwitchGroup.CommercialFeeds,
-    "gu-bookshop",
-    "If this switch is on, commercial components will be fed by the Guardian Bookshop feed.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
   val BookLookupSwitch = Switch(
     SwitchGroup.CommercialFeeds,
     "book-lookup",


### PR DESCRIPTION
## What does this change?
Remove the following switches:
- TravelFeedFetchSwitch
- TravelFeedParseSwitch 
- JobsFeedFetchSwitch 
- JobsFeedParseSwitch
- EventsFeedSwitch 
- GuBookshopFeedsSwitch 

It's been determined by an audit of our switches that they're no longer needed, the feeds these switch will now be fixed to their 'on' state and will require a code change to disable.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (optional)

I've tested that the feed URLs still function the same on CODE vs PROD

- `/commercial/travel/api/offers.json`
- `/commercial/jobs/api/jobs.json`
- `/commercial/books/api/book.json`
- `/commercial/books/api/books.json`
- `/commercial/api/liveevent.json` (currently broken on PROD?)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
