### PR TITLE
Bump commercial to 10.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "^10.8.0",
+		"@guardian/commercial": "10.5.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@^10.8.0":
-  version "10.8.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.8.0.tgz#2033142e874dffba725319e5d23ce3dd0a044c66"
-  integrity sha512-tHrzUyKBBoFS0JUha4kiv5aPD5Q3ej0pjVFiseu6NtPGijaK5JmAnlF4UitbRUP46dlOnoDA3RVAVZ02hcBTbw==
+"@guardian/commercial@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.5.0.tgz#171f2f14a19de2587d9b224646381bc7e9f45a63"
+  integrity sha512-m9kCUhfoUO0caJlZO16YpQ2YJ6t6txYAKrANoG7O8qlDltMk4UZzw5e4WT7anJcofSXxsepGyfnPF42zRboxQQ==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
Bring in the changes from https://github.com/guardian/commercial/releases/tag/v10.5.0