### PR TITLE
Remove soulmates configuration

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -490,7 +490,6 @@ class GuardianConfiguration extends GuLogging {
       configuration.getMandatoryStringProperty("guardian.page.dfp.mobileAppsAdUnitRoot")
     lazy val dfpAccountId = configuration.getMandatoryStringProperty("guardian.page.dfpAccountId")
 
-    lazy val soulmatesApiUrl = configuration.getStringProperty("soulmates.api.url")
     lazy val travelFeedUrl = configuration.getStringProperty("travel.feed.url")
 
     // root dir relative to S3 bucket

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -67,7 +67,6 @@ aws.region=eu-west-1
 # Commercial links
 commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
-commercial.soulmates_url=https://soulmates.theguardian.com
 
 # Journalism
 journalism.callouts.url=http://www.theguardian.com


### PR DESCRIPTION
- Remove configuration items for Soulmates, because the service doesn't exist any more. 💔