### PR TITLE
Ab/add survey link

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -552,4 +552,14 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
+  val VerticalVideoSurvey = Switch(
+    SwitchGroup.Feature,
+    "vertical-video-survey",
+    "When ON, shows the vertical video survey link",
+    owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
 }

--- a/common/app/views/fragments/containers/facia_cards/verticalVideoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/verticalVideoContainer.scala.html
@@ -8,6 +8,7 @@
 @import model.VideoFaciaProperties
 @import layout.FaciaCardHeader
 @import model.Pillar.RichPillar
+@import conf.switches.Switches.{VerticalVideoSurvey}
 
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 
@@ -115,11 +116,12 @@ data-layout="vertical-video"
         @fragments.inlineSvg("chevron-right", "icon", Seq("vertical-video-playlist__icon", "vertical-video-playlist__icon--next"))
         </a>
     </div>
-    <div class="vertical-video__ext-link">
-        We're experimenting with vertical video.&nbsp;
-        <a href="https://guardiannewsandmedia.formstack.com/forms/vertical_video"
-        target="_blank"
-        rel="noopener noreferrer">Tell us what you think</a>
-    </div>
-
+    @if(VerticalVideoSurvey.isSwitchedOn) {
+        <div class="vertical-video__ext-link">
+            We're experimenting with vertical video.&nbsp;
+            <a href="https://guardiannewsandmedia.formstack.com/forms/vertical_video"
+            target="_blank"
+            rel="noopener noreferrer">Tell us what you think</a>
+        </div>
+    }
 </div>

--- a/common/app/views/fragments/containers/facia_cards/verticalVideoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/verticalVideoContainer.scala.html
@@ -18,7 +18,7 @@
         </h2>
     </header>
 </div>
-<div class="video-playlist video-playlist--start js-video-playlist fc-container--rolled-up-hide vertical-playlist__padding"
+<div class="video-playlist video-playlist--start js-video-playlist fc-container--rolled-up-hide"
 data-number-of-videos="@(containerDefinition.collectionEssentials.items.zipWithIndex.length - 1)"
 data-component="vertical-video-playlist"
 data-layout="vertical-video"
@@ -28,7 +28,7 @@ data-layout="vertical-video"
     >
     </a>
 
-    <ul class="u-unstyled video-playlist__inner js-video-playlist-inner vertical-video-height">
+    <ul class="u-unstyled video-playlist__inner js-video-playlist-inner vertical-video-height vertical-playlist__margin">
         <li class="video-playlist__item video-title vertical-video-title--leftcol fc-container__header__title vertical-video">
         @treats(containerDefinition, frontProperties)
         </li>
@@ -115,4 +115,11 @@ data-layout="vertical-video"
         @fragments.inlineSvg("chevron-right", "icon", Seq("vertical-video-playlist__icon", "vertical-video-playlist__icon--next"))
         </a>
     </div>
+    <div class="vertical-video__ext-link">
+        We're experimenting with vertical video.&nbsp;
+        <a href="https://guardiannewsandmedia.formstack.com/forms/vertical_video"
+        target="_blank"
+        rel="noopener noreferrer">Tell us what you think</a>
+    </div>
+
 </div>

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -805,7 +805,7 @@ $video-width-desktop: 700px;
         width: 80%
     }
 
-        @include mq(leftCol)  {
+    @include mq(leftCol)  {
         margin-left: 180px;
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -189,14 +189,13 @@ $video-width-desktop: 700px;
 }
 
 .vertical-video-playlist__control {
-    height: 70px;
     width: 300px;
     display: flex;
     gap: 16px;
     justify-content: flex-start;
     align-items: center;
     margin-left: 20px;
-
+    padding-bottom: 24px;
     @include mq($from: 375px, $until: phablet) {
         position: absolute;
         bottom: 80px;
@@ -207,14 +206,12 @@ $video-width-desktop: 700px;
         align-items: flex-start;
         z-index: 10;
         width: calc(100% - 320px);
+        padding-bottom: 0;
     }
 
     @include mq($from: mobileLandscape, $until: phablet) {
         width: calc(100% - 330px);
     }
-
-
-
 
     @include mq(leftCol)  {
         margin-left: 180px;
@@ -692,8 +689,12 @@ $video-width-desktop: 700px;
     }
 }
 
-.vertical-playlist__padding {
-    padding-bottom: 18px;
+.vertical-playlist__margin {
+    margin-bottom: 20px;
+    @include mq($from: phablet) {
+        margin-bottom: 24px
+    }
+
 }
 
 .vertical-video-overlay {
@@ -792,3 +793,30 @@ $video-width-desktop: 700px;
         }
     }
 }
+
+.vertical-video__ext-link {
+    @include fs-textSans(2);
+    color: $brightness-100;
+    margin-left: 20px;
+    margin-right: 20px;
+    padding-bottom: 16px;
+
+    @include mq($until: phablet) {
+        width: 80%
+    }
+
+        @include mq(leftCol)  {
+        margin-left: 180px;
+    }
+
+    @include mq(wide)  {
+        margin-left: 260px;
+    }
+
+    a {
+        text-decoration: underline;
+        color: $brightness-100;
+    }
+
+}
+


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
