### PR TITLE
Remove Vertical Video 

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,7 +10,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      VerticalVideoContainer,
       Lightbox,
       ServerSideLiveblogInlineAds,
       EuropeNetworkFront,
@@ -21,15 +20,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
-
-object VerticalVideoContainer
-    extends Experiment(
-      name = "vertical-video-container",
-      description = "When ON, Vertical Video Container is displayed",
-      owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
-      sellByDate = LocalDate.of(2023, 7, 31),
-      participationGroup = Perc0A,
-    )
 
 object Lightbox
     extends Experiment(

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -7,7 +7,6 @@
 @import views.support.Commercial.container.shouldRenderAsPaidContainer
 @import views.support.GetClasses
 @import conf.switches.Switches.{MostViewedFronts, VerticalVideo => VerticalVideoSwitch}
-@import experiments.VerticalVideoContainer
 @import experiments.ActiveExperiments
 
 @import conf.audio.FlagshipFrontContainer
@@ -90,13 +89,6 @@
                         </div>
                     }
 
-                    case VerticalVideo => {
-                        @if((ActiveExperiments.isParticipating(VerticalVideoContainer) || VerticalVideoSwitch.isSwitchedOn) && frontId.exists(_.matches("au"))) {
-                            <div class="gs-container">
-                            @verticalVideoContainer(containerDefinition, frontProperties)
-                            </div>
-                        }
-                    }
                     case NavMediaList => {
                         <div class="fc-container__inner">
                             @navMediaListContainer(containerDefinition, frontProperties)


### PR DESCRIPTION
## What does this change?
Removes the vertical video test and removes vertical video container from the renderer. This was only for a test and is no longer needed.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
