### PR TITLE
Set the Okta participation group to `Perc2A`

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -100,7 +100,7 @@ object Okta
        - https://github.com/guardian/dotcom-rendering/pull/8508
        - https://github.com/guardian/frontend/pull/26461
       needs to be reverted */
-      participationGroup = Perc1C,
+      participationGroup = Perc2A,
     )
 
 object LazyLoadImages


### PR DESCRIPTION
Following the 1% test (https://github.com/guardian/frontend/pull/26459), we can move Okta to a 2% test. We will not go to 5% until the commercial bundle changes are completed.

## After merging

- [x] send [comms](https://docs.google.com/document/d/1l4dJq7iJBlxYt0mz6EinXW7pvzX5aJg5o_MqR12SMQw/edit#heading=h.lxcccslw9wp)