### PR TITLE
Include category for DCR fronts

### DIFF
--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -28,6 +28,7 @@ object Helpers {
       "scriptName" -> asset.typeData.flatMap(_.scriptName),
       "html" -> asset.typeData.flatMap(_.html),
       "embedType" -> asset.typeData.flatMap(_.embedType),
+      "category" -> asset.typeData.flatMap(_.category).map(_.toString),
     ).collect { case (k, Some(v)) => (k, v) }
 }
 
@@ -124,6 +125,7 @@ case class VideoAsset(fields: Map[String, String], url: Option[String], mimeType
   val source: Option[String] = fields.get("source")
   val embeddable: Boolean = fields.get("embeddable").exists(_.toBoolean)
   val caption: Option[String] = fields.get("caption")
+  val category: Option[String] = fields.get("category")
 }
 
 object AudioAsset {

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -127,6 +127,7 @@ final case class VideoMedia(videoAssets: List[VideoAsset]) {
   val source: Option[String] = videoAssets.headOption.flatMap(_.source)
   val embeddable: Boolean = videoAssets.headOption.exists(_.embeddable)
   val caption: Option[String] = largestVideo.flatMap(_.caption)
+  val category: Option[String] = videoAssets.headOption.flatMap(_.category)
 }
 
 object AudioMedia {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.3.0"
+  val capiVersion = "19.4.2-SNAPSHOT"
   val faciaVersion = "4.0.5"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Other related PRs
- content-api-models: https://github.com/guardian/content-api-models/pull/225
- content-api-scala-client: https://github.com/guardian/content-api-scala-client/pull/389
- frontend: https://github.com/guardian/frontend/pull/26316
- **frontend (this one)**
- DCR: https://github.com/guardian/dotcom-rendering/pull/8277

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
