### PR TITLE
Allow controlling the EuropeNetworkFront via a Switch

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -1,5 +1,6 @@
 package common
 
+import conf.switches.Switches.EuropeNetworkFrontSwitch
 import navigation.EditionNavLinks
 
 import java.util.Locale
@@ -48,7 +49,8 @@ object Edition {
 
   lazy val defaultEdition: Edition = editions.Uk
   def editionsByRequest(implicit request: RequestHeader): List[Edition] = {
-    val participatingInTest = ActiveExperiments.isParticipating(EuropeNetworkFront)
+    val participatingInTest =
+      ActiveExperiments.isParticipating(EuropeNetworkFront) || EuropeNetworkFrontSwitch.isSwitchedOn
     if (!participatingInTest) all else allWithBetaEditions
   }
   def editionsSupportingSection(sectionId: String): Seq[Edition] =

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -542,4 +542,13 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
+  val EuropeNetworkFrontSwitch = Switch(
+    SwitchGroup.Feature,
+    "europe-network-front-switch",
+    "Test new europe network front",
+    owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -17,7 +17,7 @@ import services.{CollectionConfigWithId, ConfigAgent}
 import layout.slices._
 import views.html.fragments.containers.facia_cards.container
 import views.support.FaciaToMicroFormat2Helpers.getCollection
-import conf.switches.Switches.InlineEmailStyles
+import conf.switches.Switches.{EuropeNetworkFrontSwitch, InlineEmailStyles}
 import implicits.GUHeaders
 import pages.{FrontEmailHtmlPage, FrontHtmlPage}
 import utils.TargetedCollections
@@ -206,7 +206,8 @@ trait FaciaController
 
   import PressedPage.pressedPageFormat
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader): Future[Result] = {
-    val participatingInTest = ActiveExperiments.isParticipating(EuropeNetworkFront)
+    val participatingInTest =
+      ActiveExperiments.isParticipating(EuropeNetworkFront) || EuropeNetworkFrontSwitch.isSwitchedOn
     if (path == "europe" && !participatingInTest) {
       return successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
     }


### PR DESCRIPTION
## What does this change?

Adds a new switch for Europe Edition. This is addition to the already existing experiment.

_The experiment allows users from Editorial to opt in before release, we will not be doing an incremental release of the Europe front so once we go live it'll be by turning the switch on_
