### PR TITLE
Switch off liveblog right column ads AB test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "10.16.0",
+		"@guardian/commercial": "10.17.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/identity-auth": "0.4.0",

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-right-column-ads.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-right-column-ads.ts
@@ -6,7 +6,7 @@ export const liveblogRightColumnAds: ABTest = {
 	author: '@commercial-dev',
 	start: '2023-08-01',
 	expiry: '2023-09-20',
-	audience: 15 / 100,
+	audience: 0 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Desktop users with wide (1300px+) screens only',
 	successMeasure:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@10.16.0":
-  version "10.16.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.16.0.tgz#b864e11ef1fb178bb42f24f85d816b7e1c26342f"
-  integrity sha512-JMA+d5cLUVPYcARxLLGFvwDex0IBQPeKftbDG9y8EDdisyuRyGDKyCra893Ro5Tn1Cgaay4/rQj33pmkFg8i1w==
+"@guardian/commercial@10.17.0":
+  version "10.17.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-10.17.0.tgz#09304997478490ed36690475b89884ea6bf40763"
+  integrity sha512-AZTIyKqD39waxhi4hr6iyiUbVI0EvQKszPbbDLJaB8uYItVDteSeQ7kgXZxC4Nn+suXwnFcyY2eUv5v5hoke9Q==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@guardian/ab-core" "^5.0.0"


### PR DESCRIPTION
## What does this change?

Turns off the liveblog-right-column-ads AB test.

## Why?

We have reached the required number of impressions to obtain a result for the test.