### PR TITLE
Upgrade braze-components to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^4.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/braze-components": "^13.0.0",
+		"@guardian/braze-components": "^14.0.0",
 		"@guardian/commercial": "10.2.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,10 +1556,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-13.0.0.tgz#af0839b56ebd4fb1180cbc45efe2ddd66a968bcb"
-  integrity sha512-M8fi4YuAxLRgifE0gI6HDC9Sq3q8+mypSbUF6jRZMT0fzngV9NSjdaLhkR7sYkc1aKB9Cdi3IqpfBiFO1qee5w==
+"@guardian/braze-components@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.0.0.tgz#3deef75d97549af7cad6046bed2fc282d4e2f78b"
+  integrity sha512-rrYQT+41/m9tK3tRU6oiThylqp8M4IUsOrpG5cHJONp2u+uQzJGVTBG/nlEVB4Ds0gTQ18jfwLsHzztG3ILTcA==
 
 "@guardian/commercial@10.2.0":
   version "10.2.0"


### PR DESCRIPTION
v14 uses typescript v5.1.3 and the latest `@guardian/libs` and `@guardian/source` libraries
https://github.com/guardian/braze-components/pull/417

Tested in CODE