### PR TITLE
fix: Update /weather route /weather.json

### DIFF
--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -21,7 +21,7 @@ GET        /weatherapi/locations                      weather.controllers.Locati
 GET        /weatherapi/forecast/:id.json              weather.controllers.WeatherController.forecastForCityId(id)
 
 # Weather - DCR
-GET        /weather                                   weather.controllers.WeatherController.theWeather()
+GET        /weather.json                              weather.controllers.WeatherController.theWeather()
 
 # Most Read
 GET        /most-read-facebook.json                   controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "facebook")


### PR DESCRIPTION
Part of: https://github.com/guardian/dotcom-rendering/issues/6378

## What does this change?
Changes the `/weather` route to `/weather.json`. This seems to be the general pattern. I'm not sure it matters too much, except in making someone in the future wonder why it's different. This is for that person.

