### PR TITLE
Use `isUserLoggedInOktaRefactor` in `reader-revenue-dev-utils`

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -10,7 +10,7 @@ import {
 	initMvtCookie,
 } from '../analytics/mvt-cookie';
 import { clearParticipations } from '../experiments/ab-local-storage';
-import {getAuthStatus, isUserLoggedInOktaRefactor} from '../identity/api';
+import { isUserLoggedInOktaRefactor } from '../identity/api';
 import userPrefs from '../user-prefs';
 import { pageShouldHideReaderRevenue } from './contributions-utilities';
 import {
@@ -56,33 +56,18 @@ const clearCommonReaderRevenueStateAndReload = (asExistingSupporter) => {
 
     isUserLoggedInOktaRefactor().then(isLoggedIn => {
         if(isLoggedIn && !asExistingSupporter) {
-            getAuthStatus().then(authStatus => {
-
-                // If logged in and in localhost authStatus will always be SignedInWithOkta
-                // because when we are in DEV we are always `InOktaExperiment`:
-                // https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/identity/api.ts#L115-L117
-                if (window.location.origin.includes('localhost') && authStatus.kind === "SignedInWithOkta") {
-                    localStorage.removeItem("gu.access_token");
-                    localStorage.removeItem("gu.id_token");
-                    removeCookie('GU_U');
-                } else {
-                    const profileUrl = window.location.origin.replace(
-                        /(www\.|m\.)/,
-                        'profile.',
-                    );
-                    window.location.assign(`${profileUrl}/signout`);
-                }
-            })
-
-        } else {
-
-            // If in localhost and SignedInWithCookie it will reach this point
-            // because in DEV we are always `InOktaExperiment`
-            // so adding this as a fallback. This will be also triggered when in localhost
-            // and SignedOutWithCookies or SignedOutWithOkta
-            if (window.location.origin.includes('localhost'))
+            if (window.location.origin.includes('localhost')) {
+                localStorage.removeItem("gu.access_token");
+                localStorage.removeItem("gu.id_token");
                 removeCookie('GU_U');
-
+            } else {
+                const profileUrl = window.location.origin.replace(
+                    /(www\.|m\.)/,
+                    'profile.',
+                );
+                window.location.assign(`${profileUrl}/signout`);
+            }
+        } else {
             window.location.reload();
         }
     })


### PR DESCRIPTION
## What is the value of this and can you measure success?

Replaces `isUserLoggedIn` with  `isUserLoggedInOktaRefactor` in `reader-revenue-dev-utils`. This is an intermediate step towards the Okta migration. The end goal is to completely get rid of the method `isUserLoggedIn`. See [parent ticket](https://github.com/guardian/frontend/issues/26347).

This code is used by devs for [testing the Reader Revue components](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/21-test-reader-revenue-components.md). These [helper methods](http://reader-revenue-bookmarklets.s3-website-eu-west-1.amazonaws.com/) enable devs to see the different Reader Revenue components regardless of whether they are signed in or not. The method that is refactored in this PR clears the reader revenue state and the specific flow "manually" logs out the user if they are:
* in localhost 
* logged in (either in Okta or not)
* and have requested to see a banner for non-supporters. 

### Before

* `GU_U` cookie is present and I am requesting to see a banner as a non-supporter.

<img width="1718" alt="image" src="https://github.com/guardian/frontend/assets/19683595/bee1e6ca-4e68-408a-9a61-87ae5558aa67">


* Non-supporter banner appears and `GU_U` cookie gets cleared.


<img width="1723" alt="image" src="https://github.com/guardian/frontend/assets/19683595/8b4ee78c-734f-4151-808e-500d583691e4">


### After

#### Off Okta

<img width="1728" alt="image" src="https://github.com/guardian/frontend/assets/19683595/ed033c5f-2717-41a2-b793-a9beea7e00e7">

<img width="1727" alt="image" src="https://github.com/guardian/frontend/assets/19683595/5d6782a7-91ba-41dd-b598-f525b99bc36d">


#### On Okta
`gu.access_token` and `gu.id_token` are present and I am requesting to see a banner as a non-supporter.

<img width="1720" alt="image" src="https://github.com/guardian/frontend/assets/19683595/d38ad8f6-1089-4ee3-a715-6f846d6f6bf4">


**To fix:** `gu.access_token` and `gu.id_token` get removed from `localStorage` but banner doesn't show. I am not sure if when in Okta, this is enough to show the banner.

<img width="1724" alt="image" src="https://github.com/guardian/frontend/assets/19683595/c24410f4-a05f-4b4f-a2da-51b537a728fb">


Closes #26430 

