### PR TITLE
Ab test for sign in gate

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -77,7 +77,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-copy-test-jan-2023",
+    "ab-sign-in-gate-copy-test-repeat-sept-2023",
     "Test the impact of changing the copy in the sign in gate",
     owners = Seq(Owner.withEmail("personalisation@guardian.co.uk")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -8,7 +8,7 @@ import { liveblogRightColumnAds } from './tests/liveblog-right-column-ads';
 import { prebidKargo } from './tests/prebid-kargo';
 import { publicGoodTest } from './tests/public-good';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
-import { signInGateCopyTestJan2023 } from './tests/sign-in-gate-copy-test-variant';
+import { signInGateCopyTestRepeatSept2023} from './tests/sign-in-gate-copy-test-variant';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 
@@ -17,7 +17,7 @@ import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
-	signInGateCopyTestJan2023,
+	signInGateCopyTestRepeatSept2023,
 	remoteRRHeaderLinksTest,
 	deeplyReadArticleFooterTest,
 	consentlessAds,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -8,7 +8,7 @@ import { liveblogRightColumnAds } from './tests/liveblog-right-column-ads';
 import { prebidKargo } from './tests/prebid-kargo';
 import { publicGoodTest } from './tests/public-good';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
-import { signInGateCopyTestRepeatSept2023} from './tests/sign-in-gate-copy-test-variant';
+import { signInGateCopyTestRepeatSept2023 } from './tests/sign-in-gate-copy-test-variant';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
@@ -1,7 +1,7 @@
-export const signInGateCopyTestJan2023 = {
-	id: 'SignInGateCopyTestJan2023',
+export const signInGateCopyTestRepeatSept2023 = {
+	id: 'SignInGateCopyTestRepeatSept2023',
 	start: '2023-08-30',
-	expiry: '2023-09-14',
+	expiry: '2023-10-01',
 	author: 'Lindsey Dew',
 	description: 'Test varying the copy in the call to action for sign in gate',
 	audience: 1.0,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
@@ -8,7 +8,7 @@ export const signInGateCopyTestRepeatSept2023 = {
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria: '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-	dataLinkNames: 'SignInGateCopyTest',
+	dataLinkNames: 'SignInGateCopyTestRepeatSept2023',
 	idealOutcome:
 		'One variants performs at least 2% better than the control and/OR 10% better than the other variant. Neither variant performs 5% worse than the control',
 	showForSensitive: false,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
@@ -1,10 +1,10 @@
 export const signInGateCopyTestRepeatSept2023 = {
 	id: 'SignInGateCopyTestRepeatSept2023',
 	start: '2023-08-30',
-	expiry: '2023-10-01',
+	expiry: '2025-12-01',
 	author: 'Lindsey Dew',
 	description: 'Test varying the copy in the call to action for sign in gate',
-	audience: 1.0,
+	audience: 0.9,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria: '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-test-variant.js
@@ -1,10 +1,10 @@
 export const signInGateCopyTestJan2023 = {
 	id: 'SignInGateCopyTestJan2023',
-	start: '2023-01-23',
-	expiry: '2023-07-03',
+	start: '2023-08-30',
+	expiry: '2023-09-14',
 	author: 'Lindsey Dew',
 	description: 'Test varying the copy in the call to action for sign in gate',
-	audience: 0.0,
+	audience: 1.0,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria: '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
@@ -22,9 +22,5 @@ export const signInGateCopyTestJan2023 = {
 			id: 'take-a-moment',
 			test: () => {},
 		},
-		{
-			id: 'sign-in-copy-control',
-			test: () => {}
-		}
 	],
 };


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
This adds a switch for the sign in copy test for the sign in gate. Corresponding DCR PR: https://github.com/guardian/dotcom-rendering/pull/8766

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
