### PR TITLE
Remove action card test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,7 +16,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       HeaderTopBarSearchCapi,
       BorkFCP,
       BorkFID,
-      ActionCardRedesign,
       VerticalVideoContainer,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -121,15 +120,6 @@ object FrontsBannerAds
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
       sellByDate = LocalDate.of(2023, 9, 6),
       participationGroup = Perc5A,
-    )
-
-object ActionCardRedesign
-    extends Experiment(
-      name = "action-card-redesign",
-      description = "Creates a new action card design on fronts pages",
-      owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
-      sellByDate = LocalDate.of(2023, 9, 8),
-      participationGroup = Perc20A,
     )
 
 object VerticalVideoContainer

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -4,8 +4,6 @@
 @import views.support._
 @import layout.FrontendLatestSnap
 @import implicits.ItemKickerImplicits._
-@import experiments.ActiveExperiments
-@import experiments.ActionCardRedesign
 
 @headline() = {
     <span class="@labelCssClasses fc-item__headline">
@@ -43,12 +41,6 @@
                     @headline()
                 }
             }
-        }
-        @if(isAction && ActiveExperiments.isParticipating(ActionCardRedesign)) {
-            <button class="fc-item__action-tell-us-btn">
-                <span>Tell us</span>
-                @fragments.inlineSvg("arrow-right", "icon")
-            </button>
         }
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -222,35 +222,6 @@ $fc-item-gutter: $gs-gutter / 4;
     font-weight: 700;
 }
 
-.fc-item__action-tell-us-btn {
-    @include fs-textSans(3);
-    font-size: 15px;
-    margin: 8px 0px;
-    display: flex;
-    color: $brightness-7;
-    box-sizing: border-box;
-    align-items: center;
-    background: transparent;
-    transition: .3s ease-in-out;
-    height: 24px;
-    min-height: 24px;
-    padding: 0 7px 1px 11px;
-    border-radius: 24px;
-    line-height: 1.35;
-    font-weight: 700;
-    border: 1px solid #000000;
-    svg {
-        color: #000000;
-        margin-right: -4px;
-        flex: 0 0 auto;
-        display: block;
-        fill: currentColor;
-        position: relative;
-        width: 27px;
-        height: auto;
-    }
-}
-
 .fc-item__byline {
     margin-bottom: 0;
     font-style: italic;


### PR DESCRIPTION
## What does this change?
Removes the action card test. The test has finished and it was decided we would not go ahead with this button so the code is no longer required.
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
