### PR TITLE
Don't prefetch Frontend's assets for DCR-rendered fronts

### DIFF
--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -12,7 +12,7 @@ import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import controllers.{FaciaControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import feed.MostViewedLifecycle
-import http.{CommonFilters, PreloadFilters}
+import http.{CommonFilters}
 import model.ApplicationIdentity
 import services.ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
@@ -77,7 +77,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   )
 
   val frontendBuildInfo: FrontendBuildInfo = frontend.facia.BuildInfo
-  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters ++ wire[PreloadFilters].filters
+  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 
   def actorSystem: ActorSystem

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -226,12 +226,12 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
   it should "render email fronts" in {
     val emailRequest = FakeRequest("GET", "/email/uk/daily")
-    val emailJsonResponse = faciaController.renderFront("email/uk/daily")(emailRequest)
-    status(emailJsonResponse) shouldBe 200
-    assertThrows[JsonParseException](contentAsJson(emailJsonResponse))
-    contentAsString(emailJsonResponse)
-    contentAsString(emailJsonResponse) should include("<!DOCTYPE html")
-    val responseHeaders = headers(emailJsonResponse)
+    val emailHtmlResponse = faciaController.renderFront("email/uk/daily")(emailRequest)
+    status(emailHtmlResponse) shouldBe 200
+    assertThrows[JsonParseException](contentAsJson(emailHtmlResponse))
+    contentAsString(emailHtmlResponse)
+    contentAsString(emailHtmlResponse) should include("<!DOCTYPE html")
+    val responseHeaders = headers(emailHtmlResponse)
     responseHeaders("Surrogate-Control") should include("max-age=900")
   }
 


### PR DESCRIPTION
We use the `Link` header on responses to instruct the browser to preload assets like scripts and styles associated with the page's content.

However, all HTML responses from `facia` currently ask browsers to preload Frontend's static assets [^1], even for DCR-rendered fronts. This means we are asking browsers to download assets they'll never use!

This change refactors `FaciaController` to omit the preload header, except for Frontend-rendered HTML fronts. This change does not preload DCR's static assets (implemented in https://github.com/guardian/dotcom-rendering/pull/8657).

See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload for more details on asset preloading.

## Testing

This has been tested on CODE.

The `Link` header diff before/after:

### for a DCR-rendered front:

Note: we no longer see Frontend assets in the `Link` header

<img width="1225" alt="image" src="https://github.com/guardian/frontend/assets/705427/0d8452c5-e02b-48c2-8d5a-c110a7ad2592">

### for a Frontend-rendered front:

Note: we still see Frontend's assets  in the `Link` header

<img width="1231" alt="image" src="https://github.com/guardian/frontend/assets/705427/9185f9dd-682b-4590-8f31-c9f647c25733">


Part of https://github.com/guardian/dotcom-rendering/issues/8550

[^1]: https://github.com/guardian/frontend/blob/main/facia/app/AppLoader.scala#L80