### PR TITLE
feat: remove check to not use DCR on /au front

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -47,9 +47,6 @@ object FrontChecks {
   def hasOnlySupportedCollections(faciaPage: PressedPage) =
     faciaPage.collections.forall(collection => SUPPORTED_COLLECTIONS.contains(collection.collectionType))
 
-  /** Required until we fully support the Labs container & finish the vertical video test */
-  def isNotAustralianFront(faciaPage: PressedPage) = faciaPage.id != "au"
-
   /*
    * This list contains JSON.HTML thrashers that DCR allows. These thrashers should not actually be rendered by DCR
    * but instead have an alternate way of being rendered on DCR.
@@ -97,7 +94,6 @@ object FaciaPicker extends GuLogging {
     Map(
       ("hasNoUnsupportedSnapLinkCards", FrontChecks.hasNoUnsupportedSnapLinkCards(faciaPage)),
       ("hasOnlySupportedCollections", FrontChecks.hasOnlySupportedCollections(faciaPage)),
-      ("isNotAustralianFront", FrontChecks.isNotAustralianFront(faciaPage)),
     )
   }
 

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -273,13 +273,4 @@ import layout.slices.EmailLayouts
     FrontChecks.hasOnlySupportedCollections(faciaPage) should be(false)
   }
 
-  it should "Should not render the Australian front" in {
-    FrontChecks.isNotAustralianFront(auFaciaPage) should be(false)
-  }
-
-  it should "Should render the UK, US and International fronts" in {
-    FrontChecks.isNotAustralianFront(ukFaciaPage) should be(true)
-    FrontChecks.isNotAustralianFront(usFaciaPage) should be(true)
-    FrontChecks.isNotAustralianFront(internationalFaciaPageWithTargetedTerritories) should be(true)
-  }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?
We will serve content from the `/au`, and thus all network fronts, from DCR.

## What does this change?
Removes the `isNotAustralianFront` check from `FaciaPicker`

