### PR TITLE
Okta: Discussion API

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/api.ts
+++ b/static/src/javascripts/projects/common/modules/discussion/api.ts
@@ -151,6 +151,6 @@ export const reportComment = (
 ): Promise<CommentResponse> =>
 	send(`/comment/${id}/reportAbuse`, 'POST', report);
 
-/** @type {(id: Id = 'me'): Promise<UserResponse>} */
-export const getUser = (id: Id = 'me'): Promise<UserResponse> =>
-	send(`/profile/${id}?strict_sanctions_check=false`, 'GET');
+/** @type {(): Promise<UserResponse>} */
+export const getUser = (): Promise<UserResponse> =>
+	send(`/profile/me?strict_sanctions_check=false`, 'GET');

--- a/static/src/javascripts/projects/common/modules/discussion/api.ts
+++ b/static/src/javascripts/projects/common/modules/discussion/api.ts
@@ -58,11 +58,11 @@ const defaultInitParams: RequestInit = {
 	},
 };
 
-export const send = (
+export const send = <T = CommentResponse>(
 	endpoint: string,
 	method: 'GET' | 'POST',
 	data?: Comment | AbuseReport,
-): Promise<CommentResponse> =>
+): Promise<T> =>
 	Promise.resolve(config.get('switches.enableDiscussionSwitch'))
 		.then((isDiscussionEnabled) =>
 			isDiscussionEnabled
@@ -112,14 +112,14 @@ export const send = (
 						...requestAuthOptions.headers,
 						'Content-Type': 'application/x-www-form-urlencoded',
 					},
-				}).then((resp) => resp.json() as Promise<CommentResponse>);
+				}).then((resp) => resp.json() as Promise<T>);
 			}
 
 			return fetch(url, {
 				...defaultInitParams,
 				...requestAuthOptions,
 				method,
-			}).then((resp) => resp.json() as Promise<CommentResponse>);
+			}).then((resp) => resp.json() as Promise<T>);
 		});
 
 export const postComment = (
@@ -151,5 +151,6 @@ export const reportComment = (
 ): Promise<CommentResponse> =>
 	send(`/comment/${id}/reportAbuse`, 'POST', report);
 
-export const getUser = (id: Id = 'me'): Promise<CommentResponse> =>
+/** @type {(id: Id = 'me'): Promise<UserResponse>} */
+export const getUser = (id: Id = 'me'): Promise<UserResponse> =>
 	send(`/profile/${id}?strict_sanctions_check=false`, 'GET');

--- a/static/src/javascripts/projects/common/modules/discussion/api.ts
+++ b/static/src/javascripts/projects/common/modules/discussion/api.ts
@@ -23,6 +23,24 @@ type CommentResponse = {
 	errorCode?: string;
 };
 
+type UserResponse = {
+	status: 'ok' | 'error';
+	userProfile: {
+		userId: string;
+		displayName: string;
+		webUrl: string;
+		apiUrl: string;
+		avatar: string;
+		secureAvatarUrl: string;
+		isStaff: boolean;
+		privateFields: {
+			canPostComment: boolean;
+			isPremoderated: boolean;
+			hasCommented: boolean;
+		};
+	};
+};
+
 type AbuseReport = {
 	categoryId: number;
 	reason?: string;

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -183,7 +183,7 @@ const isInOktaExperiment =
 	window.guardian.config.page.stage === 'DEV' ||
 	window.guardian.config.tests?.oktaVariant === 'variant';
 
-const getAuthStatus = async (): Promise<AuthStatus> => {
+export const getAuthStatus = async (): Promise<AuthStatus> => {
 	if (isInOktaExperiment) {
 		const { isSignedInWithOktaAuthState } = await import('./okta');
 		const authState = await isSignedInWithOktaAuthState();


### PR DESCRIPTION
Refactor the Discussion API module to support Okta

- Add relevant auth options when `fetch`ing
- Add a `UserResponse` type to model the response from DAPI's `/profile/{id}` endpoint
- Add a generic type parameter to the `send` function. This function is used to fetch from multiple endpoints, and so callers should be able to specify `send`s return type
- Remove the `id` parameter from `getUser`, because no callers of this function pass an argument.

Closes #26355 