### PR TITLE
fix: scheduler off by default

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -192,7 +192,7 @@ trait PerformanceSwitches {
     "scheduler",
     "Schedule JavaScript tasks using a centralised scheduler in dotcom-rendering",
     owners = Seq(Owner.withGithub("@guardian/open-journalism")),
-    safeState = On,
+    safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

The DCR task scheduler should not be the default.

Follow-up on #26520 – Necessary for https://github.com/guardian/dotcom-rendering/pull/8648

## What does this change?

The switch for the DCR scheduler is off by default.

## Screenshots

N/A

## Checklist

- [x] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)