### PR TITLE
Update to fapi-client v4.0.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
   val capiVersion = "19.4.0"
-  val faciaVersion = "4.0.5"
+  val faciaVersion = "4.0.6"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -36,7 +36,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.2.0"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play27" % faciaVersion
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play28" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % identityLibVersion


### PR DESCRIPTION
This is a small upgrade, catching up with the recent dependency updates of https://github.com/guardian/facia-scala-client/releases/tag/v4.0.6, before the more extensive update in https://github.com/guardian/facia-scala-client/pull/287 is introduced.

This update has already been tested in Ophan's PromotionPoller with https://github.com/guardian/ophan/pull/5540, successfully deployed to Prodution.

Note that as https://github.com/guardian/frontend is _already_ using Play 2.8, it should probably be using `fapi-client-play28`, rather than `fapi-client-play27`, so I've also updated that.
