### PR TITLE
Fallback to International edition if Fastly thinks users should be in Europe edition and switch not enabled yet.

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -90,7 +90,7 @@ object Edition {
       .orElse(editionFromCookie)
       // Fastly does not have switch information so we will always try and set the edition to Europe
       // if a user is in CoE and then fallback to INT edition in Frontend if that user is not part of the experiment.
-      .map(edition => if (edition.equals("EUR") && !participatingInTest) "INT" else edition)
+      .map(edition => if (edition == "EUR" && !participatingInTest) "INT" else edition)
       .getOrElse(defaultEdition.id)
   }
 

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -82,9 +82,15 @@ object Edition {
     // in production no cookies make it this far
     val editionFromCookie = request.cookies.get("GU_EDITION").map(_.value)
 
+    val participatingInTest =
+      ActiveExperiments.isParticipating(EuropeNetworkFront)(request) || EuropeNetworkFrontSwitch.isSwitchedOn
+
     editionFromParameter
       .orElse(editionFromHeader)
       .orElse(editionFromCookie)
+      // Fastly does not have switch information so we will always try and set the edition to Europe
+      // if a user is in CoE and then fallback to INT edition in Frontend if that user is not part of the experiment.
+      .map(edition => if (edition.equals("EUR") && !participatingInTest) "INT" else edition)
       .getOrElse(defaultEdition.id)
   }
 


### PR DESCRIPTION
## What does this change?

When Fastly tells us the user is in the Europe edition fallback to the international edition if the Europe Switch/Experiment is off.

Fastly is not able to tell which Switches are on are off, so Fastly just considers the Europe switch to always be on and lets Frontend deal with the consequences.

Frontend falls back to the UK edition if it doesn't recognize the Fastly provided edition, this is not ideal as when we merge our VCL PR a bunch of people that had previously been seeing the International edition would suddenly start seeing the UK edition.


Required for https://github.com/guardian/fastly-edge-cache/pull/1006 to be merged.
Part of https://github.com/guardian/platform/issues/1543

## Screenshots

Simulated locally by forcing the `X-GU-Edition` header to `EUR`

| Before      | After (Switch Off)      | After (Switch On) |
|-------------|------------|--|
| ![before][] | ![after][] | ![after2][] |

[before]: https://github.com/guardian/frontend/assets/21217225/ab4f0d8c-5993-4925-9ede-5e3e4a95a277
[after]: https://github.com/guardian/frontend/assets/21217225/818a4e25-603b-43e3-845a-04d6d7a06f71
[after2]: https://github.com/guardian/frontend/assets/21217225/9ddd7a10-0cd4-4883-994a-e794fbf1003e

