### PR TITLE
Set the Okta experiment's participation group to Perc1C

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -71,7 +71,7 @@ object Okta
        - https://github.com/guardian/dotcom-rendering/pull/8508
        - https://github.com/guardian/frontend/pull/26461
       needs to be reverted */
-      participationGroup = Perc0E,
+      participationGroup = Perc1C,
     )
 
 // Removing while we are still implementing this content type in DCR


### PR DESCRIPTION
We are ready to start testing the Okta migration across Frontend and DCR with 1% of readers.

In DCR, if you are in the Okta experiment, we are logging all errors to Sentry (https://github.com/guardian/dotcom-rendering/pull/8508), so we can monitor the migration's impact.