### PR TITLE
Add optional `mainMediaAtom` field to `PressedStory`

### DIFF
--- a/common/app/model/PressedElements.scala
+++ b/common/app/model/PressedElements.scala
@@ -5,5 +5,6 @@ import model.{VideoElement}
 
 final case class PressedElements(
     mainVideo: Option[VideoElement],
+    mainMediaAtom: Option[MediaAtom],
     mediaAtoms: Seq[MediaAtom],
 )


### PR DESCRIPTION
## What is the value of this and can you measure success?

- Places the main media atom for a pressed story in its own field, making it easier for platforms to select the correct atom

Previously, identifying the main media atom element on any platform involved parsing the `main` field, finding the atom's HTML element and extrating the `data-atom-id` attribute, then using that value to find the correct element in the array. Instead of pushing that responsibility to platforms, it makes sense to include it as a calculated field here.

This is one step towards fixing https://github.com/guardian/dotcom-rendering/issues/8679, which is caused by us not knowing which is the main media atom - we just take the one at index `0`, which may not be correct. The next step is to consume the `mainMediaAtom` field in DCR.

The `PressedElements` model already sets a precedent for this, with the `mainVideo` property.

## Screenshots

### Updated JSON

<img width="666" alt="image" src="https://github.com/guardian/frontend/assets/705427/c83b13f2-16bd-4411-a418-eee7ae0f5005">

### Before / After

| Before | After |
|--------|--------|
| <img width="1214" alt="image" src="https://github.com/guardian/frontend/assets/705427/3e6c4fae-1f9f-41da-ac74-bc1dce9c890e"> | <img width="1212" alt="image" src="https://github.com/guardian/frontend/assets/705427/6bdbaec0-9647-4caa-bf1a-0b1019227e09"> |

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering - it's an optional field

## Alternatives considered

- Add a `mainMediaAtomId` field to `metadata` instead
- Add a `isMain` field to the atom model
