### PR TITLE
feat: remove coronavirus from uk and international navs

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -19,7 +19,6 @@ object NavLinks {
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = Some("US news"))
   val usPolitics = NavLink("US Politics", "/us-news/us-politics", longTitle = Some("US politics"))
-  val coronavirus = NavLink("Coronavirus", "/world/coronavirus-outbreak", longTitle = Some("Coronavirus"))
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")
@@ -267,7 +266,6 @@ object NavLinks {
       climateCrisis,
       newsletters,
       football,
-      coronavirus,
       ukBusiness,
       ukEnvironment,
       politics,
@@ -313,7 +311,6 @@ object NavLinks {
     children = List(
       world,
       ukNews,
-      coronavirus,
       climateCrisis,
       ukEnvironment,
       science,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -220,13 +220,6 @@
 					"classList": []
 				},
 				{
-					"title": "Coronavirus",
-					"url": "/world/coronavirus-outbreak",
-					"longTitle": "Coronavirus",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "Business",
 					"url": "/business",
 					"children": [
@@ -2697,13 +2690,6 @@
 							"classList": []
 						}
 					],
-					"classList": []
-				},
-				{
-					"title": "Coronavirus",
-					"url": "/world/coronavirus-outbreak",
-					"longTitle": "Coronavirus",
-					"children": [],
 					"classList": []
 				},
 				{


### PR DESCRIPTION
## What is the value of this and can you measure success?

Resolves #26327.

## What does this change?

Removes "Coronavirus" as option from nav bars for `/uk` and `/international` fronts

## Screenshots

Before: 
![before]
After:
![after]

[before]: https://github.com/guardian/frontend/assets/43961396/83f62375-37cb-48e8-ae81-06d30e3cbd95
[after]: https://github.com/guardian/frontend/assets/43961396/efe92581-6863-4f16-a8dc-d48b075bd6aa

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
<!--
The following are not applicable to this PR:
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)
-->

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
