### PR TITLE
Draft: Migration to Okta for auth

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js
@@ -13,6 +13,7 @@ try {
             }
 
             // Short version of cookie.get(), inspired by Google Analytics' code
+            // TODO: Okta
             var cookieData = (function(a) {
                 var d = new window.Array(),
                     e = new window.Array();

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -122,6 +122,8 @@ class CommentsController(
 
   }
 
+  // TODO: Okta
+  // Forward Authenticated header and X-Gu-Is-Oauth if in the Okta experiment
   def reportAbuseSubmission(commentId: Int): Action[AnyContent] =
     csrfCheck {
       Action.async { implicit request =>

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -222,11 +222,14 @@ trait DiscussionApiLike extends Http with GuLogging {
     )
   }
 
+  // Not sure why we don't use DAPI's report abuse endpoint here?
   def postAbuseReport(abuseReport: DiscussionAbuseReport, cookie: Option[Cookie])(implicit
       executionContext: ExecutionContext,
   ): Future[WSResponse] = {
     val url = s"${apiRoot}/comment/${abuseReport.commentId}/reportAbuse"
     val headers = Seq("D2-X-UID" -> conf.Configuration.discussion.d2Uid, guClientHeader)
+    // TODO: Okta
+    // Forward Authenticated header and X-Gu-Is-Oauth if in the Okta experiment
     if (cookie.isDefined) { headers :+ ("Cookie" -> s"SC_GU_U=${cookie.get}") }
     failIfDisabled().flatMap(_ =>
       wsClient.url(url).withHttpHeaders(headers: _*).withRequestTimeout(2.seconds).post(abuseReportToMap(abuseReport)),

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -13,6 +13,7 @@ object AuthenticatedActions {
   type AuthRequest[A] = AuthenticatedRequest[A, AuthenticatedUser]
 }
 
+// TODO: Okta
 class AuthenticatedActions(
     authService: AuthenticationService,
     identityApiClient: IdApiClient,

--- a/identity/app/controllers/DiscardingIdentityCookies.scala
+++ b/identity/app/controllers/DiscardingIdentityCookies.scala
@@ -11,6 +11,7 @@ object DiscardingIdentityCookies {
   def discardingCookieForRootDomain(name: String): DiscardingCookie =
     DiscardingCookie(name, secure = true, domain = Some(Configuration.id.domain))
 
+  // TODO: Okta
   def apply(result: Result): Result =
     result
       .discardingCookies(

--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -29,6 +29,7 @@ class AuthenticationService(
         .userHasAuthenticatedWithinDurationFromSCGULACookie(Hours.hours(1).toStandardDuration, identityId, cookie.value)
     }
 
+  // TODO: Okta
   /** User has SC_GU_U and GU_U cookies */
   def fullyAuthenticatedUser[A](request: RequestHeader): Option[AuthenticatedUser] = {
     identityAuthService

--- a/identity/app/views/formstack/formstackFormComposer.scala.html
+++ b/identity/app/views/formstack/formstackFormComposer.scala.html
@@ -443,6 +443,7 @@ a {
                 };
 
                 if (userFromCookieCache === null) {
+                    // TODO: Okta
                     var cookieData = readCookie('GU_U'),
                     userData = cookieData ? JSON.parse(decodeBase64(cookieData.split('.')[0])) : null;
                     if (userData) {

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -132,6 +132,7 @@ class AuthenticatedActionsTest
       }
     }
 
+    // TODO: Okta
     "not redirect and return 200 when a user is authenticated via a GU_U cookie" in new TestFixture {
       val originalUrl = "https://profile.thegulocal.com/consents"
       val request = Request(FakeRequest("GET", originalUrl), AnyContent())
@@ -150,6 +151,7 @@ class AuthenticatedActionsTest
       }
     }
 
+    // TODO: Okta
     "redirect to reauth when a user is authenticated via a GU_U cookie but not recently" in new TestFixture {
       val originalUrl = "https://profile.thegulocal.com/consents"
       val request = Request(FakeRequest("GET", originalUrl), AnyContent())

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -53,6 +53,7 @@ const clearCommonReaderRevenueStateAndReload = (asExistingSupporter) => {
 		fakeOneOffContributor();
 	}
 
+    // TODO: Okta
 	if (isUserLoggedIn() && !asExistingSupporter) {
 		if (window.location.origin.includes('localhost')) {
 			// Assume they don't have identity running locally

--- a/static/src/javascripts/projects/common/modules/identity/api.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.spec.js
@@ -69,6 +69,7 @@ describe('Identity API', () => {
         expect(decodedString).toBe(string);
     });
 
+    // TODO: Okta
     it('gets user from the idapi', done => {
         const expectedUser = {};
         const apiCallback = user => {

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -89,6 +89,7 @@ export type IdentityUserIdentifiers = {
 
 let userFromCookieCache: IdentityUserFromCache = null;
 
+// TODO: Okta
 const cookieName = 'GU_U';
 const signOutCookieName = 'GU_SO';
 const fbCheckKey = 'gu.id.nextFbCheck';
@@ -168,6 +169,7 @@ export const buildNewsletterUpdatePayload = (
 	return newsletter;
 };
 
+// TODO: Okta
 export const isUserLoggedIn = (): boolean => getUserFromCookie() !== null;
 
 export const getUserFromApi = mergeCalls(

--- a/static/vendor/javascripts/formstack-interactive/0.1/boot.js
+++ b/static/vendor/javascripts/formstack-interactive/0.1/boot.js
@@ -13,6 +13,7 @@ define([], function () {
                 iframe.contentWindow.postMessage(JSON.stringify(message), '*');
             }
 
+            // TODO: Okta
             function _isSignedIn() {
                 return document.cookie.match('GU_U=');
             }


### PR DESCRIPTION
TODO

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
