### PR TITLE
Remove Women's World Cup 2023

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -27,7 +27,6 @@ class LeagueTableController(
 
   // Competitions must be added to this list to show up at /football/tables
   val tableOrder: Seq[String] = Seq(
-    "Women's World Cup 2023",
     "World Cup 2022",
     "Premier League",
     "Bundesliga",
@@ -36,6 +35,7 @@ class LeagueTableController(
     "Ligue 1",
     "Women's Super League",
     "Champions League",
+    "Euro 2024 qualifying",
     "Women's Champions League",
     "Europa League",
     "Carabao Cup",
@@ -56,7 +56,6 @@ class LeagueTableController(
     "Women's Euro 2022",
     "World Cup 2022 qualifying",
     "Nations League",
-    "Euro 2024 qualifying",
   )
 
   def sortedCompetitions: Seq[Competition] =

--- a/sport/app/football/views/tablesList/tablesPage.scala.html
+++ b/sport/app/football/views/tablesList/tablesPage.scala.html
@@ -1,5 +1,6 @@
 @import football.controllers.TablesPage
 @import views.support.`package`.Seq2zipWithRowInfo
+@import football.views.html.tablesList.tableView
 @(page: TablesPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @mainLegacy(page.page, Some("football")){


### PR DESCRIPTION


## What is the value of this and can you measure success?
Keep up-to-date with the football tournaments.

## What does this change?
* Remove Women's World Cup 2023
* Move Euro 2024 qualifying below Champions League
* Add missing import

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1025" alt="image" src="https://github.com/guardian/frontend/assets/19683595/10a01705-11a0-44e1-92cf-939ce8bbc79a"> | <img width="1059" alt="image" src="https://github.com/guardian/frontend/assets/19683595/2530ee43-0f60-4b9b-aa76-3a3916e1f088"> |
| <img width="920" alt="image" src="https://github.com/guardian/frontend/assets/19683595/e8d3cd15-8d47-4111-873b-43878ba62682"> | <img width="1022" alt="image" src="https://github.com/guardian/frontend/assets/19683595/5781e008-eebc-41d9-8429-e7b798fe1d00"> |
| <img width="475" alt="image" src="https://github.com/guardian/frontend/assets/19683595/e2588e9e-dc17-404a-86f6-463998f8bbdb"> | <img width="400" alt="image" src="https://github.com/guardian/frontend/assets/19683595/776a3990-dfb0-47c1-905b-7df701d6a465"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png



## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
