### PR TITLE
fix: bump expiry of offer-http3/dcr-network-fronts switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -74,7 +74,7 @@ object DCRNetworkFronts
       name = "dcr-network-fronts",
       description = "Network fronts rendered by DCR",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2023, 7, 3),
+      sellByDate = LocalDate.of(2023, 7, 7),
       participationGroup = Perc1A,
     )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -110,7 +110,7 @@ object OfferHttp3
       name = "offer-http3",
       description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
       owners = Seq(Owner.withGithub("paulmr")),
-      sellByDate = LocalDate.of(2023, 7, 3),
+      sellByDate = LocalDate.of(2023, 7, 31),
       participationGroup = Perc1E,
     )
 


### PR DESCRIPTION
## What does this change?
Another day, another switch.
Bumps the HTTP3 switch till the end of the month.

