### PR TITLE
Cartoon element

### DIFF
--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -44,7 +44,7 @@ class ImageContentController(
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] =
     image(Edition(request), path).flatMap {
       case Right((content, mainBlock)) =>
-        val tier = ImageContentPicker.getTier(content)
+        val tier = ImageContentPicker.getTier(content, mainBlock)
 
         tier match {
           case RemoteRender => remoteRender(content, mainBlock)

--- a/applications/app/services/dotcomrendering/ImageContentPicker.scala
+++ b/applications/app/services/dotcomrendering/ImageContentPicker.scala
@@ -17,13 +17,11 @@ object ImageContentPicker extends GuLogging {
   ): RenderType = {
     val dcrCanRender =
       mainBlock.exists(block => block.elements.forall(element => element.`type` == ElementType.Cartoon))
-    // Currently defaulting to false until we implement image articles in DCR
-    val dcrShouldRender = false
 
     val tier = {
       if (request.forceDCROff) LocalRender
       else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender && dcrShouldRender) RemoteRender
+      else if (dcrCanRender) RemoteRender
       else LocalRender
     }
 

--- a/applications/app/services/dotcomrendering/ImageContentPicker.scala
+++ b/applications/app/services/dotcomrendering/ImageContentPicker.scala
@@ -1,5 +1,6 @@
 package services.dotcomrendering
 
+import com.gu.contentapi.client.model.v1.{Block, ElementType}
 import common.GuLogging
 import model.Cors.RichRequestHeader
 import model.ImageContentPage
@@ -8,32 +9,21 @@ import utils.DotcomponentsLogger
 
 object ImageContentPicker extends GuLogging {
 
-  /**
-    *
-    * Add to this function any logic for including/excluding
-    * an image article from being rendered with DCR
-    *
-    * Currently defaulting to false until we implement image articles in DCR
-    *
-    * */
-  private def dcrCouldRender(imageContentPage: ImageContentPage): Boolean = {
-    false
-  }
-
   def getTier(
       imageContentPage: ImageContentPage,
+      mainBlock: Option[Block],
   )(implicit
       request: RequestHeader,
   ): RenderType = {
-
-    // Setting to false while still implementing this content type in DCR
-    val participatingInTest = false //ActiveExperiments.isParticipating(DCRImageContent)
-    val dcrCanRender = dcrCouldRender(imageContentPage)
+    val dcrCanRender =
+      mainBlock.exists(block => block.elements.forall(element => element.`type` == ElementType.Cartoon))
+    // Currently defaulting to false until we implement image articles in DCR
+    val dcrShouldRender = false
 
     val tier = {
       if (request.forceDCROff) LocalRender
       else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender && participatingInTest) RemoteRender
+      else if (dcrCanRender && dcrShouldRender) RemoteRender
       else LocalRender
     }
 

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.contentapi.client.model.v1.Asset
+import com.gu.contentapi.client.model.v1.{Asset, CartoonImage}
 import play.api.libs.json.{Json, Writes}
 import views.support.{ImgSrc, Naked, Orientation}
 
@@ -39,6 +39,18 @@ object ImageAsset {
       mediaType = asset.`type`.name,
       mimeType = asset.mimeType,
       url = asset.typeData.flatMap(_.secureFile).orElse(asset.file),
+    )
+  }
+  def make(cartoonImage: CartoonImage, index: Int): ImageAsset = {
+    ImageAsset(
+      index = index,
+      fields = Map(
+        "height" -> cartoonImage.height.map(_.toString),
+        "width" -> cartoonImage.width.map(_.toString),
+      ).collect { case (k, Some(v)) => (k, v) },
+      mediaType = "image", // TODO: derive this from mimetype?
+      mimeType = Some(cartoonImage.mimeType),
+      url = Some(cartoonImage.file),
     )
   }
   implicit val imageAssetWrites: Writes[ImageAsset] = Json.writes[ImageAsset]

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.contentapi.client.model.v1.{Asset, CartoonImage}
+import com.gu.contentapi.client.model.v1.{Asset, AssetType, CartoonImage}
 import play.api.libs.json.{Json, Writes}
 import views.support.{ImgSrc, Naked, Orientation}
 
@@ -48,7 +48,7 @@ object ImageAsset {
         "height" -> cartoonImage.height.map(_.toString),
         "width" -> cartoonImage.width.map(_.toString),
       ).collect { case (k, Some(v)) => (k, v) },
-      mediaType = "image", // TODO: derive this from mimetype?
+      mediaType = AssetType.Cartoon.name,
       mimeType = Some(cartoonImage.mimeType),
       url = Some(cartoonImage.file),
     )

--- a/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
@@ -19,8 +19,8 @@ object CartoonExtraction {
   }
 
   private def getCartoonVariants(cartoonData: CartoonElementFields): Option[List[DcrCartoonVariant]] = {
-    cartoonData.variants.map(maybeVariant =>
-      maybeVariant
+    cartoonData.variants.map(variants =>
+      variants
         .map(variant =>
           DcrCartoonVariant(
             viewportSize = variant.viewportSize,

--- a/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
@@ -15,17 +15,19 @@ object CartoonExtraction {
     )
   }
 
-  private def getCartoonVariants(cartoonData: CartoonElementFields): Option[List[DcrCartoonVariant]] = {
-    cartoonData.variants.map(variants =>
-      variants
-        .map(variant =>
-          DcrCartoonVariant(
-            viewportSize = variant.viewportSize,
-            images = getImageAssets(variant.images.toList),
-          ),
-        )
-        .toList,
-    )
+  private def getCartoonVariants(cartoonData: CartoonElementFields): List[DcrCartoonVariant] = {
+    cartoonData.variants
+      .map(variants =>
+        variants
+          .map(variant =>
+            DcrCartoonVariant(
+              viewportSize = variant.viewportSize,
+              images = getImageAssets(variant.images.toList),
+            ),
+          )
+          .toList,
+      )
+      .getOrElse(List.empty)
   }
 
   private def getImageAssets(images: List[CartoonImage]): List[ImageAsset] = {

--- a/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
@@ -14,7 +14,7 @@ object CartoonExtraction {
       source = cartoonElementFields.source,
       displayCredit = cartoonElementFields.displayCredit,
       photographer = cartoonElementFields.photographer,
-      imageType = cartoonElementFields.imageType
+      imageType = cartoonElementFields.imageType,
     )
   }
 

--- a/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
@@ -4,15 +4,18 @@ import com.gu.contentapi.client.model.v1.{CartoonElementFields, CartoonImage}
 import model.ImageAsset
 
 object CartoonExtraction {
-  def extractCartoon(cartoonElementFields: CartoonElementFields): CartoonBlockElement = {
-    CartoonBlockElement(
-      variants = getCartoonVariants(cartoonElementFields),
-      role = Role(cartoonElementFields.role, Inline),
-      credit = cartoonElementFields.credit,
-      caption = cartoonElementFields.caption,
-      alt = cartoonElementFields.alt,
-      displayCredit = cartoonElementFields.displayCredit,
-    )
+  def extractCartoon(cartoonElementFields: CartoonElementFields): Option[CartoonBlockElement] = {
+    val variants = getCartoonVariants(cartoonElementFields)
+    Option.when(cartoonIsValid(variants)) {
+      CartoonBlockElement(
+        variants = getCartoonVariants(cartoonElementFields),
+        role = Role(cartoonElementFields.role, Inline),
+        credit = cartoonElementFields.credit,
+        caption = cartoonElementFields.caption,
+        alt = cartoonElementFields.alt,
+        displayCredit = cartoonElementFields.displayCredit,
+      )
+    }
   }
 
   private def getCartoonVariants(cartoonData: CartoonElementFields): List[DcrCartoonVariant] = {
@@ -36,8 +39,8 @@ object CartoonExtraction {
     }
   }
 
-  def cartoonIsValid(cartoonBlockElement: CartoonBlockElement): Boolean = {
-    cartoonBlockElement.variants.exists(variant =>
+  private def cartoonIsValid(variants: List[DcrCartoonVariant]): Boolean = {
+    variants.exists(variant =>
       variant.viewportSize == "large" &&
         variant.images.nonEmpty &&
         variant.images.head.fields.contains("height") &&

--- a/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
@@ -11,10 +11,7 @@ object CartoonExtraction {
       credit = cartoonElementFields.credit,
       caption = cartoonElementFields.caption,
       alt = cartoonElementFields.alt,
-      source = cartoonElementFields.source,
       displayCredit = cartoonElementFields.displayCredit,
-      photographer = cartoonElementFields.photographer,
-      imageType = cartoonElementFields.imageType,
     )
   }
 

--- a/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
@@ -35,4 +35,13 @@ object CartoonExtraction {
       case (a, i) => ImageAsset.make(a, i)
     }
   }
+
+  def cartoonIsValid(cartoonBlockElement: CartoonBlockElement): Boolean = {
+    cartoonBlockElement.variants.exists(variant =>
+      variant.viewportSize == "large" &&
+        variant.images.nonEmpty &&
+        variant.images.head.fields.contains("height") &&
+        variant.images.head.fields.contains("width"),
+    )
+  }
 }

--- a/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
@@ -1,0 +1,37 @@
+package model.dotcomrendering.pageElements
+
+import com.gu.contentapi.client.model.v1.{CartoonElementFields, CartoonImage}
+import model.ImageAsset
+
+object CartoonExtraction {
+  def extractCartoon(cartoonElementFields: CartoonElementFields): CartoonBlockElement = {
+    CartoonBlockElement(
+      variants = getCartoonVariants(cartoonElementFields),
+      role = Role(cartoonElementFields.role, Inline),
+      credit = cartoonElementFields.credit,
+      caption = cartoonElementFields.caption,
+      alt = cartoonElementFields.alt,
+      source = cartoonElementFields.source,
+      displayCredit = cartoonElementFields.displayCredit,
+    )
+  }
+
+  private def getCartoonVariants(cartoonData: CartoonElementFields): Option[List[DcrCartoonVariant]] = {
+    cartoonData.variants.map(maybeVariant =>
+      maybeVariant
+        .map(variant =>
+          DcrCartoonVariant(
+            viewportSize = variant.viewportSize,
+            images = getImageAssets(variant.images.toList),
+          ),
+        )
+        .toList,
+    )
+  }
+
+  private def getImageAssets(images: List[CartoonImage]): List[ImageAsset] = {
+    images.zipWithIndex.map {
+      case (a, i) => ImageAsset.make(a, i)
+    }
+  }
+}

--- a/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CartoonExtraction.scala
@@ -13,6 +13,8 @@ object CartoonExtraction {
       alt = cartoonElementFields.alt,
       source = cartoonElementFields.source,
       displayCredit = cartoonElementFields.displayCredit,
+      photographer = cartoonElementFields.photographer,
+      imageType = cartoonElementFields.imageType
     )
   }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -169,7 +169,7 @@ case class DcrCartoonVariant(
     images: List[ImageAsset],
 )
 case class CartoonBlockElement(
-    variants: Option[List[DcrCartoonVariant]],
+    variants: List[DcrCartoonVariant],
     role: Role,
     credit: Option[String],
     caption: Option[String],

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -15,6 +15,7 @@ import conf.Configuration
 import layout.ContentWidths.{BodyMedia, ImmersiveMedia, MainMedia}
 import model.content._
 import model.dotcomrendering.InteractiveSwitchOver
+import model.dotcomrendering.pageElements.CartoonExtraction._
 import model.{ImageAsset, ImageElement, ImageMedia, VideoAsset}
 import org.joda.time.DateTime
 import org.jsoup.Jsoup
@@ -910,7 +911,7 @@ object PageElement {
           ),
         )
 
-      case Cartoon => element.cartoonTypeData.map(CartoonExtraction.extractCartoon).toList
+      case Cartoon => element.cartoonTypeData.map(extractCartoon).filter(cartoonIsValid).toList
 
       case Image =>
         def ensureHTTPS(src: String): String = src.replace("http:", "https:")

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -3,6 +3,8 @@ package model.dotcomrendering.pageElements
 import java.net.URLEncoder
 import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
 import com.gu.contentapi.client.model.v1.{
+  CartoonImage,
+  CartoonVariant,
   ElementType,
   EmbedTracking,
   SponsorshipType,
@@ -285,12 +287,18 @@ case class GuVideoBlockElement(
 object GuVideoBlockElement {
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
 }
-
 case class CartoonBlockElement(
-    //todo rest of model
+    cartoonVariants: Option[List[CartoonVariant]],
+    role: Option[String],
+    credit: Option[String],
+    caption: Option[String],
+    alt: Option[String],
+    source: Option[String],
     displayCredit: Option[Boolean],
 ) extends PageElement
 object CartoonBlockElement {
+  implicit val CartoonImageWrites: Writes[CartoonImage] = Json.writes[CartoonImage]
+  implicit val CartoonVariantWrites: Writes[CartoonVariant] = Json.writes[CartoonVariant]
   implicit val CartoonBlockElementWrites: Writes[CartoonBlockElement] = Json.writes[CartoonBlockElement]
 }
 
@@ -1824,7 +1832,17 @@ object PageElement {
    */
   val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
 
-  private def cartoonToPageElement(element: ApiBlockElement): Option[CartoonBlockElement] = {
-    element.cartoonTypeData.map(cartoonData => ???)
+  private[pageElements] def cartoonToPageElement(element: ApiBlockElement): Option[CartoonBlockElement] = {
+    element.cartoonTypeData.map(cartoonData =>
+      CartoonBlockElement(
+        cartoonVariants = cartoonData.cartoonVariants.map(_.toList),
+        role = cartoonData.role,
+        credit = cartoonData.credit,
+        caption = cartoonData.caption,
+        alt = cartoonData.alt,
+        source = cartoonData.source,
+        displayCredit = cartoonData.displayCredit,
+      ),
+    )
   }
 }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -911,7 +911,7 @@ object PageElement {
           ),
         )
 
-      case Cartoon => element.cartoonTypeData.map(extractCartoon).filter(cartoonIsValid).toList
+      case Cartoon => element.cartoonTypeData.flatMap(extractCartoon).toList
 
       case Image =>
         def ensureHTTPS(src: String): String = src.replace("http:", "https:")

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -286,6 +286,14 @@ object GuVideoBlockElement {
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
 }
 
+case class CartoonBlockElement(
+    //todo rest of model
+    displayCredit: Option[Boolean],
+) extends PageElement
+object CartoonBlockElement {
+  implicit val CartoonBlockElementWrites: Writes[CartoonBlockElement] = Json.writes[CartoonBlockElement]
+}
+
 case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
 object ImageSource {
   implicit val ImageSourceWrites: Writes[ImageSource] = Json.writes[ImageSource]
@@ -809,6 +817,7 @@ object PageElement {
       case _: YoutubeBlockElement         => true
       case _: WitnessBlockElement         => true
       case _: VineBlockElement            => true
+      case _: CartoonBlockElement         => true
       // TODO we should quick fail here for these rather than pointlessly go to DCR
       case table: TableBlockElement if table.isMandatory.exists(identity) => true
 
@@ -891,6 +900,8 @@ object PageElement {
             element.richLinkTypeData.flatMap(_.sponsorship).map(Sponsorship(_)),
           ),
         )
+
+      case Cartoon => cartoonToPageElement(element).toList
 
       case Image =>
         def ensureHTTPS(src: String): String = src.replace("http:", "https:")
@@ -1813,4 +1824,7 @@ object PageElement {
    */
   val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
 
+  private def cartoonToPageElement(element: ApiBlockElement): Option[CartoonBlockElement] = {
+    element.cartoonTypeData.map(cartoonData => ???)
+  }
 }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -174,10 +174,7 @@ case class CartoonBlockElement(
     credit: Option[String],
     caption: Option[String],
     alt: Option[String],
-    source: Option[String],
     displayCredit: Option[Boolean],
-    photographer: Option[String],
-    imageType: Option[String],
 ) extends PageElement
 object CartoonBlockElement {
   implicit val CartoonVariantWrites: Writes[DcrCartoonVariant] = Json.writes[DcrCartoonVariant]

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -176,6 +176,8 @@ case class CartoonBlockElement(
     alt: Option[String],
     source: Option[String],
     displayCredit: Option[Boolean],
+    photographer: Option[String],
+    imageType: Option[String]
 ) extends PageElement
 object CartoonBlockElement {
   implicit val CartoonVariantWrites: Writes[DcrCartoonVariant] = Json.writes[DcrCartoonVariant]

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -177,7 +177,7 @@ case class CartoonBlockElement(
     source: Option[String],
     displayCredit: Option[Boolean],
     photographer: Option[String],
-    imageType: Option[String]
+    imageType: Option[String],
 ) extends PageElement
 object CartoonBlockElement {
   implicit val CartoonVariantWrites: Writes[DcrCartoonVariant] = Json.writes[DcrCartoonVariant]

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -178,6 +178,7 @@ object BlockElement {
 
       case EnumUnknownElementType(f) => Some(UnknownBlockElement(None))
       case Callout                   => Some(UnsupportedBlockElement(None))
+      case Cartoon                   => Some(UnsupportedBlockElement(None))
 
     }
   }

--- a/common/test/model/dotcomrendering/pageElements/CartoonExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CartoonExtractionTest.scala
@@ -1,0 +1,60 @@
+package model.dotcomrendering.pageElements
+
+import com.gu.contentapi.client.model.v1.{CartoonElementFields, CartoonImage, CartoonVariant}
+import model.ImageAsset
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CartoonExtractionTest extends AnyFlatSpec with Matchers {
+  "CartoonExtraction" should "transform a cartoon element from Content API" in {
+    val cartoonElementFields = CartoonElementFields(
+      variants = Some(
+        scala.collection.Seq(
+          CartoonVariant(
+            viewportSize = "large",
+            images = scala.collection.Seq(
+              CartoonImage(
+                mimeType = "image/jpeg",
+                file = "https://link-to-my-image",
+                width = Some(500),
+                height = Some(300),
+              ),
+            ),
+          ),
+        ),
+      ),
+      credit = Some("credit"),
+      caption = Some("caption"),
+      alt = Some("alt"),
+      source = Some("source"),
+      displayCredit = Some(true),
+    )
+    val dcrElement: CartoonBlockElement = CartoonExtraction.extractCartoon(cartoonElementFields)
+
+    dcrElement.variants should be(
+      Some(
+        List(
+          DcrCartoonVariant(
+            "large",
+            List(
+              ImageAsset(
+                0,
+                Map("height" -> "300", "width" -> "500"),
+                "Cartoon",
+                Some("image/jpeg"),
+                Some("https://link-to-my-image"),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+    dcrElement.role should be(Inline)
+    dcrElement.credit should be(Some("credit"))
+    dcrElement.caption should be(Some("caption"))
+    dcrElement.alt should be(Some("alt"))
+    dcrElement.source should be(Some("source"))
+    dcrElement.displayCredit should be(Some(true))
+  }
+
+}

--- a/common/test/model/dotcomrendering/pageElements/CartoonExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CartoonExtractionTest.scala
@@ -26,7 +26,6 @@ class CartoonExtractionTest extends AnyFlatSpec with Matchers {
       credit = Some("credit"),
       caption = Some("caption"),
       alt = Some("alt"),
-      source = Some("source"),
       displayCredit = Some(true),
     )
     val dcrElement: CartoonBlockElement = CartoonExtraction.extractCartoon(cartoonElementFields)
@@ -53,7 +52,6 @@ class CartoonExtractionTest extends AnyFlatSpec with Matchers {
     dcrElement.credit should be(Some("credit"))
     dcrElement.caption should be(Some("caption"))
     dcrElement.alt should be(Some("alt"))
-    dcrElement.source should be(Some("source"))
     dcrElement.displayCredit should be(Some(true))
   }
 

--- a/common/test/model/dotcomrendering/pageElements/CartoonExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CartoonExtractionTest.scala
@@ -41,7 +41,7 @@ class CartoonExtractionTest extends AnyFlatSpec with Matchers {
     )
 
   "CartoonExtraction" should "transform a cartoon element from Content API" in {
-    val dcrElement: CartoonBlockElement = cartoonElementFields(validCartoonVariant).map(extractCartoon).get
+    val dcrElement: CartoonBlockElement = cartoonElementFields(validCartoonVariant).flatMap(extractCartoon).get
 
     dcrElement.variants should be(
       List(
@@ -67,10 +67,7 @@ class CartoonExtractionTest extends AnyFlatSpec with Matchers {
   }
 
   it should "filter out invalid cartoon elements" in {
-    val dcrElement: Option[CartoonBlockElement] = cartoonElementFields(invalidCartoonVariant)
-      .map(extractCartoon)
-      .filter(cartoonIsValid)
-
+    val dcrElement: Option[CartoonBlockElement] = cartoonElementFields(invalidCartoonVariant).flatMap(extractCartoon)
     dcrElement should be(None)
   }
 }

--- a/common/test/model/dotcomrendering/pageElements/CartoonExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CartoonExtractionTest.scala
@@ -31,18 +31,16 @@ class CartoonExtractionTest extends AnyFlatSpec with Matchers {
     val dcrElement: CartoonBlockElement = CartoonExtraction.extractCartoon(cartoonElementFields)
 
     dcrElement.variants should be(
-      Some(
-        List(
-          DcrCartoonVariant(
-            "large",
-            List(
-              ImageAsset(
-                0,
-                Map("height" -> "300", "width" -> "500"),
-                "Cartoon",
-                Some("image/jpeg"),
-                Some("https://link-to-my-image"),
-              ),
+      List(
+        DcrCartoonVariant(
+          "large",
+          List(
+            ImageAsset(
+              0,
+              Map("height" -> "300", "width" -> "500"),
+              "Cartoon",
+              Some("image/jpeg"),
+              Some("https://link-to-my-image"),
             ),
           ),
         ),

--- a/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
@@ -1,10 +1,10 @@
 package model.dotcomrendering.pageElements
 
-import com.gu.contentapi.client.model.v1.EmbedTracking
 import com.gu.contentapi.client.model.v1.EmbedTracksType.{DoesNotTrack, EnumUnknownEmbedTracksType, Tracks, Unknown}
-import org.scalatest.matchers.should.Matchers
-import model.dotcomrendering.pageElements.PageElement.containsThirdPartyTracking
+import com.gu.contentapi.client.model.v1._
+import model.dotcomrendering.pageElements.PageElement.{cartoonToPageElement, containsThirdPartyTracking}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class PageElementTest extends AnyFlatSpec with Matchers {
   "PageElement" should "classify capi tracking value correctly" in {
@@ -13,5 +13,37 @@ class PageElementTest extends AnyFlatSpec with Matchers {
     containsThirdPartyTracking(Some(EmbedTracking(Tracks))) should equal(true)
     containsThirdPartyTracking(Some(EmbedTracking(Unknown))) should equal(true)
     containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99)))) should equal(true)
+  }
+
+  "PageElement" should "transform a cartoon element from Content API" in {
+    val variants = scala.collection.Seq(
+      CartoonVariant(
+        viewportSize = "large",
+        images = scala.collection.Seq(CartoonImage(mimeType = "image/jpeg", file = "https://link-to-my-image")),
+      ),
+    )
+    val contentApiElement = BlockElement(
+      `type` = ElementType.Cartoon,
+      cartoonTypeData = Some(
+        CartoonElementFields(
+          cartoonVariants = Some(variants),
+          role = Some("role"),
+          credit = Some("credit"),
+          caption = Some("caption"),
+          alt = Some("alt"),
+          source = Some("source"),
+          displayCredit = Some(true),
+        ),
+      ),
+    )
+    val dcrElement: CartoonBlockElement = cartoonToPageElement(contentApiElement).get
+
+    dcrElement.cartoonVariants should be(Some(variants.toList))
+    dcrElement.role should be(Some("role"))
+    dcrElement.credit should be(Some("credit"))
+    dcrElement.caption should be(Some("caption"))
+    dcrElement.alt should be(Some("alt"))
+    dcrElement.source should be(Some("source"))
+    dcrElement.displayCredit should be(Some(true))
   }
 }

--- a/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
@@ -5,6 +5,7 @@ import com.gu.contentapi.client.model.v1._
 import model.dotcomrendering.pageElements.PageElement.{cartoonToPageElement, containsThirdPartyTracking}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import model.ImageAsset
 
 class PageElementTest extends AnyFlatSpec with Matchers {
   "PageElement" should "classify capi tracking value correctly" in {
@@ -19,15 +20,21 @@ class PageElementTest extends AnyFlatSpec with Matchers {
     val variants = scala.collection.Seq(
       CartoonVariant(
         viewportSize = "large",
-        images = scala.collection.Seq(CartoonImage(mimeType = "image/jpeg", file = "https://link-to-my-image")),
+        images = scala.collection.Seq(
+          CartoonImage(
+            mimeType = "image/jpeg",
+            file = "https://link-to-my-image",
+            width = Some(500),
+            height = Some(300),
+          ),
+        ),
       ),
     )
     val contentApiElement = BlockElement(
       `type` = ElementType.Cartoon,
       cartoonTypeData = Some(
         CartoonElementFields(
-          cartoonVariants = Some(variants),
-          role = Some("role"),
+          variants = Some(variants),
           credit = Some("credit"),
           caption = Some("caption"),
           alt = Some("alt"),
@@ -38,8 +45,25 @@ class PageElementTest extends AnyFlatSpec with Matchers {
     )
     val dcrElement: CartoonBlockElement = cartoonToPageElement(contentApiElement).get
 
-    dcrElement.cartoonVariants should be(Some(variants.toList))
-    dcrElement.role should be(Some("role"))
+    dcrElement.variants should be(
+      Some(
+        List(
+          DcrCartoonVariant(
+            "large",
+            List(
+              ImageAsset(
+                0,
+                Map("height" -> "300", "width" -> "500"),
+                "image",
+                Some("image/jpeg"),
+                Some("https://link-to-my-image"),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+    dcrElement.role should be(Inline)
     dcrElement.credit should be(Some("credit"))
     dcrElement.caption should be(Some("caption"))
     dcrElement.alt should be(Some("alt"))

--- a/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
@@ -2,10 +2,9 @@ package model.dotcomrendering.pageElements
 
 import com.gu.contentapi.client.model.v1.EmbedTracksType.{DoesNotTrack, EnumUnknownEmbedTracksType, Tracks, Unknown}
 import com.gu.contentapi.client.model.v1._
-import model.dotcomrendering.pageElements.PageElement.{cartoonToPageElement, containsThirdPartyTracking}
+import model.dotcomrendering.pageElements.PageElement.containsThirdPartyTracking
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import model.ImageAsset
 
 class PageElementTest extends AnyFlatSpec with Matchers {
   "PageElement" should "classify capi tracking value correctly" in {
@@ -14,60 +13,5 @@ class PageElementTest extends AnyFlatSpec with Matchers {
     containsThirdPartyTracking(Some(EmbedTracking(Tracks))) should equal(true)
     containsThirdPartyTracking(Some(EmbedTracking(Unknown))) should equal(true)
     containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99)))) should equal(true)
-  }
-
-  "PageElement" should "transform a cartoon element from Content API" in {
-    val variants = scala.collection.Seq(
-      CartoonVariant(
-        viewportSize = "large",
-        images = scala.collection.Seq(
-          CartoonImage(
-            mimeType = "image/jpeg",
-            file = "https://link-to-my-image",
-            width = Some(500),
-            height = Some(300),
-          ),
-        ),
-      ),
-    )
-    val contentApiElement = BlockElement(
-      `type` = ElementType.Cartoon,
-      cartoonTypeData = Some(
-        CartoonElementFields(
-          variants = Some(variants),
-          credit = Some("credit"),
-          caption = Some("caption"),
-          alt = Some("alt"),
-          source = Some("source"),
-          displayCredit = Some(true),
-        ),
-      ),
-    )
-    val dcrElement: CartoonBlockElement = cartoonToPageElement(contentApiElement).get
-
-    dcrElement.variants should be(
-      Some(
-        List(
-          DcrCartoonVariant(
-            "large",
-            List(
-              ImageAsset(
-                0,
-                Map("height" -> "300", "width" -> "500"),
-                "image",
-                Some("image/jpeg"),
-                Some("https://link-to-my-image"),
-              ),
-            ),
-          ),
-        ),
-      ),
-    )
-    dcrElement.role should be(Inline)
-    dcrElement.credit should be(Some("credit"))
-    dcrElement.caption should be(Some("caption"))
-    dcrElement.alt should be(Some("alt"))
-    dcrElement.source should be(Some("source"))
-    dcrElement.displayCredit should be(Some(true))
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.3.2-SNAPSHOT"
+  val capiVersion = "19.4.0-beta.0"
   val faciaVersion = "4.0.5"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.3.0"
+  val capiVersion = "19.3.2-SNAPSHOT"
   val faciaVersion = "4.0.5"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.4.0-beta.0"
+  val capiVersion = "19.3.3-beta.1"
   val faciaVersion = "4.0.5"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.3.3-beta.1"
+  val capiVersion = "19.4.0"
   val faciaVersion = "4.0.5"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
### Do not merge until the CAPI model library version we require has been released and the pr to support the Picture content type has been merged (https://github.com/guardian/dotcom-rendering/pull/8562)

Co-authored-by: @alinaboghiu 

## What does this change?
This adds support for the new Cartoon element in the Picture content type. It does two things:

1. Adds a filter to the `ImageContentController` to send Picture content with a Cartoon element to DCR (Pictures with an Image willl continue to be rendered by frontend)
2. Transforms the Cartoon element from CAPI into a format that DCR needs in order to render this element

All other work to support this element is being completed on the DCR side (https://github.com/guardian/dotcom-rendering/pull/8408)

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
