### PR TITLE
Pass contributionsServiceUrl to DCR for fronts

### DIFF
--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -31,6 +31,7 @@ case class DotcomFrontsRenderingDataModel(
     mostCommented: Option[Trail],
     mostShared: Option[Trail],
     deeplyRead: Option[Seq[Trail]],
+    contributionsServiceUrl: String,
 )
 
 object DotcomFrontsRenderingDataModel {
@@ -91,6 +92,7 @@ object DotcomFrontsRenderingDataModel {
       mostCommented = mostCommented.flatMap(ContentCard.fromApiContent).flatMap(Trail.contentCardToTrail),
       mostShared = mostShared.flatMap(ContentCard.fromApiContent).flatMap(Trail.contentCardToTrail),
       deeplyRead = deeplyRead,
+      contributionsServiceUrl = Configuration.contributionsService.url,
     )
   }
 


### PR DESCRIPTION
For DCR articles this config item [is passed through by Frontend](https://github.com/guardian/frontend/blob/b8ad26315f80fd01aeb4b758fae377dffc3290e7/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala#L557).
But for fronts it's not - [and currently it's hardcoded](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/layouts/FrontLayout.tsx#L686)