### PR TITLE
Bump commercial package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "11.4.0",
+		"@guardian/commercial": "^11.6.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,10 +1556,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@11.4.0":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.4.0.tgz#8be0ceebfd4c583fbcfc112c42410b6ada46a97f"
-  integrity sha512-xAWhMGh/FKJ8bs+jAhB22WMIOlOTcmsPWYs8+byucI/H0+a/C69VyKsYsUjOeDXw5bUt3iy4GXobD4A/tY2p2w==
+"@guardian/commercial@^11.6.0":
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.6.0.tgz#66723e4b47d9748b5feeb390664a88bc1b613fe8"
+  integrity sha512-szlGIPsH42l9qvLDiyWI6/35l2bF3ZbBYkJFU41sJlUQckaRIj92IU7SeiRoh0hxghI+Q66oduuFiJEBMcFOZA==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Bumps the commercial package to bring in the changes listed here: https://github.com/guardian/commercial/releases/tag/v11.6.0 and here: https://github.com/guardian/commercial/releases/tag/v11.5.0