### PR TITLE
Remove Membership Access Requirements

### DIFF
--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -47,7 +47,6 @@ object HtmlPageHelpers {
         .isAdFree(request)
     Map(
       ("has-page-skin", page.metadata.hasPageSkin(request) && showAds),
-      ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
       ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
     )
   }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -32,7 +32,6 @@
         id="top"
         class="@RenderClasses(Map(
             ("has-page-skin", page.metadata.hasPageSkin(request) && showAdverts),
-            ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-super-sticky-banner", false),
             ("is-immersive", content.exists(_.content.isImmersive)),

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -58,46 +58,6 @@ const showHiringMessage = () => {
     }
 };
 
-const handleMembershipAccess = () => {
-    const { membershipUrl, membershipAccess, contentId } = config.get('page');
-
-    const redirect = () => {
-        window.location.assign(
-            `${membershipUrl}/membership-content?referringContent=${contentId}&membershipAccess=${membershipAccess}`
-        );
-    };
-
-    const updateDOM = (resp) => {
-        const requireClass = 'has-membership-access-requirement';
-        const requiresPaidTier = membershipAccess.includes('paid-members-only');
-        // Check the users access matches the content
-        const canViewContent = requiresPaidTier
-            ? !!resp.tier && resp.isPaidTier
-            : !!resp.tier;
-
-        if (canViewContent) {
-            const { body } = document;
-
-            if (body) {
-                fastdom.mutate(() => body.classList.remove(requireClass));
-            }
-        } else {
-            redirect();
-        }
-    };
-
-    if (isUserLoggedIn()) {
-        fetchJson(`${membershipUrl}/user/me`, {
-            mode: 'cors',
-            credentials: 'include',
-        })
-            .then(updateDOM)
-            .catch(redirect);
-    } else {
-        redirect();
-    }
-};
-
 const addScrollHandler = () => {
     let scrollRunning = false;
 
@@ -208,17 +168,6 @@ const bootStandard = () => {
     }
 
     ophan.setEventEmitter(mediator);
-
-    /*  Membership access
-        Items with either of the following fields require Membership access
-        - membershipAccess=members-only
-        - membershipAccess=paid-members-only
-        Authenticating requires CORS and withCredentials. If we don't cut the
-        mustard then pass through.
-    */
-    if (config.get('page.requiresMembershipAccess')) {
-        handleMembershipAccess();
-    }
 
     if(window.guardian.config.switches.headerTopNav
         && document.querySelector('.header-top-nav')

--- a/static/src/stylesheets/base/_base.scss
+++ b/static/src/stylesheets/base/_base.scss
@@ -13,9 +13,6 @@ html {
 body {
     background-color: #ffffff;
 }
-.is-modern .has-membership-access-requirement {
-    visibility: hidden !important;
-}
 
 ::selection {
     background: $highlight-main;


### PR DESCRIPTION
## What is the value of this and can you measure success?

We don't believe this feature exists any more, so we'd like to remove the code to reduce the maintenance burden. If we don't remove this we'll have to consider how we migrate it to Okta. Resolves #26341, which also contains more information.

## What does this change?

Removes code related to a CSS class that hides content based on membership status. Also removes the JavaScript code used to make a request to find out the user's membership status, and unhide the content (remove the class) if that status matches the requirement.
