### PR TITLE
Refactor cookie refresh to Okta

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -53,6 +53,7 @@ import { readerRevenueBanner } from 'common/modules/commercial/reader-revenue-ba
 import { puzzlesBanner } from 'common/modules/commercial/puzzles-banner';
 import { init as initGoogleAnalytics } from 'common/modules/tracking/google-analytics';
 import { bufferedNotificationListener } from 'common/modules/bufferedNotificationListener';
+import { eitherInOktaExperimentOrElse } from 'common/modules/identity/api';
 
 const initialiseTopNavItems = () => {
     const header = document.getElementById('header');
@@ -163,9 +164,14 @@ const showHistoryInMegaNav = () => {
 };
 
 const idCookieRefresh = () => {
-    if (config.get('switches.idCookieRefresh')) {
-        initCookieRefresh();
-    }
+    /** We only want to call `initCookieRefresh` if the user is not in the Okta experiment
+     * and the switch is on.
+     */
+    eitherInOktaExperimentOrElse(() => undefined, () => {
+        if (config.get('switches.idCookieRefresh')) {
+            initCookieRefresh();
+        }
+    })
 };
 
 const windowEventListeners = () => {

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -193,20 +193,13 @@ export const getAuthStatus = async (): Promise<AuthStatus> => {
 };
 
 export const isUserLoggedIn = (): boolean => getUserFromCookie() !== null;
-export const isUserLoggedInOktaRefactor = (): Promise<boolean> => {
-	return new Promise((resolve) => {
-		void getAuthStatus().then((authStatus) => {
-			if (
-				authStatus.kind === 'SignedInWithCookies' ||
-				authStatus.kind === 'SignedInWithOkta'
-			) {
-				resolve(true);
-			} else {
-				resolve(false);
-			}
-		});
-	});
-};
+export const isUserLoggedInOktaRefactor = (): Promise<boolean> =>
+	getAuthStatus().then((authStatus) =>
+		authStatus.kind === 'SignedInWithCookies' ||
+		authStatus.kind === 'SignedInWithOkta'
+			? true
+			: false,
+	);
 
 /**
  * Decide request options based on an {@link AuthStatus}. Requests to authenticated APIs require different options depending on whether

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -144,6 +144,26 @@ const isInOktaExperiment =
 	window.guardian.config.page.stage === 'DEV' ||
 	window.guardian.config.tests?.oktaVariant === 'variant';
 
+/**
+ * Runs `inOkta` if the user is enrolled in the Okta experiment, otherwise runs `notInOkta`
+ * @param inOkta runs if the user is enrolled in the Okta experiment
+ * @param notInOkta runs if the user is **not** enrolled in the Okta experiment
+ */
+export const eitherInOktaExperimentOrElse = async <A, B>(
+	inOkta: (authStatus: SignedInWithOkta | SignedOutWithOkta) => A,
+	notInOkta: () => B,
+): Promise<void> => {
+	const authStatus = await getAuthStatus();
+	switch (authStatus.kind) {
+		case 'SignedInWithOkta':
+		case 'SignedOutWithOkta':
+			inOkta(authStatus);
+			break;
+		default:
+			notInOkta();
+	}
+};
+
 export const getAuthStatus = async (): Promise<AuthStatus> => {
 	if (isInOktaExperiment) {
 		const { isSignedInWithOktaAuthState } = await import('./okta');

--- a/static/src/javascripts/projects/common/modules/identity/cookierefresh.ts
+++ b/static/src/javascripts/projects/common/modules/identity/cookierefresh.ts
@@ -1,3 +1,6 @@
+/**
+ * Once the Okta migration is complete and in front of 100% of users, we can delete this module.
+ */
 import { storage } from '@guardian/libs';
 import {
 	isUserLoggedIn,

--- a/static/src/javascripts/projects/common/modules/identity/cookierefresh.ts
+++ b/static/src/javascripts/projects/common/modules/identity/cookierefresh.ts
@@ -3,7 +3,7 @@
  */
 import { storage } from '@guardian/libs';
 import {
-	isUserLoggedIn,
+	isUserLoggedInOktaRefactor,
 	refreshOktaSession,
 } from 'common/modules/identity/api';
 
@@ -26,9 +26,9 @@ const shouldRefreshCookie: (
 	return currentTime - Number(lastRefresh) > days30InMillis;
 };
 
-const init: () => void = () => {
+const init: () => Promise<void> = async () => {
 	const lastRefreshKey = 'identity.lastRefresh';
-	if (storage.local.isAvailable() && isUserLoggedIn()) {
+	if (storage.local.isAvailable() && (await isUserLoggedInOktaRefactor())) {
 		const currentTime: number = new Date().getTime();
 		// The storage API could return any type handled by JSON.parse, so
 		// we will assume the type is 'unknown' and attempt to parse the value into

--- a/static/src/javascripts/projects/common/modules/identity/okta.ts
+++ b/static/src/javascripts/projects/common/modules/identity/okta.ts
@@ -1,5 +1,6 @@
 import type { CustomClaims, IdentityAuthState } from '@guardian/identity-auth';
 import { IdentityAuth } from '@guardian/identity-auth';
+import config from 'lib/config';
 
 // the `id_token.profile.theguardian` scope is used to get custom claims
 export type CustomIdTokenClaims = CustomClaims & {
@@ -53,6 +54,8 @@ function getIdentityAuth() {
 				'guardian.members-data-api.read.self', // allows the access token to be used to make requests to the members data api to read the user's membership status
 				'id_token.profile.theguardian', // populates the id token with application specific profile information
 			],
+			idCookieSessionRefresh:
+				config.get('switches.idCookieRefresh') ?? false,
 		});
 	}
 	return identityAuth;


### PR DESCRIPTION
[`@guardian/identity-auth@0.4.0`](https://github.com/guardian/csnx/releases/tag/%40guardian%2Fidentity-auth%400.4.0) includes functionality to replace the `cookierefresh.ts` module [^1]. As the migration to Okta is still underway, this PR:

- runs `cookierefresh.ts`, only if the user is not in the Okta experiment and and the `idCookieRefresh` switch is on
- otherwise, passes the `idCookieRefresh` switch state to the `IdentityAuth` constructor

Additionally, this PR refactors the `isUserLoggedIn` check in `cookierefresh` to Okta.

Closes #26420 
Closes #26423 
Closes #26344 

[^1]: https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/identity/cookierefresh.ts