### PR TITLE
Okta: refactor `getUserFromCookie`

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -342,9 +342,9 @@ class CommentBox extends Component {
             return Promise.resolve();
         };
 
-        if (!this.getUserData().emailVerified) {
+        if (!this.getUserData().statusFields.userEmailValidated) {
             // Cookie could be stale so lets check from the api
-            const createdDate = new Date(this.getUserData().accountCreatedDate);
+            const createdDate = new Date(this.getUserData().dates.accountCreatedDate);
 
             if (createdDate > this.options.priorToVerificationDate) {
                 return getUserFromApiOrOkta().then(user => {
@@ -462,7 +462,7 @@ class CommentBox extends Component {
             const onboardingUsername = this.getElem('onboarding-username');
 
             if (onboardingAuthor) {
-                onboardingAuthor.innerHTML = this.getUserData().displayName;
+                onboardingAuthor.innerHTML = this.getUserData().publicFields.displayName;
             }
 
             this.setState('onboarding-visible');

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.spec.js
@@ -11,9 +11,16 @@ jest.mock('common/modules/discussion/user-avatars', () => ({
 }));
 jest.mock('common/modules/identity/api', () => ({
     getUserFromCookie: jest.fn().mockReturnValue({
-        displayName: 'testy',
+        publicFields: {
+            displayName: 'testy',
+        },
         id: 1,
-        accountCreatedDate: new Date(1392719401338),
+        dates: {
+            accountCreatedDate: new Date(1392719401338),
+        },
+        statusFields: {
+            userEmailValidated: false
+        }
     }),
     getUserFromApiOrOkta: jest.fn().mockResolvedValue({
             statusFields: {

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -31,7 +31,6 @@ type IdentityUserFromCache = {
 	statusFields: {
 		userEmailValidated: boolean;
 	};
-	primaryEmailAddress: string;
 	id: number;
 	rawResponse: string;
 } | null;
@@ -79,7 +78,6 @@ export const getUserFromCookie = (): IdentityUserFromCache => {
 			const displayName = decodeURIComponent(userData[2]);
 			userFromCookieCache = {
 				id: parseInt(userData[0], 10),
-				primaryEmailAddress: userData[1], // not sure where this is stored now - not in the cookie any more
 				publicFields: {
 					displayName,
 				},

--- a/static/src/javascripts/projects/common/modules/navigation/profile.js
+++ b/static/src/javascripts/projects/common/modules/navigation/profile.js
@@ -68,7 +68,7 @@ class Profile {
             // the username in the header
             if (!$container.hasClass('is-signed-in')) {
                 fastdom.mutate(() => {
-                    $content.text(user.displayName);
+                    $content.text(user.publicFields.displayName);
                     $container.addClass('is-signed-in');
                     $register.hide();
                 });


### PR DESCRIPTION
The `GU_U` cookie contains a base64 encoded user object. This will continue to be the case following the migration to Okta. This change:

- removes unused fields from the cookie object's type
- fixes code accessing fields from the cookie

It looks like we could access all this information from the Okta user's identity token in the future.

Closes [26343](https://github.com/guardian/frontend/issues/26343)