### PR TITLE
update node version in readme

### DIFF
--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -116,22 +116,32 @@ You may find it useful to add [this script](https://gist.github.com/sndrs/5940e9
 is present.
 
 Frontend uses a `.nvmrc` file which specifies a given version of node as a requirement. If you use
-[nvm](https://github.com/creationix/nvm#install-script) to manage multiple versions of Node on your machine, you can run `nvm use` to swich to the version specified by `.nvmrc`. If that version number is not available locally, you might have to install the missing version with `nvm install <version number>`. You may also be using `asdf` or `fnm`).
+[nvm](https://github.com/creationix/nvm#install-script) to manage multiple versions of Node on your machine, you can run `nvm use` to swich to the version specified by `.nvmrc`. If that version number is not available locally, you might have to install the missing version with `nvm install <version number>`. You may also be using `asdf` or `fnm`.
 
-Alternatively you could use your system Node, for instance using the following:
+Alternatively you could directly install Node on your system.
+See [.nvmrc](https://github.com/guardian/frontend/blob/main/.nvmrc) for the current version and install that version using your preferred package manager.
+For example:
 
 Ubuntu:
 
 ```bash
-$ curl -sL https://deb.nodesource.com/setup_12.x | sudo bash -
+$ curl -sL https://deb.nodesource.com/setup_18.x | sudo bash -
 $ sudo apt-get install -y nodejs
 ```
 
 Mac:
 
 ```bash
+$ brew install node@[current-version]
+```
+
+eg:
+
+```bash
 $ brew install node@18.16.0
 ```
+
+
 
 ### Client side code
 

--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -116,7 +116,7 @@ You may find it useful to add [this script](https://gist.github.com/sndrs/5940e9
 is present.
 
 Frontend uses a `.nvmrc` file which specifies a given version of node as a requirement. If you use
-[nvm](https://github.com/creationix/nvm#install-script) to manage multiple versions of Node on your machine, you can run `nvm use` to swich to the version specified by `.nvmrc`. If that version number is not available locally, you might have to install the missing version with `nvm install <version number>`. (As a result of upgrades to the new M1 machines you may be using `asdf` or `fnm`).
+[nvm](https://github.com/creationix/nvm#install-script) to manage multiple versions of Node on your machine, you can run `nvm use` to swich to the version specified by `.nvmrc`. If that version number is not available locally, you might have to install the missing version with `nvm install <version number>`. You may also be using `asdf` or `fnm`).
 
 Alternatively you could use your system Node, for instance using the following:
 

--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -116,7 +116,7 @@ You may find it useful to add [this script](https://gist.github.com/sndrs/5940e9
 is present.
 
 Frontend uses a `.nvmrc` file which specifies a given version of node as a requirement. If you use
-[nvm](https://github.com/creationix/nvm#install-script) to manage multiple versions of Node on your machine, you can run `nvm use` to swich to the version specified by `.nvmrc`. If that version number is not available locally, you might have to install the missing version with `nvm install <version number>`.
+[nvm](https://github.com/creationix/nvm#install-script) to manage multiple versions of Node on your machine, you can run `nvm use` to swich to the version specified by `.nvmrc`. If that version number is not available locally, you might have to install the missing version with `nvm install <version number>`. (As a result of upgrades to the new M1 machines you may be using `asdf` or `fnm`).
 
 Alternatively you could use your system Node, for instance using the following:
 
@@ -130,7 +130,7 @@ $ sudo apt-get install -y nodejs
 Mac:
 
 ```bash
-$ brew install node@12.22
+$ brew install node@18.16.0
 ```
 
 ### Client side code


### PR DESCRIPTION
## What does this change?

Currently the readme does a good job of suggesting using a node version manager (`nvm use`)

The current version suggested is not in line with the node version in the `.nvmrc` file.
Also a pointer towards other node version managers which may be used in the department.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
