### PR TITLE
Add soccer to usNewsPillar

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -299,6 +299,7 @@ object NavLinks {
       world,
       usEnvironment,
       usPolitics,
+      soccer,
       usBusiness,
       tech,
       science,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -916,6 +916,47 @@
                 "children" : [ ],
                 "classList" : [ ]
             }, {
+                "title" : "Soccer",
+                "url" : "/soccer",
+                "children" : [ {
+                    "title" : "Live scores",
+                    "url" : "/football/live",
+                    "longTitle" : "football/live",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Tables",
+                    "url" : "/football/tables",
+                    "longTitle" : "football/tables",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Fixtures",
+                    "url" : "/football/fixtures",
+                    "longTitle" : "football/fixtures",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Results",
+                    "url" : "/football/results",
+                    "longTitle" : "football/results",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Competitions",
+                    "url" : "/football/competitions",
+                    "longTitle" : "football/competitions",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Clubs",
+                    "url" : "/football/teams",
+                    "longTitle" : "football/teams",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            }, {
                 "title" : "Business",
                 "url" : "/business",
                 "children" : [ {


### PR DESCRIPTION
## What is the value of this and can you measure success?
Adds soccer to usNewsPillar.
## What does this change?
Requested by CP.
## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/110032454/ec438c8f-3a85-46a5-a79b-2c3c6726a8e6
[after]: https://github.com/guardian/frontend/assets/110032454/63f52bd0-6fdf-430f-8da9-2cabb9ab9d97



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
