### PR TITLE
Build on pushes to a branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: "Build"
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
 
 permissions:
   id-token: write


### PR DESCRIPTION
This modifies the existing behaviour following the migration to GHA, where builds are only triggered once a PR is opened.

This change builds the project on a push to a branch, whether there is a PR or not. This means we can deploy a branch from RiffRaff without waiting for a PR.

