### PR TITLE
bump commercial to 10.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "10.9.0",
+		"@guardian/commercial": "10.9.1",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.9.0.tgz#b05c521662bd2c0183fa8c1b9c5402118e4dc8cd"
-  integrity sha512-GiZeWQ1f9fBXfkmTuKtdIR/CPUiESVBew/jdegNCo+lUP9hzs3ik2tSVClpZUsoR9ohsqfF2TiWRaYhP9SoSyg==
+"@guardian/commercial@10.9.1":
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.9.1.tgz#b17121c117c085ccb3b5070145c10e6a4c87b4ee"
+  integrity sha512-OWKwttSigy181pAeuNhppSosVa7BMysGtSLVxNItNCC194MEBwxtK7IwzcFsP7Gk6t3w0gtO1V8uj8y0gIRklg==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
## What is the value of this and can you measure success?

- Minor fix for the `right` ad slot: https://github.com/guardian/commercial/pull/964

## What does this change?

- bumps commercial to 10.9.1