### PR TITLE
Remove authenticated actions from `EmailsTab`

### DIFF
--- a/identity/app/controllers/editprofile/tabs/EmailsTab.scala
+++ b/identity/app/controllers/editprofile/tabs/EmailsTab.scala
@@ -5,11 +5,6 @@ import controllers.editprofile._
 import play.api.mvc.{Action, AnyContent}
 
 trait EmailsTab extends EditProfileControllerComponents {
-
-  import authenticatedActions._
-
-  val emailFilter = emailValidationFilter
-
   private def redirectToManage(path: String): Action[AnyContent] =
     Action { implicit request =>
       Redirect(url = s"${Configuration.id.mmaUrl}/${path}", MOVED_PERMANENTLY)


### PR DESCRIPTION
Authenticated actions have not been used in this module since https://github.com/guardian/frontend/pull/21745. Removing the import makes this module less confusing.

The email filter was added in https://github.com/guardian/frontend/commit/32cab6cd93112cb73b842369176cfb1a36ac1337#diff-b00ae514148add813fed209461c95fc23b4e978fd89fcb5c10bb6bebe699ee68R12 to display a form, but the form was removed in #21745 as well.