### PR TITLE
Cartoon Element

### DIFF
--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -44,7 +44,7 @@ class ImageContentController(
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] =
     image(Edition(request), path).flatMap {
       case Right((content, mainBlock)) =>
-        val tier = ImageContentPicker.getTier(content)
+        val tier = ImageContentPicker.getTier(content, mainBlock)
 
         tier match {
           case RemoteRender => remoteRender(content, mainBlock)

--- a/applications/app/services/dotcomrendering/ImageContentPicker.scala
+++ b/applications/app/services/dotcomrendering/ImageContentPicker.scala
@@ -1,5 +1,6 @@
 package services.dotcomrendering
 
+import com.gu.contentapi.client.model.v1.{Block, ElementType}
 import common.GuLogging
 import model.Cors.RichRequestHeader
 import model.ImageContentPage
@@ -8,32 +9,21 @@ import utils.DotcomponentsLogger
 
 object ImageContentPicker extends GuLogging {
 
-  /**
-    *
-    * Add to this function any logic for including/excluding
-    * an image article from being rendered with DCR
-    *
-    * Currently defaulting to false until we implement image articles in DCR
-    *
-    * */
-  private def dcrCouldRender(imageContentPage: ImageContentPage): Boolean = {
-    false
-  }
-
   def getTier(
       imageContentPage: ImageContentPage,
+      mainBlock: Option[Block],
   )(implicit
       request: RequestHeader,
   ): RenderType = {
-
-    // Setting to false while still implementing this content type in DCR
-    val participatingInTest = false //ActiveExperiments.isParticipating(DCRImageContent)
-    val dcrCanRender = dcrCouldRender(imageContentPage)
+    val dcrCanRender =
+      mainBlock.exists(block => block.elements.forall(element => element.`type` == ElementType.Cartoon))
+    // Currently defaulting to false until we implement image articles in DCR
+    val dcrShouldRender = false
 
     val tier = {
       if (request.forceDCROff) LocalRender
       else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender && participatingInTest) RemoteRender
+      else if (dcrCanRender && dcrShouldRender) RemoteRender
       else LocalRender
     }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -3,6 +3,8 @@ package model.dotcomrendering.pageElements
 import java.net.URLEncoder
 import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
 import com.gu.contentapi.client.model.v1.{
+  CartoonImage,
+  CartoonVariant,
   ElementType,
   EmbedTracking,
   SponsorshipType,
@@ -285,12 +287,18 @@ case class GuVideoBlockElement(
 object GuVideoBlockElement {
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
 }
-
 case class CartoonBlockElement(
-    //todo rest of model
+    cartoonVariants: Option[List[CartoonVariant]],
+    role: Option[String],
+    credit: Option[String],
+    caption: Option[String],
+    alt: Option[String],
+    source: Option[String],
     displayCredit: Option[Boolean],
 ) extends PageElement
 object CartoonBlockElement {
+  implicit val CartoonImageWrites: Writes[CartoonImage] = Json.writes[CartoonImage]
+  implicit val CartoonVariantWrites: Writes[CartoonVariant] = Json.writes[CartoonVariant]
   implicit val CartoonBlockElementWrites: Writes[CartoonBlockElement] = Json.writes[CartoonBlockElement]
 }
 
@@ -1824,7 +1832,17 @@ object PageElement {
    */
   val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
 
-  private def cartoonToPageElement(element: ApiBlockElement): Option[CartoonBlockElement] = {
-    element.cartoonTypeData.map(cartoonData => ???)
+  private[pageElements] def cartoonToPageElement(element: ApiBlockElement): Option[CartoonBlockElement] = {
+    element.cartoonTypeData.map(cartoonData =>
+      CartoonBlockElement(
+        cartoonVariants = cartoonData.cartoonVariants.map(_.toList),
+        role = cartoonData.role,
+        credit = cartoonData.credit,
+        caption = cartoonData.caption,
+        alt = cartoonData.alt,
+        source = cartoonData.source,
+        displayCredit = cartoonData.displayCredit,
+      ),
+    )
   }
 }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -286,6 +286,14 @@ object GuVideoBlockElement {
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
 }
 
+case class CartoonBlockElement(
+    //todo rest of model
+    displayCredit: Option[Boolean],
+) extends PageElement
+object CartoonBlockElement {
+  implicit val CartoonBlockElementWrites: Writes[CartoonBlockElement] = Json.writes[CartoonBlockElement]
+}
+
 case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
 object ImageSource {
   implicit val ImageSourceWrites: Writes[ImageSource] = Json.writes[ImageSource]
@@ -809,6 +817,7 @@ object PageElement {
       case _: YoutubeBlockElement         => true
       case _: WitnessBlockElement         => true
       case _: VineBlockElement            => true
+      case _: CartoonBlockElement         => true
       // TODO we should quick fail here for these rather than pointlessly go to DCR
       case table: TableBlockElement if table.isMandatory.exists(identity) => true
 
@@ -891,6 +900,8 @@ object PageElement {
             element.richLinkTypeData.flatMap(_.sponsorship).map(Sponsorship(_)),
           ),
         )
+
+      case Cartoon => cartoonToPageElement(element).toList
 
       case Image =>
         def ensureHTTPS(src: String): String = src.replace("http:", "https:")
@@ -1813,4 +1824,7 @@ object PageElement {
    */
   val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
 
+  private def cartoonToPageElement(element: ApiBlockElement): Option[CartoonBlockElement] = {
+    element.cartoonTypeData.map(cartoonData => ???)
+  }
 }

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -178,6 +178,7 @@ object BlockElement {
 
       case EnumUnknownElementType(f) => Some(UnknownBlockElement(None))
       case Callout                   => Some(UnsupportedBlockElement(None))
+      case Cartoon                   => Some(UnsupportedBlockElement(None))
 
     }
   }

--- a/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
@@ -1,10 +1,10 @@
 package model.dotcomrendering.pageElements
 
-import com.gu.contentapi.client.model.v1.EmbedTracking
 import com.gu.contentapi.client.model.v1.EmbedTracksType.{DoesNotTrack, EnumUnknownEmbedTracksType, Tracks, Unknown}
-import org.scalatest.matchers.should.Matchers
-import model.dotcomrendering.pageElements.PageElement.containsThirdPartyTracking
+import com.gu.contentapi.client.model.v1._
+import model.dotcomrendering.pageElements.PageElement.{cartoonToPageElement, containsThirdPartyTracking}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class PageElementTest extends AnyFlatSpec with Matchers {
   "PageElement" should "classify capi tracking value correctly" in {
@@ -13,5 +13,37 @@ class PageElementTest extends AnyFlatSpec with Matchers {
     containsThirdPartyTracking(Some(EmbedTracking(Tracks))) should equal(true)
     containsThirdPartyTracking(Some(EmbedTracking(Unknown))) should equal(true)
     containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99)))) should equal(true)
+  }
+
+  "PageElement" should "transform a cartoon element from Content API" in {
+    val variants = scala.collection.Seq(
+      CartoonVariant(
+        viewportSize = "large",
+        images = scala.collection.Seq(CartoonImage(mimeType = "image/jpeg", file = "https://link-to-my-image")),
+      ),
+    )
+    val contentApiElement = BlockElement(
+      `type` = ElementType.Cartoon,
+      cartoonTypeData = Some(
+        CartoonElementFields(
+          cartoonVariants = Some(variants),
+          role = Some("role"),
+          credit = Some("credit"),
+          caption = Some("caption"),
+          alt = Some("alt"),
+          source = Some("source"),
+          displayCredit = Some(true),
+        ),
+      ),
+    )
+    val dcrElement: CartoonBlockElement = cartoonToPageElement(contentApiElement).get
+
+    dcrElement.cartoonVariants should be(Some(variants.toList))
+    dcrElement.role should be(Some("role"))
+    dcrElement.credit should be(Some("credit"))
+    dcrElement.caption should be(Some("caption"))
+    dcrElement.alt should be(Some("alt"))
+    dcrElement.source should be(Some("source"))
+    dcrElement.displayCredit should be(Some(true))
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.3.0"
+  val capiVersion = "19.3.2-SNAPSHOT"
   val faciaVersion = "4.0.5"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
