### PR TITLE
Get weather from edition if there is a city not found error

### DIFF
--- a/onward/app/weather/controllers/WeatherController.scala
+++ b/onward/app/weather/controllers/WeatherController.scala
@@ -86,29 +86,26 @@ class WeatherController(weatherApi: WeatherApi, val controllerComponents: Contro
             .headOption match {
             case Some(location) => Future.successful(CityResponse.fromLocationResponse(location))
             case None =>
-              Future.failed(
-                CityNotfoundException(
-                  s"Could not match country [${maybeCountry}], " +
-                    s"city [${maybeCity}] and region [${maybeRegion}]" +
-                    s"to a valid location.",
-                ),
-              )
+              getWeatherFromEdition(request)
           }
         }
       case (_, _) =>
-        val edition = Edition(request)
-        CityResponse.fromEdition(edition) match {
-          case Some(defaultLocation) => Future.successful(defaultLocation)
-          case None =>
-            Future.failed(
-              CityNotfoundException(
-                s"Could not work out a default location for edition [${edition}].",
-              ),
-            )
-        }
+        getWeatherFromEdition(request)
     }
   }
 
+  private def getWeatherFromEdition(request: Request[AnyContent]) = {
+    val edition = Edition(request)
+    CityResponse.fromEdition(edition) match {
+      case Some(defaultLocation) => Future.successful(defaultLocation)
+      case None =>
+        Future.failed(
+          CityNotfoundException(
+            s"Could not work out a default location for edition [${edition}].",
+          ),
+        )
+    }
+  }
 }
 
 case class CityNotfoundException(message: String) extends Exception(message)

--- a/onward/app/weather/controllers/WeatherController.scala
+++ b/onward/app/weather/controllers/WeatherController.scala
@@ -2,7 +2,7 @@ package weather.controllers
 
 import common.JsonComponent.resultFor
 import common.Seqs.RichSeq
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent}
+import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent}
 import model.Cached
 import play.api.libs.json.Json.{stringify, toJson}
 import play.api.mvc._
@@ -14,7 +14,8 @@ import scala.concurrent.duration._
 
 class WeatherController(weatherApi: WeatherApi, val controllerComponents: ControllerComponents)
     extends BaseController
-    with ImplicitControllerExecutionContext {
+    with ImplicitControllerExecutionContext
+    with GuLogging {
   val MaximumForecastDays = 10
 
   def theWeather(): Action[AnyContent] =
@@ -86,6 +87,11 @@ class WeatherController(weatherApi: WeatherApi, val controllerComponents: Contro
             .headOption match {
             case Some(location) => Future.successful(CityResponse.fromLocationResponse(location))
             case None =>
+              log.warn(
+                s"Could not match country [$maybeCountry], " +
+                  s"city [$maybeCity] and region [$maybeRegion]" +
+                  s"to a valid location.",
+              )
               getWeatherFromEdition(request)
           }
         }
@@ -101,7 +107,7 @@ class WeatherController(weatherApi: WeatherApi, val controllerComponents: Contro
       case None =>
         Future.failed(
           CityNotfoundException(
-            s"Could not work out a default location for edition [${edition}].",
+            s"Could not work out a default location for edition [$edition].",
           ),
         )
     }


### PR DESCRIPTION
## What is the value of this and can you measure success?
ELK was logging a significant number of `CityNotFoundException` from the weather API. This was because accuweather response was an empty array - the city was not found. 

## What does this change?
This PR adds an initial fix to resolve these errors. It extracts the fallback for getting the weather by edition into is own private method and uses it in place of the error message. 

This fallback will also error if the edition is not found but there should be far fewer. 

~There is a secondary piece of work to improve the city search by searching on LatLong instead of city codes.~


## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
