### PR TITLE
Use Okta to get sign in status for Reader Revenue header.

### DIFF
--- a/static/src/javascripts/projects/common/modules/support/header.ts
+++ b/static/src/javascripts/projects/common/modules/support/header.ts
@@ -7,9 +7,9 @@ import { submitComponentEvent } from 'common/modules/commercial/acquisitions-oph
 import {
 	getLastOneOffContributionDate,
 	getPurchaseInfo,
-	shouldHideSupportMessaging,
+	shouldHideSupportMessagingOkta,
 } from 'common/modules/commercial/user-features';
-import { isUserLoggedIn } from 'common/modules/identity/api';
+import { isUserLoggedInOktaRefactor } from 'common/modules/identity/api';
 import {
 	dynamicImport,
 	ModulesVersion,
@@ -20,25 +20,25 @@ import config from 'lib/config';
 import { getCountryCode } from 'lib/geolocation';
 import { reportError } from 'lib/report-error';
 
-const buildHeaderLinksPayload = (): HeaderPayload => {
+const buildHeaderLinksPayload = async (): Promise<HeaderPayload> => {
 	const countryCode = getCountryCode();
 	return {
 		tracking,
 		targeting: {
-			showSupportMessaging: !shouldHideSupportMessaging(),
+			showSupportMessaging: !(await shouldHideSupportMessagingOkta()),
 			countryCode,
 			modulesVersion: ModulesVersion,
 			mvtId: getMvtValue() ?? 0,
 			lastOneOffContributionDate:
 				getLastOneOffContributionDate() ?? undefined,
 			purchaseInfo: getPurchaseInfo(),
-			isSignedIn: isUserLoggedIn(),
+			isSignedIn: await isUserLoggedInOktaRefactor(),
 		},
 	};
 };
 
 export const fetchAndRenderHeaderLinks = async (): Promise<void> => {
-	const requestData = buildHeaderLinksPayload();
+	const requestData = await buildHeaderLinksPayload();
 	const isEnabled = config.get<boolean>('switches.remoteHeader', false);
 	const { contentType } = window.guardian.config.page;
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Use Okta to check sign in status when rendering the Reader Revenue header.

## What does this change?

 - Use Okta to check sign in status when rendering the Reader Revenue header.
 - Copies some of the existing functions for checking sign in status to use Okta and avoid immediately changing everything to Okta.
