### PR TITLE
Cleans up the team code in our patch for pa's codeFor helper

### DIFF
--- a/sport/app/football/model/GuTeamCode.scala
+++ b/sport/app/football/model/GuTeamCode.scala
@@ -1,5 +1,6 @@
 package football.model
 
+import model.CompetitionDisplayHelpers.cleanTeamCode
 import pa._
 
 object GuTeamCodes {
@@ -13,7 +14,8 @@ object GuTeamCodes {
     // This is a temporary fix. The, better, long term fix is to upgrade the PA library (and check that the new library
     // come with the correct value for North Macedonia), at which point this object should be removed.
 
-    val code = TeamCodes.codeFor(team)
+    val code = cleanTeamCode(TeamCodes.codeFor(team))
+
     if (code == "MAC") {
       "MKD"
     } else {


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
We were patching the pa.TeamCodes.codeFor, which was not using our helper to cleanup the team code, which resulted in the wrong code being used in the table stats

## Screenshots



| | Before      | After      |
| --|-------------|------------|
| Fixtures page | <img width="241" alt="image" src="https://github.com/guardian/frontend/assets/26366706/06f73575-ec77-4de8-8a98-b55e727ed357"> | <img width="258" alt="image" src="https://github.com/guardian/frontend/assets/26366706/bb92674a-7760-4d73-a14d-4d728c59157f"> |
| Overview page | <img width="242" alt="image" src="https://github.com/guardian/frontend/assets/26366706/197c6e87-c755-4516-8fb4-9c7ac9c1a4e8"> | <img width="202" alt="image" src="https://github.com/guardian/frontend/assets/26366706/bb75c5b3-d1d1-4bc5-bcae-3a5cb865fe6f"> |
| Results page | <img width="241" alt="image" src="https://github.com/guardian/frontend/assets/26366706/75c367fb-632c-4e9b-ba76-ac004e7e5bfa"> | <img width="242" alt="image" src="https://github.com/guardian/frontend/assets/26366706/658f15b4-4eae-453d-b0e4-ef57a847f6c5"> |


## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
