### PR TITLE
Refactor football team code cleaner

### DIFF
--- a/sport/app/football/model/GuTeamCode.scala
+++ b/sport/app/football/model/GuTeamCode.scala
@@ -1,25 +1,33 @@
 package football.model
 
-import model.CompetitionDisplayHelpers.cleanTeamCode
 import pa._
 
 object GuTeamCodes {
   def codeFor(team: FootballTeam): String = {
 
-    // Date: June 2021
+    // Date: June 2021, Updated July 2023 to include more incorrect codes
     // Author: Pascal
 
     // Introducing this function to patches pa.TeamCodes.codeFor in order to replace the currently PA incorrect
-    // short code for North Macedonia. PA's current library says "MAC", but the correct value is "MKD".
+    // short codes below.
     // This is a temporary fix. The, better, long term fix is to upgrade the PA library (and check that the new library
-    // come with the correct value for North Macedonia), at which point this object should be removed.
+    // comes with the correct values), at which point this object should be removed.
 
-    val code = cleanTeamCode(TeamCodes.codeFor(team))
-
-    if (code == "MAC") {
-      "MKD"
-    } else {
-      code
+    // We need to match on name, as South Africa and South Korea both default to "SOU"
+    team.name match {
+      case "China PR"        => "CHN"
+      case "Costa Rica"      => "CRC"
+      case "Japan"           => "JPN"
+      case "Morocco"         => "MAR"
+      case "Netherlands"     => "NED"
+      case "North Macedonia" => "MKD"
+      case "New Zealand"     => "NZL"
+      case "Rep of Ireland"  => "IRL"
+      case "South Africa"    => "RSA"
+      case "South Korea"     => "KOR"
+      case "Spain"           => "ESP"
+      case "Switzerland"     => "SUI"
+      case _                 => TeamCodes.codeFor(team)
     }
   }
 }

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -181,10 +181,4 @@ object CompetitionDisplayHelpers {
       .replace("Czech Republic", "Czech Rep.")
       .replace("Holland", "Netherlands")
   }
-
-  def cleanTeamCode(teamCode: String): String = {
-    teamCode
-      .replace("JAP", "JPN")
-      .replace("HOL", "NED")
-  }
 }

--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -3,7 +3,7 @@
 @import views.support.RenderClasses
 @import views.{NudgePercent, PercentMaker}
 @import pa.LineUpPlayer
-@import model.CompetitionDisplayHelpers.{cleanTeamName, cleanTeamCode}
+@import model.CompetitionDisplayHelpers.{cleanTeamName}
 
 @import football.model.GuTeamCodes
 @(page: MatchPage)(implicit request: RequestHeader)
@@ -48,8 +48,8 @@
                        data-chart-show-values="true">
                     <thead hidden>
                         <tr>
-                            <th>@cleanTeamCode(GuTeamCodes.codeFor(away))</th>
-                            <th>@cleanTeamCode(GuTeamCodes.codeFor(home))</th>
+                            <th>(GuTeamCodes.codeFor(away))</th>
+                            <th>(GuTeamCodes.codeFor(home))</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
## What does this change?
We had 2 cleaners for the football teams code value, this change removes `cleanTeamCode` in favour of the patch on `pa.TeamCodes.codeFor`, as `codeFor` is used in a lot more places (cleanTeamCode was only used once, and wrapped codeFor anyway).

This change also extends the list of codes to correct as per the email sent across by Editorial.

Resolves https://github.com/guardian/dotcom-rendering/issues/8364


## Screenshots

|Country| Before      | After      |
|--|-------------|------------|
|New Zealand – NZL | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/65a4241f-cc84-482f-b26b-8bcef7f2eac8">| <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/98a0b715-a414-4c23-97bf-2667a72a3d31"> |
|Switzerland – SUI | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/65a4241f-cc84-482f-b26b-8bcef7f2eac8">| <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/98a0b715-a414-4c23-97bf-2667a72a3d31"> ||Republic of Ireland – IRL | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/23cdd5d3-c0dd-4dbf-8632-1b3f3afa8fc3"> | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/4f95defa-9cf7-4de7-99e8-389337c7ce04"> |
|Nigeria – NGA | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/adbe42f8-dd0b-47e9-95be-121759ea8f59"> | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/23673dbf-3296-43e2-ae97-e0dff96ed990"> |
|Spain – ESP | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/49072689-a400-4fdd-b071-d07d95628f7f"> | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/bbbd8fac-1696-4e23-899e-df0ce2989a3f"> |
|Costa Rica – CRC |<img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/49072689-a400-4fdd-b071-d07d95628f7f"> | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/bbbd8fac-1696-4e23-899e-df0ce2989a3f"> |
|China – CHN | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/e877e83f-c0fd-41ec-af01-9ecd4329b542"> | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/a3592019-933d-4348-99db-082ff7bbcfbb"> |
|Netherlands – NED | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/90c7f682-fdb9-437a-8b28-e60c9040beda"> | <img width="266" alt="image" src="https://github.com/guardian/frontend/assets/26366706/d46c2b24-2dc7-420a-8271-e13a1f36d0af"> |
|South Africa – RSA | <img width="268" alt="image" src="https://github.com/guardian/frontend/assets/26366706/0d65d5d4-546c-4887-ab7b-51b2b3fa777e"> | <img width="268" alt="image" src="https://github.com/guardian/frontend/assets/26366706/22494526-cc14-4fb4-b7f1-78fba31dfdf9"> |
|Morocco – MAR | <img width="268" alt="image" src="https://github.com/guardian/frontend/assets/26366706/38349829-2019-4583-8ca4-4dc33a067fc4"> | <img width="268" alt="image" src="https://github.com/guardian/frontend/assets/26366706/252aa95b-51e6-4bc3-b422-3a10d5214216"> |
|South Korea – KOR | <img width="268" alt="image" src="https://github.com/guardian/frontend/assets/26366706/38349829-2019-4583-8ca4-4dc33a067fc4"> | <img width="268" alt="image" src="https://github.com/guardian/frontend/assets/26366706/252aa95b-51e6-4bc3-b422-3a10d5214216"> |
|North Macedonia – MKD | <img width="260" alt="image" src="https://github.com/guardian/frontend/assets/26366706/bea6eb04-23a5-4b5f-b0cb-e1b0739f6072"> | <img width="260" alt="image" src="https://github.com/guardian/frontend/assets/26366706/b35be950-1a34-4dad-8bbb-f7063510ec2c"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
