### PR TITLE
feat: remove bork tests

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -17,8 +17,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       Okta,
       HeaderTopBarSearchCapi,
       AdaptiveSite,
-      BorkFCP,
-      BorkFID,
       OfferHttp3,
       FrontsBannerAds,
     )
@@ -97,24 +95,6 @@ object AdaptiveSite
       owners = Seq(Owner.withName("Open Journalism")),
       sellByDate = LocalDate.of(2023, 8, 1),
       participationGroup = Perc1A,
-    )
-
-object BorkFCP
-    extends Experiment(
-      name = "bork-fcp",
-      description = "Synthetically degrades First Contentful Paint (FCP)",
-      owners = Seq(Owner.withName("Open Journalism")),
-      sellByDate = LocalDate.of(2023, 8, 1),
-      participationGroup = Perc1C,
-    )
-
-object BorkFID
-    extends Experiment(
-      name = "bork-fid",
-      description = "Synthetically degrades First Input Delay (FID)",
-      owners = Seq(Owner.withName("Open Journalism")),
-      sellByDate = LocalDate.of(2023, 8, 1),
-      participationGroup = Perc1D,
     )
 
 object OfferHttp3


### PR DESCRIPTION
_N.B. merge on July 19th, 2023_

## What is the value of this and can you measure success?

We have capture enough data for our degradation/“bork” experiments.

## What does this change?

Remove the experiments from our definitions.

## Screenshots

N/A

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
