### PR TITLE
Dblatcher/email template placeholder comments

### DIFF
--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -127,11 +127,16 @@
 
 @defining(page.article) { article =>
     @row(Seq("no-pad")) {
+        @brazePlaceholder(s"Above Banner")
+    }
+    @row(Seq("no-pad")) {
         <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
             @imgForArticle(page.banner, page.email.map(_.name))
         </a>
     }
-
+    @row(Seq("no-pad")) {
+        @brazePlaceholder(s"header")
+    }
     @page.fallbackSeriesText.map { seriesName =>
         @row(Seq("padded")) {
             <h3 class="text--brand">@seriesName</h3>

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -207,9 +207,11 @@
 }
 
 
-@fullRow(Seq()) {
+@brazePlaceholder(s"Above Banner")
+@fullRow(Seq("no-top-pad")) {
     @imgForFront(page.banner, page.email.map(_.name))
 }
+@brazePlaceholder(s"header")
 
 @renderContentContainer(collection: EmailContentContainer, collectionIndex: Int) = {
     @brazePlaceholder(s"Above Collection ${collectionIndex + 1}")

--- a/static/src/stylesheets/email/_util.scss
+++ b/static/src/stylesheets/email/_util.scss
@@ -13,6 +13,11 @@
     padding: 0;
 }
 
+// td
+.no-top-pad {
+    padding-top: 0;
+}
+
 // table
 .body {
     background: $body-color;


### PR DESCRIPTION
## What is the value of this and can you measure success?

The DRR team want the option to insert dynamic (IE can vary according to user) content in email newsletters above or below the main banner. 

There is an existing mechanism for this by adding  HTML comments in the templates which  are replaced with the required content when the content is being sent from Braze. To support the new slots, we need to add extra comments to the frontend templates

## What does this change?

Adds placeholder comments above and below the banner image on the article-based (e.g. https://www.theguardian.com/culture/2023/may/12/the-guide-jury-duty-amazon-freevee/email) and fronts-based (e.g. https://www.theguardian.com/email/uk/daily) email templates

## Screenshots

### fronts-based email
| Before      | After  (with test adverts)     |
|-------------|------------|
| <img width="572" alt="Screenshot 2023-08-23 at 13 05 04" src="https://github.com/guardian/frontend/assets/30567854/5057b66f-1a8d-4a10-913d-cdaac6b4d2d7"> | <img width="572" alt="Screenshot 2023-08-23 at 13 05 15" src="https://github.com/guardian/frontend/assets/30567854/08575b40-eadd-433f-ba54-b3af0794ec67"> |

### article-based email
| Before      | After  (with test adverts)     |
|-------------|------------|
| <img width="459" alt="Screenshot 2023-08-23 at 13 00 31" src="https://github.com/guardian/frontend/assets/30567854/96826453-4e87-4bf3-875e-e0d18cb6ed1d">| <img width="459" alt="Screenshot 2023-08-23 at 13 00 21" src="https://github.com/guardian/frontend/assets/30567854/f8d2a501-a895-4b51-b387-9a57ee66d8b6">|






## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
