### PR TITLE
Extend expired experiments. Bump commercial

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -30,7 +30,7 @@ object FrontsBannerAdsDcr
       name = "fronts-banner-ads-dcr",
       description = "Creates a new ad experience on fronts pages, replacing MPUs with banner ads",
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
-      sellByDate = LocalDate.of(2023, 9, 1),
+      sellByDate = LocalDate.of(2023, 11, 1),
       participationGroup = Perc0A,
     )
 
@@ -49,7 +49,7 @@ object ServerSideLiveblogInlineAds
       description =
         "Test whether we can load liveblog inline ads server-side without negative effects on user experience or revenue",
       owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
-      sellByDate = LocalDate.of(2023, 9, 1),
+      sellByDate = LocalDate.of(2023, 11, 1),
       participationGroup = Perc0C,
     )
 
@@ -58,7 +58,7 @@ object EuropeNetworkFront
       name = "europe-network-front",
       description = "Test new europe network front",
       owners = Seq(Owner.withGithub("rowannekabalan")),
-      sellByDate = LocalDate.of(2023, 8, 31),
+      sellByDate = LocalDate.of(2023, 9, 15),
       participationGroup = Perc0D,
     )
 
@@ -99,6 +99,15 @@ object HeaderTopBarSearchCapi
       participationGroup = Perc1B,
     )
 
+object OfferHttp3
+    extends Experiment(
+      name = "offer-http3",
+      description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
+      owners = Seq(Owner.withGithub("paulmr")),
+      sellByDate = LocalDate.of(2023, 9, 15),
+      participationGroup = Perc1E,
+    )
+
 object Okta
     extends Experiment(
       name = "okta",
@@ -106,15 +115,6 @@ object Okta
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 9, 7),
       participationGroup = Perc20A,
-    )
-
-object OfferHttp3
-    extends Experiment(
-      name = "offer-http3",
-      description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
-      owners = Seq(Owner.withGithub("paulmr")),
-      sellByDate = LocalDate.of(2023, 8, 31),
-      participationGroup = Perc1E,
     )
 
 object DeeplyRead

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "^11.6.0",
+		"@guardian/commercial": "^11.7.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,10 +1556,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@^11.6.0":
-  version "11.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.6.0.tgz#66723e4b47d9748b5feeb390664a88bc1b613fe8"
-  integrity sha512-szlGIPsH42l9qvLDiyWI6/35l2bF3ZbBYkJFU41sJlUQckaRIj92IU7SeiRoh0hxghI+Q66oduuFiJEBMcFOZA==
+"@guardian/commercial@^11.7.0":
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.7.0.tgz#2dd432011250525ed85f1ac8db495885f039f49f"
+  integrity sha512-sC3ceZr+VFyneCfA9sFNlc9jsAPBIc8EIZn0MIQkjyISkl0hiGR48yM34Mpmv/yCx/xQ/tk056lX8yiZAy/VBA==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
## What does this change?

- Extend two experiments that have expired, by two weeks (`EuropeNetworkFront` and `OfferHttp3`)
- Extend two commercial experiments that will expire tomorrow. Both of these are 0% tests will be started soon.
- Bumps commercial

# Why

- An expired test may fail the build
- We don't want to use the Fabric ad size for fronts-banner ads at this time