### PR TITLE
Increase `Okta` experiment to 5%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -99,7 +99,7 @@ object Okta
        - https://github.com/guardian/dotcom-rendering/pull/8508
        - https://github.com/guardian/frontend/pull/26461
       needs to be reverted */
-      participationGroup = Perc2A,
+      participationGroup = Perc5A,
     )
 
 object OfferHttp3

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -97,7 +97,6 @@ object Okta
       sellByDate = LocalDate.of(2023, 8, 31),
       /* Do not increase without considering if
        - https://github.com/guardian/dotcom-rendering/pull/8508
-       - https://github.com/guardian/frontend/pull/26461
       needs to be reverted */
       participationGroup = Perc5A,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -94,7 +94,7 @@ object Okta
       name = "okta",
       description = "Use Okta for authentication",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2023, 8, 31),
+      sellByDate = LocalDate.of(2023, 9, 7),
       /* Do not increase without considering if
        - https://github.com/guardian/dotcom-rendering/pull/8508
       needs to be reverted */

--- a/static/src/javascripts/lib/raven.ts
+++ b/static/src/javascripts/lib/raven.ts
@@ -64,10 +64,6 @@ const sentryOptions: RavenOptions = {
 	shouldSendCallback(data: { tags: { ignored?: unknown } }) {
 		const isIgnored = !!data.tags.ignored;
 
-		const isInOktaExperiment =
-			!!window.guardian.config.switches.okta &&
-			window.guardian.config.tests?.oktaVariant === 'variant';
-
 		// Sample at a very small rate.
 		const isInSample = Math.random() < 0.008;
 
@@ -77,8 +73,7 @@ const sentryOptions: RavenOptions = {
 
 		return (
 			!!enableSentryReporting &&
-			// we want to bypass the sample rate if the user is in the Okta experiment
-			(isInOktaExperiment || isInSample) &&
+			isInSample &&
 			!isIgnored &&
 			!adblockBeingUsed
 		);


### PR DESCRIPTION
Before merging, we should:

- [x] Merge https://github.com/guardian/dotcom-rendering/pull/8681
- [x] Revert https://github.com/guardian/frontend/pull/26461

to ensure we don't use up all our Sentry allowance. Regular error sampling should be fine.

After merging:

- [x] Send [comms](https://docs.google.com/document/d/1l4dJq7iJBlxYt0mz6EinXW7pvzX5aJg5o_MqR12SMQw/edit#heading=h.68zmqn7dxzhc)