### PR TITLE
Bypass Sentry sampling rate in Okta experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -68,7 +68,9 @@ object Okta
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 8, 31),
       /* Do not increase without considering if
-        https://github.com/guardian/dotcom-rendering/pull/8508 needs to be reverted */
+       - https://github.com/guardian/dotcom-rendering/pull/8508
+       - https://github.com/guardian/frontend/pull/26461
+      needs to be reverted */
       participationGroup = Perc0E,
     )
 

--- a/static/src/javascripts/lib/raven.ts
+++ b/static/src/javascripts/lib/raven.ts
@@ -64,6 +64,10 @@ const sentryOptions: RavenOptions = {
 	shouldSendCallback(data: { tags: { ignored?: unknown } }) {
 		const isIgnored = !!data.tags.ignored;
 
+		const isInOktaExperiment =
+			!!window.guardian.config.switches.okta &&
+			window.guardian.config.tests?.oktaVariant === 'variant';
+
 		// Sample at a very small rate.
 		const isInSample = Math.random() < 0.008;
 
@@ -73,7 +77,8 @@ const sentryOptions: RavenOptions = {
 
 		return (
 			!!enableSentryReporting &&
-			isInSample &&
+			// we want to bypass the sample rate if the user is in the Okta experiment
+			(isInOktaExperiment || isInSample) &&
 			!isIgnored &&
 			!adblockBeingUsed
 		);


### PR DESCRIPTION
During the initial rollout of the Okta migration, we want to capture all errors in Sentry. This should be reverted once the participation group increases to a large number of users.

