### PR TITLE
Add Ophan ESM experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,6 +15,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       Lightbox,
       ServerSideLiveblogInlineAds,
       EuropeNetworkFront,
+      OphanEsm,
       SectionFrontsBannerAds,
       HeaderTopBarSearchCapi,
       AdaptiveSite,
@@ -87,6 +88,15 @@ object HeaderTopBarSearchCapi
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 10, 10),
       participationGroup = Perc1B,
+    )
+
+object OphanEsm
+    extends Experiment(
+      name = "ophan-esm",
+      description = "Use ophan-tracker-js@2, which uses native ES Modules",
+      owners = Seq(Owner.withGithub("@guardian/ophan")),
+      sellByDate = LocalDate.of(2023, 10, 3),
+      participationGroup = Perc2A,
     )
 
 object OfferHttp3


### PR DESCRIPTION
## What is the value of this and can you measure success?

We can confidently release the v2 of `ophan-tracker-js` out of beta. See https://github.com/guardian/dotcom-rendering/pull/8593 for consumption.

## What does this change?

Enable a server-side test which checks that the ESM version works just as well as the previous RequireJS build

## Screenshots

N/A

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
