### PR TITLE
Mob/remove reposition comments

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordFooter.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordFooter.scala.html
@@ -3,10 +3,6 @@
 
     @fragments.discussionFooter(crosswordPage.item.content, crosswordPage.item.trail.isCommentable, crosswordPage.item.trail.isClosedForComments, crosswordPage.item.content.shortUrlId)
 
-    @if(crosswordPage.item.trail.isCommentable) {
-        <div class="js-repositioned-comments content__repositioned-comments"></div>
-    }
-
     @fragments.onwardPlaceholder(isPaidContent = false)
 
 </div>

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -17,9 +17,7 @@
         @if(!(Commercial.isAdFree(request) && isPaidContent)) {
             @fragments.onwardPlaceholder(isPaidContent)
         }
-    } {
-        <div class="js-repositioned-comments content__repositioned-comments"></div>
-    } {
+    } { } {
         @fragments.mostPopularPlaceholder(content.metadata.sectionId)
     } {
         @* The high-relevant commercial component will be inserted on the client-side


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
