### PR TITLE
Update SurveySwitch description

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -19,7 +19,7 @@ trait CommercialSwitches {
   val SurveySwitch = Switch(
     Commercial,
     "surveys",
-    "For delivering surveys, enables the requesting of the out-of-page slot on non-fronts",
+    "For delivering surveys, enables the requesting of the out-of-page slot on non-fronts. Switch OFF if there are no surveys active in GAM",
     owners = Seq(Owner.withName("unknown")),
     safeState = Off,
     sellByDate = never,


### PR DESCRIPTION
## What is the value of this and can you measure success?

Documents how the `SurveySwitch` is being used, as it is not clear. The switch was implemented in #16971.

The Survey launches from a dedicated 'out of page' (OOP) slot which is present on almost all pages. 

Turning off the switch when we don't have a survey to run reduces the amount of unfilled impressions, which we would otherwise have to pay for.

## What does this change?

Adds a description of when the switch ought to be turned OFF.

