### PR TITLE
Okta: Add a request options helper

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -235,6 +235,32 @@ export const isUserLoggedInOktaRefactor = (): Promise<boolean> => {
 	});
 };
 
+/**
+ * Decide request options based on an {@link AuthStatus}. Requests to authenticated APIs require different options depending on whether
+ * you are in the Okta experiment or not.
+ * @param authStatus
+ * @returns where `authStatus` is:
+ * - `SignedInWithCookies`, set the `credentials` option to `"include"`
+ * - `SignedInWithOkta`, set the `Authorization` header with a Bearer
+ *   Access Token
+ */
+// @ts-expect-error -- we know this is unused for now
+const getOptionsHeadersWithOkta = (
+	authStatus: SignedInWithCookies | SignedInWithOkta,
+): RequestInit => {
+	if (authStatus.kind === 'SignedInWithCookies') {
+		return {
+			credentials: 'include',
+		};
+	}
+
+	return {
+		headers: {
+			Authorization: `Bearer: ${authStatus.accessToken.accessToken}`,
+		},
+	};
+};
+
 export const getUserFromApi = mergeCalls(
 	(mergingCallback: (u: IdentityUser | null) => void) => {
 		if (isUserLoggedIn()) {

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -244,8 +244,7 @@ export const isUserLoggedInOktaRefactor = (): Promise<boolean> => {
  * - `SignedInWithOkta`, set the `Authorization` header with a Bearer
  *   Access Token
  */
-// @ts-expect-error -- we know this is unused for now
-const getOptionsHeadersWithOkta = (
+export const getOptionsHeadersWithOkta = (
 	authStatus: SignedInWithCookies | SignedInWithOkta,
 ): RequestInit => {
 	if (authStatus.kind === 'SignedInWithCookies') {


### PR DESCRIPTION
Requests to authenticated APIs need different options depending on if the user is in the Okta experiment or not.

If the user is in the Okta experiment, the request should include an `Authorization` header with a bearer access token value.

If the user is not in the Okta experiment, the request should include cookies by setting the `credentials` option to `include`.

Resolves https://github.com/guardian/frontend/issues/26360.