### PR TITLE
Simplify pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,6 @@
+## What is the value of this and can you measure success?
+
 ## What does this change?
-
-## Does this change need to be reproduced in dotcom-rendering ?
-
-- [ ] No
-- [ ] Yes (please indicate your plans for DCR Implementation)
 
 ## Screenshots
 
@@ -18,56 +15,16 @@
 
 -->
 
-## What is the value of this and can you measure success?
-
 ## Checklist
 
-### Does this affect other platforms?
-
-- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
-- [ ] Apps
-- [ ] Other (please specify)
-
-### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
-
-<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
-<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
-
-- [ ] No
-- [ ] Yes (please give details)
-
-### Does this change break ad-free?
-
-<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
-<!-- merchandising, page skins and paid-for content -->
-<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
-<!-- scenario -->
-
-- [ ] No
-- [ ] It did, but tests caught it and I fixed it
-- [ ] It did, but there was no test coverage so I added that then fixed it
-
-### Does this change update the version of CAPI we're using?
-
-<!-- Please see the notes linked below if you need further info. -->
-
-- [ ] No, all the existing database files are just fine
-- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
-
-### Accessibility test checklist
-
-<!-- for changes that affect how a page appears in the browser -->
-
-- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
-
-### Tested
-
-- [ ] Locally
-- [ ] On CODE (optional)
+- [ ] Tested locally, and on CODE if necessary
+- [ ] Will not break dotcom-rendering
+- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
+- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
+  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
+  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
+  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)
 
 <!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
 <!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
-
-<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
+<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->


### PR DESCRIPTION
## What does this change?

Simplifies the pull request template:

- asks for the value of the change first and foremost – _why_ is more important than _what_
- moves "does it need to be reproduced in DCR" to the checklist section
- removes "does this affect other platforms" - AMP is deprioritised, while apps templates are irrelevant to frontend. This same question is not asked of changes to DCR
- removes "does this affect GLabs Paid Content Pages" – these pages are increasingly served by DCR, and this question is not asked of changes to DCR
- removes "does this change break ad-free" – this experience is increasingly served by DCR, and this question is not asked of changes to DCR
- removes "tested" section as uninteresting – we expect contributors to test their work, asking them to tick a box achieves  nothing 
- updates link to the team that maintains the frontend repo
- fixes broken accessibility testing links

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

This change makes it easier to write a description for a PR, saving the need to delete numerous irrelevant, confusing, arbitrary and rarely used sections from the template.

Fixes guardian/frontend#25852

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
