### PR TITLE
Update path for Newletters Request

### DIFF
--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -21,7 +21,7 @@ case class NewsletterApi(wsClient: WSClient)(implicit executionContext: Executio
     with implicits.WSRequests {
 
   def getNewsletters(): Future[Either[String, List[NewsletterResponse]]] = {
-    getBody("newsletters").map { json =>
+    getBody("api/legacy/newsletters/cheese").map { json =>
       json.validate[List[NewsletterResponse]] match {
         case succ: JsSuccess[List[NewsletterResponse]] =>
           Right(succ.get)

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -37,7 +37,6 @@ case class NewsletterApi(wsClient: WSClient)(implicit executionContext: Executio
     } yield {
       val url = s"${ensureHostSecure(host)}/$path"
       log.info(s"Making request to newsletters API: $url")
-      println(s"Making request to newsletters API: $url")
       wsClient
         .url(url)
         .withRequestTimeout(10.seconds)

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -21,7 +21,7 @@ case class NewsletterApi(wsClient: WSClient)(implicit executionContext: Executio
     with implicits.WSRequests {
 
   def getNewsletters(): Future[Either[String, List[NewsletterResponse]]] = {
-    getBody("api/legacy/newsletters/cheese").map { json =>
+    getBody("api/legacy/newsletters").map { json =>
       json.validate[List[NewsletterResponse]] match {
         case succ: JsSuccess[List[NewsletterResponse]] =>
           Right(succ.get)

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -20,7 +20,7 @@ case class NewsletterApi(wsClient: WSClient)(implicit executionContext: Executio
     extends GuLogging
     with implicits.WSRequests {
 
-  def getNewsletters: Future[Either[String, List[NewsletterResponse]]] = {
+  def getNewsletters(): Future[Either[String, List[NewsletterResponse]]] = {
     getBody("api/legacy/newsletters").map { json =>
       json.validate[List[NewsletterResponse]] match {
         case succ: JsSuccess[List[NewsletterResponse]] =>

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -20,7 +20,7 @@ case class NewsletterApi(wsClient: WSClient)(implicit executionContext: Executio
     extends GuLogging
     with implicits.WSRequests {
 
-  def getNewsletters(): Future[Either[String, List[NewsletterResponse]]] = {
+  def getNewsletters: Future[Either[String, List[NewsletterResponse]]] = {
     getBody("api/legacy/newsletters").map { json =>
       json.validate[List[NewsletterResponse]] match {
         case succ: JsSuccess[List[NewsletterResponse]] =>
@@ -37,6 +37,7 @@ case class NewsletterApi(wsClient: WSClient)(implicit executionContext: Executio
     } yield {
       val url = s"${ensureHostSecure(host)}/$path"
       log.info(s"Making request to newsletters API: $url")
+      println(s"Making request to newsletters API: $url")
       wsClient
         .url(url)
         .withRequestTimeout(10.seconds)


### PR DESCRIPTION
## What does this change?

Updates the path to fetch newsletters data. This is mapped to a new host which will return the same response as the existing endpoint but which will allow us to deprecate that legacy system. The new API will permit newsletters to extend our functionality. There is no change for Frontend other than the path of the data. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Migration to the new Newsletters API - this will allow us to deprecate the existing system.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
