### PR TITLE
Migrate `user-features.ts` to Okta

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -14,6 +14,7 @@ import {
     refresh as refreshUserFeatures,
     extendContribsCookieExpiry,
 } from 'common/modules/commercial/user-features';
+import { reportError } from 'lib/report-error';
 import { initCommentCount } from 'common/modules/discussion/comment-count';
 import { init as initCookieRefresh } from 'common/modules/identity/cookierefresh';
 import { initNavigation } from 'common/modules/navigation/navigation';
@@ -361,7 +362,6 @@ const init = () => {
         ['c-public-api', initPublicApi],
         ['c-media-listeners', mediaListener],
         ['c-accessibility-prefs', initAccessibilityPreferences],
-        ['c-user-features', refreshUserFeatures],
         ['c-membership', initMembership],
         ['c-message-slots', initialiseMessageSlots],
         ['c-reader-revenue-dev-utils', initReaderRevenueDevUtils],
@@ -369,6 +369,10 @@ const init = () => {
         ['c-load-google-analytics', loadGoogleAnalytics],
         ['c-google-analytics', initGoogleAnalytics],
     ]);
+
+    return refreshUserFeatures().catch((err) => {
+        reportError(err, { module: 'c-user-features' })
+    })
 };
 
 export { init };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
@@ -5,7 +5,6 @@ import { fetchJson } from '../../../../lib/fetch-json';
 import type { AuthStatus } from '../identity/api';
 import {
 	getAuthStatus as getAuthStatus_,
-	isUserLoggedIn as isUserLoggedIn_,
 	isUserLoggedInOktaRefactor as isUserLoggedInOktaRefactor_,
 } from '../identity/api';
 import {
@@ -26,7 +25,6 @@ import {
 
 jest.mock('../../../../lib/raven');
 jest.mock('projects/common/modules/identity/api', () => ({
-	isUserLoggedIn: jest.fn(),
 	isUserLoggedInOktaRefactor: jest.fn(),
 	getAuthStatus: jest.fn(),
 	getOptionsHeadersWithOkta: jest.fn(),
@@ -36,9 +34,6 @@ jest.mock('../../../../lib/fetch-json', () => ({
 }));
 
 const fetchJsonSpy = fetchJson as jest.MockedFunction<typeof fetchJson>;
-const isUserLoggedIn = isUserLoggedIn_ as jest.MockedFunction<
-	typeof isUserLoggedIn_
->;
 
 const isUserLoggedInOktaRefactor =
 	isUserLoggedInOktaRefactor_ as jest.MockedFunction<
@@ -118,7 +113,6 @@ describe('Refreshing the features data', () => {
 	describe('If user signed in', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
-			isUserLoggedIn.mockReturnValue(true);
 			isUserLoggedInOktaRefactor.mockResolvedValue(true);
 			getAuthStatus.mockResolvedValue({
 				kind: 'SignedInWithOkta',
@@ -191,11 +185,8 @@ describe('Refreshing the features data', () => {
 	describe('If user signed out', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
-			isUserLoggedIn.mockReturnValue(false);
-			isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(false));
-			getAuthStatus.mockReturnValue(
-				Promise.resolve({ kind: 'SignedOutWithOkta' }),
-			);
+			isUserLoggedInOktaRefactor.mockResolvedValue(false);
+			getAuthStatus.mockResolvedValue({ kind: 'SignedOutWithOkta' });
 			fetchJsonSpy.mockReturnValue(Promise.resolve());
 		});
 
@@ -234,16 +225,14 @@ describe('Refreshing the features data', () => {
 describe('The account data update warning getter', () => {
 	it('Is not set when the user is logged out', () => {
 		jest.resetAllMocks();
-		isUserLoggedIn.mockReturnValue(false);
-		isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(false));
+		isUserLoggedInOktaRefactor.mockResolvedValue(false);
 		expect(accountDataUpdateWarning()).toBe(null);
 	});
 
 	describe('When the user is logged in', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
-			isUserLoggedIn.mockReturnValue(true);
-			isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(true));
+			isUserLoggedInOktaRefactor.mockResolvedValue(true);
 		});
 
 		it('Is the same when the user has an account data update link cookie', () => {
@@ -261,8 +250,7 @@ describe('The account data update warning getter', () => {
 describe('The isAdFreeUser getter', () => {
 	it('Is false when the user is logged out', () => {
 		jest.resetAllMocks();
-		isUserLoggedIn.mockReturnValue(false);
-		isUserLoggedInOktaRefactor.mockReturnValue(Promise.resolve(false));
+		isUserLoggedInOktaRefactor.mockResolvedValue(false);
 		expect(isAdFreeUser()).toBe(false);
 	});
 });
@@ -270,7 +258,6 @@ describe('The isAdFreeUser getter', () => {
 describe('The isPayingMember getter', () => {
 	it('Is false when the user is logged out', async () => {
 		jest.resetAllMocks();
-		isUserLoggedIn.mockReturnValue(false);
 		isUserLoggedInOktaRefactor.mockResolvedValue(false);
 		expect(await isPayingMember()).toBe(false);
 	});
@@ -278,7 +265,6 @@ describe('The isPayingMember getter', () => {
 	describe('When the user is logged in', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
-			isUserLoggedIn.mockReturnValue(true);
 			isUserLoggedInOktaRefactor.mockResolvedValue(true);
 		});
 
@@ -303,7 +289,7 @@ describe('The isPayingMember getter', () => {
 describe('The isRecurringContributor getter', () => {
 	it('Is false when the user is logged out', async () => {
 		jest.resetAllMocks();
-		isUserLoggedIn.mockReturnValue(false);
+		isUserLoggedInOktaRefactor.mockResolvedValue(false);
 		expect(await isRecurringContributor()).toBe(false);
 	});
 
@@ -311,7 +297,6 @@ describe('The isRecurringContributor getter', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
 			isUserLoggedInOktaRefactor.mockResolvedValue(true);
-			isUserLoggedIn.mockReturnValue(true);
 		});
 
 		it('Is true when the user has a `true` recurring contributor cookie', async () => {
@@ -335,14 +320,14 @@ describe('The isRecurringContributor getter', () => {
 describe('The isDigitalSubscriber getter', () => {
 	it('Is false when the user is logged out', () => {
 		jest.resetAllMocks();
-		isUserLoggedIn.mockReturnValue(false);
+		isUserLoggedInOktaRefactor.mockResolvedValue(false);
 		expect(isDigitalSubscriber()).toBe(false);
 	});
 
 	describe('When the user is logged in', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
-			isUserLoggedIn.mockReturnValue(true);
+			isUserLoggedInOktaRefactor.mockResolvedValue(false);
 		});
 
 		it('Is true when the user has a `true` digital subscriber cookie', () => {
@@ -365,14 +350,14 @@ describe('The isDigitalSubscriber getter', () => {
 describe('The shouldNotBeShownSupportMessaging getter', () => {
 	it('Returns false when the user is logged out', () => {
 		jest.resetAllMocks();
-		isUserLoggedIn.mockReturnValue(false);
+		isUserLoggedInOktaRefactor.mockResolvedValue(false);
 		expect(shouldNotBeShownSupportMessaging()).toBe(false);
 	});
 
 	describe('When the user is logged in', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
-			isUserLoggedIn.mockReturnValue(true);
+			isUserLoggedInOktaRefactor.mockResolvedValue(true);
 		});
 
 		it('Returns true when the user has a `true` hide support messaging cookie', () => {
@@ -410,10 +395,10 @@ describe('Storing new feature data', () => {
 		jest.resetAllMocks();
 		fetchJsonSpy.mockReturnValue(Promise.resolve(mockResponse));
 		deleteAllFeaturesData();
-		isUserLoggedIn.mockReturnValue(true);
-		getAuthStatus.mockReturnValue(
-			Promise.resolve({ kind: 'SignedInWithOkta' } as AuthStatus),
-		);
+		isUserLoggedInOktaRefactor.mockResolvedValue(true);
+		getAuthStatus.mockResolvedValue({
+			kind: 'SignedInWithOkta',
+		} as AuthStatus);
 	});
 
 	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -196,7 +196,6 @@ const refresh = async (): Promise<void> => {
 	} else if ((await userHasDataAfterSignout()) && !forcedAdFreeMode) {
 		deleteOldData();
 	}
-	return Promise.resolve();
 };
 
 const supportSiteRecurringCookiePresent = () =>

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -185,16 +185,16 @@ const userNeedsNewFeatureData = (): boolean =>
 	(adFreeDataIsPresent() && adFreeDataIsOld()) ||
 	(isDigitalSubscriber() && !adFreeDataIsPresent());
 
-const userHasDataAfterSignout = (): boolean =>
-	!isUserLoggedIn() && userHasData();
+const userHasDataAfterSignout = async (): Promise<boolean> =>
+	!(await isUserLoggedInOktaRefactor()) && userHasData();
 
 /**
  * Updates the user's data in a lazy fashion
  */
-const refresh = (): Promise<void> => {
-	if (isUserLoggedIn() && userNeedsNewFeatureData()) {
+const refresh = async (): Promise<void> => {
+	if ((await isUserLoggedInOktaRefactor()) && userNeedsNewFeatureData()) {
 		return requestNewData();
-	} else if (userHasDataAfterSignout() && !forcedAdFreeMode) {
+	} else if ((await userHasDataAfterSignout()) && !forcedAdFreeMode) {
 		deleteOldData();
 	}
 	return Promise.resolve();

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -17,7 +17,6 @@ import type { UserFeaturesResponse } from '../../../../types/membership';
 import {
 	getAuthStatus,
 	getOptionsHeadersWithOkta,
-	isUserLoggedIn,
 	isUserLoggedInOktaRefactor,
 } from '../../modules/identity/api';
 import { cookieIsExpiredOrMissing, timeInDaysFromNow } from './lib/cookie';


### PR DESCRIPTION
## What does this change?

- Replaces all instances of `isUserLoggedIn` in `user-features.ts` with `isUserLoggedInOktaRefactor`.
- Removes the mock of `isUserLoggedIn` from `user-features.spec.ts` 
- Rather than passing the refresh function to catchErrorsWithContext, which is expecting a synchronous fn, we implement a catch.

Resolves https://github.com/guardian/frontend/issues/26415