### PR TITLE
Vertical carousel styling

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/verticalVideoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/verticalVideoContainer.scala.html
@@ -101,9 +101,10 @@ data-layout="vertical-video"
         >
         @fragments.inlineSvg("chevron-left", "icon", Seq("vertical-video-playlist__icon", "vertical-video-playlist__icon--prev"))
         </a>
-        <span style="color: white">
+        <span class="vertical-video__counter">
             <span id="vertical-carousel-count">1</span>
-            of @(containerDefinition.collectionEssentials.items.zipWithIndex.length)</span>
+            of @(containerDefinition.collectionEssentials.items.zipWithIndex.length)
+        </span>
         <a
         class="js-video-playlist-next"
         data-link-name="vertical-video-container-next"

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -762,25 +762,19 @@ $video-width-desktop: 700px;
 
 .vertical-video-overlay__duration {
     @include fs-textSans(2);
-    position: absolute;
-    right: 4px;
-    z-index: 2;
-
-    border: 2px solid #000000;
-    border-radius: 500px;
-    background-color: #000000;
-    width: 57px;
-    height: 28px;
-    margin-top: 8px;
-    margin-right: 8px;
-    font-weight: 700;
-    color: #ffffff;
-    display: flex;
-    justify-content: center;
-
-    span {
-        padding-top: 4px;
+    @include mq($until: mobileMedium) {
+        margin-right: 8px;
     }
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background-color: rgba(0, 0, 0, .7);
+    width: fit-content;
+    padding: 4px 12px;
+    border-radius: 16px;
+    color:  $brightness-100;
+    font-weight: 700;
+    z-index: 2;
 }
 
 .fc-item__video-container {

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -248,6 +248,11 @@ $video-width-desktop: 700px;
     }
 }
 
+.vertical-video__counter {
+    color: $brightness-100;
+    user-select: none;
+}
+
 .video-playlist__overlay {
     position: absolute;
     display: block;


### PR DESCRIPTION
## What does this change?
Tweaks the vertical carousel styling

1. Updates the duration pill styling and makes background have an opacity of 0.7
2. Moves the counter styling into the css file and prevents text from being selectable

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/20416599/ed2011ee-e408-47eb-8487-86892d70297a
[after]: https://github.com/guardian/frontend/assets/20416599/f23067b1-2ce4-4cf0-b0d3-018e209df700


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
