### PR TITLE
Commercial switch no longer gates slot rendering (plus, a new switch for Googletag)

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -2,10 +2,9 @@
 
 @import play.api.libs.json.Json
 @import views.html.fragments.crosswords._
-@import conf.switches.Switches.CommercialSwitch
 @import views.support.Commercial.{shouldShowAds, isAdFree}
 
-@defining(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage) && !isAdFree(request)) { adsEnabled =>
+@defining(shouldShowAds(crosswordPage) && !isAdFree(request)) { adsEnabled =>
 <div class="l-side-margins">
     <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
         @crosswordMetaHeader(crosswordPage)

--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -3,19 +3,15 @@
     isMobile: Boolean = false
 )(implicit request: RequestHeader)
 
-@import conf.switches.Switches.CommercialSwitch
-
-@if(CommercialSwitch.isSwitchedOn) {
-    @defining((isMobile, id) match {
-        case (true, 0) => "top-above-nav"
-        case _         => s"inline$id"
-    }) { case(slotName: String) =>
-        @fragments.commercial.adSlot(
-            slotName,
-            Seq("gallery-inline", "dark") ++ (if(isMobile) Some("mobile") else None),
-            Map(),
-            optId = if(isMobile) Some(s"$slotName--mobile") else None,
-            optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
-        ){ }
-    }
+@defining((isMobile, id) match {
+    case (true, 0) => "top-above-nav"
+    case _         => s"inline$id"
+}) { case(slotName: String) =>
+    @fragments.commercial.adSlot(
+        slotName,
+        Seq("gallery-inline", "dark") ++ (if(isMobile) Some("mobile") else None),
+        Map(),
+        optId = if(isMobile) Some(s"$slotName--mobile") else None,
+        optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
+    ){ }
 }

--- a/article/app/views/fragments/articleAsideSlot.scala.html
+++ b/article/app/views/fragments/articleAsideSlot.scala.html
@@ -5,9 +5,7 @@
 
 )(implicit request: RequestHeader)
 
-@import conf.switches.Switches.CommercialSwitch
-
-@if(CommercialSwitch.isSwitchedOn && shouldShowAds) {
+@if(shouldShowAds) {
   <div class="aside-slot-container js-aside-slot-container" aria-hidden="true">
   @fragments.commercial.adSlot(
       "right",

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -6,10 +6,21 @@ import conf.switches.SwitchGroup.{Commercial, CommercialPrebid, Membership}
 
 trait CommercialSwitches {
 
+  // TODO(@chrislomaxjones) Remove this switch once we update the client to use the new `ShouldLoadGoogleTagSwitch`
   val CommercialSwitch = Switch(
     Commercial,
     "commercial",
     "If this switch is OFF, no calls will be made to the ad server. BEWARE!",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
+  val ShouldLoadGoogleTagSwitch = Switch(
+    Commercial,
+    "should-load-googletag",
+    "If this switch is OFF, the commercial bundle won't load the googletag script. This is intended for use as a failsafe, and will disable all forms of advertising that are managed via Google Ad Manager, including Prebid and A9.",
     owners = group(Commercial),
     safeState = On,
     sellByDate = never,

--- a/common/app/views/fragments/commercial/commercialComponent.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponent.scala.html
@@ -1,13 +1,9 @@
 @()(implicit request: RequestHeader)
 
-@import conf.switches.Switches.CommercialSwitch
-
-@if(CommercialSwitch.isSwitchedOn) {
-    @fragments.commercial.adSlot(
-        "merchandising",
-        Seq("commercial-component"),
-        Map(),
-        showLabel=false,
-        refresh=false
-    ){ }
-}
+@fragments.commercial.adSlot(
+    "merchandising",
+    Seq("commercial-component"),
+    Map(),
+    showLabel=false,
+    refresh=false
+){ }

--- a/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
@@ -1,13 +1,9 @@
 @(isPaidContent: Boolean, hasPageSkin: Boolean = false)(implicit request: RequestHeader)
 
-@import conf.switches.Switches.CommercialSwitch
-
-@if(CommercialSwitch.isSwitchedOn) {
-    @fragments.commercial.adSlot(
-        "merchandising-high",
-        Seq("commercial-component-high"),
-        Map(),
-        showLabel=false,
-        refresh=false
-    ){ }
-}
+@fragments.commercial.adSlot(
+    "merchandising-high",
+    Seq("commercial-component-high"),
+    Map(),
+    showLabel=false,
+    refresh=false
+){ }

--- a/common/app/views/fragments/commercial/standardAd.scala.html
+++ b/common/app/views/fragments/commercial/standardAd.scala.html
@@ -7,8 +7,4 @@
     outOfPage: Boolean = false
 )(implicit request: RequestHeader)
 
-@import conf.switches.Switches.CommercialSwitch
-
-@if(CommercialSwitch.isSwitchedOn) {
-    @fragments.commercial.adSlot(name, adTypes, sizeMapping, showLabel, refresh, outOfPage){ }
-}
+@fragments.commercial.adSlot(name, adTypes, sizeMapping, showLabel, refresh, outOfPage){ }

--- a/common/app/views/fragments/items/facia_cards/sliceSlot.scala.html
+++ b/common/app/views/fragments/items/facia_cards/sliceSlot.scala.html
@@ -1,18 +1,14 @@
 @(id: Int, isMobile: Boolean = false)(implicit request: RequestHeader)
 
-@import conf.switches.Switches.CommercialSwitch
-
-@if(CommercialSwitch.isSwitchedOn) {
-    @defining((isMobile, id) match {
-        case (true, 0) => "top-above-nav"
-        case _         => s"inline$id"
-    }) { case(slotName) =>
-        @fragments.commercial.adSlot(
-            slotName,
-            Seq("container-inline") ++ (if(isMobile) Some("mobile") else None),
-            Map(),
-            optId = if(isMobile) Some(s"$slotName--mobile") else None,
-            optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
-        ){ }
-    }
+@defining((isMobile, id) match {
+    case (true, 0) => "top-above-nav"
+    case _         => s"inline$id"
+}) { case(slotName) =>
+    @fragments.commercial.adSlot(
+        slotName,
+        Seq("container-inline") ++ (if(isMobile) Some("mobile") else None),
+        Map(),
+        optId = if(isMobile) Some(s"$slotName--mobile") else None,
+        optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
+    ){ }
 }

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -171,10 +171,6 @@ const go = () => {
 		const fetchCommercial = () => {
 			const noop = () => Promise.resolve({ bootCommercial: () => {} });
 
-			if (!config.get('switches.commercial')) {
-				return noop();
-			}
-
 			markTime('commercial request');
 
 			if (!config.get('page.isHosted', false)) {


### PR DESCRIPTION
## What does this change?

Remove checks that the `CommercialSwitch` is switched on before rendering ad slots on Frontend. This means that ad slots will render regardless of whether "commercial" has been switched off.

Additionally, we add a new switch `ShouldLoadGoogletagSwitch`, which will henceforth control whether we load the Googletag script and perform any advertising via Google Ad Manager. This switch will be consumed by the client-side code in the commercial bundle.

We'll leave the original `CommercialSwitch` in place for now. However, we'll now boot the Commercial JS regardless of this switch state. This brings Frontend in line with the behaviour of DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - ad slots are not rendered conditionally in the same way.
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The `CommercialSwitch` is defined to be used exclusively as a failsafe, and disables advertising across the site. Since we expect the switch to be used so rarely, and in such exceptional circumstances, it doesn't feel terribly important that we hide slots when we do use it. This will also help keep the surface area the switch controls small, and the definition clear.

We add a new switch that will have a much clearer purpose than the existing one - to simply control whether or not we load the Googletag script and perform advertising via Google Ad Manager. This new switch will not control the rendering of slots, and again will act as a failsafe.

### Tested

- [ ] Locally
- [x] On CODE (optional)
