### PR TITLE
Remove limit inline merch AB test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -87,16 +87,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-limit-inline-merch",
-    "Test the impact of limiting the eligibility of inline merchandising ad slots",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 9, 20)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-liveblog-right-column-ads",
     "Test the commercial impact of different strategies for displaying ads in the right column on liveblog pages.",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),


### PR DESCRIPTION
## What is the value of this and can you measure success?

This test has completed. We revert to the original behaviour, since this was just an experiment to assess the impact of removing this slot on other advertising on the page.

## What does this change?

Remove the switch that controlled the experiment to limit the presence of inline merchandising. See #26153.