### PR TITLE
Bump commercial to 10.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "10.12.0",
+		"@guardian/commercial": "10.13.0",
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@10.12.0":
-  version "10.12.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.12.0.tgz#a19c634286a98a965163e44323425a66a2631728"
-  integrity sha512-kXWEPFteiNv/EhizVeM9nVf5pEIjqvFC2jDekpyGPB2MS33GneEMlnTlKDZNDcQHOzg4Zy663Che60ElEfk7+g==
+"@guardian/commercial@10.13.0":
+  version "10.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.13.0.tgz#96168b738725768b0b61552dca242065e5a53d9a"
+  integrity sha512-K68LfmqEemUNwzqMIRAvWTuSFHjhBi/vcm7P2NEPrJBpsyel1U+yA5dYPbtlborkGV5/LR4gv5KhqPoNBgP5cg==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"
@@ -10516,7 +10516,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js:
+"prebid.js@github:guardian/prebid.js":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What is the value of this and can you measure success?

Bump commercial to [10.13.0](https://github.com/guardian/commercial/releases/tag/v10.13.0)

## What does this change?

Adds 'external ads' i.e. ads placed in external content like thrashers but recognised by the commercial runtime and fulfilled.
