### PR TITLE
Render Old Deadblogs In DCR

### DIFF
--- a/article/app/services/dotcomrendering/ArticlePicker.scala
+++ b/article/app/services/dotcomrendering/ArticlePicker.scala
@@ -17,8 +17,6 @@ object ArticlePageChecks {
 
   def isNotAGallery(page: PageWithStoryPackage): Boolean = !page.item.tags.isGallery
 
-  def isNotLiveBlog(page: PageWithStoryPackage): Boolean = !page.item.tags.isLiveBlog
-
   def isNotPaidContent(page: PageWithStoryPackage): Boolean = !page.item.tags.isPaidContent
 }
 
@@ -28,7 +26,6 @@ object ArticlePicker {
     Map(
       ("isSupportedType", ArticlePageChecks.isSupportedType(page)),
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
-      ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
     )
   }
 
@@ -38,7 +35,6 @@ object ArticlePicker {
       Set(
         "isSupportedType",
         "isNotAGallery",
-        "isNotLiveBlog",
       ),
     )
 


### PR DESCRIPTION
## Why?

Frontend thinks that some old deadblogs are standard articles. Previously these were filtered out from being rendered by DCR. However, now that we support deadblogs in DCR we can allow these through.
