### PR TITLE
deeply read ab test

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -522,16 +522,6 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val DeeplyReadSwitch = Switch(
-    SwitchGroup.Feature,
-    "deeply-read-switch",
-    "When ON, shows the new most popular component containing mode viewed and deeply read articles",
-    owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val VerticalVideo = Switch(
     SwitchGroup.Feature,
     "vertical-video",

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -27,7 +27,7 @@ object DeeplyRead
     extends Experiment(
       name = "deeply-read",
       description = "When ON, deeply read footer section is displayed",
-      owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
+      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 10, 31),
       participationGroup = Perc50,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -2,6 +2,7 @@ package experiments
 
 import conf.switches.Owner
 import experiments.ParticipationGroups._
+
 import java.time.LocalDate
 
 /*
@@ -17,9 +18,19 @@ object ActiveExperiments extends ExperimentsDefinition {
       HeaderTopBarSearchCapi,
       AdaptiveSite,
       OfferHttp3,
+      DeeplyRead,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
+
+object DeeplyRead
+    extends Experiment(
+      name = "deeply-read",
+      description = "When ON, deeply read footer section is displayed",
+      owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
+      sellByDate = LocalDate.of(2023, 10, 31),
+      participationGroup = Perc50,
+    )
 
 object Lightbox
     extends Experiment(

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -27,7 +27,7 @@ import contentapi.ContentApiClient
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
-import experiments.{ActiveExperiments, EuropeNetworkFront}
+import experiments.{ActiveExperiments, DeeplyRead, EuropeNetworkFront}
 import play.api.http.ContentTypes.JSON
 import services.dotcomrendering.{FaciaPicker, RemoteRender}
 import services.fronts.{FrontJsonFapi, FrontJsonFapiLive}
@@ -212,7 +212,9 @@ trait FaciaController
     }
 
     val networkFrontEdition = Edition.allWithBetaEditions.find(_.networkFrontId == path)
-    val deeplyRead = if (Switches.DeeplyReadSwitch.isSwitchedOn) {
+    val participatingInDeeplyReadTest = ActiveExperiments.isParticipating(DeeplyRead)
+    log.info(s"deeply read test is: ${participatingInDeeplyReadTest}")
+    val deeplyRead = if (participatingInDeeplyReadTest) {
       networkFrontEdition.map(deeplyReadAgent.getTrails)
     } else None
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
- Adds server side AB test for deeply read data that is passed to DCR for the deeply read footer section
- Removes the old DeeplyReadSwitch 


Relevant DCR PR: https://github.com/guardian/dotcom-rendering/pull/8439