### PR TITLE
Bump commercial to 10.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "10.11.0",
+		"@guardian/commercial": "10.12.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@10.11.0":
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.11.0.tgz#0ec42a4d0e0ad0ac808a9b741972fe9833a21e6b"
-  integrity sha512-XRVR2nmCeEDkzM3UdXNBmlqPvdk2ohccDqnI5Ylft38X3s0ERBsvCZf2psoAJkIWIsDtP2ROAP05Y9DRdXuq0A==
+"@guardian/commercial@10.12.0":
+  version "10.12.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.12.0.tgz#a19c634286a98a965163e44323425a66a2631728"
+  integrity sha512-kXWEPFteiNv/EhizVeM9nVf5pEIjqvFC2jDekpyGPB2MS33GneEMlnTlKDZNDcQHOzg4Zy663Che60ElEfk7+g==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
Bring in the changes from [10.12.0](https://github.com/guardian/commercial/releases/tag/v10.12.0)