### PR TITLE
Remove fronts banner test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -19,7 +19,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       BorkFCP,
       BorkFID,
       OfferHttp3,
-      FrontsBannerAds,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -114,13 +113,4 @@ object OfferHttp3
       owners = Seq(Owner.withGithub("paulmr")),
       sellByDate = LocalDate.of(2023, 7, 31),
       participationGroup = Perc1E,
-    )
-
-object FrontsBannerAds
-    extends Experiment(
-      name = "fronts-banner-ads",
-      description = "Creates a new ad experience on fronts pages",
-      owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
-      sellByDate = LocalDate.of(2023, 9, 6),
-      participationGroup = Perc5A,
     )

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -22,7 +22,6 @@ import play.api.mvc.RequestHeader
 import services.SkimLinksCache
 import views.html.fragments.affiliateLinksDisclaimer
 import views.support.Commercial.isAdFree
-import experiments.{ActiveExperiments, FrontsBannerAds}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
@@ -818,9 +817,6 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
     val slices: List[Element] = document.getElementsByClass("fc-slice__item--mpu-candidate").asScala.toList
 
     for (slice <- slices) {
-      if (ActiveExperiments.isParticipating(FrontsBannerAds)) {
-        slice.addClass("fc-slice__item--mpu-candidate--hide-desktop")
-      }
       slice.append(s"${sliceSlot(slices.indexOf(slice) + 1)}")
     }
 
@@ -856,13 +852,7 @@ case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boole
         slot <- adSlot
       } {
         container.after(slot)
-        if (ActiveExperiments.isParticipating(FrontsBannerAds)) {
-          slot.wrap(
-            """<div class="fc-container fc-container--commercial fc-container--commercial--hide-desktop"></div>""",
-          )
-        } else {
-          slot.wrap("""<div class="fc-container fc-container--commercial"></div>""")
-        }
+        slot.wrap("""<div class="fc-container fc-container--commercial"></div>""")
       }
     }
     document

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -3,7 +3,6 @@
 @import views.support.RenderClasses
 @import views.support.Commercial.container.isFirstNonThrasherContainer
 @import implicits.Requests._
-@import experiments.{ActiveExperiments, FrontsBannerAds}
 
 @(faciaPage: model.PressedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
@@ -56,11 +55,7 @@
                 @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
 
                 @if(!isPaid) {
-                    @if(ActiveExperiments.isParticipating(FrontsBannerAds)) {
-                        <div class="fc-container fc-container--commercial js-container--commercial fc-container--commercial--hide-desktop">@fragments.commercial.commercialComponent()</div>
-                    } else {
-                        <div class="fc-container fc-container--commercial js-container--commercial">@fragments.commercial.commercialComponent()</div>
-                    }
+                    <div class="fc-container fc-container--commercial js-container--commercial">@fragments.commercial.commercialComponent()</div>
                 }
             </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.0",
-		"@guardian/commercial": "10.5.0",
+		"@guardian/commercial": "10.6.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -159,20 +159,6 @@
 }
 
 /**
- * Fronts-banner ads
- */
-.fronts-banner-container {
-    display: flex;
-    justify-content: center;
-    background-color: $brightness-97;
-    margin-bottom: 24px;
-
-    @include mq($until: desktop) {
-        display: none;
-    }
-}
-
-/**
  * Inline ads
  */
 .ad-slot--inline,

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -28,13 +28,6 @@ $header-image-size-desktop: 100px;
     padding-bottom: 0;
 }
 
-// For the Fronts OKR test May 2023
-@include mq(desktop) {
-    .facia-page[data-link-name='Front | /uk'] .fc-container--commercial--hide-desktop {
-        display: none;
-    }
-}
-
 .fc-container__inner,
 .facia-container__inner {
     padding-top: $gs-baseline / 4;

--- a/static/src/stylesheets/module/facia-garnett/_items.scss
+++ b/static/src/stylesheets/module/facia-garnett/_items.scss
@@ -63,14 +63,6 @@
 @import 'item-types/_fc-item--type-comment';
 @import 'item-types/_fc-item--type-immersive';
 
-
-// For the Fronts OKR test May 2023
-@include mq(desktop) {
-    .facia-page[data-link-name='Front | /uk'] .fc-slice__item--mpu-candidate.fc-slice__item--mpu-candidate--hide-desktop {
-        display: none;
-    }
-}
-
 .fc-slice__item {
     width: 100%;
     position: relative;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -22,13 +22,6 @@ $header-image-size-desktop: 100px;
     padding-bottom: 0;
 }
 
-// For the Fronts OKR test May 2023
-@include mq(desktop) {
-    .facia-page[data-link-name='Front | /uk'] .fc-container--commercial--hide-desktop {
-        display: none;
-    }
-}
-
 .fc-container__inner,
 .facia-container__inner {
     padding-top: $gs-baseline / 4;

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -19,13 +19,6 @@
 @import 'item-layouts/fc-item--full-media-100';
 @import 'item-layouts/fc-item--fluid';
 
-// For the Fronts OKR test May 2023
-@include mq(desktop) {
-    .facia-page[data-link-name='Front | /uk'] .fc-slice__item--mpu-candidate.fc-slice__item--mpu-candidate--hide-desktop {
-        display: none;
-    }
-}
-
 // overrides of current slices
 
 .fc-slice__item {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.0.tgz#3b362f66cc4c37920ed452187a7cc33dec9314a0"
   integrity sha512-SsTrqdYfNq9k63VhicCrnF0WhWCwhxZKyERVzTt5NMt4mG4iWqrrpa+G7SdVQockf3OYEizv4WJtPRt/N1F9pg==
 
-"@guardian/commercial@10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.5.0.tgz#171f2f14a19de2587d9b224646381bc7e9f45a63"
-  integrity sha512-m9kCUhfoUO0caJlZO16YpQ2YJ6t6txYAKrANoG7O8qlDltMk4UZzw5e4WT7anJcofSXxsepGyfnPF42zRboxQQ==
+"@guardian/commercial@10.6.0":
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.6.0.tgz#315325ce9625540bb22574bad9eace2552543706"
+  integrity sha512-xs50dVkUrSwRtH3Y3e1ruDkQTpL+lT1nbZHyiml5JYYzs1VCOoVBWlFdTbuKeXRLoMrmWQB6A2/wkS+eGUccZg==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
## What does this change?

Removes the Fronts Banner AB test

## What is the value of this and can you measure success?

In Q1, we ran an AB test that involved displaying banner ads instead of MPUs on the UK Network Front. This test has now been completed. We have no plans to implement fronts banner ads on pages rendered by Frontend, so this code has been removed.