### PR TITLE
Dblatcher/use dcr newsletters page

### DIFF
--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -33,24 +33,6 @@ class SignupPageController(
   val defaultCacheDuration: Duration = 15.minutes
   val remoteRenderer = DotcomRenderingService()
 
-  private def localRenderNewslettersPage()(implicit
-      request: RequestHeader,
-  ): Result = {
-    val groupedNewsletters: Either[String, GroupedNewslettersResponse] =
-      newsletterSignupAgent.getGroupedNewsletters()
-    groupedNewsletters match {
-      case Right(groupedNewsletters) =>
-        Cached(defaultCacheDuration)(
-          RevalidatableResult.Ok(
-            NewsletterHtmlPage.html(StaticPages.simpleNewslettersPage(request.path, groupedNewsletters)),
-          ),
-        )
-      case Left(e) =>
-        log.error(s"API call to get newsletters failed: $e")
-        NoCache(InternalServerError)
-    }
-  }
-
   private def remoteRenderNewslettersPage()(implicit
       request: RequestHeader,
   ): Result = {
@@ -79,11 +61,7 @@ class SignupPageController(
   ): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
-        if (request.forceDCR) {
-          remoteRenderNewslettersPage()
-        } else {
-          localRenderNewslettersPage()
-        }
+        remoteRenderNewslettersPage()
       }
     }
 
@@ -107,22 +85,12 @@ class SignupPageController(
     }
   }
 
-  private def renderNewslettersJson()(implicit
-      request: RequestHeader,
-  ): Result = {
-    Cached(CacheTime.NotFound)(Cached.WithoutRevalidationResult(NotFound))
-  }
-
   def renderNewslettersJson()(implicit
       executionContext: ExecutionContext = this.executionContext,
   ): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
-        if (request.forceDCR) {
-          renderDCRNewslettersJson()
-        } else {
-          renderNewslettersJson()
-        }
+        renderDCRNewslettersJson()
       }
     }
 }

--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -3,12 +3,10 @@ package controllers
 import common.{GuLogging, ImplicitControllerExecutionContext}
 import model.{ApplicationContext, Cached, NoCache}
 import model.Cached.RevalidatableResult
-import pages.NewsletterHtmlPage
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents, RequestHeader, Result}
 import play.filters.csrf.CSRFAddToken
 import renderers.DotcomRenderingService
-import services.newsletters.GroupedNewslettersResponse.GroupedNewslettersResponse
 import services.newsletters.NewsletterSignupAgent
 import services.newsletters.model.NewsletterResponse
 import staticpages.StaticPages
@@ -17,7 +15,6 @@ import implicits.Requests.RichRequestHeader
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import model.dotcomrendering.DotcomNewslettersPageRenderingDataModel
-import model.SimplePage
 import model.CacheTime
 
 class SignupPageController(

--- a/common/app/services/newsletters/NewsletterIllustrations.scala
+++ b/common/app/services/newsletters/NewsletterIllustrations.scala
@@ -32,9 +32,11 @@ object NewsletterIllustrations {
     "minute-us" ->
       "https://media.guim.co.uk/dc41d329183de03943d483df5e68f91a0f263a4e/0_0_5000_3000/500.jpg",
     "best-of-opinion" ->
-      "https://media.guim.co.uk/4ef30ca444a6980ad09f9c651b620000ede91d68/2943_7_2997_1798/500.png",
+      "https://uploads.guim.co.uk/2023/08/10/Opinion_UK_-_1_-_5-3.jpg",
     "best-of-opinion-us" ->
-      "https://media.guim.co.uk/4ef30ca444a6980ad09f9c651b620000ede91d68/3623_5_3289_1976/500.png",
+      "https://uploads.guim.co.uk/2023/08/10/Opinion_US_1_-_america_-_5-3.jpg",
+    "best-of-opinion-au" ->
+      "https://uploads.guim.co.uk/2023/08/10/Opinion_-_1_-_australia_-_5-3.jpg",
     "this-is-europe" ->
       "https://media.guim.co.uk/0f029b430f0ce52d3e675b66dcfd7e9b86bf2b9b/0_1_1250_750/500.jpg",
     "patriarchy" ->
@@ -72,7 +74,7 @@ object NewsletterIllustrations {
     "whats-on" ->
       "https://media.guim.co.uk/f1a5b65778882bd256d16f33149101435a21754e/0_0_1520_912/500.jpg",
     "word-of-mouth" ->
-      "https://media.guim.co.uk/763740b8e350cea9a3e28e262f29894d3e9da140/0_0_4200_2521/500.jpg",
+      "https://uploads.guim.co.uk/2023/08/10/Word_of_Mouth.png",
     "fashion-statement" ->
       "https://media.guim.co.uk/12c671d139fa632a086b16c6f14d5b89e3112b42/0_0_760_456/500.jpg",
     "house-to-home" ->


### PR DESCRIPTION
## What does this change?

Changes the `SignupPageController` to put the dcr version of the /email-newsletters page on the main path (currently served at /email-newsletters?dcr while being developed - see https://github.com/guardian/dotcom-rendering/issues/8423)

Updates the `NewsletterIllustration` url for 4 Newsletters.

Initially putting the page live behind a switch on this PR : https://github.com/guardian/frontend/pull/26490
This PR can be merged after the switch is no longer needed.

Note that this PR does not remove the html Scala template for `NewsletterHtmlPage` and the associated code (CSS, JS and html Scala fragments), in case there is a need to go back to the frontend-rendered version. This can be done on a subsequent PR once it is confirmed that new DCR version of the  page is staying in place.


## What is the value of this and can you measure success?
New design implemented.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="900" alt="Screenshot 2023-08-10 at 16 25 03" src="https://github.com/guardian/frontend/assets/30567854/bfa83496-b192-4ac7-ae92-8d469b44dade">| <img width="900" alt="Screenshot 2023-08-10 at 16 24 35" src="https://github.com/guardian/frontend/assets/30567854/154ec0d9-e69e-42eb-bc12-4978d8aa646e">|




## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)
