### PR TITLE
Migrate `isRecurringContributor` to Okta

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
@@ -19,7 +19,7 @@ import {
 	isPayingMember,
 	isPostAskPauseOneOffContributor,
 	isRecentOneOffContributor,
-	isRecurringContributorOkta,
+	isRecurringContributor,
 	refresh,
 	shouldNotBeShownSupportMessaging,
 } from './user-features';
@@ -303,7 +303,7 @@ describe('The isRecurringContributor getter', () => {
 	it('Is false when the user is logged out', async () => {
 		jest.resetAllMocks();
 		isUserLoggedIn.mockReturnValue(false);
-		expect(await isRecurringContributorOkta()).toBe(false);
+		expect(await isRecurringContributor()).toBe(false);
 	});
 
 	describe('When the user is logged in', () => {
@@ -315,18 +315,18 @@ describe('The isRecurringContributor getter', () => {
 
 		it('Is true when the user has a `true` recurring contributor cookie', async () => {
 			addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
-			expect(await isRecurringContributorOkta()).toBe(true);
+			expect(await isRecurringContributor()).toBe(true);
 		});
 
 		it('Is false when the user has a `false` recurring contributor cookie', async () => {
 			addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'false');
-			expect(await isRecurringContributorOkta()).toBe(false);
+			expect(await isRecurringContributor()).toBe(false);
 		});
 
 		it('Is true when the user has no recurring contributor cookie', async () => {
 			// If we don't know, we err on the side of caution, rather than annoy paying users
 			removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
-			expect(await isRecurringContributorOkta()).toBe(true);
+			expect(await isRecurringContributor()).toBe(true);
 		});
 	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
@@ -6,6 +6,7 @@ import type { AuthStatus } from '../identity/api';
 import {
 	getAuthStatus as getAuthStatus_,
 	isUserLoggedIn as isUserLoggedIn_,
+	isUserLoggedInOktaRefactor as isUserLoggedInOktaRefactor_,
 } from '../identity/api';
 import {
 	accountDataUpdateWarning,
@@ -18,7 +19,7 @@ import {
 	isPayingMember,
 	isPostAskPauseOneOffContributor,
 	isRecentOneOffContributor,
-	isRecurringContributor,
+	isRecurringContributorOkta,
 	refresh,
 	shouldNotBeShownSupportMessaging,
 } from './user-features';
@@ -26,6 +27,7 @@ import {
 jest.mock('../../../../lib/raven');
 jest.mock('projects/common/modules/identity/api', () => ({
 	isUserLoggedIn: jest.fn(),
+	isUserLoggedInOktaRefactor: jest.fn(),
 	getAuthStatus: jest.fn(),
 	getOptionsHeadersWithOkta: jest.fn(),
 }));
@@ -37,6 +39,11 @@ const fetchJsonSpy = fetchJson as jest.MockedFunction<typeof fetchJson>;
 const isUserLoggedIn = isUserLoggedIn_ as jest.MockedFunction<
 	typeof isUserLoggedIn_
 >;
+
+const isUserLoggedInOktaRefactor =
+	isUserLoggedInOktaRefactor_ as jest.MockedFunction<
+		typeof isUserLoggedInOktaRefactor_
+	>;
 
 const getAuthStatus = getAuthStatus_ as jest.MockedFunction<
 	typeof getAuthStatus_
@@ -112,9 +119,10 @@ describe('Refreshing the features data', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
 			isUserLoggedIn.mockReturnValue(true);
-			getAuthStatus.mockReturnValue(
-				Promise.resolve({ kind: 'SignedInWithOkta' } as AuthStatus),
-			);
+			isUserLoggedInOktaRefactor.mockResolvedValue(true);
+			getAuthStatus.mockResolvedValue({
+				kind: 'SignedInWithOkta',
+			} as AuthStatus);
 			fetchJsonSpy.mockReturnValue(Promise.resolve());
 		});
 
@@ -184,6 +192,7 @@ describe('Refreshing the features data', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
 			isUserLoggedIn.mockReturnValue(false);
+			isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(false));
 			getAuthStatus.mockReturnValue(
 				Promise.resolve({ kind: 'SignedOutWithOkta' }),
 			);
@@ -226,6 +235,7 @@ describe('The account data update warning getter', () => {
 	it('Is not set when the user is logged out', () => {
 		jest.resetAllMocks();
 		isUserLoggedIn.mockReturnValue(false);
+		isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(false));
 		expect(accountDataUpdateWarning()).toBe(null);
 	});
 
@@ -233,6 +243,7 @@ describe('The account data update warning getter', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
 			isUserLoggedIn.mockReturnValue(true);
+			isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(true));
 		});
 
 		it('Is the same when the user has an account data update link cookie', () => {
@@ -251,6 +262,7 @@ describe('The isAdFreeUser getter', () => {
 	it('Is false when the user is logged out', () => {
 		jest.resetAllMocks();
 		isUserLoggedIn.mockReturnValue(false);
+		isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(false));
 		expect(isAdFreeUser()).toBe(false);
 	});
 });
@@ -259,6 +271,7 @@ describe('The isPayingMember getter', () => {
 	it('Is false when the user is logged out', () => {
 		jest.resetAllMocks();
 		isUserLoggedIn.mockReturnValue(false);
+		isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(false));
 		expect(isPayingMember()).toBe(false);
 	});
 
@@ -287,32 +300,33 @@ describe('The isPayingMember getter', () => {
 });
 
 describe('The isRecurringContributor getter', () => {
-	it('Is false when the user is logged out', () => {
+	it('Is false when the user is logged out', async () => {
 		jest.resetAllMocks();
 		isUserLoggedIn.mockReturnValue(false);
-		expect(isRecurringContributor()).toBe(false);
+		expect(await isRecurringContributorOkta()).toBe(false);
 	});
 
 	describe('When the user is logged in', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
+			isUserLoggedInOktaRefactor.mockResolvedValue(true);
 			isUserLoggedIn.mockReturnValue(true);
 		});
 
-		it('Is true when the user has a `true` recurring contributor cookie', () => {
+		it('Is true when the user has a `true` recurring contributor cookie', async () => {
 			addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
-			expect(isRecurringContributor()).toBe(true);
+			expect(await isRecurringContributorOkta()).toBe(true);
 		});
 
-		it('Is false when the user has a `false` recurring contributor cookie', () => {
+		it('Is false when the user has a `false` recurring contributor cookie', async () => {
 			addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'false');
-			expect(isRecurringContributor()).toBe(false);
+			expect(await isRecurringContributorOkta()).toBe(false);
 		});
 
-		it('Is true when the user has no recurring contributor cookie', () => {
+		it('Is true when the user has no recurring contributor cookie', async () => {
 			// If we don't know, we err on the side of caution, rather than annoy paying users
 			removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
-			expect(isRecurringContributor()).toBe(true);
+			expect(await isRecurringContributorOkta()).toBe(true);
 		});
 	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -313,13 +313,6 @@ const isPostAskPauseOneOffContributor = (askPauseDays = 90): boolean => {
 	return daysSinceLastContribution > askPauseDays;
 };
 
-// TODO: Remove as part of Okta migration
-const isRecurringContributor = (): boolean =>
-	// If the user is logged in, but has no cookie yet, play it safe and assume they're a contributor
-	(isUserLoggedIn() &&
-		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) !== 'false') ||
-	supportSiteRecurringCookiePresent();
-
 const isRecurringContributorOkta = async (): Promise<boolean> =>
 	((await isUserLoggedInOktaRefactor()) &&
 		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) !== 'false') ||
@@ -415,7 +408,6 @@ export {
 	isPayingMember,
 	isRecentOneOffContributor,
 	isRecurringContributorOkta,
-	isRecurringContributor,
 	isDigitalSubscriber,
 	shouldHideSupportMessaging,
 	refresh,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -313,7 +313,7 @@ const isPostAskPauseOneOffContributor = (askPauseDays = 90): boolean => {
 	return daysSinceLastContribution > askPauseDays;
 };
 
-const isRecurringContributorOkta = async (): Promise<boolean> =>
+const isRecurringContributor = async (): Promise<boolean> =>
 	((await isUserLoggedInOktaRefactor()) &&
 		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) !== 'false') ||
 	supportSiteRecurringCookiePresent();
@@ -335,7 +335,7 @@ const shouldNotBeShownSupportMessaging = (): boolean =>
 const shouldHideSupportMessaging = async (): Promise<boolean> =>
 	shouldNotBeShownSupportMessaging() ||
 	isRecentOneOffContributor() || // because members-data-api is unaware of one-off contributions so relies on cookie
-	(await isRecurringContributorOkta()); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie
+	(await isRecurringContributor()); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie
 
 const readerRevenueRelevantCookies = [
 	PAYING_MEMBER_COOKIE,
@@ -407,7 +407,7 @@ export {
 	isAdFreeUser,
 	isPayingMember,
 	isRecentOneOffContributor,
-	isRecurringContributorOkta,
+	isRecurringContributor,
 	isDigitalSubscriber,
 	shouldHideSupportMessaging,
 	refresh,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -414,6 +414,7 @@ export {
 	isAdFreeUser,
 	isPayingMember,
 	isRecentOneOffContributor,
+	isRecurringContributorOkta,
 	isRecurringContributor,
 	isDigitalSubscriber,
 	shouldHideSupportMessaging,

--- a/static/src/javascripts/projects/common/modules/support/epic.ts
+++ b/static/src/javascripts/projects/common/modules/support/epic.ts
@@ -16,7 +16,7 @@ import { submitComponentEvent } from 'common/modules/commercial/acquisitions-oph
 import { setupRemoteEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import {
 	getLastOneOffContributionTimestamp,
-	isRecurringContributor,
+	isRecurringContributorOkta,
 	shouldHideSupportMessaging,
 } from 'common/modules/commercial/user-features';
 import { getArticleCounts } from 'common/modules/support/articleCount';
@@ -75,7 +75,7 @@ const buildEpicPayload = async (): Promise<EpicPayload> => {
 		isPaidContent: isPaidContent,
 		tags: buildKeywordTags().concat([buildSeriesTag()]),
 		showSupportMessaging: !(await shouldHideSupportMessaging()),
-		isRecurringContributor: isRecurringContributor(),
+		isRecurringContributor: await isRecurringContributorOkta(),
 		lastOneOffContributionDate:
 			getLastOneOffContributionTimestamp() ?? undefined,
 		mvtId: getMvtValue() ?? 0,

--- a/static/src/javascripts/projects/common/modules/support/epic.ts
+++ b/static/src/javascripts/projects/common/modules/support/epic.ts
@@ -16,7 +16,7 @@ import { submitComponentEvent } from 'common/modules/commercial/acquisitions-oph
 import { setupRemoteEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import {
 	getLastOneOffContributionTimestamp,
-	isRecurringContributorOkta,
+	isRecurringContributor,
 	shouldHideSupportMessaging,
 } from 'common/modules/commercial/user-features';
 import { getArticleCounts } from 'common/modules/support/articleCount';
@@ -75,7 +75,7 @@ const buildEpicPayload = async (): Promise<EpicPayload> => {
 		isPaidContent: isPaidContent,
 		tags: buildKeywordTags().concat([buildSeriesTag()]),
 		showSupportMessaging: !(await shouldHideSupportMessaging()),
-		isRecurringContributor: await isRecurringContributorOkta(),
+		isRecurringContributor: await isRecurringContributor(),
 		lastOneOffContributionDate:
 			getLastOneOffContributionTimestamp() ?? undefined,
 		mvtId: getMvtValue() ?? 0,


### PR DESCRIPTION
## What is the value of this and can you measure success?
Replaces any occurrences of `isRecurringContributor` with `isRecurringContributorOkta` (which has been renamed to `isRecurringContributor`.