### PR TITLE
Add a comment to Okta switch about reverting logging in DCR

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -67,6 +67,8 @@ object Okta
       description = "Use Okta for authentication",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 8, 31),
+      /* Do not increase without considering if
+        https://github.com/guardian/dotcom-rendering/pull/8508 needs to be reverted */
       participationGroup = Perc0E,
     )
 


### PR DESCRIPTION
In DCR, if the Okta switch is on and the user is enrolled in the experiment, we send all errors to Sentry instead of a 1% sample. 

If we increase the participation group size of the Okta experiment without first reverting https://github.com/guardian/dotcom-rendering/pull/8508, we will quickly go over our allowance in Sentry.