### PR TITLE
Add scheduler performance switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -186,4 +186,14 @@ trait PerformanceSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
+
+  val Scheduler = Switch(
+    SwitchGroup.Performance,
+    "scheduler",
+    "Schedule JavaScript tasks using a centralised scheduler in dotcom-rendering",
+    owners = Seq(Owner.withGithub("@guardian/open-journalism")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

JavaScript tasks will use a centralised scheduler in dotcom-rendering: https://github.com/guardian/dotcom-rendering/pull/8648

## What does this change?

Add a `PerformanceSwitch`

## Screenshots

N/A

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
