### PR TITLE
add switch for dcr newsletters page

### DIFF
--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import common.{GuLogging, ImplicitControllerExecutionContext}
+import conf.switches.Switches.{UseDcrNewslettersPage}
 import model.{ApplicationContext, Cached, NoCache}
 import model.Cached.RevalidatableResult
 import pages.NewsletterHtmlPage
@@ -79,7 +80,7 @@ class SignupPageController(
   ): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
-        if (request.forceDCR) {
+        if (request.forceDCR || UseDcrNewslettersPage.isSwitchedOn) {
           remoteRenderNewslettersPage()
         } else {
           localRenderNewslettersPage()
@@ -118,7 +119,7 @@ class SignupPageController(
   ): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
-        if (request.forceDCR) {
+        if (request.forceDCR || UseDcrNewslettersPage.isSwitchedOn) {
           renderDCRNewslettersJson()
         } else {
           renderNewslettersJson()

--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -45,4 +45,13 @@ trait NewslettersSwitches {
     exposeClientSide = false,
   )
 
+  val UseDcrNewslettersPage = Switch(
+    SwitchGroup.Newsletters,
+    "use-dcr-newsletters-page",
+    "Use the dcr rendered version of the email newsletters page by default",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?
Uses the new  version of the all newsletters page (see https://github.com/guardian/dotcom-rendering/issues/8423), but adds a switch to allow use to go back to the current version if required

## What does this change?
Sets a Switch (defaulting to `On`) to control whether to use the dcr version of the all newsletters page by default

This PR should not be merged until after the following change to "platform" has been merged and deployed:
https://github.com/guardian/platform/pull/1542
The platform PR  will add the new endpoint /email/many to the nextgen api. **EDIT - this is done now**

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="900" alt="Screenshot 2023-08-10 at 16 25 03" src="https://github.com/guardian/frontend/assets/30567854/bfa83496-b192-4ac7-ae92-8d469b44dade">| <img width="900" alt="Screenshot 2023-08-10 at 16 24 35" src="https://github.com/guardian/frontend/assets/30567854/154ec0d9-e69e-42eb-bc12-4978d8aa646e">|


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
