### PR TITLE
Bump commercial to 10.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "10.14.0",
+		"@guardian/commercial": "10.16.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,16 +1561,16 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@10.14.0":
-  version "10.14.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.14.0.tgz#98f8540d09b86f03606c8eaf70d8e7bdb7c7231b"
-  integrity sha512-9fZhNXw/WsEMG7xVCst8VjJ1xQ25Ony9BAZLQDPGv5tOjZSglDGNOqalFCuU4chiU8/cKPgXoBYa37LPWpFVpQ==
+"@guardian/commercial@10.16.0":
+  version "10.16.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.16.0.tgz#b864e11ef1fb178bb42f24f85d816b7e1c26342f"
+  integrity sha512-JMA+d5cLUVPYcARxLLGFvwDex0IBQPeKftbDG9y8EDdisyuRyGDKyCra893Ro5Tn1Cgaay4/rQj33pmkFg8i1w==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"
-    "@guardian/consent-management-platform" "^13.5.0"
+    "@guardian/consent-management-platform" "^13.6.1"
     "@guardian/core-web-vitals" "^5.0.0"
-    "@guardian/libs" "^15.0.0"
+    "@guardian/libs" "15.6.3"
     "@guardian/source-foundations" "^12.0.0"
     "@guardian/support-dotcom-components" "^1.0.7"
     "@octokit/core" "^4.0.5"
@@ -1583,11 +1583,6 @@
     tslib "^2.5.3"
     web-vitals "^3.3.2"
     wolfy87-eventemitter "^5.2.9"
-
-"@guardian/consent-management-platform@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.5.0.tgz#61a97c823f6b18f62a6517a3374f6e7bdfca121d"
-  integrity sha512-9iz04lyonWAbUeZ7B+fNp0KbgAervsWDO3A4CE/3e+d876AQj0I3TwU7W4jpWxI4tthcA6UVk7Y6faaS8l+lFw==
 
 "@guardian/consent-management-platform@^13.6.1":
   version "13.6.1"
@@ -1628,6 +1623,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-0.4.0.tgz#11fc3b9daec7b4186cf0822b18d6379dbdac8ce5"
   integrity sha512-+lXmoMhrACvibKYBIwKQ15zyWGiGKC+mOg8831R8ilwF3vwXuXnzCLy1EpLTlSfDf72IOAuGyX4gDOqdQP8R/w==
 
+"@guardian/libs@15.6.3":
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.3.tgz#3c748640bfe706ef8ecbd44c101567bf2b769f4a"
+  integrity sha512-WRHnZGXMn7TD2p/gXWdK+u2ZnS+CAvQ1pdBEjT3x61Ab1YhxOYEIkF5gT+l2kACuJZ7a8pWwuO6CA89JcfZfrw==
+
 "@guardian/libs@^10.0.0":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
@@ -1637,11 +1637,6 @@
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-14.0.0.tgz#07022b652430a1c5d6b16f8aa105ae3d73da4e7c"
   integrity sha512-rB4h4FlD3EcoCY66f3xjO7alnXiimPOynL9znvX/xP2nAVpG4UyedJnIpupw4KPqJuB0lZMih6EeXq0a1XnI3w==
-
-"@guardian/libs@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.0.0.tgz#c3fbb1d7fdafaefe156232b7088f43e2ff4cd18b"
-  integrity sha512-UnNxcJHYDfpElrxc7sbfwSJ82erH3mjdKsALAgevggsbhOSAkE9yoCn+XMBPN7iQ14bEHZPYyOMt0y1hNCItyg==
 
 "@guardian/prettier@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Add changes since last version, [available here](https://github.com/guardian/commercial/releases)
## What does this change?
bump commercial
