### PR TITLE
Drop integrate-ima test to zero audience

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,7 +51,7 @@ trait ABTestSwitches {
     "Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos",
     owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 7, 14)),
+    sellByDate = Some(LocalDate.of(2023, 11, 30)),
     exposeClientSide = true,
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -8,7 +8,8 @@ export const integrateIma: ABTest = {
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',
-	audience: 5 / 100,
+	// we might revisit this test so setting to zero for now
+	audience: 0 / 100,
 	audienceOffset: 10 / 100,
 	audienceCriteria: 'Opt in',
 	successMeasure:


### PR DESCRIPTION
## What does this change?

Drop integrate-ima test to zero audience

We might revisit this test so setting to zero for now
