### PR TITLE
Increase parallel json presses from 32 to 64

### DIFF
--- a/common/app/services/fronts/FrontJsonFapi.scala
+++ b/common/app/services/fronts/FrontJsonFapi.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait FrontJsonFapi extends GuLogging {
   lazy val stage: String = Configuration.facia.stage.toUpperCase
   val bucketLocation: String
-  val parallelJsonPresses = 32
+  val parallelJsonPresses = 64
   val futureSemaphore = new FutureSemaphore(parallelJsonPresses)
 
   def blockingOperations: BlockingOperations


### PR DESCRIPTION
Co-authored-by: Roberto Tyley <roberto.tyley@guardian.co.uk>
Co-authored-by: Ioanna Kokkini <ioannakok@users.noreply.github.com>
Co-authored-by: Ravi <7014230+arelra@users.noreply.github.com>

## What does this change?

- Increase parallel json presses from 32 to 64
We believe that the limit was too low. There are 2 instances of this class sharing 128 threads, so it can probably be higher.

This change is part of a solution to https://github.com/guardian/frontend/issues/26335.

See https://github.com/guardian/frontend/pull/18331 for where the limit originates from.
