### PR TITLE
Bump commercial to 10.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.0.0",
-		"@guardian/commercial": "10.3.0",
+		"@guardian/commercial": "10.4.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.0.0.tgz#3deef75d97549af7cad6046bed2fc282d4e2f78b"
   integrity sha512-rrYQT+41/m9tK3tRU6oiThylqp8M4IUsOrpG5cHJONp2u+uQzJGVTBG/nlEVB4Ds0gTQ18jfwLsHzztG3ILTcA==
 
-"@guardian/commercial@10.3.0":
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.3.0.tgz#28cae8f01dacbf8f5c4b92b471da53f0c5bac1d7"
-  integrity sha512-JKiRU5/4JHEcZZaVVpaTju3V6vnf5iReDc3QpavuFB5jHHgeqG01EQ4gIT5Ee6fYuVxL4bMicJUPeQmOd8wNOA==
+"@guardian/commercial@10.4.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.4.0.tgz#95bff83ca85533b555311a23dc787b0b28aaf1fa"
+  integrity sha512-2hgFjJXnyQEoKAy3iy5YUR9+pMKXwHVmMTftk5plGvdsAkOKQIhaJNPG/kcJhYoXh64wpk4TQYKmSpVA7N93Eg==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"
@@ -10511,7 +10511,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js:
+"prebid.js@github:guardian/prebid.js":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?
Include this fix https://github.com/guardian/commercial/pull/942

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
