### PR TITLE
fix: add deeplyreadlifecycle to facia

### DIFF
--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -11,7 +11,7 @@ import conf.CachedHealthCheckLifeCycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import controllers.{FaciaControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
-import feed.MostViewedLifecycle
+import feed.{DeeplyReadLifecycle, MostViewedLifecycle}
 import http.{CommonFilters, PreloadFilters}
 import model.ApplicationIdentity
 import services.ophan.SurgingContentAgentLifecycle
@@ -62,6 +62,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
     wire[SwitchboardLifecycle],
     wire[CachedHealthCheckLifeCycle],
     wire[MostViewedLifecycle],
+    wire[DeeplyReadLifecycle],
   )
 
   lazy val router: Router = wire[Routes]

--- a/facia/app/feed/DeeplyReadLifecycle.scala
+++ b/facia/app/feed/DeeplyReadLifecycle.scala
@@ -1,0 +1,42 @@
+package feed
+
+import agents.DeeplyReadAgent
+import app.LifecycleComponent
+import common.{AkkaAsync, JobScheduler}
+import play.api.inject.ApplicationLifecycle
+
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext, Future}
+
+class DeeplyReadLifecycle(
+    appLifecycle: ApplicationLifecycle,
+    jobs: JobScheduler,
+    akkaAsync: AkkaAsync,
+    deeplyReadAgent: DeeplyReadAgent,
+) extends LifecycleComponent {
+
+  implicit val executionContext = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+
+  appLifecycle.addStopHook { () =>
+    Future {
+      descheduleAll()
+    }
+  }
+
+  private def descheduleAll(): Unit = {
+    jobs.deschedule("DeeplyReadAgentsHighFrequencyRefreshJob")
+  }
+
+  override def start(): Unit = {
+
+    descheduleAll()
+
+    jobs.scheduleEveryNMinutes("DeeplyReadAgentsHighFrequencyRefreshJob", 5) {
+      deeplyReadAgent.refresh()
+    }
+
+    akkaAsync.after1s {
+      deeplyReadAgent.refresh()
+    }
+  }
+}


### PR DESCRIPTION
## What is the value of this and can you measure success?
This adds the `deeplyreadlifecycle` to the facia app to ensure that it is refreshed every 5 minutes.  

[We do something similar in the onward journey app](https://github.com/guardian/frontend/blob/main/onward/app/feed/OnwardJourneyLifecycle.scala#L45).

The giveaway was that when looking at how often we were fetching data from the `facia` app, the weekends seemed to be a little bare, and it wasn't on a regular frequency. 

![Screenshot 2023-08-29 at 12 09 35](https://github.com/guardian/frontend/assets/31692/06af86f4-75e6-4586-bf5d-c22c74952ec0)

The experiment is currently off, to test this we could turn it back on and watch the logs to ensure we're getting updates every 5 minutes.

Co-authored-by: Marjan Kalanaki <marjan.kalanaki@guardian.co.uk>