### PR TITLE
Okta: Release to 100%

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -13,4 +13,14 @@ trait IdentitySwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val Okta = Switch(
+    group = SwitchGroup.Identity,
+    name = "okta",
+    description = "Use Okta for authentication",
+    owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,7 +16,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       ServerSideLiveblogInlineAds,
       EuropeNetworkFront,
       SectionFrontsBannerAds,
-      Okta,
       HeaderTopBarSearchCapi,
       AdaptiveSite,
       OfferHttp3,
@@ -106,15 +105,6 @@ object FrontsBannerAdsDcr
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
       sellByDate = LocalDate.of(2023, 11, 1),
       participationGroup = Perc5A,
-    )
-
-object Okta
-    extends Experiment(
-      name = "okta",
-      description = "Use Okta for authentication",
-      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2023, 9, 7),
-      participationGroup = Perc20A,
     )
 
 object DeeplyRead

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -107,11 +107,7 @@ export type AuthStatus =
 	| SignedOutWithOkta
 	| SignedInWithOkta;
 
-// We want to be in the experiment if in the development environment
-// or if we have opted in to the Okta server side experiment
-const isInOktaExperiment =
-	window.guardian.config.stage === 'DEV' ||
-	window.guardian.config.tests?.oktaVariant === 'variant';
+const useOkta = !!window.guardian.config.switches.okta;
 
 /**
  * Runs `inOkta` if the user is enrolled in the Okta experiment, otherwise runs `notInOkta`
@@ -134,7 +130,7 @@ export const eitherInOktaExperimentOrElse = async <A, B>(
 };
 
 export const getAuthStatus = async (): Promise<AuthStatus> => {
-	if (isInOktaExperiment) {
+	if (useOkta) {
 		const { isSignedInWithOktaAuthState } = await import('./okta');
 		const authState = await isSignedInWithOktaAuthState();
 		if (authState.isAuthenticated) {


### PR DESCRIPTION
## What's changing?

We want to release Okta to 100% of readers. Right now we're using a server side experiment, which has a maximum of 50% enrolment. In order to get to 100%, we need to convert the Experiment to a Feature Switch.

This change:
- moves the Okta experiment to a feature switch
- refactors the enrolment check to simply check if the switch is on or off.

We will need to make similar enrolment check refactors in DCR and the Commercial bundle.

Part of [#26551](https://github.com/guardian/frontend/issues/26551)