### PR TITLE
Refactor format field to be required

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -111,7 +111,7 @@ object PressedContentFormat {
 
     def reads(json: JsValue): JsResult[PressedContent] = {
       (json \ "type").transform[JsString](Reads.JsStringReads) match {
-        case JsSuccess(JsString("LinkSnap"), _)       => {
+        case JsSuccess(JsString("LinkSnap"), _) => {
           // we know a Link Snap will never have Format but this is a required field in DCR so we add a default here.
           val snapLinkJsonWithFormat = json.as[JsObject] + ("format" -> Json.toJson(ContentFormat.defaultContentFormat))
           JsSuccess(snapLinkJsonWithFormat.as[LinkSnap](linkSnapFormat))

--- a/common/app/model/dotcomrendering/Trail.scala
+++ b/common/app/model/dotcomrendering/Trail.scala
@@ -158,7 +158,7 @@ object Trail {
       isLiveBlog = content.properties.isLiveBlog,
       pillar = content.maybePillar.map(pillarToString).getOrElse("news"),
       designType = content.properties.maybeContent.map(_.metadata.designType).getOrElse(Article).toString,
-      format = content.format.getOrElse(ContentFormat.defaultContentFormat),
+      format = content.format,
       webPublicationDate = content.webPublicationDate.withZone(DateTimeZone.UTC).toString,
       headline = content.header.headline,
       mediaType = content.card.mediaType.map(_.toString()),

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -21,7 +21,7 @@ sealed trait PressedContent {
 
   lazy val participatesInDeduplication: Boolean = properties.embedType.isEmpty
 
-  def format: Option[ContentFormat] // Define as option as not needed by LinkSnap
+  def format: ContentFormat
 
   def withoutTrailText: PressedContent
 
@@ -66,7 +66,7 @@ final case class CuratedContent(
     override val card: PressedCard,
     override val discussion: PressedDiscussionSettings,
     override val display: PressedDisplaySettings,
-    override val format: Option[ContentFormat],
+    override val format: ContentFormat,
     enriched: Option[
       EnrichedContent,
     ], // This is currently an option, as we introduce the new field. It can then become a value type.
@@ -85,7 +85,7 @@ object CuratedContent {
       card = PressedCard.make(content),
       discussion = PressedDiscussionSettings.make(content),
       display = PressedDisplaySettings.make(content),
-      format = Some(ContentFormat.fromFapiContentFormat(content.format)),
+      format = ContentFormat.fromFapiContentFormat(content.format),
       supportingContent = content.supportingContent.map(PressedContent.make),
       cardStyle = CardStyle.make(content.cardStyle),
       enriched = Some(EnrichedContent.empty),
@@ -99,7 +99,7 @@ final case class SupportingCuratedContent(
     override val card: PressedCard,
     override val discussion: PressedDiscussionSettings,
     override val display: PressedDisplaySettings,
-    override val format: Option[ContentFormat],
+    override val format: ContentFormat,
     cardStyle: CardStyle,
 ) extends PressedContent {
   override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
@@ -113,7 +113,7 @@ object SupportingCuratedContent {
       card = PressedCard.make(content),
       discussion = PressedDiscussionSettings.make(content),
       display = PressedDisplaySettings.make(content),
-      format = Some(ContentFormat.fromFapiContentFormat(content.format)),
+      format = ContentFormat.fromFapiContentFormat(content.format),
       cardStyle = CardStyle.make(content.cardStyle),
     )
   }
@@ -125,7 +125,7 @@ final case class LinkSnap(
     override val card: PressedCard,
     override val discussion: PressedDiscussionSettings,
     override val display: PressedDisplaySettings,
-    override val format: Option[ContentFormat],
+    override val format: ContentFormat,
     enriched: Option[
       EnrichedContent,
     ], // This is currently an option, as we introduce the new field. It can then become a value type.
@@ -142,7 +142,7 @@ object LinkSnap {
       discussion = PressedDiscussionSettings.make(content),
       display = PressedDisplaySettings.make(content),
       enriched = Some(EnrichedContent.empty),
-      format = None,
+      format = ContentFormat.defaultContentFormat,
     )
   }
 }
@@ -153,7 +153,7 @@ final case class LatestSnap(
     override val card: PressedCard,
     override val discussion: PressedDiscussionSettings,
     override val display: PressedDisplaySettings,
-    override val format: Option[ContentFormat],
+    override val format: ContentFormat,
 ) extends PressedContent {
 
   override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
@@ -167,7 +167,7 @@ object LatestSnap {
       card = PressedCard.make(content),
       discussion = PressedDiscussionSettings.make(content),
       display = PressedDisplaySettings.make(content),
-      format = Some(ContentFormat.fromFapiContentFormat(content.format)),
+      format = ContentFormat.fromFapiContentFormat(content.format),
     )
   }
 }

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -7,7 +7,7 @@ import com.sun.syndication.feed.module.mediarss.MediaEntryModule
 import com.sun.syndication.feed.synd.SyndPerson
 import implicits.Dates.jodaToJavaInstant
 import model.pressed._
-import model.{ImageAsset, ImageMedia}
+import model.{ContentFormat, ImageAsset, ImageMedia}
 import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -1416,11 +1416,10 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
       card = card,
       discussion = discussionSettings,
       display = displaySettings,
-      format = None,
+      format = ContentFormat.defaultContentFormat,
       enriched = None,
       supportingContent = supportingContent.toList,
       cardStyle = CardStyle.make(Editorial),
     )
   }
-
 }

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -127,7 +127,7 @@ object FixtureBuilder {
       enriched = None,
       supportingContent = Nil,
       cardStyle = DefaultCardstyle,
-      format = Some(ContentFormat.defaultContentFormat),
+      format = ContentFormat.defaultContentFormat,
     )
   }
 
@@ -140,7 +140,7 @@ object FixtureBuilder {
       discussion = mkDiscussion(),
       display = mkDisplay(),
       enriched = None,
-      format = Some(ContentFormat.defaultContentFormat),
+      format = ContentFormat.defaultContentFormat,
     )
   }
 }


### PR DESCRIPTION
## What does this change?
Whilst investigating a validation error in DCR, we found that frontend and dcr models had falled out of sync. Pressed content in Frontend had Format as optional but this is required in DCR. Frontend had Format as optional because Link Snaps never have a format field as they're third party content.

This PR refactors the format field to be required and provides a default "standard" format for Link Snaps so that the two models are aligned.


paired with @AshCorr, @sophie-macmillan, and @jamesgorrie 

Fixes part 2 of https://github.com/guardian/frontend/issues/26464
## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
