### PR TITLE
feat: add timezone to match times on spider

### DIFF
--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -28,8 +28,8 @@
             }
             @if(fm.isFixture){
                 <div class="football-match__date">
-                    <span class="football-match__kickoff">@fm.date.format(DateTimeFormatter.ofPattern("HH:mm ").withZone(Edition(request).timezoneId))</span>
-                    @fm.date.withZoneSameInstant(Edition(request).timezoneId).toLocalDate.format(DateTimeFormatter.ofPattern("E dd MMMM"))
+                    <span class="football-match__kickoff">@fm.date.format(DateTimeFormatter.ofPattern("HH:mm  z").withZone(Edition(request).timezoneId))</span>
+                    @fm.date.withZoneSameInstant(Edition(request).timezoneId).toLocalDate.format(DateTimeFormatter.ofPattern("E dd MMMM "))
                 </div>
             }
 


### PR DESCRIPTION
Adds the timezone to the spider chart.

This is to make it more obvious, especially in the context of the thrasher, which localises to the EC2 box that builds it and cannot be localised to a readers edition, so always BST.

There are other ways we explored this with eEditorial and @HarryFischer - but most felt like we should look at how we do the spider diagram generally, so we went simple.


## Screenshots
| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/31692/64ab1fab-8c37-48d3-b29b-f0dc70b6ec88
[after]: https://github.com/guardian/frontend/assets/31692/4d596980-5522-41b7-bc90-793e6fc800f6
