### PR TITLE
Fix Prebid entry in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10494,7 +10494,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-"prebid.js@github:guardian/prebid.js#b8263f2":
+prebid.js@guardian/prebid.js#b8263f2:
   version "7.54.4"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/b8263f2e041833b0ec0d05d14de6c3f1bdd466ff"
   dependencies:


### PR DESCRIPTION
## What is the value of this and can you measure success?

Snyk seems to fail when encountering this entry in the yarn.lock file.

## What does this change?

Fix the yarn.lock Prebid.js entry by running the following locally:

```
yarn cache clean prebid.js
yarn install --force
```
