### PR TITLE
Extend `ab-limit-inline-merch` switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -91,7 +91,7 @@ trait ABTestSwitches {
     "Test the impact of limiting the eligibility of inline merchandising ad slots",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 9, 1)),
+    sellByDate = Some(LocalDate.of(2023, 9, 20)),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?
Extend `ab-limit-inline-merch` switch until the 20th of September

## What is the value of this and can you measure success?
We need this for tests to pass



