### PR TITLE
Start liveblog right column ads test

### DIFF
--- a/docs/03-dev-howtos/01-ab-testing.md
+++ b/docs/03-dev-howtos/01-ab-testing.md
@@ -190,6 +190,8 @@ export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
 ];
 ```
 
+To collect metrics for a client-side test, add your test here: `static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts`.
+
 ### Forcing yourself into a test
 Add #ab-<TestName>=<VariantName> to the end of your URL (in dev or prod) to force yourself into a test.
 e.g. www.theguardian.com/news#ab-MyGreatTest=GreenButton. **Note that this will only work if the `canRun` of your test and variant is true on that pageview.**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "10.9.1",
+		"@guardian/commercial": "10.10.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "0.3.0",

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-right-column-ads.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-right-column-ads.ts
@@ -4,9 +4,9 @@ import { noop } from '../../../../../lib/noop';
 export const liveblogRightColumnAds: ABTest = {
 	id: 'LiveblogRightColumnAds',
 	author: '@commercial-dev',
-	start: '2023-07-15',
+	start: '2023-08-01',
 	expiry: '2023-09-20',
-	audience: 0 / 100,
+	audience: 15 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Desktop users with wide (1300px+) screens only',
 	successMeasure:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@10.9.1":
-  version "10.9.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.9.1.tgz#b17121c117c085ccb3b5070145c10e6a4c87b4ee"
-  integrity sha512-OWKwttSigy181pAeuNhppSosVa7BMysGtSLVxNItNCC194MEBwxtK7IwzcFsP7Gk6t3w0gtO1V8uj8y0gIRklg==
+"@guardian/commercial@10.10.0":
+  version "10.10.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.10.0.tgz#d610162aab654bee0b38d7f2d9d6e088a5e2eb53"
+  integrity sha512-QnSRLI9vuOOREZtFC5PP8y7YQXF5FjJIGbcf/DNIAbJTRxejeA2Mr4nj5SzYL6zryvUtRjeGXhilCTk5cMFSkA==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
## What does this change?

Sets the audience to 15% for the liveblog right column ads AB test

## Why?

- This will start the AB test and allow us to create metrics.
- Setting the audience to 15% so that the participation group of each control and variant (of which there are two) will be 5%.