### PR TITLE
Fix set username when commenting

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/api.ts
+++ b/static/src/javascripts/projects/common/modules/discussion/api.ts
@@ -41,6 +41,8 @@ type UserResponse = {
 	};
 };
 
+type Response = UserResponse | CommentResponse;
+
 type AbuseReport = {
 	categoryId: number;
 	reason?: string;
@@ -58,7 +60,7 @@ const defaultInitParams: RequestInit = {
 	},
 };
 
-export const send = <T = CommentResponse>(
+export const send = <T extends Response = CommentResponse>(
 	endpoint: string,
 	method: 'GET' | 'POST',
 	data?: Comment | AbuseReport,

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -188,29 +188,17 @@ class CommentBox extends Component {
         this.setState('preview-visible');
     }
 
-    fail(xhr) {
-        let response;
-
-        // if our API is down, it returns HTML
-        // this is not so good for JSON.parse
-        try {
-            response = JSON.parse(xhr.responseText);
-        } catch (e) {
-            response = {};
-        }
-
+    fail(errResp) {
         this.setFormState();
 
-        if (xhr.status === 0) {
-            this.error('API_CORS_BLOCKED');
-        } else if (response.errorCode === 'EMAIL_NOT_VALIDATED') {
+        if (errResp.errorCode === 'EMAIL_NOT_VALIDATED') {
             this.invalidEmailError();
-        } else if (response.errorCode === 'IP_ADDRESS_BLOCKED') {
+        } else if (errResp.errorCode === 'IP_ADDRESS_BLOCKED') {
             this.error('IP_THROTTLED');
-        } else if (this.errorMessages[response.errorCode]) {
-            this.error(response.errorCode);
+        } else if (this.errorMessages[errResp.errorCode]) {
+            this.error(errResp.errorCode);
         } else {
-            this.error('API_ERROR', this.errorMessages.API_ERROR + xhr.status); // templating would be ideal here
+            this.error('API_ERROR', `${this.errorMessages.API_ERROR} ${errResp.statusCode}`); // templating would be ideal here
         }
     }
 
@@ -274,8 +262,9 @@ class CommentBox extends Component {
             this.setFormState(true);
 
             return postComment(this.getDiscussionId(), comment)
-                .then((resp) => this.postCommentSuccess(comment, resp))
-                .catch((err) => this.fail(err));
+                .then((resp) => resp.status === 'ok' ? resp : Promise.reject(resp))
+                .then((okResp) => this.postCommentSuccess(comment, okResp))
+                .catch((errResp) => this.fail(errResp));
         };
 
         const updateUsernameSuccess = (resp) => {
@@ -598,8 +587,9 @@ class CommentBox extends Component {
 
         if (this.errors.length === 0) {
             previewComment(comment)
+                .then(resp => resp.status === 'ok' ? resp : Promise.reject(resp))
                 .then((resp) => callback(comment, resp))
-                .catch((err) => this.fail(err));
+                .catch((errResp) => this.fail(errResp));
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -262,9 +262,8 @@ class CommentBox extends Component {
             this.setFormState(true);
 
             return postComment(this.getDiscussionId(), comment)
-                .then((resp) => resp.status === 'ok' ? resp : Promise.reject(resp))
-                .then((okResp) => this.postCommentSuccess(comment, okResp))
-                .catch((errResp) => this.fail(errResp));
+                .then((resp) => resp.status === 'ok' ? this.postCommentSuccess(comment, resp) : this.fail(resp))
+                .catch((err) => console.error(`Post Comment to DAPI failed`, err));
         };
 
         const updateUsernameSuccess = (resp) => {
@@ -587,9 +586,8 @@ class CommentBox extends Component {
 
         if (this.errors.length === 0) {
             previewComment(comment)
-                .then(resp => resp.status === 'ok' ? resp : Promise.reject(resp))
-                .then((resp) => callback(comment, resp))
-                .catch((errResp) => this.fail(errResp));
+                .then(resp => resp.status === 'ok' ? callback(comment, resp) : this.fail(resp))
+                .catch((err) => console.error("Preview comment failed", err));
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.spec.js
@@ -189,11 +189,7 @@ describe('Comment box', () => {
                 commentBody.value = validCommentText;
 
                 postComment.mockReturnValueOnce(
-                    // eslint-disable-next-line prefer-promise-reject-errors
-                    Promise.reject({
-                        responseText: apiPostValidCommentButDiscussionClosed,
-                        status: 409,
-                    })
+                    Promise.resolve(JSON.parse(apiPostValidCommentButDiscussionClosed))
                 );
 
                 return commentBox.postComment().then(() => {
@@ -211,11 +207,7 @@ describe('Comment box', () => {
                 commentBody.value = validCommentText;
 
                 postComment.mockReturnValueOnce(
-                    // eslint-disable-next-line prefer-promise-reject-errors
-                    Promise.reject({
-                        responseText: apiPostValidCommentButReadOnlyMode,
-                        status: 503,
-                    })
+                    Promise.resolve(JSON.parse(apiPostValidCommentButReadOnlyMode))
                 );
 
                 return commentBox.postComment().then(() => {
@@ -251,11 +243,7 @@ describe('Comment box', () => {
                 commentBody.value = validCommentText;
 
                 postComment.mockReturnValueOnce(
-                    // eslint-disable-next-line prefer-promise-reject-errors
-                    Promise.reject({
-                        responseText: apiPostValidCommentButIdentityUsernameMissing,
-                        status: 400,
-                    })
+                    Promise.resolve(JSON.parse(apiPostValidCommentButIdentityUsernameMissing))
                 );
 
                 return commentBox.postComment().then(() => {


### PR DESCRIPTION
When a user tries to submit a comment, DAPI checks to see if the user has a username. If there is no username, DAPI returns an error:
```
{
  "status": "error",
  "statusCode": 400,
  "message": "Username is missing",
  "errorCode": "USERNAME_MISSING"
}
```

Previously we determined if a user has a username by performing a null check on the `userProfile.displayName` value from DAPI's `/profile/me` endpoint[1] :

https://github.com/guardian/frontend/blob/b0798f7f68bc633512ba4a4ba90e644b1bcad8db/static/src/javascripts/projects/common/modules/discussion/loader.js#L604

However, DAPI now populates `displayName` with "Guardian User" if you have not explicitly set a username, making a `null` check incorrect. It's probably not correct for us to check if `displayName === 'Guardian User'` either.

This change fixes error handling from DAPI, so we can show the relevant error to the user. In the case of a missing username, we provide a link to MMA where they can set a username and then attempt to make the comment again:

<img width="904" alt="Screenshot 2023-08-02 at 09 30 38" src="https://github.com/guardian/frontend/assets/705427/9a8aeea5-7fce-4702-a973-28033aae04db">

Closes #26350 
Closes #26414 

[1]: Response shape from DAPI's `/profile/me` endpoint
```
{
  "status": "ok",
  "userProfile": {
    // other keys here
    "displayName": "Guardian User", // <-- 
    "privateFields": {
      // other keys here
    }
  }
}
```