### PR TITLE
Tests should not require AWS credentials

### DIFF
--- a/admin/test/TestAppLoader.scala
+++ b/admin/test/TestAppLoader.scala
@@ -1,13 +1,11 @@
 import app.FrontendComponents
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
-import test.WithTestContentApiClient
 
-trait TestComponents extends WithTestContentApiClient {
+trait TestComponents {
   self: AppComponents =>
-  override lazy val contentApiClient = testContentApiClient
 
-  // Do not run lifecycle components in tests
+  // Don't run lifecycle components in tests
   override lazy val lifecycleComponents = List()
 }
 

--- a/article/test/TestAppLoader.scala
+++ b/article/test/TestAppLoader.scala
@@ -1,17 +1,32 @@
 import app.FrontendComponents
+import services.S3Client
+import org.mockito.Mockito._
+import org.scalatestplus.mockito.MockitoSugar
+import model.{MessageUsConfigData, TopicsApiResponse}
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import renderers.DotcomRenderingService
 import test.WithTestContentApiClient
 import test.DCRFake
 
-trait TestComponents extends WithTestContentApiClient {
+trait TestComponents extends WithTestContentApiClient with WithTestTopicService with WithTestMessageUsService {
   self: AppComponents =>
 
   override lazy val contentApiClient = testContentApiClient
 
   // Relying on DCR output for tests is always a mistake.
   override lazy val remoteRender: DotcomRenderingService = new DCRFake()
+
+  // Do not run lifecycle components in tests
+  override lazy val lifecycleComponents = List()
+}
+
+trait WithTestTopicService extends TopicServices with MockitoSugar {
+  override lazy val topicS3Client: S3Client[TopicsApiResponse] = mock[S3Client[TopicsApiResponse]]
+}
+
+trait WithTestMessageUsService extends MessageUsServices with MockitoSugar {
+  override lazy val messageUsS3Client: S3Client[MessageUsConfigData] = mock[S3Client[MessageUsConfigData]]
 }
 
 class TestAppLoader extends AppLoader {


### PR DESCRIPTION
## What does this change?

Before this change, running tests locally _when you don't have any AWS credentials from Janus_ results in failed tests, which I think is undesired behaviour.

The tests fail because some modules attempt to load AWS credentials in order to do things like load a file from S3. Most code that interacts with AWS is mocked during tests. However, some code running in application lifecycle components is not mocked.

This change introduces mocking or disabling of lifecycle components during tests.

## Why weren't the tests failing before?

They were, but I think most people don't experience the failures as they have AWS credentials when working with Janus.

The tests also run on TeamCity. Somehow, the TeamCity agents have ambiently available AWS credentials, meaning the tests pass. I have not figured out how the TeamCity agents get their credentials.

## How to test

- Remove your AWS credentials. On macOS, you can `mv ~/.aws/credentials ~/.aws/credentials_backup`
- Run tests with `STAGE=DEVINFRA ./sbt test`
