### PR TITLE
Bump the commercial package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.0",
-		"@guardian/commercial": "10.6.0",
+		"@guardian/commercial": "^10.7.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.0.tgz#3b362f66cc4c37920ed452187a7cc33dec9314a0"
   integrity sha512-SsTrqdYfNq9k63VhicCrnF0WhWCwhxZKyERVzTt5NMt4mG4iWqrrpa+G7SdVQockf3OYEizv4WJtPRt/N1F9pg==
 
-"@guardian/commercial@10.6.0":
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.6.0.tgz#315325ce9625540bb22574bad9eace2552543706"
-  integrity sha512-xs50dVkUrSwRtH3Y3e1ruDkQTpL+lT1nbZHyiml5JYYzs1VCOoVBWlFdTbuKeXRLoMrmWQB6A2/wkS+eGUccZg==
+"@guardian/commercial@^10.7.0":
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.7.0.tgz#b7429d38c3d249f5d65d1a7f2840afbfc5ab6eba"
+  integrity sha512-IiQ24w1ZYU8mHbVZK/OIekNgErD4/erqkgtWMjtZ87ZBoOkHdn9dTtpgNK09zPdlw6xhoRGv6sxuoPyMflLt8Q==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
## What does this change?
Bumps the commercial package version to fix an issue with user features and the mobile sticky close button.

Changelog: https://github.com/guardian/commercial/blob/main/CHANGELOG.md#1070
