### PR TITLE
New self-serve styleable Braze banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^4.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/braze-components": "^14.0.0",
+		"@guardian/braze-components": "^14.1.0",
 		"@guardian/commercial": "10.3.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,8 @@
 		"@guardian/ab-core": "^4.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-<<<<<<< HEAD
 		"@guardian/braze-components": "^14.1.0",
-		"@guardian/commercial": "10.3.0",
-=======
-		"@guardian/braze-components": "^14.0.0",
 		"@guardian/commercial": "10.4.0",
->>>>>>> main
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,10 +1556,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.0.0.tgz#3deef75d97549af7cad6046bed2fc282d4e2f78b"
-  integrity sha512-rrYQT+41/m9tK3tRU6oiThylqp8M4IUsOrpG5cHJONp2u+uQzJGVTBG/nlEVB4Ds0gTQ18jfwLsHzztG3ILTcA==
+"@guardian/braze-components@^14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.0.tgz#3b362f66cc4c37920ed452187a7cc33dec9314a0"
+  integrity sha512-SsTrqdYfNq9k63VhicCrnF0WhWCwhxZKyERVzTt5NMt4mG4iWqrrpa+G7SdVQockf3OYEizv4WJtPRt/N1F9pg==
 
 "@guardian/commercial@10.3.0":
   version "10.3.0"


### PR DESCRIPTION
## What does this change?
Currently the styling of Braze banners is hardcoded. Marketing colleagues have requested that we create a new banner more amenable to self-serve styling, in particular the ability to set text and background colours, and the position of the accompanying image.

This PR updates the version number of the braze-components dependency (where the code changes have been implemented).

Link to the related PR: https://github.com/guardian/braze-components/pull/416

## Screenshots
This PR does not impact on the display of any other Frontend component.