### PR TITLE
Remove `relatedWidgetEnabled` from deprecated `commercial-features.ts`

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -6,7 +6,6 @@
 
 import { log } from '@guardian/libs';
 import { getCurrentBreakpoint } from 'lib/detect-breakpoint';
-import { isUserLoggedIn } from '../identity/api';
 import userPrefs from '../user-prefs';
 import { isAdFreeUser } from './user-features';
 
@@ -50,7 +49,6 @@ class CommercialFeatures {
 	carrotTrafficDriver: boolean;
 	highMerch: boolean;
 	thirdPartyTags: boolean;
-	relatedWidgetEnabled: boolean;
 	commentAdverts: boolean;
 	liveblogAdverts: boolean;
 	adFree: boolean;
@@ -170,16 +168,6 @@ class CommercialFeatures {
 			!isIdentityPage &&
 			!this.isSecureContact &&
 			!!window.guardian.config.switches.redplanetForAus;
-
-		this.relatedWidgetEnabled =
-			this.dfpAdvertising &&
-			!this.adFree &&
-			!noadsUrl &&
-			!sensitiveContent &&
-			isArticle &&
-			!window.guardian.config.page.isPreview &&
-			!!window.guardian.config.page.showRelatedContent &&
-			!(isUserLoggedIn() && window.guardian.config.page.commentable);
 
 		this.commentAdverts =
 			this.dfpAdvertising &&


### PR DESCRIPTION

## What does this change?
Removes `relatedWidgetEnabled` from deprecated `commercial-features.ts`.

This file has been deprecated as per the [comment at the top of the file](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts#L1), and as `relatedWidgetEnabled` [has already been removed from the replacement code](https://github.com/guardian/commercial/pull/844), it makes more sense to remove it rather than migrate it to Okta.
