### PR TITLE
Fix missing @ syntax

### DIFF
--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -48,8 +48,8 @@
                        data-chart-show-values="true">
                     <thead hidden>
                         <tr>
-                            <th>(GuTeamCodes.codeFor(away))</th>
-                            <th>(GuTeamCodes.codeFor(home))</th>
+                            <th>@(GuTeamCodes.codeFor(away))</th>
+                            <th>@(GuTeamCodes.codeFor(home))</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
## What does this change?
Adds a missing @ to [matchStatsComponent.scala.html](https://github.com/guardian/frontend/pull/26383/files#diff-66d8a437a358df7eee6c293ba3bcffaa752c3c4b92d8c62b277f3edfae084311). I refactored this as part of https://github.com/guardian/frontend/pull/26378 and missed that i'd broken the rendering of the teamNames as DCR is used for rendering articles.

Fixes https://github.com/guardian/frontend/issues/26382
## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="641" alt="image" src="https://github.com/guardian/frontend/assets/26366706/b3490ac4-78b6-4a82-a817-e17a20e6cbf7"> |<img width="641" alt="image" src="https://github.com/guardian/frontend/assets/26366706/02612cc2-1212-4d55-af35-9e6c6d02c031"> |



## Checklist

- [x] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  