### PR TITLE
Use equalsIgnoreCase and use editions objects instead of hardcoded st…

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -90,7 +90,9 @@ object Edition {
       .orElse(editionFromCookie)
       // Fastly does not have switch information so we will always try and set the edition to Europe
       // if a user is in CoE and then fallback to INT edition in Frontend if that user is not part of the experiment.
-      .map(edition => if (edition == "EUR" && !participatingInTest) "INT" else edition)
+      .map(edition =>
+        if (edition.equalsIgnoreCase(editions.Europe.id) && !participatingInTest) editions.International.id else edition,
+      )
       .getOrElse(defaultEdition.id)
   }
 


### PR DESCRIPTION
## What does this change?

Use `equalsIgnoreCase` instead of `==`. I think this would have caused quite a big bug with all EU edition users being defaulted to International if we had merged the VCL changes. When testing locally I setting the `X-GU-Edition` header to uppercase, like the cookie, but Fastly actually sets this header to a lowercase value.

Also uses Edition IDs instead of hardcoding Strings.
