### PR TITLE
Migrate from Akka to Pekko

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -8,7 +8,7 @@ import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import controllers.{AdminControllers, HealthCheck}
 import _root_.dfp.DfpDataCacheLifecycle
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import concurrent.BlockingOperations
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import http.{AdminFilters, AdminHttpErrorHandler, CommonGzipFilter}
@@ -36,7 +36,7 @@ class AppLoader extends FrontendApplicationLoader {
 trait AdminServices extends I18nComponents {
   def wsClient: WSClient
   def akkaAsync: AkkaAsync
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
   implicit val executionContext: ExecutionContext
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   lazy val contentApiClient = wire[ContentApiClient]
@@ -101,7 +101,7 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
     DfpApiMetrics.DfpApiErrors,
   )
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[AdminHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonGzipFilter].filters ++ wire[AdminFilters].filters

--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -8,7 +8,7 @@ import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import controllers.{AdminControllers, HealthCheck}
 import _root_.dfp.DfpDataCacheLifecycle
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import concurrent.BlockingOperations
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import http.{AdminFilters, AdminHttpErrorHandler, CommonGzipFilter}

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -4,7 +4,7 @@ import concurrent.BlockingOperations
 import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
 import com.google.api.ads.admanager.axis.v202308._
 import org.joda.time.DateTime
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/admin/test/services/ParameterStoreServiceTest.scala
+++ b/admin/test/services/ParameterStoreServiceTest.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import concurrent.BlockingOperations
 import org.scalatest.concurrent.ScalaFutures
 import org.mockito.Mockito._

--- a/admin/test/services/ParameterStoreServiceTest.scala
+++ b/admin/test/services/ParameterStoreServiceTest.scala
@@ -1,6 +1,6 @@
 package services
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import concurrent.BlockingOperations
 import org.scalatest.concurrent.ScalaFutures
 import org.mockito.Mockito._
@@ -11,8 +11,8 @@ import org.scalatestplus.mockito.MockitoSugar
 class ParameterStoreServiceTest extends AnyFlatSpec with ScalaFutures with Matchers with MockitoSugar {
 
   "findParameterBySubstring" should "retrieve a parameter from the parameter store by substring" in {
-    val actorSystem = ActorSystem()
-    val blockingOperations = new BlockingOperations(actorSystem)
+    val pekkoActorSystem = PekkoActorSystem()
+    val blockingOperations = new BlockingOperations(pekkoActorSystem)
 
     val parameterStore = mock[ParameterStore]
     when(parameterStore.getPath("/frontend", isRecursiveSearch = true)) thenReturn Map(

--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle
@@ -97,5 +97,5 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
@@ -49,6 +49,5 @@ trait AppComponents extends FrontendComponents {
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
-
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import _root_.commercial.targeting.TargetingLifecycle
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common.Assets.DiscussionExternalAssetsLifecycle

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import _root_.commercial.targeting.TargetingLifecycle
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common.Assets.DiscussionExternalAssetsLifecycle
@@ -98,5 +98,5 @@ trait AppComponents extends FrontendComponents with ArticleControllers with Topi
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
+++ b/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
@@ -1,6 +1,6 @@
 package services
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.LifecycleComponent
 import common.AutoRefresh
 import model.{TagDefinition, TagIndexListings}
@@ -12,7 +12,7 @@ import scala.language.postfixOps
 class NewspaperBooksAndSectionsAutoRefresh(
     newspaperBookSectionTagAgent: NewspaperBookSectionTagAgent,
     newspaperBookTagAgent: NewspaperBookTagAgent,
-)(implicit actorSystem: ActorSystem, executionContext: ExecutionContext)
+)(implicit pekkoActorSystem: PekkoActorSystem, executionContext: ExecutionContext)
     extends LifecycleComponent {
   override def start(): Unit = {
     newspaperBookTagAgent.start()

--- a/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
+++ b/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.LifecycleComponent
 import common.AutoRefresh
 import model.{TagDefinition, TagIndexListings}

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ val common = library("common")
       capiAws,
       okhttp,
       pekkoActor,
+      pekkoStream,
     ) ++ jackson,
     TestAssets / mappings ~= filterAssets,
   )

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ val common = library("common")
       identityModel,
       capiAws,
       okhttp,
+      pekkoActor,
     ) ++ jackson,
     TestAssets / mappings ~= filterAssets,
   )

--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle
@@ -35,7 +35,7 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait CommercialServices {
   def wsClient: WSClient
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
   implicit val executionContext: ExecutionContext
 
   lazy val magentoService = wire[MagentoService]
@@ -79,5 +79,5 @@ trait AppComponents extends FrontendComponents with CommercialControllers with C
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -1,12 +1,12 @@
 package commercial.model.merchandise.books
 
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
+import org.apache.pekko.pattern.CircuitBreaker
+import org.apache.pekko.util.Timeout
 import commercial.model.feeds.{FeedParseException, FeedReadException, FeedReader, FeedRequest}
 import commercial.model.merchandise.Book
 import common.{Box, GuLogging}
 import conf.Configuration
-import org.apache.pekko.pattern.CircuitBreaker
-import org.apache.pekko.util.Timeout
 import play.api.libs.json._
 import play.api.libs.oauth.{ConsumerKey, OAuthCalculator, RequestToken}
 import play.api.libs.ws.{WSClient, WSSignatureCalculator}

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -1,12 +1,12 @@
 package commercial.model.merchandise.books
 
-import org.apache.pekko.actor.ActorSystem
-import akka.pattern.CircuitBreaker
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import akka.util.Timeout
 import commercial.model.feeds.{FeedParseException, FeedReadException, FeedReader, FeedRequest}
 import commercial.model.merchandise.Book
 import common.{Box, GuLogging}
 import conf.Configuration
+import org.apache.pekko.pattern.CircuitBreaker
 import play.api.libs.json._
 import play.api.libs.oauth.{ConsumerKey, OAuthCalculator, RequestToken}
 import play.api.libs.ws.{WSClient, WSSignatureCalculator}
@@ -15,10 +15,10 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-class BookFinder(actorSystem: ActorSystem, magentoService: MagentoService) extends GuLogging {
+class BookFinder(pekkoActorSystem: PekkoActorSystem, magentoService: MagentoService) extends GuLogging {
 
   private implicit val bookActorExecutionContext: ExecutionContext =
-    actorSystem.dispatchers.lookup("akka.actor.book-lookup")
+    pekkoActorSystem.dispatchers.lookup("akka.actor.book-lookup")
   private implicit val bookActorTimeout: Timeout = 0.2.seconds
   private implicit val magentoServiceImplicit = magentoService
 
@@ -48,7 +48,7 @@ object BookAgent extends GuLogging {
   }
 }
 
-class MagentoService(actorSystem: ActorSystem, wsClient: WSClient) extends GuLogging {
+class MagentoService(pekkoActorSystem: PekkoActorSystem, wsClient: WSClient) extends GuLogging {
 
   private case class MagentoProperties(oauth: WSSignatureCalculator, urlPrefix: String)
 
@@ -72,10 +72,10 @@ class MagentoService(actorSystem: ActorSystem, wsClient: WSClient) extends GuLog
   }
 
   private implicit val bookLookupExecutionContext: ExecutionContext =
-    actorSystem.dispatchers.lookup("akka.actor.book-lookup")
+    pekkoActorSystem.dispatchers.lookup("akka.actor.book-lookup")
 
   private final val circuitBreaker = new CircuitBreaker(
-    scheduler = actorSystem.scheduler,
+    scheduler = pekkoActorSystem.scheduler,
     maxFailures = 5,
     callTimeout = 3.seconds,
     resetTimeout = 5.minutes,

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -1,12 +1,12 @@
 package commercial.model.merchandise.books
 
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
-import akka.util.Timeout
 import commercial.model.feeds.{FeedParseException, FeedReadException, FeedReader, FeedRequest}
 import commercial.model.merchandise.Book
 import common.{Box, GuLogging}
 import conf.Configuration
 import org.apache.pekko.pattern.CircuitBreaker
+import org.apache.pekko.util.Timeout
 import play.api.libs.json._
 import play.api.libs.oauth.{ConsumerKey, OAuthCalculator, RequestToken}
 import play.api.libs.ws.{WSClient, WSSignatureCalculator}

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -1,6 +1,6 @@
 package commercial.model.merchandise.books
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import akka.pattern.CircuitBreaker
 import akka.util.Timeout
 import commercial.model.feeds.{FeedParseException, FeedReadException, FeedReader, FeedRequest}

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -37,8 +37,6 @@ trait FrontendComponents
 
   lazy val prefix = "/"
 
-// implicit lazy val as = actorSystem
-
   implicit val pekkoActorSystem: PekkoActorSystem = PekkoActorSystem.create()
   applicationLifecycle.addStopHook(() => {
     pekkoActorSystem.terminate()

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -37,7 +37,6 @@ trait FrontendComponents
 
   lazy val prefix = "/"
 
-
 // implicit lazy val as = actorSystem
 
   implicit val pekkoActorSystem: PekkoActorSystem = PekkoActorSystem.create()

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -10,6 +10,7 @@ import play.api.routing.Router
 import play.filters.csrf.CSRFComponents
 import controllers.AssetsComponents
 import play.api.{Application, ApplicationLoader, BuiltInComponents, LoggerConfigurator, OptionalDevContext}
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 
 trait FrontendApplicationLoader extends ApplicationLoader {
 
@@ -36,10 +37,16 @@ trait FrontendComponents
 
   lazy val prefix = "/"
 
-  implicit lazy val as = actorSystem
+
+// implicit lazy val as = actorSystem
+
+  implicit val pekkoActorSystem: PekkoActorSystem = PekkoActorSystem.create()
+  applicationLifecycle.addStopHook(() => {
+    pekkoActorSystem.terminate()
+  })
 
   lazy val jobScheduler = new JobScheduler(appContext)
-  lazy val akkaAsync = new AkkaAsync(environment, actorSystem)
+  lazy val akkaAsync = new AkkaAsync(environment, pekkoActorSystem)
   lazy val appMetrics = ApplicationMetrics()
   lazy val guardianConf = new GuardianConfiguration
   lazy val mode = environment.mode

--- a/common/app/common/AutoRefresh.scala
+++ b/common/app/common/AutoRefresh.scala
@@ -1,7 +1,7 @@
 package common
 
 import scala.concurrent.duration.FiniteDuration
-import org.apache.pekko.actor.{ActorSystem, Cancellable}
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem, Cancellable}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -35,9 +35,9 @@ abstract class AutoRefresh[A](initialDelay: FiniteDuration, interval: FiniteDura
     }
   }
 
-  final def start()(implicit actorSystem: ActorSystem, executionContext: ExecutionContext): Unit = {
+  final def start()(implicit pekkoActorSystem: PekkoActorSystem, executionContext: ExecutionContext): Unit = {
     log.info(s"Starting refresh cycle after $initialDelay repeatedly over $interval delay")
-    val cancellable = actorSystem.scheduler.scheduleWithFixedDelay(initialDelay, interval) { new Task() }
+    val cancellable = pekkoActorSystem.scheduler.scheduleWithFixedDelay(initialDelay, interval) { new Task() }
     subscription = Some(cancellable)
   }
 

--- a/common/app/common/AutoRefresh.scala
+++ b/common/app/common/AutoRefresh.scala
@@ -1,7 +1,7 @@
 package common
 
 import scala.concurrent.duration.FiniteDuration
-import akka.actor.{ActorSystem, Cancellable}
+import org.apache.pekko.actor.{ActorSystem, Cancellable}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}

--- a/common/app/common/Logback/KinesisAdapter.scala
+++ b/common/app/common/Logback/KinesisAdapter.scala
@@ -1,9 +1,9 @@
 package common.Logback
 
 import java.util.concurrent.ThreadPoolExecutor
-import akka.actor.ActorSystem
-import akka.dispatch.MessageDispatcher
-import akka.pattern.CircuitBreaker
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.dispatch.MessageDispatcher
+import org.apache.pekko.pattern.CircuitBreaker
 import ch.qos.logback.classic.spi.ILoggingEvent
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider

--- a/common/app/common/akka.scala
+++ b/common/app/common/akka.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration._
 import play.api.{Environment => PlayEnv, Mode}
 
 import scala.concurrent.ExecutionContext
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 class AkkaAsync(env: PlayEnv, actorSystem: ActorSystem) {
   implicit val ec: ExecutionContext = actorSystem.dispatcher

--- a/common/app/common/akka.scala
+++ b/common/app/common/akka.scala
@@ -4,10 +4,10 @@ import scala.concurrent.duration._
 import play.api.{Environment => PlayEnv, Mode}
 
 import scala.concurrent.ExecutionContext
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 
-class AkkaAsync(env: PlayEnv, actorSystem: ActorSystem) {
-  implicit val ec: ExecutionContext = actorSystem.dispatcher
+class AkkaAsync(env: PlayEnv, pekkoActorSystem: PekkoActorSystem) {
+  implicit val ec: ExecutionContext = pekkoActorSystem.dispatcher
 
   // "apply" isn't expressive and doesn't explain what it does.
   // If you were considering using that function, use after1s instead as it doesn't leave any ambiguity.
@@ -20,6 +20,6 @@ class AkkaAsync(env: PlayEnv, actorSystem: ActorSystem) {
   // want to check in
   def after(delay: FiniteDuration)(body: => Unit): Unit =
     if (env.mode != Mode.Test) {
-      actorSystem.scheduler.scheduleOnce(delay)(body)
+      pekkoActorSystem.scheduler.scheduleOnce(delay)(body)
     }
 }

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -1,7 +1,6 @@
 package common
 
 import java.util.concurrent.TimeoutException
-import akka.pattern.CircuitBreakerOpenException
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.v1.ErrorResponse
 import conf.switches.Switch
@@ -17,6 +16,7 @@ import play.twirl.api.Html
 import model.ApplicationContext
 import http.ResultWithPreconnectPreload
 import http.HttpPreconnections
+import org.apache.pekko.pattern.CircuitBreakerOpenException
 import renderers.{DCRLocalConnectException, DCRTimeoutException}
 
 object `package`

--- a/common/app/concurrent/BlockingOperations.scala
+++ b/common/app/concurrent/BlockingOperations.scala
@@ -1,12 +1,12 @@
 package concurrent
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import org.apache.pekko.dispatch.MessageDispatcher
 
 import scala.concurrent.Future
 
-class BlockingOperations(actorSystem: ActorSystem) {
-  private val blockingOperations: MessageDispatcher = actorSystem.dispatchers.lookup("akka.blocking-operations")
+class BlockingOperations(pekkoActorSystem: PekkoActorSystem) {
+  private val blockingOperations: MessageDispatcher = pekkoActorSystem.dispatchers.lookup("akka.blocking-operations")
 
   def executeBlocking[T](block: => T): Future[T] = {
     Future(block)(blockingOperations)

--- a/common/app/concurrent/BlockingOperations.scala
+++ b/common/app/concurrent/BlockingOperations.scala
@@ -1,7 +1,7 @@
 package concurrent
 
-import akka.actor.ActorSystem
-import akka.dispatch.MessageDispatcher
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.dispatch.MessageDispatcher
 
 import scala.concurrent.Future
 

--- a/common/app/concurrent/CircuitBreakerRegistry.scala
+++ b/common/app/concurrent/CircuitBreakerRegistry.scala
@@ -1,7 +1,7 @@
 package concurrent
 
-import akka.actor.ActorSystem
-import akka.pattern.CircuitBreaker
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.pattern.CircuitBreaker
 import common.GuLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/common/app/concurrent/CircuitBreakerRegistry.scala
+++ b/common/app/concurrent/CircuitBreakerRegistry.scala
@@ -1,6 +1,6 @@
 package concurrent
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import org.apache.pekko.pattern.CircuitBreaker
 import common.GuLogging
 
@@ -11,7 +11,7 @@ object CircuitBreakerRegistry extends GuLogging {
 
   def withConfig(
       name: String,
-      system: ActorSystem,
+      system: PekkoActorSystem,
       maxFailures: Int,
       callTimeout: FiniteDuration,
       resetTimeout: FiniteDuration,

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -2,7 +2,7 @@ package contentapi
 
 import java.util.concurrent.TimeUnit
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import com.github.nscala_time.time.Implicits._
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1.{Edition => _, _}
@@ -136,7 +136,7 @@ final case class CircuitBreakingContentApiClient(
 
   private[this] val circuitBreaker = CircuitBreakerRegistry.withConfig(
     name = "content-api-client",
-    system = ActorSystem("content-api-client-circuit-breaker"),
+    system = PekkoActorSystem("content-api-client-circuit-breaker"),
     maxFailures = contentApi.circuitBreakerErrorThreshold,
     callTimeout = contentApi.timeout + Duration
       .create(400, MILLISECONDS), // +400 to differentiate between circuit breaker and capi timeouts

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -2,7 +2,7 @@ package contentapi
 
 import java.util.concurrent.TimeUnit
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.github.nscala_time.time.Implicits._
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1.{Edition => _, _}

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -1,6 +1,6 @@
 package renderers
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.contentapi.client.model.v1.{Block, Blocks, Content}
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -1,6 +1,6 @@
 package renderers
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import com.gu.contentapi.client.model.v1.{Block, Blocks, Content}
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
@@ -49,7 +49,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
   private[this] val circuitBreaker = CircuitBreakerRegistry.withConfig(
     name = "dotcom-rendering-client",
-    system = ActorSystem("dotcom-rendering-client-circuit-breaker"),
+    system = PekkoActorSystem("dotcom-rendering-client-circuit-breaker"),
     maxFailures = Configuration.rendering.circuitBreakerMaxFailures,
     callTimeout = Configuration.rendering.timeout.plus(200.millis),
     resetTimeout = Configuration.rendering.timeout * 4,

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -1,6 +1,5 @@
 package services
 
-import akka.util.Timeout
 import app.LifecycleComponent
 import com.gu.facia.api.models.{Front, _}
 import com.gu.facia.client.ApiClient
@@ -11,6 +10,7 @@ import conf.Configuration
 import fronts.FrontsApi
 import model.pressed.CollectionConfig
 import model.{ApplicationContext, FrontProperties, SeoDataJson}
+import org.apache.pekko.util.Timeout
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
 

--- a/common/app/services/indexAutoRefreshes.scala
+++ b/common/app/services/indexAutoRefreshes.scala
@@ -1,6 +1,6 @@
 package services
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.LifecycleComponent
 import common.AutoRefresh
 import model.TagIndexListings
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.language.postfixOps
 
-class IndexListingsLifecycle(implicit actorSystem: ActorSystem, executionContext: ExecutionContext)
+class IndexListingsLifecycle(implicit pekkoActorSystem: PekkoActorSystem, executionContext: ExecutionContext)
     extends LifecycleComponent {
   override def start(): Unit = {
     KeywordSectionIndexAutoRefresh.start()

--- a/common/app/services/indexAutoRefreshes.scala
+++ b/common/app/services/indexAutoRefreshes.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.LifecycleComponent
 import common.AutoRefresh
 import model.TagIndexListings

--- a/common/test/concurrent/BlockingOperationsTest.scala
+++ b/common/test/concurrent/BlockingOperationsTest.scala
@@ -1,12 +1,12 @@
 package concurrent
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class BlockingOperationsTest extends AnyFlatSpec with Matchers with ScalaFutures {
-  val system = ActorSystem()
+  val system = PekkoActorSystem()
 
   "BlockingOperations" should "execute blocks in a thread pool" in {
     val blockingOperaitons = new BlockingOperations(system)

--- a/common/test/concurrent/BlockingOperationsTest.scala
+++ b/common/test/concurrent/BlockingOperationsTest.scala
@@ -1,6 +1,6 @@
 package concurrent
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -1,14 +1,9 @@
 package test
 
-import org.apache.pekko.actor.ActorSystem
-
-import java.io.File
-import java.net.URL
 import akka.stream.Materializer
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.gargoylesoftware.htmlunit.{BrowserVersion, WebClient}
 import common.Lazy
-import concurrent.BlockingOperations
 import contentapi._
 import model.{ApplicationContext, ApplicationIdentity, PressedPage, PressedPageType}
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
@@ -26,6 +21,8 @@ import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFConfig}
 import recorder.{ContentApiHttpRecorder, HttpRecorder}
 import services.fronts.FrontJsonFapiLive
 
+import java.io.File
+import java.net.URL
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Codec.UTF8
 import scala.util.{Failure, Success, Try}

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -1,6 +1,6 @@
 package test
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 import java.io.File
 import java.net.URL

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -1,7 +1,7 @@
 import _root_.commercial.CommercialLifecycle
 import _root_.commercial.controllers.CommercialControllers
 import _root_.commercial.targeting.TargetingLifecycle
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import agents.MostViewedAgent
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import business.StocksDataLifecycle

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -1,7 +1,7 @@
 import _root_.commercial.CommercialLifecycle
 import _root_.commercial.controllers.CommercialControllers
 import _root_.commercial.targeting.TargetingLifecycle
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import agents.MostViewedAgent
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import business.StocksDataLifecycle
@@ -90,7 +90,7 @@ trait AppComponents
   override lazy val optionalDevContext = new OptionalDevContext(devContext)
   override lazy val sourceMapper = devContext.map(_.sourceMapper)
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
   override def router: Router = wire[Routes]
   override def appIdentity: ApplicationIdentity = ApplicationIdentity("dev-build")
 

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import dev.DevAssetsController
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
@@ -49,5 +49,5 @@ trait AppComponents extends FrontendComponents with DiscussionControllers with D
   val frontendBuildInfo: FrontendBuildInfo = frontend.discussion.BuildInfo
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import dev.DevAssetsController
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -15,7 +15,7 @@ import play.api.mvc.EssentialFilter
 import services.ConfigAgentLifecycle
 import router.Routes
 import _root_.commercial.targeting.TargetingLifecycle
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -15,7 +15,7 @@ import play.api.mvc.EssentialFilter
 import services.ConfigAgentLifecycle
 import router.Routes
 import _root_.commercial.targeting.TargetingLifecycle
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =
@@ -64,5 +64,5 @@ trait AppComponents extends FrontendComponents {
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = Nil
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import agents.{DeeplyReadAgent, MostViewedAgent}
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
@@ -35,7 +35,7 @@ class AppLoader extends FrontendApplicationLoader {
 trait FapiServices {
   implicit val executionContext: ExecutionContext
   def wsClient: WSClient
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
   lazy val frontJsonFapiLive = wire[FrontJsonFapiLive]
   lazy val frontJsonFapiDraft = wire[FrontJsonFapiDraft]
   lazy val blockingOperations = wire[BlockingOperations]
@@ -81,5 +81,5 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import agents.{DeeplyReadAgent, MostViewedAgent}
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common._

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -1,29 +1,26 @@
 package test
 
 import agents.{DeeplyReadAgent, MostViewedAgent}
-import org.apache.pekko.actor.ActorSystem
 import com.fasterxml.jackson.core.JsonParseException
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import common.editions.{Uk, Us}
-import implicits.FakeRequests
-import concurrent.BlockingOperations
-import play.api.libs.json.JsArray
-import play.api.test._
-import play.api.test.Helpers._
-import services.{ConfigAgent, OphanApi}
-import org.scalatest._
 import controllers.FaciaControllerImpl
 import helpers.FaciaTestData
+import implicits.FakeRequests
+import org.mockito.Matchers.{any, anyString}
 import org.mockito.Mockito.when
-import org.mockito.Matchers.any
-import org.mockito.Matchers.anyString
+import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.JsArray
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
+import play.api.test.Helpers._
+import play.api.test._
+import services.{ConfigAgent, OphanApi}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 @DoNotDiscover class FaciaControllerTest
     extends AnyFlatSpec

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -1,7 +1,7 @@
 package test
 
 import agents.{DeeplyReadAgent, MostViewedAgent}
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.fasterxml.jackson.core.JsonParseException
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import common.editions.{Uk, Us}

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -1,7 +1,7 @@
 package metadata
 
 import agents.{DeeplyReadAgent, MostViewedAgent}
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import concurrent.BlockingOperations
 import conf.Configuration

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -1,9 +1,7 @@
 package metadata
 
 import agents.{DeeplyReadAgent, MostViewedAgent}
-import org.apache.pekko.actor.ActorSystem
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
-import concurrent.BlockingOperations
 import conf.Configuration
 import conf.switches.Switches.DCRFronts
 import controllers.FaciaControllerImpl
@@ -15,10 +13,10 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json._
 import play.api.test.Helpers._
 import services.{ConfigAgent, OphanApi}
-
-import scala.concurrent.duration._
-import scala.concurrent.Await
 import test._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 @DoNotDiscover class FaciaMetaDataTest
     extends AnyFlatSpec

--- a/facia/test/controllers/front/FrontHeadlineTest.scala
+++ b/facia/test/controllers/front/FrontHeadlineTest.scala
@@ -1,11 +1,12 @@
 package controllers.front
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import common.facia.FixtureBuilder
 import model.Cached.RevalidatableResult
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers
+import play.api.test.Helpers.defaultAwaitTimeout
 
 import scala.concurrent.duration._
 import scala.concurrent.Future

--- a/identity/app/AppLoader.scala
+++ b/identity/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import http.IdentityHttpErrorHandler
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
@@ -45,7 +45,7 @@ trait AppLifecycleComponents {
     wire[NewsletterSignupLifecycle],
   )
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }
 
 trait AppComponents

--- a/identity/app/AppLoader.scala
+++ b/identity/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import http.IdentityHttpErrorHandler
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import business.{StocksData, StocksDataLifecycle}
@@ -35,7 +35,7 @@ class AppLoader extends FrontendApplicationLoader {
 trait OnwardServices {
   def wsClient: WSClient
   def environment: Environment
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
   implicit def appContext: ApplicationContext
   implicit val executionContext: ExecutionContext
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
@@ -88,5 +88,5 @@ trait AppComponents extends FrontendComponents with OnwardControllers with Onwar
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import business.{StocksData, StocksDataLifecycle}

--- a/onward/app/business/StocksDataLifecycle.scala
+++ b/onward/app/business/StocksDataLifecycle.scala
@@ -1,6 +1,6 @@
 package business
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.LifecycleComponent
 import play.api.inject.ApplicationLifecycle
 
@@ -8,7 +8,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class StocksDataLifecycle(appLifecycle: ApplicationLifecycle, stocksData: StocksData)(implicit
     ec: ExecutionContext,
-    actorSystem: ActorSystem,
+    pekkoActorSystem: PekkoActorSystem,
 ) extends LifecycleComponent {
 
   appLifecycle.addStopHook { () =>

--- a/onward/app/business/StocksDataLifecycle.scala
+++ b/onward/app/business/StocksDataLifecycle.scala
@@ -1,6 +1,6 @@
 package business
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.LifecycleComponent
 import play.api.inject.ApplicationLifecycle
 

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import com.softwaremill.macwire._
 import weather.controllers.{LocationsController, WeatherController}
 import business.StocksData
@@ -30,7 +30,7 @@ trait OnwardControllers {
   def mostViewedVideoAgent: MostViewedVideoAgent
   def mostViewedGalleryAgent: MostViewedGalleryAgent
   def mostViewedAudioAgent: MostViewedAudioAgent
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
   def controllerComponents: ControllerComponents
   def remoteRenderer: DotcomRenderingService
   def popularInTagService: PopularInTagService

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.softwaremill.macwire._
 import weather.controllers.{LocationsController, WeatherController}
 import business.StocksData

--- a/onward/app/feed/MostPopularSocialAutoRefresh.scala
+++ b/onward/app/feed/MostPopularSocialAutoRefresh.scala
@@ -1,6 +1,6 @@
 package feed
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.LifecycleComponent
 import common.AutoRefresh
 import play.api.inject.ApplicationLifecycle
@@ -24,7 +24,7 @@ class MostPopularSocialAutoRefresh(ophanApi: OphanApi) extends AutoRefresh[MostR
 class MostPopularFacebookAutoRefreshLifecycle(
     appLifeCycle: ApplicationLifecycle,
     mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh,
-)(implicit ec: ExecutionContext, actorSystem: ActorSystem)
+)(implicit ec: ExecutionContext, pekkoActorSystem: PekkoActorSystem)
     extends LifecycleComponent {
 
   appLifeCycle.addStopHook { () =>

--- a/onward/app/feed/MostPopularSocialAutoRefresh.scala
+++ b/onward/app/feed/MostPopularSocialAutoRefresh.scala
@@ -1,6 +1,6 @@
 package feed
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.LifecycleComponent
 import common.AutoRefresh
 import play.api.inject.ApplicationLifecycle

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -2,7 +2,6 @@ package weather
 
 import java.net.{URI, URLEncoder}
 import java.util.concurrent.TimeoutException
-
 import org.apache.pekko.actor.{ActorSystem, Scheduler}
 import common.{GuLogging, ResourcesHelper}
 import conf.Configuration
@@ -16,10 +15,11 @@ import model.ApplicationContext
 import scala.concurrent.duration._
 import play.api.{MarkerContext, Mode}
 import net.logstash.logback.marker.Markers.append
+import org.apache.pekko.pattern.after
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-import akka.pattern.after
+
 
 class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: ActorSystem)(implicit
     ec: ExecutionContext,

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -20,7 +20,6 @@ import org.apache.pekko.pattern.after
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-
 class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: ActorSystem)(implicit
     ec: ExecutionContext,
 ) extends ResourcesHelper

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -3,7 +3,7 @@ package weather
 import java.net.{URI, URLEncoder}
 import java.util.concurrent.TimeoutException
 
-import akka.actor.{ActorSystem, Scheduler}
+import org.apache.pekko.actor.{ActorSystem, Scheduler}
 import common.{GuLogging, ResourcesHelper}
 import conf.Configuration
 import play.api.libs.json.{JsValue, Json}

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -2,7 +2,7 @@ package weather
 
 import java.net.{URI, URLEncoder}
 import java.util.concurrent.TimeoutException
-import org.apache.pekko.actor.{ActorSystem, Scheduler}
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem, Scheduler}
 import common.{GuLogging, ResourcesHelper}
 import conf.Configuration
 import play.api.libs.json.{JsValue, Json}
@@ -20,7 +20,7 @@ import org.apache.pekko.pattern.after
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: ActorSystem)(implicit
+class WeatherApi(wsClient: WSClient, context: ApplicationContext, pekkoActorSystem: PekkoActorSystem)(implicit
     ec: ExecutionContext,
 ) extends ResourcesHelper
     with GuLogging {
@@ -66,7 +66,7 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
     val weatherApiResponse: Future[JsValue] = WeatherApi.retryWeatherRequest(
       () => getJsonRequest(url),
       requestRetryDelay,
-      actorSystem.scheduler,
+      pekkoActorSystem.scheduler,
       requestRetryMax,
     )
     weatherApiResponse.failed.foreach {

--- a/onward/test/weather/WeatherApiTest.scala
+++ b/onward/test/weather/WeatherApiTest.scala
@@ -1,6 +1,6 @@
 package weather
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import org.scalatest.concurrent.ScalaFutures
 import play.api.libs.json.{JsString, JsValue}
 import org.mockito.Mockito._
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 import scala.language.postfixOps
 
 class WeatherApiTest extends AnyFlatSpec with ScalaFutures with Matchers with MockitoSugar {
-  val actorSystem = ActorSystem()
+  val actorSystem = PekkoActorSystem()
 
   "retryWeatherRequest" should "return for a successful future" in {
     val jsValue = JsString("Test")

--- a/onward/test/weather/WeatherApiTest.scala
+++ b/onward/test/weather/WeatherApiTest.scala
@@ -1,6 +1,6 @@
 package weather
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import org.scalatest.concurrent.ScalaFutures
 import play.api.libs.json.{JsString, JsValue}
 import org.mockito.Mockito._

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import agents.MostViewedAgent
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import agents.MostViewedAgent
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle
@@ -68,7 +68,7 @@ trait PreviewLifecycleComponents
       wire[MessageUsLifecycle],
     )
 
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }
 
 trait PreviewControllerComponents

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,9 +6,6 @@ object Dependencies {
   // Once we're able to upgrade identityLibVersion to >=4.10 we should
   // remove the http4s-core dependency eviction below. (Unless we've
   // started needing it for something else in the meantime.)
-  val pekkoVersion = "1.0.1"
-  val pekkoActor = "org.apache.pekko" %% "pekko-actor" % pekkoVersion
-  val pekkoStream = "org.apache.pekko" %% "pekko-stream" % pekkoVersion
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
   val capiVersion = "19.4.0"
@@ -75,6 +72,9 @@ object Dependencies {
   val jerseyClient = "com.sun.jersey" % "jersey-client" % jerseyVersion
   val w3cSac = "org.w3c.css" % "sac" % "1.3"
   val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "8.10.0"
+  val pekkoVersion = "1.0.1"
+  val pekkoActor = "org.apache.pekko" %% "pekko-actor" % pekkoVersion
+  val pekkoStream = "org.apache.pekko" %% "pekko-stream" % pekkoVersion
 
   val logback2 = "net.logstash.logback" % "logstash-logback-encoder" % "4.6"
   // logback2  to prevent "error: reference to logback is ambiguous;"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,9 @@ object Dependencies {
   // Once we're able to upgrade identityLibVersion to >=4.10 we should
   // remove the http4s-core dependency eviction below. (Unless we've
   // started needing it for something else in the meantime.)
+  val pekkoVersion = "1.0.1"
+  val pekkoActor = "org.apache.pekko" %% "pekko-actor" % pekkoVersion
+  val pekkoStream = "org.apache.pekko" %% "pekko-stream" % pekkoVersion
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
   val capiVersion = "19.4.0"

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import common._

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import common._
@@ -61,5 +61,5 @@ trait AppComponents extends FrontendComponents {
   val frontendBuildInfo: FrontendBuildInfo = frontend.rss.BuildInfo
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import akka.stream.Materializer
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -1,5 +1,5 @@
-import org.apache.pekko.actor.ActorSystem
-import akka.stream.Materializer
+
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
@@ -16,6 +16,7 @@ import football.controllers.{FootballControllers, HealthCheck}
 import http.{CommonFilters, CorsHttpErrorHandler}
 import jobs.CricketStatsJob
 import model.ApplicationIdentity
+import org.apache.pekko.stream.{Materializer => PekkoMaterializer}
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import play.api.http.{HttpErrorHandler, HttpRequestHandler}
@@ -39,8 +40,10 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait SportServices {
   def wsClient: WSClient
-  def actorSystem: ActorSystem
-  def materializer: Materializer
+  def pekkoActorSystem: PekkoActorSystem
+
+  def pekkoMaterializer: PekkoMaterializer = PekkoMaterializer.matFromSystem(pekkoActorSystem)
+
   implicit val executionContext: ExecutionContext
 
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
@@ -87,5 +90,5 @@ trait AppComponents
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
-  def actorSystem: ActorSystem
+  def pekkoActorSystem: PekkoActorSystem
 }

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -1,4 +1,3 @@
-
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._

--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -1,13 +1,15 @@
 package cricket.feed
 
+
+import org.apache.pekko.NotUsed
+import org.apache.pekko.pattern.{ask, pipe}
+import org.apache.pekko.stream.{CompletionStrategy, Materializer, OverflowStrategy, ThrottleMode}
+
 import java.util.concurrent.TimeUnit
-import akka.NotUsed
-import akka.actor.Status.{Failure, Success}
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import akka.pattern.{ask, pipe}
-import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.{CompletionStrategy, Materializer, OverflowStrategy, ThrottleMode}
-import akka.util.Timeout
+import org.apache.pekko.actor.{Actor, ActorRef, Props, ActorSystem => PekkoActorSystem}
+import org.apache.pekko.actor.Status.{Failure, Success}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.util.Timeout
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -40,8 +42,8 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
   }
 }
 
-class CricketThrottler(actorSystem: ActorSystem, materializer: Materializer) {
-  private val cricketThrottlerActor: ActorRef = actorSystem.actorOf(Props(new CricketThrottlerActor()(materializer)))
+class CricketThrottler(pekkoActorSystem: PekkoActorSystem, materializer: Materializer) {
+  private val cricketThrottlerActor: ActorRef = pekkoActorSystem.actorOf(Props(new CricketThrottlerActor()(materializer)))
 
   def throttle[T](task: () => Future[T])(implicit ec: ExecutionContext, tag: ClassTag[T]): Future[T] = {
     // we have a long timeout to allow for the large number of requests to be made when the app starts up, at 1s/request

--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -1,6 +1,5 @@
 package cricket.feed
 
-
 import org.apache.pekko.NotUsed
 import org.apache.pekko.pattern.{ask, pipe}
 import org.apache.pekko.stream.{CompletionStrategy, Materializer, OverflowStrategy, ThrottleMode}
@@ -43,7 +42,8 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
 }
 
 class CricketThrottler(pekkoActorSystem: PekkoActorSystem, materializer: Materializer) {
-  private val cricketThrottlerActor: ActorRef = pekkoActorSystem.actorOf(Props(new CricketThrottlerActor()(materializer)))
+  private val cricketThrottlerActor: ActorRef =
+    pekkoActorSystem.actorOf(Props(new CricketThrottlerActor()(materializer)))
 
   def throttle[T](task: () => Future[T])(implicit ec: ExecutionContext, tag: ClassTag[T]): Future[T] = {
     // we have a long timeout to allow for the large number of requests to be made when the app starts up, at 1s/request

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -1,6 +1,6 @@
 package conf.cricketPa
 
-import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import common.Chronos
 import common.GuLogging
 import cricket.feed.CricketThrottler
@@ -18,12 +18,12 @@ object PaFeed {
   val dateFormat = Chronos.dateFormatter("yyyy-MM-dd", ZoneId.of("UTC"))
 }
 
-class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends GuLogging {
+class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materializer: Materializer) extends GuLogging {
 
   private val paEndpoint = "https://cricket-api.guardianapis.com/v1"
   private val credentials = conf.SportConfiguration.pa.cricketKey.map { ("Apikey", _) }
   private val xmlContentType = ("Accept", "application/xml")
-  private implicit val throttler = new CricketThrottler(actorSystem, materializer)
+  private implicit val throttler = new CricketThrottler(pekkoActorSystem, materializer)
 
   private def getMatchPaResponse(apiMethod: String)(implicit executionContext: ExecutionContext): Future[String] = {
     credentials

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -1,6 +1,6 @@
 package conf.cricketPa
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import akka.stream.Materializer
 import common.Chronos
 import common.GuLogging

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -1,10 +1,11 @@
 package conf.cricketPa
 
+
 import org.apache.pekko.actor.ActorSystem
-import akka.stream.Materializer
 import common.Chronos
 import common.GuLogging
 import cricket.feed.CricketThrottler
+import org.apache.pekko.stream.Materializer
 
 import java.time.{LocalDate, ZoneId}
 import play.api.libs.ws.WSClient

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -1,6 +1,5 @@
 package conf.cricketPa
 
-
 import org.apache.pekko.actor.ActorSystem
 import common.Chronos
 import common.GuLogging


### PR DESCRIPTION
## What is the value of this and can you measure success?
Replaces explicit uses of Akka with Pekko equivalent. To bring us in line with licensing requirements and allow us to continue receiving security patches.

*I have left akka.stream.Materializer as from the [doc](https://docs.google.com/document/d/1gGYkt7OspuT_g2aQejJ4lNPUL3LtmeEywE-hbiP6lLQ/edit#heading=h.c6x2nrygx9jt) seems like we might be able to continue using these*

## What does this change?
Resolves https://github.com/guardian/dotcom-rendering/issues/8783

<!--
## Screenshots

 Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
