### PR TITLE
Remove the Commercial switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -6,17 +6,6 @@ import conf.switches.SwitchGroup.{Commercial, CommercialPrebid, Membership}
 
 trait CommercialSwitches {
 
-  // TODO(@chrislomaxjones) Remove this switch once we update the client to use the new `ShouldLoadGoogleTagSwitch`
-  val CommercialSwitch = Switch(
-    Commercial,
-    "commercial",
-    "If this switch is OFF, no calls will be made to the ad server. BEWARE!",
-    owners = group(Commercial),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val ShouldLoadGoogleTagSwitch = Switch(
     Commercial,
     "should-load-googletag",


### PR DESCRIPTION
## What does this change?

Remove the `CommercialSwitch`.

## Why?

We use a new switch `switches.shouldLoadGoogletag` to specifically control whether we load the Googletag script. This was introduced in https://github.com/guardian/frontend/pull/26295 and consumed in https://github.com/guardian/commercial/pull/940. Now that this switch is no longer used, we can remove it.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
