### PR TITLE
Bump commercial to `10.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.0",
-		"@guardian/commercial": "10.4.0",
+		"@guardian/commercial": "10.5.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.0.tgz#3b362f66cc4c37920ed452187a7cc33dec9314a0"
   integrity sha512-SsTrqdYfNq9k63VhicCrnF0WhWCwhxZKyERVzTt5NMt4mG4iWqrrpa+G7SdVQockf3OYEizv4WJtPRt/N1F9pg==
 
-"@guardian/commercial@10.4.0":
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.4.0.tgz#95bff83ca85533b555311a23dc787b0b28aaf1fa"
-  integrity sha512-2hgFjJXnyQEoKAy3iy5YUR9+pMKXwHVmMTftk5plGvdsAkOKQIhaJNPG/kcJhYoXh64wpk4TQYKmSpVA7N93Eg==
+"@guardian/commercial@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.5.0.tgz#171f2f14a19de2587d9b224646381bc7e9f45a63"
+  integrity sha512-m9kCUhfoUO0caJlZO16YpQ2YJ6t6txYAKrANoG7O8qlDltMk4UZzw5e4WT7anJcofSXxsepGyfnPF42zRboxQQ==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
## What is the value of this and can you measure success?

Bring in the changes in commercial `10.5.0` (see [this PR](https://github.com/guardian/commercial/pull/943)).

## What does this change?

Bump commercial to `10.5.0`.
