### PR TITLE
us/soccer subnav quick fix

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -115,7 +115,7 @@ object NavLinks {
       NavLink("Clubs", "/football/teams", Some("football/teams")),
     ),
   )
-  val soccer = NavLink("Soccer", "/us/soccer")
+  val soccer = football.copy(title = "Soccer", url = "/us/soccer", longTitle = Some("US soccer"))
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
   val rugbyUnion = NavLink("Rugby union", "/sport/rugby-union")
@@ -745,4 +745,5 @@ object NavigationData {
     (Edition.all
       .map(e => e.networkFrontId -> toJson(e.navigationLinks)) :+ "tagPages" -> toJson(NavLinks.tagPages)).toMap,
   )
+
 }

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -79,7 +79,7 @@ object NavMenu {
 
   def apply(page: Page, edition: Edition): NavMenu = {
     val root = navRoot(edition)
-    val currentUrl = getSectionOrPageUrl(page, edition)
+    val currentUrl = if (getSectionOrPageUrl(page, edition) == "/soccer") "/us/soccer" else getSectionOrPageUrl(page, edition)
     val currentNavLink = findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks)
     val currentParent = currentNavLink.flatMap(link => findParent(link, edition, root.children, root.otherLinks))
     val currentPillar = getPillar(currentParent, edition, root.children, root.otherLinks)
@@ -259,7 +259,8 @@ object NavMenu {
           if (currentNavHasChildren) {
             currentNavLink.map(_.children).getOrElse(Nil)
           } else {
-            currentParent.map(_.children).getOrElse(Nil)
+            currentParent.map(_.children)
+              .getOrElse(Nil)
           }
 
         parent match {

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -79,7 +79,8 @@ object NavMenu {
 
   def apply(page: Page, edition: Edition): NavMenu = {
     val root = navRoot(edition)
-    val currentUrl = if (getSectionOrPageUrl(page, edition) == "/soccer") "/us/soccer" else getSectionOrPageUrl(page, edition)
+    val currentUrl =
+      if (getSectionOrPageUrl(page, edition) == "/soccer") "/us/soccer" else getSectionOrPageUrl(page, edition)
     val currentNavLink = findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks)
     val currentParent = currentNavLink.flatMap(link => findParent(link, edition, root.children, root.otherLinks))
     val currentPillar = getPillar(currentParent, edition, root.children, root.otherLinks)
@@ -259,7 +260,8 @@ object NavMenu {
           if (currentNavHasChildren) {
             currentNavLink.map(_.children).getOrElse(Nil)
           } else {
-            currentParent.map(_.children)
+            currentParent
+              .map(_.children)
               .getOrElse(Nil)
           }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
The subnav in us/soccer should show the 'soccer' link not 'football'. 
Resolves https://github.com/guardian/frontend/issues/26466
## What does this change?
Copies the children from football nav and transforms the currentUrl property to /us/soccer. Without this the subnav will not display. This is just a hack as haven't discovered what requires this match.
## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/110032454/4c40d2ec-ce4c-40b1-9db3-73c1fe837749
[after]: https://github.com/guardian/frontend/assets/110032454/f23f57a5-ebd3-4152-a712-bb54b7fdd602


## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
