### PR TITLE
feat(Experiments): add adaptive site 1% test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,6 +16,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeNetworkFront,
       Okta,
       HeaderTopBarSearchCapi,
+      AdaptiveSite,
       BorkFCP,
       BorkFID,
       OfferHttp3,
@@ -87,6 +88,15 @@ object HeaderTopBarSearchCapi
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 9, 6),
       participationGroup = Perc1B,
+    )
+
+object AdaptiveSite
+    extends Experiment(
+      name = "adaptive-site",
+      description = "Enables serving an adaptive version of the site that responds to page performance",
+      owners = Seq(Owner.withName("Open Journalism")),
+      sellByDate = LocalDate.of(2023, 8, 1),
+      participationGroup = Perc1A,
     )
 
 object BorkFCP


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows us to serve a version of the that adapts to page performance.

## What does this change?

Adds an adaptive site experiment to expire on 1st Aug.

## Screenshots

N/A

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)
