### PR TITLE
Increase Okta's participation group size to 50%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -95,7 +95,7 @@ object Okta
       description = "Use Okta for authentication",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 9, 7),
-      participationGroup = Perc20A,
+      participationGroup = Perc50,
     )
 
 object OfferHttp3


### PR DESCRIPTION
Continues the Okta rollout.

## After merging

- [ ] send [comms](https://docs.google.com/document/d/1l4dJq7iJBlxYt0mz6EinXW7pvzX5aJg5o_MqR12SMQw/edit#heading=h.w108ksnznjme)

Closes #26551.

