### PR TITLE
Bump commercial to 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^14.1.1",
-		"@guardian/commercial": "11.8.1",
+		"@guardian/commercial": "11.9.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,10 +1556,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-14.1.1.tgz#12672e3992ad3eab3bade848861ca01631a0edf5"
   integrity sha512-wHuJwdOC2hsTBie+zWJYFyasP4fOJXOPcKXpN2Cp+GlljPah3YtS2Fbgn8pcxxt8d5JKO9ra7sHKvX8FNxkAyg==
 
-"@guardian/commercial@11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.8.1.tgz#ba4f85bcfe2ba9660910e475bb1b78bde6801765"
-  integrity sha512-Bpzxg5G8I+ox2NsgqDSm0JygiOLgBndWLF+a+dTKM8kmiKIZtRTbLcqK5lVPSprHc5HaInWyC7/f/ebJbYQlnA==
+"@guardian/commercial@11.9.0":
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.9.0.tgz#8f8ee116cd6b8fd228d15f53be0480639c13f258"
+  integrity sha512-GFdg3hsVhDcUQnmXZgcVsKtq4DbfSKeZw4mTUqaL8NQ3fO3QRvhP3tS5cQGqSu6p7K+dzaThVveMHbXekbLcFA==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
Bring in the changes from [11.9.0](https://github.com/guardian/commercial/releases/tag/v11.9.0)