### PR TITLE
Create liveblog right-hand ads AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -95,4 +95,13 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  Switch(
+    ABTests,
+    "ab-liveblog-right-column-ads",
+    "Test the commercial impact of different strategies for displaying ads in the right column on liveblog pages.",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 9, 20)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
+import { liveblogRightColumnAds } from './tests/liveblog-right-column-ads';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateCopyTestJan2023 } from './tests/sign-in-gate-copy-test-variant';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -21,4 +22,5 @@ export const concurrentTests: readonly ABTest[] = [
 	integrateIma,
 	billboardsInMerch,
 	elementsManager,
+	liveblogRightColumnAds,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-right-column-ads.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-right-column-ads.ts
@@ -27,5 +27,5 @@ export const liveblogRightColumnAds: ABTest = {
 			test: noop,
 		},
 	],
-	canRun: () => true,
+	canRun: () => window.guardian.config.page.contentType === 'LiveBlog',
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-right-column-ads.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-right-column-ads.ts
@@ -1,0 +1,31 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const liveblogRightColumnAds: ABTest = {
+	id: 'LiveblogRightColumnAds',
+	author: '@commercial-dev',
+	start: '2023-07-15',
+	expiry: '2023-09-20',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Desktop users with wide (1300px+) screens only',
+	successMeasure:
+		'Displaying an advert in the right-hand column on liveblog pages below the top 1000px of the content will have a significant revenue increase.',
+	description:
+		'Test the commercial impact of different advert display strategies in the right column on liveblog pages',
+	variants: [
+		{
+			id: 'control',
+			test: noop,
+		},
+		{
+			id: 'minimum-stickiness',
+			test: noop,
+		},
+		{
+			id: 'multiple-adverts',
+			test: noop,
+		},
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What is the value of this and can you measure success?

We want to test the effects of two different strategies of utilising the right-hand column on liveblog pages:
- One advert that is sticky for the whole length of the column.
- Multiple adverts that are sticky for a specific height, with a gap between advert containers

## What does this change?

Creates an AB test for placing adverts in the right-hand column

## Other PR's

- [Dotcom-rendering](https://github.com/guardian/dotcom-rendering/pull/8289)
- [Commercial](https://github.com/guardian/commercial/pull/947)

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
