### PR TITLE
Refactor `setConsent` to Okta

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -413,14 +413,20 @@ export const updateUsername = (username: string): unknown => {
 };
 
 export const setConsent = (consents: SettableConsent): Promise<void> =>
-	fetch(`${idApiRoot}/users/me/consents`, {
-		method: 'PATCH',
-		credentials: 'include',
-		mode: 'cors',
-		body: JSON.stringify(consents),
-	}).then((resp) => {
-		if (resp.ok) return Promise.resolve();
-		return Promise.reject();
+	getAuthStatus().then((authStatus) => {
+		if (
+			authStatus.kind === 'SignedInWithCookies' ||
+			authStatus.kind === 'SignedInWithOkta'
+		) {
+			const authOptions = getOptionsHeadersWithOkta(authStatus);
+
+			return fetch(`${idApiRoot}/users/me/consents`, {
+				method: 'PATCH',
+				...authOptions,
+				mode: 'cors',
+				body: JSON.stringify(consents),
+			}).then((resp) => (resp.ok ? Promise.resolve() : Promise.reject()));
+		}
 	});
 
 export { getUserCookie as getCookie };


### PR DESCRIPTION

As part of the Okta migration, refactor the `setConsent` function so that we send the correct header options when the user is signed in with the cookie or with okta. When the user is:
- `SignedInWithCookies`, we set the `credentials` option to `"include"`
- `SignedInWithOkta`, we set the `Authorization` header with a Bearer

Closes #26351 
