### PR TITLE
Refactor sign in gate helper to Okta

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -6,7 +6,7 @@ import {
     getSynchronousTestsToRun,
     isInABTestSynchronous,
 } from 'common/modules/experiments/ab';
-import { isUserLoggedIn } from 'common/modules/identity/api';
+import { isUserLoggedInOktaRefactor } from 'common/modules/identity/api';
 import { cmp } from '@guardian/consent-management-platform';
 import { submitClickEventTracking } from './component-event-tracking';
 
@@ -41,9 +41,6 @@ const retrieveDismissedCount = (
         return 0;
     }
 };
-
-// wrapper over isLoggedIn
-export const isLoggedIn = isUserLoggedIn;
 
 // wrapper over isInABTestSynchronous
 export const isInTest = test => isInABTestSynchronous(test);
@@ -143,13 +140,15 @@ export const setGatePageTargeting = (
     isGateDismissed,
     canShowCheck
 ) => {
-    if (isUserLoggedIn()) {
-        setGoogleTargeting('signed in');
-    } else if (isGateDismissed) {
-        setGoogleTargeting('dismissed');
-    } else {
-        setGoogleTargeting(canShowCheck);
-    }
+    isUserLoggedInOktaRefactor().then(isLoggedIn => {
+        if (isLoggedIn) {
+            setGoogleTargeting('signed in');
+        } else if (isGateDismissed) {
+            setGoogleTargeting('dismissed');
+        } else {
+            setGoogleTargeting(canShowCheck);
+        }
+    })
 };
 
 // use the dailyArticleCount from the local storage to see how many articles the user has viewed in a day

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -28,7 +28,7 @@ jest.mock('@guardian/libs', () => ({
 }));
 
 jest.mock('common/modules/identity/api', () => ({
-    isUserLoggedIn: jest.fn(() => false),
+    isUserLoggedInOktaRefactor: jest.fn().mockResolvedValue(false),
 }));
 
 jest.mock('lib/config', () => ({
@@ -57,7 +57,7 @@ const fakeIsInABTestSynchronous = require('common/modules/experiments/ab')
 const fakeLocal = require('@guardian/libs').storage.local;
 
 const fakeIsUserLoggedIn = require('common/modules/identity/api')
-    .isUserLoggedIn;
+    .isUserLoggedInOktaRefactor;
 
 const fakeConfig = require('lib/config');
 
@@ -128,7 +128,7 @@ describe('Sign in gate test', () => {
         });
 
         it('should return false if the user is logged in', () => {
-            fakeIsUserLoggedIn.mockReturnValueOnce(true);
+            fakeIsUserLoggedIn.mockResolvedValueOnce(true);
             return signInGate.canShow().then(show => {
                 expect(show).toBe(false);
             });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -1,8 +1,8 @@
+import { isUserLoggedInOktaRefactor } from '../../api';
 import { componentName } from '../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
-    isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
     isIOS9,
@@ -16,16 +16,18 @@ import { designShow } from './design/example';
 const variant = 'example';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
-const canShow = (name = '') => {
+/** @type {(name: string) => Promise<boolean>} */
+const canShow = async (name = '') => {
     const isGateDismissed = hasUserDismissedGate({
         name,
         variant,
         componentName,
     });
+    const isLoggedIn = await isUserLoggedInOktaRefactor();
     const canShowCheck =
         !isGateDismissed &&
         isNPageOrHigherPageView(3) &&
-        !isLoggedIn() &&
+        !isLoggedIn &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
         !isIOS9();

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/control.js
@@ -1,8 +1,8 @@
+import { isUserLoggedInOktaRefactor } from 'common/modules/identity/api';
 import { componentName } from '../../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
-    isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
     isIOS9,
@@ -14,16 +14,18 @@ import {
 const variant = 'main-control-4';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
-const canShow = (name = '') => {
+/** @type {(name: string) => Promise<boolean>} */
+const canShow = async (name = '') => {
     const isGateDismissed = hasUserDismissedGate({
         name,
         variant,
         componentName,
     });
+    const isLoggedIn = await isUserLoggedInOktaRefactor();
     const canShowCheck =
         !isGateDismissed &&
         isNPageOrHigherPageView(3) &&
-        !isLoggedIn() &&
+        !isLoggedIn &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
         !isInvalidTag() &&

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
@@ -1,7 +1,7 @@
+import { isUserLoggedInOktaRefactor } from 'common/modules/identity/api';
 import { componentName } from '../../component';
 import {
     isNPageOrHigherPageView,
-    isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
     isInvalidTag,
@@ -17,17 +17,19 @@ import { designShow } from '../design/main-variant';
 const variant = 'main-variant-4';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
-const canShow = (name = '') => {
+/** @type {(name: string) => Promise<boolean>} */
+const canShow = async (name = '') => {
     const isGateDismissed = hasUserDismissedGateMoreThanCount(
         variant,
         name,
         componentName,
         5
     );
+    const isLoggedIn = await isUserLoggedInOktaRefactor();
     const canShowCheck =
         !isGateDismissed &&
         isNPageOrHigherPageView(3) &&
-        !isLoggedIn() &&
+        !isLoggedIn &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
         !isInvalidTag() &&


### PR DESCRIPTION
Use `isUserLoggedInOktaRefactor`, which conditionally checks logged in status using Okta if you are enrolled in the Okta experiment. Otherwise, it checks using cookies.

`isUserLoggedInOktaRefactor` is async, so this refactors to use Promises where necessary. Although the `canShow` functions now return Promises, the call-site of `canShow` is already using the Promise API so no changes are required here:
https://github.com/guardian/frontend/blob/3b7618ca93737aa65896b547f607cb3ddbc43127/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js#L14-L29

Resolves https://github.com/guardian/frontend/issues/26428