### PR TITLE
Upgrade DFP API to latest version

### DIFF
--- a/admin/app/dfp/AdUnitAgent.scala
+++ b/admin/app/dfp/AdUnitAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder
 import common.dfp.GuAdUnit
 import conf.Configuration
 import ApiHelper.toSeq

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202308._
 import common.GuLogging
 import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
 

--- a/admin/app/dfp/CustomFieldAgent.scala
+++ b/admin/app/dfp/CustomFieldAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.v202208.{CustomFieldValue, LineItem, TextValue}
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder
+import com.google.api.ads.admanager.axis.v202308.{CustomFieldValue, LineItem, TextValue}
 import common.dfp.GuCustomField
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/CustomTargetingAgent.scala
+++ b/admin/app/dfp/CustomTargetingAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.v202208.{CustomTargetingKey, CustomTargetingValue}
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder
+import com.google.api.ads.admanager.axis.v202308.{CustomTargetingKey, CustomTargetingValue}
 import common.GuLogging
 import common.dfp.{GuCustomTargeting, GuCustomTargetingValue}
 import concurrent.BlockingOperations

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202308._
 import common.dfp._
 import dfp.ApiHelper.{isPageSkin, optJavaInt, toJodaTime, toSeq}
 

--- a/admin/app/dfp/DataValidation.scala
+++ b/admin/app/dfp/DataValidation.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202308._
 import common.dfp._
 import dfp.ApiHelper.toSeq
 

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -2,8 +2,8 @@ package dfp
 
 // StatementBuilder query language is PQL defined here:
 // https://developers.google.com/ad-manager/api/pqlreference
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder
+import com.google.api.ads.admanager.axis.v202308._
 import com.madgag.scala.collection.decorators.MapDecorator
 import common.GuLogging
 import common.dfp._

--- a/admin/app/dfp/PlacementAgent.scala
+++ b/admin/app/dfp/PlacementAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder
 import common.dfp.GuAdUnit
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/Reader.scala
+++ b/admin/app/dfp/Reader.scala
@@ -1,8 +1,8 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder.SUGGESTED_PAGE_LIMIT
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder.SUGGESTED_PAGE_LIMIT
+import com.google.api.ads.admanager.axis.v202308._
 
 import scala.annotation.tailrec
 

--- a/admin/app/dfp/ServicesWrapper.scala
+++ b/admin/app/dfp/ServicesWrapper.scala
@@ -1,7 +1,7 @@
 package dfp
 
 import com.google.api.ads.admanager.axis.factory.AdManagerServices
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202308._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 
 private[dfp] class ServicesWrapper(session: AdManagerSession) {

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder
+import com.google.api.ads.admanager.axis.v202308._
 import common.GuLogging
 
 import scala.util.control.NonFatal

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -2,8 +2,8 @@ package dfp
 
 import com.google.api.ads.common.lib.auth.OfflineCredentials
 import com.google.api.ads.common.lib.auth.OfflineCredentials.Api
-import com.google.api.ads.admanager.axis.utils.v202208.{ReportDownloader, StatementBuilder}
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.utils.v202308.{ReportDownloader, StatementBuilder}
+import com.google.api.ads.admanager.axis.v202308._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 import com.google.common.io.CharSource
 import common.GuLogging

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -3,10 +3,10 @@ package jobs
 import java.time.{LocalDate, LocalDateTime}
 
 import app.LifecycleComponent
-import com.google.api.ads.admanager.axis.v202208.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
-import com.google.api.ads.admanager.axis.v202208.DateRangeType.CUSTOM_DATE
-import com.google.api.ads.admanager.axis.v202208.Dimension.{CUSTOM_CRITERIA, DATE}
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202308.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
+import com.google.api.ads.admanager.axis.v202308.DateRangeType.CUSTOM_DATE
+import com.google.api.ads.admanager.axis.v202308.Dimension.{CUSTOM_CRITERIA, DATE}
+import com.google.api.ads.admanager.axis.v202308._
 import common.{AkkaAsync, Box, JobScheduler, GuLogging}
 import dfp.DfpApi
 import play.api.inject.ApplicationLifecycle

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -2,7 +2,7 @@ package dfp
 
 import concurrent.BlockingOperations
 import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
-import com.google.api.ads.admanager.axis.v202208._
+import com.google.api.ads.admanager.axis.v202308._
 import org.joda.time.DateTime
 import akka.actor.ActorSystem
 import org.scalatest.flatspec.AnyFlatSpec

--- a/admin/test/dfp/ReaderTest.scala
+++ b/admin/test/dfp/ReaderTest.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202308.StatementBuilder
 import dfp.Reader.read
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.5"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "4.20.0"
+  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.2.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play27" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion


### PR DESCRIPTION
Co-authored-by: @chrislomaxjones

## What is the value of this and can you measure success?
The current DFP API version has been depreciated, leading to error messages and failed API requests. Updating the API version should resolve these.

## What does this change?
Updates the `dfp-axis` package to the latest version, `5.2.0`, and updates the code to use the DFP API version `v202308`. This version is supported until August 2024.

The depreciation schedule can be found [here](https://developers.google.com/ad-manager/api/deprecation).

The API was last updated in this PR: https://github.com/guardian/frontend/pull/25586

## Screenshots

When testing the upgraded API version on CODE, we observed that the API exception errors stopped when the upgrade was deployed:

![Screenshot 2023-09-06 at 15 38 51](https://github.com/guardian/frontend/assets/108270776/c876be8f-900d-49f7-833f-825820850f43)

We also checked that the inline-merchandise targeting and non-refreshable line items were being updated from the API as expected.
