### PR TITLE
Bump commercial to 5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
 		"@guardian/commercial": "^10.8.0",
+		"@guardian/commercial-bundle": "5.2.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
 		"@guardian/commercial": "^10.8.0",
-		"@guardian/commercial-bundle": "5.2.0",
+		"@guardian/commercial-bundle": "5.3.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "^10.7.0",
+		"@guardian/commercial": "^10.8.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,6 +1561,34 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
+"@guardian/commercial-bundle@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.2.0.tgz#8e14a548fea494da6f2f7ce3fc692bb4ec7055b0"
+  integrity sha512-Ndf9bgRDR7vj3vDPbi5M2Cnlb9Eh2n7+by/jboqZBOFTf3UBL+6cR5/9rKjcq4ChpErbYoBfAF9WgnFMGQ6xIA==
+  dependencies:
+    "@guardian/ab-core" "^4.0.0"
+    "@guardian/commercial-core" "^7.0.0"
+    "@guardian/consent-management-platform" "^13.0.2"
+    "@guardian/core-web-vitals" "^4.0.0"
+    "@guardian/libs" "^14.0.0"
+    "@guardian/source-foundations" "^10.0.1"
+    "@guardian/support-dotcom-components" "^1.0.7"
+    "@octokit/core" "^4.0.5"
+    fastdom "^1.0.11"
+    lodash-es "^4.17.21"
+    ophan-tracker-js "^1.4.0"
+    prebid.js guardian/prebid.js#2e3b96d
+    process "^0.11.10"
+    raven-js "^3.27.2"
+    tslib "^2.4.1"
+    web-vitals "^2.1.2"
+    wolfy87-eventemitter "^5.2.9"
+
+"@guardian/commercial-core@^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-7.1.0.tgz#ebe05454873707a6b5eef238e10751379059c276"
+  integrity sha512-Ue1Km1W4w7J8ZYH+qqLgEPyk6j7TOz6Tn94yDPac30oDo3hauJDSH35wZRbwcJBc8hlKPCtqAEXSvtcx42pcig==
+
 "@guardian/commercial@^10.8.0":
   version "10.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.8.0.tgz#2033142e874dffba725319e5d23ce3dd0a044c66"
@@ -1583,6 +1611,11 @@
     tslib "^2.5.3"
     web-vitals "^3.3.2"
     wolfy87-eventemitter "^5.2.9"
+
+"@guardian/consent-management-platform@^13.0.2":
+  version "13.6.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
+  integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
 
 "@guardian/consent-management-platform@^13.5.0":
   version "13.5.0"
@@ -1650,7 +1683,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@guardian/source-foundations@^10.0.0":
+"@guardian/source-foundations@^10.0.0", "@guardian/source-foundations@^10.0.1":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-10.0.1.tgz#fe9d5d1bee9dd1b0d3d579d21a99f6051aa47649"
   integrity sha512-q7FHvQO2JN463SHRjLNKeywW8KUfjoao6oiULoyHssI07saol2rE0W8BdPCeD9337FNztiOxMGOmXWSBUIdYJw==
@@ -10516,7 +10549,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js:
+prebid.js@guardian/prebid.js, prebid.js@guardian/prebid.js#2e3b96d:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:
@@ -13301,6 +13334,11 @@ wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-vitals@^2.1.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.4.tgz#76563175a475a5e835264d373704f9dde718290c"
+  integrity sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==
 
 web-vitals@^3.3.0:
   version "3.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@^10.7.0":
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.7.0.tgz#b7429d38c3d249f5d65d1a7f2840afbfc5ab6eba"
-  integrity sha512-IiQ24w1ZYU8mHbVZK/OIekNgErD4/erqkgtWMjtZ87ZBoOkHdn9dTtpgNK09zPdlw6xhoRGv6sxuoPyMflLt8Q==
+"@guardian/commercial@^10.8.0":
+  version "10.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.8.0.tgz#2033142e874dffba725319e5d23ce3dd0a044c66"
+  integrity sha512-tHrzUyKBBoFS0JUha4kiv5aPD5Q3ej0pjVFiseu6NtPGijaK5JmAnlF4UitbRUP46dlOnoDA3RVAVZ02hcBTbw==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,13 +1561,13 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial-bundle@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.2.0.tgz#8e14a548fea494da6f2f7ce3fc692bb4ec7055b0"
-  integrity sha512-Ndf9bgRDR7vj3vDPbi5M2Cnlb9Eh2n7+by/jboqZBOFTf3UBL+6cR5/9rKjcq4ChpErbYoBfAF9WgnFMGQ6xIA==
+"@guardian/commercial-bundle@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-bundle/-/commercial-bundle-5.3.0.tgz#167e16496fca1a7b4133eea33363a72f30d697f2"
+  integrity sha512-3fChRCc8Jy38k8wggON9iU5S/KG8fa1Q+fYjA8nF0YqNOXqCrDwsYv7qVGIpjN2jNPVxOuftrWdlAUNq/8oEvg==
   dependencies:
     "@guardian/ab-core" "^4.0.0"
-    "@guardian/commercial-core" "^7.0.0"
+    "@guardian/commercial-core" "^7.1.0"
     "@guardian/consent-management-platform" "^13.0.2"
     "@guardian/core-web-vitals" "^4.0.0"
     "@guardian/libs" "^14.0.0"
@@ -1584,7 +1584,7 @@
     web-vitals "^2.1.2"
     wolfy87-eventemitter "^5.2.9"
 
-"@guardian/commercial-core@^7.0.0":
+"@guardian/commercial-core@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-7.1.0.tgz#ebe05454873707a6b5eef238e10751379059c276"
   integrity sha512-Ue1Km1W4w7J8ZYH+qqLgEPyk6j7TOz6Tn94yDPac30oDo3hauJDSH35wZRbwcJBc8hlKPCtqAEXSvtcx42pcig==


### PR DESCRIPTION
Bring in the changes from https://github.com/guardian/commercial/releases/tag/v5.3.0