### PR TITLE
Upgrade @guardian/commercial@11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "0.0.0-beta-20230821142818",
+		"@guardian/commercial": "11.1.1",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "11.0.0",
+		"@guardian/commercial": "0.0.0-beta-20230821142818",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,10 +1556,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@0.0.0-beta-20230821142818":
-  version "0.0.0-beta-20230821142818"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-0.0.0-beta-20230821142818.tgz#b97dec3b16e38515900312774aafd5c0c99ddc7f"
-  integrity sha512-XTLARyf6chFQpFsKMzXXUtwezlz93fFXCHtnWGCjyW4y5mIYsLOWHNzOPhEVVq67Ph7brpzoTTRn68kv89Nrfg==
+"@guardian/commercial@11.1.1":
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.1.1.tgz#f30e694c94f7abc27b171b68193d81d7db3e0f64"
+  integrity sha512-+V+i+4mndTD8KXn0PSguLer1HmTWqOrxSS3Nj2yIu/UojmpoVJTSxej3RmnMHFVROdIM/nqsg69uKNwpBjp1Ug==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@octokit/core" "^4.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,17 +1556,17 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.0.0.tgz#6d8e5be7e800a5a20d552899d9f439bd137ed9f6"
-  integrity sha512-rSBjwrqrpmhlCZRJ7F4XJaWQWRrPPCSh3hMAkc0iC/WvNP7HSXPNY3EZ4aLEDcerDL9ntakC71lm6SiB/rIs+A==
+"@guardian/commercial@0.0.0-beta-20230821142818":
+  version "0.0.0-beta-20230821142818"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-0.0.0-beta-20230821142818.tgz#b97dec3b16e38515900312774aafd5c0c99ddc7f"
+  integrity sha512-XTLARyf6chFQpFsKMzXXUtwezlz93fFXCHtnWGCjyW4y5mIYsLOWHNzOPhEVVq67Ph7brpzoTTRn68kv89Nrfg==
   dependencies:
     "@changesets/cli" "^2.26.1"
     "@octokit/core" "^4.0.5"
     fastdom "^1.0.11"
     lodash-es "^4.17.21"
     ophan-tracker-js "^1.4.0"
-    prebid.js guardian/prebid.js#1d6bbdc
+    prebid.js guardian/prebid.js#b8263f2
     process "^0.11.10"
     raven-js "^3.27.2"
     tslib "^2.5.3"
@@ -1611,11 +1611,6 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-1.0.0.tgz#ea8896a45d2aef9828e590cccdd858b5f46785d1"
   integrity sha512-JUkPai2Qnuq1quQ2rtvwWhLTtISqJBNe8XpxqbIr4jGaNWn5EL3kI1scAwq5PyNEg9135E7YXWTnjLNkm3ivoA==
-
-"@guardian/libs@^10.0.0":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
-  integrity sha512-OdWReBHRWhdbErVmS15hihVzlkdU8DkKrjDsUIN0P8QZiF4twuzcU3qsPwto2UfibAwPkWqKkNwH1k8b6xNclA==
 
 "@guardian/libs@^15.6.4":
   version "15.6.4"
@@ -8778,11 +8773,17 @@ listr@^0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-live-connect-js@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-2.4.0.tgz#c98b1c1fa94f81e0b67202a456de2bd915e41e6c"
-  integrity sha512-MSBLKfnXoxH+pqwji/Mf8yZu3VZMq4tnNfwMw7NTWN5a+TBM6f0RWgwui1YMA3nHmMhX/nzxxsso0SkyKcF0fA==
+live-connect-common@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/live-connect-common/-/live-connect-common-1.0.0.tgz#9cb558cd665c0418271770854538243420cd1354"
+  integrity sha512-LBZsvykcGeVRYI1eqqXrrNZsoBdL2a8cpyrYPIiGAF/CpixbyRbvqGslaFw511lH294QB16J3fYYg21aYuaM2Q==
+
+live-connect-js@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-5.0.1.tgz#152372cf757e8af8eb4829f32979669b26cd9052"
+  integrity sha512-X/fFbKGG8MahpqIuxndApAc9udj1g5NIxL95zKPzvqoipPYoeqvh7SCDly1hPvbqsfFj/DIbOfdWbttXzCSryw==
   dependencies:
+    live-connect-common "^1.0.0"
     tiny-hashes "1.0.1"
 
 load-json-file@^4.0.0:
@@ -10493,15 +10494,15 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js#1d6bbdc:
-  version "7.26.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/1d6bbdc64411fbe719489eb06bce72b66ac6a4f3"
+"prebid.js@github:guardian/prebid.js#b8263f2":
+  version "7.54.4"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/b8263f2e041833b0ec0d05d14de6c3f1bdd466ff"
   dependencies:
     "@babel/core" "^7.16.7"
     "@babel/plugin-transform-runtime" "^7.18.9"
     "@babel/preset-env" "^7.16.8"
     "@babel/runtime" "^7.18.9"
-    "@guardian/libs" "^10.0.0"
+    "@guardian/libs" "^15.6.4"
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
@@ -10511,7 +10512,7 @@ prebid.js@guardian/prebid.js#1d6bbdc:
     express "^4.15.4"
     fun-hooks "^0.9.9"
     just-clone "^1.0.2"
-    live-connect-js "2.4.0"
+    live-connect-js "^5.0.0"
   optionalDependencies:
     fsevents "^2.3.2"
 


### PR DESCRIPTION
## What does this change?

From v11.1.1.

https://github.com/guardian/commercial/commit/9035e3d4df6c1199c31832e4597c24c89f64f1ad

From v11.1.0:

Use guardian browserlist to govern browser support:
https://github.com/guardian/commercial/commit/19627725b6587cd69eeac8a0b75fca8a1df4022e

Upgrade Prebid.js to v7.54.4:
https://github.com/guardian/commercial/commit/8535432bb395510a31e97732b069c80523359a14
