### PR TITLE
feat: lazy load images on DCR fronts experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -17,6 +17,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeNetworkFront,
       Okta,
       HeaderTopBarSearchCapi,
+      LazyLoadImages,
       AdaptiveSite,
       OfferHttp3,
       DeeplyRead,
@@ -100,6 +101,15 @@ object HeaderTopBarSearchCapi
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 9, 6),
       participationGroup = Perc1B,
+    )
+
+object LazyLoadImages
+    extends Experiment(
+      name = "lazy-load-images",
+      description = "Lazy-load images on DCR",
+      owners = Seq(Owner.withGithub("@mxdvl")),
+      sellByDate = LocalDate.of(2023, 8, 22),
+      participationGroup = Perc1C,
     )
 
 object OfferHttp3


### PR DESCRIPTION
## What is the value of this and can you measure success?

Better performance for users of our fronts

## What does this change?

Add an experiment for testing lazy-loading of images in `dotcom-rendering`: https://github.com/guardian/dotcom-rendering/pull/8524

## Screenshots

N/A

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)