### PR TITLE
Add switch and AB test for new prebid bidder Kargo

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -114,4 +114,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2023, 8, 30)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-prebid-kargo",
+    "Test Kargo as a prebid bidder for US traffic.",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2023, 9, 29)),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -451,6 +451,16 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
+  val prebidKargo: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-kargo",
+    description = "Include the Kargo adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
   val sentinelLogger: Switch = Switch(
     group = Commercial,
     name = "sentinel-logger",

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -5,6 +5,7 @@ import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer'
 import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import { liveblogRightColumnAds } from './tests/liveblog-right-column-ads';
+import { prebidKargo } from './tests/prebid-kargo';
 import { publicGoodTest } from './tests/public-good';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateCopyTestJan2023 } from './tests/sign-in-gate-copy-test-variant';
@@ -25,4 +26,5 @@ export const concurrentTests: readonly ABTest[] = [
 	elementsManager,
 	liveblogRightColumnAds,
 	publicGoodTest,
+	prebidKargo,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-kargo.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-kargo.ts
@@ -1,0 +1,28 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const prebidKargo: ABTest = {
+	id: 'PrebidKargo',
+	author: '@commercial-dev',
+	start: '2023-08-10',
+	expiry: '2023-09-29',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'USA only',
+	successMeasure: '',
+	description: 'Test Kargo as a prebid bidder for US traffic',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?
Add switch and AB test for new prebid bidder Kargo

Out convention is to have a switch for each prebid bidder

We would also like to test via a 0% AB test

