### PR TITLE
Bump `@guardian/identity-auth@0.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@guardian/commercial": "10.17.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^4.0.0",
-		"@guardian/identity-auth": "0.4.0",
+		"@guardian/identity-auth": "0.5.0",
 		"@guardian/libs": "^14.0.0",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,10 +1618,10 @@
     eslint-plugin-import "2.24.0"
     eslint-plugin-prettier "3.4.0"
 
-"@guardian/identity-auth@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-0.4.0.tgz#11fc3b9daec7b4186cf0822b18d6379dbdac8ce5"
-  integrity sha512-+lXmoMhrACvibKYBIwKQ15zyWGiGKC+mOg8831R8ilwF3vwXuXnzCLy1EpLTlSfDf72IOAuGyX4gDOqdQP8R/w==
+"@guardian/identity-auth@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-0.5.0.tgz#5bfd869ea23959cffdcb25820a7e85e8b28b8a5f"
+  integrity sha512-0nfVZp9X8cNSoWOj7sS7DmyCKCEOhnZiUzMZ2FpgjED/Kawd4bC8FhuLN65Cvd0ryW2N4zD3azVBKUK8OBogLg==
 
 "@guardian/libs@15.6.3":
   version "15.6.3"


### PR DESCRIPTION


Fixes an issue with calculating the clock skew, and will unblock us from continuing with the Okta rollout.
