### PR TITLE
Sets Ophan ESM to 50 percent participationGroup

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -96,7 +96,7 @@ object OphanEsm
       description = "Use ophan-tracker-js@2, which uses native ES Modules",
       owners = Seq(Owner.withGithub("@guardian/ophan")),
       sellByDate = LocalDate.of(2023, 10, 3),
-      participationGroup = Perc2A,
+      participationGroup = Perc50,
     )
 
 object OfferHttp3

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -123,5 +123,5 @@ object DeeplyRead
       description = "When ON, deeply read footer section is displayed",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 10, 31),
-      participationGroup = Perc50,
+      participationGroup = Perc0A,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?
This works continues from #26564, and set the participant group to 50% instead of 2%. The intention is to run this experiment for at east two weeks with a 50% split, allowing @guardian/data-journalism to check the results for any discrepancies which might need resolving. 

Our agreed approach is:

> We decided to look at whether we are seeing the amount of browsers that we'd expect with the chosen sampling, rather than a significance test on page views per group.
> 
> We've had a look at some previous 50/50 server side tests to try to get an idea of how much the samples deviate. From what I can see, there is a bit of variation (up to 0.64%), but there may well be cases where the samples deviate more than that.
> 
> It seems therefore to test for statistical significance would be difficult, particularly if you'd like to detect a 0.1% impact.
> 
> After speaking through this with my team, we've agreed that the best way forward would be to go ahead and implement the new tracker on 50% of browsers, and closely monitor the data, with attention to a split by browser (eg microsoft edge. etc).

AND

> It is difficult to give a set amount of time as in this case we don't have the metrics necessary to calculate a minimum sample size. I think we would need at least two weeks if we use the maximum possible proportion of the population.

## What does this change?

Sets the Ophan-ESM test percentage to 50%

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
