### PR TITLE
Migrate `isPayingMember` to Okta

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts
@@ -12,15 +12,11 @@ import { commercialFeatures } from './commercial-features';
 import type { CommercialFeaturesConstructor } from './commercial-features';
 import {
 	isAdFreeUser as isAdFreeUser_,
-	isPayingMember as isPayingMember_,
 	isPayingMemberOkta as isPayingMemberOkta_,
 	isRecentOneOffContributor as isRecentOneOffContributor_,
 	shouldHideSupportMessaging as shouldHideSupportMessaging_,
 } from './user-features';
 
-const isPayingMember = isPayingMember_ as jest.MockedFunction<
-	typeof isPayingMember_
->;
 const isPayingMemberOkta = isPayingMemberOkta_ as jest.MockedFunction<
 	typeof isPayingMemberOkta_
 >;
@@ -44,7 +40,6 @@ const CommercialFeatures =
 	commercialFeatures.constructor as CommercialFeaturesConstructor;
 
 jest.mock('./user-features', () => ({
-	isPayingMember: jest.fn(),
 	isPayingMemberOkta: jest.fn(),
 	isRecentOneOffContributor: jest.fn(),
 	shouldHideSupportMessaging: jest.fn(),
@@ -104,7 +99,6 @@ describe('Commercial features', () => {
 		userPrefs.removeSwitch('adverts');
 
 		getCurrentBreakpoint.mockReturnValue('desktop');
-		isPayingMember.mockReturnValue(false);
 		isPayingMemberOkta.mockResolvedValue(false);
 		isRecentOneOffContributor.mockReturnValue(false);
 		shouldHideSupportMessaging.mockResolvedValue(false);

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts
@@ -12,13 +12,13 @@ import { commercialFeatures } from './commercial-features';
 import type { CommercialFeaturesConstructor } from './commercial-features';
 import {
 	isAdFreeUser as isAdFreeUser_,
-	isPayingMemberOkta as isPayingMemberOkta_,
+	isPayingMember as isPayingMember_,
 	isRecentOneOffContributor as isRecentOneOffContributor_,
 	shouldHideSupportMessaging as shouldHideSupportMessaging_,
 } from './user-features';
 
-const isPayingMemberOkta = isPayingMemberOkta_ as jest.MockedFunction<
-	typeof isPayingMemberOkta_
+const isPayingMember = isPayingMember_ as jest.MockedFunction<
+	typeof isPayingMember_
 >;
 const isRecentOneOffContributor =
 	isRecentOneOffContributor_ as jest.MockedFunction<
@@ -40,7 +40,7 @@ const CommercialFeatures =
 	commercialFeatures.constructor as CommercialFeaturesConstructor;
 
 jest.mock('./user-features', () => ({
-	isPayingMemberOkta: jest.fn(),
+	isPayingMember: jest.fn(),
 	isRecentOneOffContributor: jest.fn(),
 	shouldHideSupportMessaging: jest.fn(),
 	isAdFreeUser: jest.fn(),
@@ -99,7 +99,7 @@ describe('Commercial features', () => {
 		userPrefs.removeSwitch('adverts');
 
 		getCurrentBreakpoint.mockReturnValue('desktop');
-		isPayingMemberOkta.mockResolvedValue(false);
+		isPayingMember.mockResolvedValue(false);
 		isRecentOneOffContributor.mockReturnValue(false);
 		shouldHideSupportMessaging.mockResolvedValue(false);
 		isAdFreeUser.mockReturnValue(false);

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts
@@ -13,12 +13,16 @@ import type { CommercialFeaturesConstructor } from './commercial-features';
 import {
 	isAdFreeUser as isAdFreeUser_,
 	isPayingMember as isPayingMember_,
+	isPayingMemberOkta as isPayingMemberOkta_,
 	isRecentOneOffContributor as isRecentOneOffContributor_,
 	shouldHideSupportMessaging as shouldHideSupportMessaging_,
 } from './user-features';
 
 const isPayingMember = isPayingMember_ as jest.MockedFunction<
 	typeof isPayingMember_
+>;
+const isPayingMemberOkta = isPayingMemberOkta_ as jest.MockedFunction<
+	typeof isPayingMemberOkta_
 >;
 const isRecentOneOffContributor =
 	isRecentOneOffContributor_ as jest.MockedFunction<
@@ -41,6 +45,7 @@ const CommercialFeatures =
 
 jest.mock('./user-features', () => ({
 	isPayingMember: jest.fn(),
+	isPayingMemberOkta: jest.fn(),
 	isRecentOneOffContributor: jest.fn(),
 	shouldHideSupportMessaging: jest.fn(),
 	isAdFreeUser: jest.fn(),
@@ -100,6 +105,7 @@ describe('Commercial features', () => {
 
 		getCurrentBreakpoint.mockReturnValue('desktop');
 		isPayingMember.mockReturnValue(false);
+		isPayingMemberOkta.mockResolvedValue(false);
 		isRecentOneOffContributor.mockReturnValue(false);
 		shouldHideSupportMessaging.mockResolvedValue(false);
 		isAdFreeUser.mockReturnValue(false);

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
@@ -16,7 +16,7 @@ import {
 	getPurchaseInfo,
 	isAdFreeUser,
 	isDigitalSubscriber,
-	isPayingMemberOkta,
+	isPayingMember,
 	isPostAskPauseOneOffContributor,
 	isRecentOneOffContributor,
 	isRecurringContributor,
@@ -272,7 +272,7 @@ describe('The isPayingMember getter', () => {
 		jest.resetAllMocks();
 		isUserLoggedIn.mockReturnValue(false);
 		isUserLoggedInOktaRefactor.mockResolvedValue(false);
-		expect(await isPayingMemberOkta()).toBe(false);
+		expect(await isPayingMember()).toBe(false);
 	});
 
 	describe('When the user is logged in', () => {
@@ -284,18 +284,18 @@ describe('The isPayingMember getter', () => {
 
 		it('Is true when the user has a `true` paying member cookie', async () => {
 			addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
-			expect(await isPayingMemberOkta()).toBe(true);
+			expect(await isPayingMember()).toBe(true);
 		});
 
 		it('Is false when the user has a `false` paying member cookie', async () => {
 			addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'false');
-			expect(await isPayingMemberOkta()).toBe(false);
+			expect(await isPayingMember()).toBe(false);
 		});
 
 		it('Is true when the user has no paying member cookie', async () => {
 			// If we don't know, we err on the side of caution, rather than annoy paying users
 			removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
-			expect(await isPayingMemberOkta()).toBe(true);
+			expect(await isPayingMember()).toBe(true);
 		});
 	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
@@ -16,7 +16,7 @@ import {
 	getPurchaseInfo,
 	isAdFreeUser,
 	isDigitalSubscriber,
-	isPayingMember,
+	isPayingMemberOkta,
 	isPostAskPauseOneOffContributor,
 	isRecentOneOffContributor,
 	isRecurringContributor,
@@ -268,33 +268,34 @@ describe('The isAdFreeUser getter', () => {
 });
 
 describe('The isPayingMember getter', () => {
-	it('Is false when the user is logged out', () => {
+	it('Is false when the user is logged out', async () => {
 		jest.resetAllMocks();
 		isUserLoggedIn.mockReturnValue(false);
-		isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(false));
-		expect(isPayingMember()).toBe(false);
+		isUserLoggedInOktaRefactor.mockResolvedValue(false);
+		expect(await isPayingMemberOkta()).toBe(false);
 	});
 
 	describe('When the user is logged in', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
 			isUserLoggedIn.mockReturnValue(true);
+			isUserLoggedInOktaRefactor.mockResolvedValue(true);
 		});
 
-		it('Is true when the user has a `true` paying member cookie', () => {
+		it('Is true when the user has a `true` paying member cookie', async () => {
 			addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
-			expect(isPayingMember()).toBe(true);
+			expect(await isPayingMemberOkta()).toBe(true);
 		});
 
-		it('Is false when the user has a `false` paying member cookie', () => {
+		it('Is false when the user has a `false` paying member cookie', async () => {
 			addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'false');
-			expect(isPayingMember()).toBe(false);
+			expect(await isPayingMemberOkta()).toBe(false);
 		});
 
-		it('Is true when the user has no paying member cookie', () => {
+		it('Is true when the user has no paying member cookie', async () => {
 			// If we don't know, we err on the side of caution, rather than annoy paying users
 			removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
-			expect(isPayingMember()).toBe(true);
+			expect(await isPayingMemberOkta()).toBe(true);
 		});
 	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -208,11 +208,6 @@ const supportSiteRecurringCookiePresent = () =>
  * Does our _existing_ data say the user is a paying member?
  * This data may be stale; we do not wait for userFeatures.refresh()
  */
-// TODO: Remove as part of Okta Migration
-const isPayingMember = (): boolean =>
-	// If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
-	isUserLoggedIn() && getCookie({ name: PAYING_MEMBER_COOKIE }) !== 'false';
-
 const isPayingMemberOkta = async (): Promise<boolean> =>
 	// If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
 	(await isUserLoggedInOktaRefactor()) &&
@@ -412,7 +407,6 @@ export {
 	accountDataUpdateWarning,
 	isAdFreeUser,
 	isPayingMemberOkta,
-	isPayingMember,
 	isRecentOneOffContributor,
 	isDigitalSubscriber,
 	shouldHideSupportMessaging,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -208,9 +208,15 @@ const supportSiteRecurringCookiePresent = () =>
  * Does our _existing_ data say the user is a paying member?
  * This data may be stale; we do not wait for userFeatures.refresh()
  */
+// TODO: Remove as part of Okta Migration
 const isPayingMember = (): boolean =>
 	// If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
 	isUserLoggedIn() && getCookie({ name: PAYING_MEMBER_COOKIE }) !== 'false';
+
+const isPayingMemberOkta = async (): Promise<boolean> =>
+	// If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
+	(await isUserLoggedInOktaRefactor()) &&
+	getCookie({ name: PAYING_MEMBER_COOKIE }) !== 'false';
 
 // Expects milliseconds since epoch
 const getSupportFrontendOneOffContributionTimestamp = (): number | null => {
@@ -405,6 +411,7 @@ const getPurchaseInfo = (): PurchaseInfo => {
 export {
 	accountDataUpdateWarning,
 	isAdFreeUser,
+	isPayingMemberOkta,
 	isPayingMember,
 	isRecentOneOffContributor,
 	isDigitalSubscriber,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -407,8 +407,6 @@ export {
 	isAdFreeUser,
 	isPayingMember,
 	isRecentOneOffContributor,
-	isRecurringContributorOkta,
-	isRecurringContributor,
 	isDigitalSubscriber,
 	shouldHideSupportMessaging,
 	refresh,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -208,7 +208,7 @@ const supportSiteRecurringCookiePresent = () =>
  * Does our _existing_ data say the user is a paying member?
  * This data may be stale; we do not wait for userFeatures.refresh()
  */
-const isPayingMemberOkta = async (): Promise<boolean> =>
+const isPayingMember = async (): Promise<boolean> =>
 	// If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
 	(await isUserLoggedInOktaRefactor()) &&
 	getCookie({ name: PAYING_MEMBER_COOKIE }) !== 'false';
@@ -406,8 +406,9 @@ const getPurchaseInfo = (): PurchaseInfo => {
 export {
 	accountDataUpdateWarning,
 	isAdFreeUser,
-	isPayingMemberOkta,
+	isPayingMember,
 	isRecentOneOffContributor,
+	isRecurringContributor,
 	isDigitalSubscriber,
 	shouldHideSupportMessaging,
 	refresh,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -407,6 +407,7 @@ export {
 	isAdFreeUser,
 	isPayingMember,
 	isRecentOneOffContributor,
+	isRecurringContributorOkta,
 	isRecurringContributor,
 	isDigitalSubscriber,
 	shouldHideSupportMessaging,

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -1,5 +1,5 @@
 import {
-    isPayingMemberOkta,
+    isPayingMember,
     accountDataUpdateWarning,
     getLastOneOffContributionTimestamp,
     getLastRecurringContributionDate,
@@ -167,7 +167,7 @@ export const initMembership = () => {
         });
     }
 
-    isPayingMemberOkta().then(isPayingMember => {
+    isPayingMember().then(isPayingMember => {
         if (isPayingMember) {
             fastdom
                 .measure(() => document.getElementsByClassName('js-become-member'))

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -1,5 +1,5 @@
 import {
-    isPayingMember,
+    isPayingMemberOkta,
     accountDataUpdateWarning,
     getLastOneOffContributionTimestamp,
     getLastRecurringContributionDate,
@@ -167,23 +167,25 @@ export const initMembership = () => {
         });
     }
 
-    if (isPayingMember()) {
-        fastdom
-            .measure(() => document.getElementsByClassName('js-become-member'))
-            .then(becomeMemberLinks => {
-                if (becomeMemberLinks.length) {
-                    becomeMemberLinks[0].setAttribute('hidden', 'hidden');
-                }
-            });
+    isPayingMemberOkta().then(isPayingMember => {
+        if (isPayingMember) {
+            fastdom
+                .measure(() => document.getElementsByClassName('js-become-member'))
+                .then(becomeMemberLinks => {
+                    if (becomeMemberLinks.length) {
+                        becomeMemberLinks[0].setAttribute('hidden', 'hidden');
+                    }
+                });
 
-        fastdom
-            .measure(() => document.getElementsByClassName('js-subscribe'))
-            .then(subscriberLinks => {
-                if (subscriberLinks.length) {
-                    subscriberLinks[0].classList.remove(
-                        'brand-bar__item--split--last'
-                    );
-                }
-            });
-    }
+            fastdom
+                .measure(() => document.getElementsByClassName('js-subscribe'))
+                .then(subscriberLinks => {
+                    if (subscriberLinks.length) {
+                        subscriberLinks[0].classList.remove(
+                            'brand-bar__item--split--last'
+                        );
+                    }
+                });
+        }
+    });
 };


### PR DESCRIPTION
## What is the value of this and can you measure success?
Replaces any occurrences of isPayingMember with isPayingMemberOkta (which has been renamed to isPayingMember.
