### PR TITLE
Add category to the media atom

### DIFF
--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -4,6 +4,7 @@ import com.gu.contentapi.client.model.v1.Asset
 import play.api.libs.json.{Json, Writes}
 import views.support.{ImgSrc, Naked, Orientation}
 
+// TODO: Check that adding category here isn't going to break, as its only present for the VideoAsset and not the Image or Audio
 object Helpers {
   def assetFieldsToMap(asset: Asset): Map[String, String] =
     Map(
@@ -28,6 +29,7 @@ object Helpers {
       "scriptName" -> asset.typeData.flatMap(_.scriptName),
       "html" -> asset.typeData.flatMap(_.html),
       "embedType" -> asset.typeData.flatMap(_.embedType),
+      "category" -> asset.typeData.flatMap(_.category).map(_.toString),
     ).collect { case (k, Some(v)) => (k, v) }
 }
 
@@ -124,6 +126,7 @@ case class VideoAsset(fields: Map[String, String], url: Option[String], mimeType
   val source: Option[String] = fields.get("source")
   val embeddable: Boolean = fields.get("embeddable").exists(_.toBoolean)
   val caption: Option[String] = fields.get("caption")
+  val category: Option[String] = fields.get("category")
 }
 
 object AudioAsset {

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -129,6 +129,7 @@ final case class VideoMedia(videoAssets: List[VideoAsset]) {
   val source: Option[String] = videoAssets.headOption.flatMap(_.source)
   val embeddable: Boolean = videoAssets.headOption.exists(_.embeddable)
   val caption: Option[String] = largestVideo.flatMap(_.caption)
+  val category: Option[String] = videoAssets.headOption.flatMap(_.category)
 }
 
 object AudioMedia {

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -92,11 +92,13 @@ final case class ImageMedia(allImages: Seq[ImageAsset]) {
 }
 
 object VideoMedia {
-  def make(capiElement: ApiElement): VideoMedia =
+  def make(capiElement: ApiElement): VideoMedia = {
     VideoMedia(
       videoAssets = capiElement.assets.filter(_.`type` == AssetType.Video).map(VideoAsset.make).sortBy(-_.width).toList,
     )
+  }
 }
+
 final case class VideoMedia(videoAssets: List[VideoAsset]) {
   private implicit val ordering = EncodingOrdering
 

--- a/common/app/model/content/Atom.scala
+++ b/common/app/model/content/Atom.scala
@@ -166,6 +166,7 @@ final case class MediaAtom(
     expired: Option[Boolean],
     activeVersion: Option[Long],
     channelId: Option[String],
+    category: Category,
 ) extends Atom {
 
   def activeAssets: Seq[MediaAsset] =
@@ -223,6 +224,7 @@ object MediaAtom extends common.GuLogging {
       expired = expired,
       activeVersion = mediaAtom.activeVersion,
       channelId = mediaAtom.metadata.flatMap(_.channelId),
+      category = Category.withName(mediaAtom.category.name),
     )
   }
 
@@ -252,6 +254,25 @@ object MediaAtom extends common.GuLogging {
       ).collect { case (k, Some(v)) => (k, v) },
     )
   }
+}
+
+//object Category extends Enumeration {
+//  type Category = Value
+//
+//  val Documentary, Explainer, Feature, News, Hosted, Paid, Livestream = Value
+//}
+sealed trait Category extends EnumEntry
+object Category extends Enum[Category] with PlayJsonEnum[Category] {
+
+  val values = findValues
+
+  case object Documentary extends Category
+  case object Explainer extends Category
+  case object Feature extends Category
+  case object News extends Category
+  case object Hosted extends Category
+  case object Paid extends Category
+  case object Livestream extends Category
 }
 
 object MediaAssetPlatform extends Enum[MediaAssetPlatform] with PlayJsonEnum[MediaAssetPlatform] {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.3.0"
+  val capiVersion = "19.4.2-SNAPSHOT"
   val faciaVersion = "4.0.5"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
This updates the `VideoMedia` model, so that the media atom's category field is included in pressed fronts. We need this field in DCR to display the video category on the video cards 'pill'

## Other PR's related to this change
- content-api-models: https://github.com/guardian/content-api-models/pull/225
- content-api-scala-client: https://github.com/guardian/content-api-scala-client/pull/389