### PR TITLE
Expose IdentityAuth on the window

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/okta.ts
+++ b/static/src/javascripts/projects/common/modules/identity/okta.ts
@@ -37,37 +37,37 @@ const getRedirectUri = (stage: Stage) => {
 	}
 };
 
-let identityAuth:
-	| IdentityAuth<AccessTokenClaims, CustomIdTokenClaims>
-	| undefined;
-
 function getIdentityAuth() {
-	if (identityAuth === undefined) {
+	if (window.guardian.identityAuth === undefined) {
 		const stage = getStage();
 
-		identityAuth = new IdentityAuth<AccessTokenClaims, CustomIdTokenClaims>(
-			{
-				issuer: getIssuer(stage),
-				clientId: getClientId(stage),
-				redirectUri: getRedirectUri(stage),
-				scopes: [
-					'openid', // required for open id connect, returns an id token
-					'profile', // populates the id token with basic profile information
-					'email', // populates the id token with the user's email address
-					'guardian.discussion-api.private-profile.read.self', // allows the access token to be used to make requests to the discussion api to read the user's profile
-					'guardian.discussion-api.update.secure', // allows the access token to be used to make requests to the discussion api to post comments, upvote etc
-					'guardian.identity-api.newsletters.read.self', // allows the access token to be used to make requests to the identity api to read the user's newsletter subscriptions
-					'guardian.identity-api.newsletters.update.self', // allows the access token to be used to make requests to the identity api to update the user's newsletter subscriptions
-					'guardian.identity-api.user.username.create.self.secure', // allows the access token to set the user's username
-					'guardian.members-data-api.read.self', // allows the access token to be used to make requests to the members data api to read the user's membership status
-					'id_token.profile.theguardian', // populates the id token with application specific profile information
-				],
-				idCookieSessionRefresh:
-					config.get('switches.idCookieRefresh') ?? false,
-			},
-		);
+		window.guardian.identityAuth = new IdentityAuth<
+			AccessTokenClaims,
+			CustomIdTokenClaims
+		>({
+			issuer: getIssuer(stage),
+			clientId: getClientId(stage),
+			redirectUri: getRedirectUri(stage),
+			scopes: [
+				'openid', // required for open id connect, returns an id token
+				'profile', // populates the id token with basic profile information
+				'email', // populates the id token with the user's email address
+				'guardian.discussion-api.private-profile.read.self', // allows the access token to be used to make requests to the discussion api to read the user's profile
+				'guardian.discussion-api.update.secure', // allows the access token to be used to make requests to the discussion api to post comments, upvote etc
+				'guardian.identity-api.newsletters.read.self', // allows the access token to be used to make requests to the identity api to read the user's newsletter subscriptions
+				'guardian.identity-api.newsletters.update.self', // allows the access token to be used to make requests to the identity api to update the user's newsletter subscriptions
+				'guardian.identity-api.user.username.create.self.secure', // allows the access token to set the user's username
+				'guardian.members-data-api.read.self', // allows the access token to be used to make requests to the members data api to read the user's membership status
+				'id_token.profile.theguardian', // populates the id token with application specific profile information
+			],
+			idCookieSessionRefresh:
+				config.get('switches.idCookieRefresh') ?? false,
+		});
 	}
-	return identityAuth;
+	return window.guardian.identityAuth as IdentityAuth<
+		AccessTokenClaims,
+		CustomIdTokenClaims
+	>;
 }
 
 export async function isSignedInWithOktaAuthState(): Promise<

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -444,6 +444,7 @@ interface Window {
 			dfpEnv?: DfpEnv;
 		};
 		notificationEventHistory?: HeaderNotification[][];
+		identityAuth?: unknown;
 	};
 	ootag: {
 		queue: Array<() => void>;


### PR DESCRIPTION
## What is the value of this and can you measure success?

Alternative to #26462 

## What does this change?

Exposes identityAuth on `window.guardian`

Instead of utilising promises this approach relies on Commercial to create an instance of `identity.auth` on window.guardian, this allows avoid the complexity of promises but with the tradeof that we need to duplicate code between Commercial and Frontend to handle creating the instance of IdentityAuth and we need to ensure that this code always remains in sync.

This approach also means that Commercial isn't blocked by the initialising of Frontend / DCR as it can just create the IdentityAuth instance itself if its not already created.
