### PR TITLE
Remove remaining usages of `isUserLoggedIn`

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -20,7 +20,6 @@ import { storage } from '@guardian/libs';
 import { fetchJson } from 'lib/fetch-json';
 import { mediator } from 'lib/mediator';
 import { addEventListener } from 'lib/events';
-import { isUserLoggedIn } from 'common/modules/identity/api';
 import { addCookie } from 'lib/cookies';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts
@@ -6,7 +6,6 @@
 
 import { getCurrentBreakpoint as getCurrentBreakpoint_ } from 'lib/detect-breakpoint';
 import config from '../../../../lib/config';
-import { isUserLoggedIn as isUserLoggedIn_ } from '../identity/api';
 import userPrefs from '../user-prefs';
 import { commercialFeatures } from './commercial-features';
 import type { CommercialFeaturesConstructor } from './commercial-features';
@@ -32,9 +31,6 @@ const isAdFreeUser = isAdFreeUser_ as jest.MockedFunction<typeof isAdFreeUser_>;
 const getCurrentBreakpoint = getCurrentBreakpoint_ as jest.MockedFunction<
 	typeof getCurrentBreakpoint_
 >;
-const isUserLoggedIn = isUserLoggedIn_ as jest.MockedFunction<
-	typeof isUserLoggedIn_
->;
 
 const CommercialFeatures =
 	commercialFeatures.constructor as CommercialFeaturesConstructor;
@@ -48,10 +44,6 @@ jest.mock('./user-features', () => ({
 
 jest.mock('lib/detect-breakpoint', () => ({
 	getCurrentBreakpoint: jest.fn(),
-}));
-
-jest.mock('../identity/api', () => ({
-	isUserLoggedIn: jest.fn(),
 }));
 
 const originalUserAgent = navigator.userAgent;
@@ -103,7 +95,6 @@ describe('Commercial features', () => {
 		isRecentOneOffContributor.mockReturnValue(false);
 		shouldHideSupportMessaging.mockResolvedValue(false);
 		isAdFreeUser.mockReturnValue(false);
-		isUserLoggedIn.mockReturnValue(true);
 
 		expect.hasAssertions();
 	});
@@ -355,7 +346,6 @@ describe('Commercial features', () => {
 	describe('Comment adverts', () => {
 		beforeEach(() => {
 			window.guardian.config.page.commentable = true;
-			isUserLoggedIn.mockReturnValue(true);
 		});
 
 		it('Displays when page has comments', () => {
@@ -364,7 +354,6 @@ describe('Commercial features', () => {
 		});
 
 		it('Will also display when the user is not logged in', () => {
-			isUserLoggedIn.mockReturnValue(false);
 			const features = new CommercialFeatures();
 			expect(features.commentAdverts).toBe(true);
 		});
@@ -418,7 +407,6 @@ describe('Commercial features', () => {
 		});
 
 		it('Does not appear when user signed out', () => {
-			isUserLoggedIn.mockReturnValue(false);
 			const features = new CommercialFeatures();
 			expect(features.commentAdverts).toBe(false);
 		});

--- a/static/src/javascripts/projects/common/modules/identity/validation-email.js
+++ b/static/src/javascripts/projects/common/modules/identity/validation-email.js
@@ -21,7 +21,7 @@ const init = () => {
 
                         // TODO: This can probably be deprecated.
                         // See https://github.com/guardian/frontend/issues/26349
-                        isUserLoggedInOktaRefactor.then(isLoggedIn => {
+                        isUserLoggedInOktaRefactor().then(isLoggedIn => {
                             if (!isLoggedIn) return;
                             sendValidationEmail().then(
                                 resp => {

--- a/static/src/javascripts/projects/common/modules/identity/validation-email.js
+++ b/static/src/javascripts/projects/common/modules/identity/validation-email.js
@@ -1,7 +1,7 @@
 import fastdom from 'lib/fastdom-promise';
 import { mediator } from 'lib/mediator';
 import {
-    isUserLoggedIn,
+    isUserLoggedInOktaRefactor,
     sendValidationEmail,
 } from 'common/modules/identity/api';
 
@@ -19,7 +19,10 @@ const init = () => {
                     (event) => {
                         event.preventDefault();
 
-                        if (isUserLoggedIn()) {
+                        // TODO: This can probably be deprecated.
+                        // See https://github.com/guardian/frontend/issues/26349
+                        isUserLoggedInOktaRefactor.then(isLoggedIn => {
+                            if (!isLoggedIn) return;
                             sendValidationEmail().then(
                                 resp => {
                                     if (resp.status === 'error') {
@@ -66,8 +69,8 @@ const init = () => {
                                             'An error occured, please click here to try again.';
                                     });
                                 }
-                            );
-                        }
+                            )
+                        })
                     }
                 );
             }


### PR DESCRIPTION
The `isUserLoggedIn` method will be deprecated as part of the Okta migration. This PR removes remaining usages of it:

- removes unused import from `static/src/javascripts/bootstraps/standard/main.js` and `static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.ts`
- refactor validation email functionality to use the Okta method. We might be able to deprecate this module entirely in the future. See https://github.com/guardian/frontend/issues/26349 for more information and discussion.