### PR TITLE
refactor(akka): update config and refactor names

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -35,7 +35,7 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait AdminServices extends I18nComponents {
   def wsClient: WSClient
-  def akkaAsync: AkkaAsync
+  def pekkoAsync: PekkoAsync
   def pekkoActorSystem: PekkoActorSystem
   implicit val executionContext: ExecutionContext
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]

--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -1,6 +1,6 @@
 package controllers
 import com.softwaremill.macwire._
-import common.AkkaAsync
+import common.PekkoAsync
 import controllers.admin._
 import controllers.admin.commercial._
 import controllers.cache.{ImageDecacheController, PageDecacheController}
@@ -12,7 +12,7 @@ import play.api.mvc.ControllerComponents
 import services.{OphanApi, ParameterStoreService, RedirectService}
 
 trait AdminControllers {
-  def akkaAsync: AkkaAsync
+  def pekkoAsync: PekkoAsync
   def wsClient: WSClient
   def ophanApi: OphanApi
   implicit def appContext: ApplicationContext

--- a/admin/app/controllers/FrontPressController.scala
+++ b/admin/app/controllers/FrontPressController.scala
@@ -1,11 +1,11 @@
 package controllers
 
-import common.{AkkaAsync, ImplicitControllerExecutionContext, GuLogging}
+import common.{PekkoAsync, ImplicitControllerExecutionContext, GuLogging}
 import jobs.{HighFrequency, LowFrequency, RefreshFrontsJob, StandardFrequency}
 import model.ApplicationContext
 import play.api.mvc._
 
-class FrontPressController(akkaAsync: AkkaAsync, val controllerComponents: ControllerComponents)(implicit
+class FrontPressController(pekkoAsync: PekkoAsync, val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
     with GuLogging
@@ -18,7 +18,7 @@ class FrontPressController(akkaAsync: AkkaAsync, val controllerComponents: Contr
 
   def queueAllFrontsForPress(): Action[AnyContent] =
     Action { implicit request =>
-      RefreshFrontsJob.runAll(akkaAsync) match {
+      RefreshFrontsJob.runAll(pekkoAsync) match {
         case Some(l) => Ok(s"Pushed ${l.length} fronts to the SQS queue")
         case None    => InternalServerError("Could not push to the SQS queue, is there an SNS topic set? (frontPressSns)")
       }
@@ -26,17 +26,17 @@ class FrontPressController(akkaAsync: AkkaAsync, val controllerComponents: Contr
 
   def queueHighFrequencyFrontsForPress(): Action[AnyContent] =
     Action { implicit request =>
-      runJob(RefreshFrontsJob.runFrequency(akkaAsync)(HighFrequency), "high frequency")
+      runJob(RefreshFrontsJob.runFrequency(pekkoAsync)(HighFrequency), "high frequency")
     }
 
   def queueStandardFrequencyFrontsForPress(): Action[AnyContent] =
     Action { implicit request =>
-      runJob(RefreshFrontsJob.runFrequency(akkaAsync)(StandardFrequency), "standard frequency")
+      runJob(RefreshFrontsJob.runFrequency(pekkoAsync)(StandardFrequency), "standard frequency")
     }
 
   def queueLowFrequencyFrontsForPress(): Action[AnyContent] =
     Action { implicit request =>
-      runJob(RefreshFrontsJob.runFrequency(akkaAsync)(LowFrequency), "low frequency")
+      runJob(RefreshFrontsJob.runFrequency(pekkoAsync)(LowFrequency), "low frequency")
     }
 
   private def runJob(didRun: Boolean, jobName: String): Result = {

--- a/admin/app/controllers/admin/InteractiveLibrarianController.scala
+++ b/admin/app/controllers/admin/InteractiveLibrarianController.scala
@@ -1,6 +1,6 @@
 package controllers.admin
 
-import common.{AkkaAsync, GuLogging, ImplicitControllerExecutionContext}
+import common.{PekkoAsync, GuLogging, ImplicitControllerExecutionContext}
 import conf.switches.Switches.ContentPresser
 import model.ApplicationContext
 import play.api.libs.ws.WSClient
@@ -11,7 +11,7 @@ import scala.concurrent.Future
 
 class InteractiveLibrarianController(
     wsClient: WSClient,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController

--- a/admin/app/controllers/admin/R2PressController.scala
+++ b/admin/app/controllers/admin/R2PressController.scala
@@ -1,6 +1,6 @@
 package controllers.admin
 
-import common.{AkkaAsync, GuLogging, ImplicitControllerExecutionContext}
+import common.{PekkoAsync, GuLogging, ImplicitControllerExecutionContext}
 import model.{ApplicationContext, R2PressMessage}
 import play.api.mvc._
 import services.{R2PagePressNotifier, R2PressedPageTakedownNotifier, RedirectService}
@@ -10,7 +10,7 @@ import java.net.URL
 import scala.util.Try
 
 class R2PressController(
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
@@ -90,7 +90,7 @@ class R2PressController(
 
   private def normaliseAndEnqueueTakedown(url: String): String = {
     getVariations(url) match {
-      case Some(urls) => urls.map(u => R2PressedPageTakedownNotifier.enqueue(akkaAsync)(u)).mkString("\n")
+      case Some(urls) => urls.map(u => R2PressedPageTakedownNotifier.enqueue(pekkoAsync)(u)).mkString("\n")
       case None       => s"$url not recognised as a valid url."
     }
   }
@@ -98,7 +98,7 @@ class R2PressController(
   def normaliseAndEnqueuePress(message: R2PressMessage): String = {
     val tryUrl = RedirectService.normaliseURL(message.url)
     tryUrl match {
-      case Some(url) => R2PagePressNotifier.enqueue(akkaAsync)(message.copy(url = url))
+      case Some(url) => R2PagePressNotifier.enqueue(pekkoAsync)(message.copy(url = url))
       case None      => s"${message.url} not recognised as a valid url."
     }
   }

--- a/admin/app/controllers/admin/SwitchboardController.scala
+++ b/admin/app/controllers/admin/SwitchboardController.scala
@@ -11,7 +11,7 @@ import tools.Store
 
 import scala.concurrent.Future
 
-class SwitchboardController(akkaAsync: AkkaAsync, val controllerComponents: ControllerComponents)(implicit
+class SwitchboardController(pekkoAsync: PekkoAsync, val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
     with GuLogging
@@ -80,7 +80,7 @@ class SwitchboardController(akkaAsync: AkkaAsync, val controllerComponents: Cont
       log.info("switches successfully updated")
 
       val changes = updates filterNot { current contains _ }
-      SwitchNotification.onSwitchChanges(akkaAsync)(requester, Configuration.environment.stage, changes)
+      SwitchNotification.onSwitchChanges(pekkoAsync)(requester, Configuration.environment.stage, changes)
       changes foreach { change =>
         log.info(s"Switch change by $requester: $change")
       }

--- a/admin/app/dfp/DfpAdUnitCacheJob.scala
+++ b/admin/app/dfp/DfpAdUnitCacheJob.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import common.{AkkaAsync, GuLogging}
+import common.{PekkoAsync, GuLogging}
 import conf.Configuration
 import tools.Store
 
@@ -8,9 +8,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class DfpAdUnitCacher(val rootAdUnit: Any, val filename: String, dfpApi: DfpApi) extends GuLogging {
 
-  def run(akkaAsync: AkkaAsync)(implicit executionContext: ExecutionContext): Future[Unit] =
+  def run(pekkoAsync: PekkoAsync)(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {
-      akkaAsync {
+      pekkoAsync {
         val adUnits = dfpApi.readActiveAdUnits(rootAdUnit.toString)
         if (adUnits.nonEmpty) {
           val rows = adUnits.map(adUnit => s"${adUnit.id},${adUnit.path.mkString(",")}")

--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -23,7 +23,7 @@ class DfpDataCacheLifecycle(
     dfpMobileAppAdUnitCacheJob: DfpMobileAppAdUnitCacheJob,
     dfpFacebookIaAdUnitCacheJob: DfpFacebookIaAdUnitCacheJob,
     dfpTemplateCreativeCacheJob: DfpTemplateCreativeCacheJob,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent {
 
@@ -75,17 +75,17 @@ class DfpDataCacheLifecycle(
     new Job[Unit] {
       val name: String = "DFP-Ad-Units-Update"
       val interval: Int = 60
-      def run(): Future[Unit] = dfpAdUnitCacheJob.run(akkaAsync)
+      def run(): Future[Unit] = dfpAdUnitCacheJob.run(pekkoAsync)
     },
     new Job[Unit] {
       val name: String = "DFP-Mobile-Apps-Ad-Units-Update"
       val interval: Int = 60
-      def run(): Future[Unit] = dfpMobileAppAdUnitCacheJob.run(akkaAsync)
+      def run(): Future[Unit] = dfpMobileAppAdUnitCacheJob.run(pekkoAsync)
     },
     new Job[Unit] {
       val name: String = "DFP-Facebook-IA-Ad-Units-Update"
       val interval: Int = 60
-      def run(): Future[Unit] = dfpFacebookIaAdUnitCacheJob.run(akkaAsync)
+      def run(): Future[Unit] = dfpFacebookIaAdUnitCacheJob.run(pekkoAsync)
     },
     new Job[Seq[GuCreativeTemplate]] {
       val name: String = "DFP-Creative-Templates-Update"
@@ -114,7 +114,7 @@ class DfpDataCacheLifecycle(
       }
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       dfpDataCacheJob.refreshAllDfpData()
       creativeTemplateAgent.refresh()
       dfpTemplateCreativeCacheJob.run()

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -7,7 +7,7 @@ import com.google.api.ads.admanager.axis.v202308.Column.{AD_SERVER_IMPRESSIONS, 
 import com.google.api.ads.admanager.axis.v202308.DateRangeType.CUSTOM_DATE
 import com.google.api.ads.admanager.axis.v202308.Dimension.{CUSTOM_CRITERIA, DATE}
 import com.google.api.ads.admanager.axis.v202308._
-import common.{AkkaAsync, Box, JobScheduler, GuLogging}
+import common.{PekkoAsync, Box, JobScheduler, GuLogging}
 import dfp.DfpApi
 import play.api.inject.ApplicationLifecycle
 
@@ -86,7 +86,7 @@ object CommercialDfpReporting extends GuLogging {
 class CommercialDfpReportingLifecycle(
     appLifecycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     dfpApi: DfpApi,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -17,7 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AdminLifecycle(
     appLifecycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     emailService: EmailService,
     fastlyCloudwatchLoadJob: FastlyCloudwatchLoadJob,
     r2PagePressJob: R2PagePressJob,
@@ -68,17 +68,18 @@ class AdminLifecycle(
     }
 
     jobs.scheduleEveryNMinutes("FrontPressJobHighFrequency", adminPressJobHighPushRateInMinutes) {
-      if (FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(akkaAsync)(HighFrequency)
+      if (FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(pekkoAsync)(HighFrequency)
       Future.successful(())
     }
 
     jobs.scheduleEveryNMinutes("FrontPressJobStandardFrequency", adminPressJobStandardPushRateInMinutes) {
-      if (FrontPressJobSwitchStandardFrequency.isSwitchedOn) RefreshFrontsJob.runFrequency(akkaAsync)(StandardFrequency)
+      if (FrontPressJobSwitchStandardFrequency.isSwitchedOn)
+        RefreshFrontsJob.runFrequency(pekkoAsync)(StandardFrequency)
       Future.successful(())
     }
 
     jobs.scheduleEveryNMinutes("FrontPressJobLowFrequency", adminPressJobLowPushRateInMinutes) {
-      if (FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(akkaAsync)(LowFrequency)
+      if (FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(pekkoAsync)(LowFrequency)
       Future.successful(())
     }
     //every 2, 17, 32, 47 minutes past the hour, on the 9th second past the minute (e.g 13:02:09, 13:17:09)
@@ -122,7 +123,7 @@ class AdminLifecycle(
     descheduleJobs()
     scheduleJobs()
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       rebuildIndexJob.run()
       AssetMetricsCache.run()
       LoadBalancer.refresh()

--- a/admin/app/services/R2PagePressNotifier.scala
+++ b/admin/app/services/R2PagePressNotifier.scala
@@ -1,6 +1,6 @@
 package services
 
-import common.{AkkaAsync, GuLogging}
+import common.{PekkoAsync, GuLogging}
 import implicits.R2PressNotification.pressMessageFormatter
 import model.R2PressMessage
 import play.api.libs.json.Json
@@ -9,9 +9,9 @@ import scala.concurrent.ExecutionContext
 
 object R2PagePressNotifier extends GuLogging {
 
-  def enqueue(akkaAsync: AkkaAsync)(message: R2PressMessage)(implicit executionContext: ExecutionContext): String = {
+  def enqueue(pekkoAsync: PekkoAsync)(message: R2PressMessage)(implicit executionContext: ExecutionContext): String = {
     try {
-      R2PressNotification.sendWithoutSubject(akkaAsync)(Json.toJson[R2PressMessage](message).toString())
+      R2PressNotification.sendWithoutSubject(pekkoAsync)(Json.toJson[R2PressMessage](message).toString())
       val msg = s"Queued for pressing: ${message.url}."
       log.info(msg)
       msg

--- a/admin/app/services/R2PressedPageTakedownNotifier.scala
+++ b/admin/app/services/R2PressedPageTakedownNotifier.scala
@@ -1,14 +1,14 @@
 package services
 
-import common.{AkkaAsync, GuLogging}
+import common.{PekkoAsync, GuLogging}
 
 import scala.concurrent.ExecutionContext
 
 object R2PressedPageTakedownNotifier extends GuLogging {
 
-  def enqueue(akkaAsync: AkkaAsync)(path: String)(implicit executionContext: ExecutionContext): String = {
+  def enqueue(pekkoAsync: PekkoAsync)(path: String)(implicit executionContext: ExecutionContext): String = {
     try {
-      R2PressedPageTakedownNotification.sendWithoutSubject(akkaAsync)(path)
+      R2PressedPageTakedownNotification.sendWithoutSubject(pekkoAsync)(path)
       val msg = s"Queued for takedown: $path"
       log.info(msg)
       msg

--- a/admin/conf/application.conf
+++ b/admin/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/applications/app/jobs/SitemapLifecycle.scala
+++ b/applications/app/jobs/SitemapLifecycle.scala
@@ -7,8 +7,9 @@ import services.{NewsSiteMap, VideoSiteMap}
 
 import scala.concurrent.ExecutionContext
 
-class SiteMapLifecycle(jobs: JobScheduler, akkaAsync: AkkaAsync, siteMapJob: SiteMapJob)(implicit ec: ExecutionContext)
-    extends LifecycleComponent {
+class SiteMapLifecycle(jobs: JobScheduler, pekkoAsync: PekkoAsync, siteMapJob: SiteMapJob)(implicit
+    ec: ExecutionContext,
+) extends LifecycleComponent {
 
   override def start(): Unit = {
     jobs.deschedule("SiteMap")
@@ -16,7 +17,7 @@ class SiteMapLifecycle(jobs: JobScheduler, akkaAsync: AkkaAsync, siteMapJob: Sit
       siteMapJob.update()
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       siteMapJob.update()
     }
   }

--- a/applications/conf/application.conf
+++ b/applications/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/archive/conf/application.conf
+++ b/archive/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/article/app/jobs/MessageUsLifecycle.scala
+++ b/article/app/jobs/MessageUsLifecycle.scala
@@ -1,7 +1,7 @@
 package jobs
 
 import app.LifecycleComponent
-import common.{AkkaAsync, JobScheduler}
+import common.{PekkoAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
 import services.MessageUsService
 
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class MessageUsLifecycle(
     appLifeCycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     messageUsService: MessageUsService,
 )(implicit
     ec: ExecutionContext,
@@ -28,7 +28,7 @@ class MessageUsLifecycle(
     scheduleJobs()
 
     // refresh message us data when app starts
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       messageUsService.refreshMessageUsData()
     }
   }

--- a/article/app/jobs/TopicLifecycle.scala
+++ b/article/app/jobs/TopicLifecycle.scala
@@ -1,7 +1,7 @@
 package jobs
 
 import app.LifecycleComponent
-import common.{AkkaAsync, JobScheduler}
+import common.{PekkoAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
 import topics.TopicService
 
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class TopicLifecycle(
     appLifeCycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     topicService: TopicService,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent {
@@ -26,7 +26,7 @@ class TopicLifecycle(
     scheduleJobs()
 
     // refresh top mentions when app starts
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       topicService.refreshTopics()
     }
   }

--- a/article/conf/application.conf
+++ b/article/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/commercial/app/CommercialLifecycle.scala
+++ b/commercial/app/CommercialLifecycle.scala
@@ -6,7 +6,7 @@ import commercial.model.merchandise.jobs.Industries
 import app.LifecycleComponent
 import commercial.model.feeds._
 import common.LoggingField._
-import common.{AkkaAsync, JobScheduler, GuLogging}
+import common.{PekkoAsync, JobScheduler, GuLogging}
 import metrics.MetricUploader
 import play.api.inject.ApplicationLifecycle
 
@@ -20,7 +20,7 @@ object CommercialMetrics {
 class CommercialLifecycle(
     appLifecycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     feedsFetcher: FeedsFetcher,
     feedsParser: FeedsParser,
     industries: Industries,
@@ -143,7 +143,7 @@ class CommercialLifecycle(
       case (job, i) => job.start(delayedStartSchedule(delayedStart = i * refreshJobDelay, refreshStep = jobRefreshStep))
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
 
       industries.refresh().failed.foreach {
         case NonFatal(e) => log.warn(s"Failed to refresh job industries: ${e.getMessage}")

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success}
 class BookFinder(pekkoActorSystem: PekkoActorSystem, magentoService: MagentoService) extends GuLogging {
 
   private implicit val bookActorExecutionContext: ExecutionContext =
-    pekkoActorSystem.dispatchers.lookup("akka.actor.book-lookup")
+    pekkoActorSystem.dispatchers.lookup("pekko.actor.book-lookup")
   private implicit val bookActorTimeout: Timeout = 0.2.seconds
   private implicit val magentoServiceImplicit = magentoService
 
@@ -72,7 +72,7 @@ class MagentoService(pekkoActorSystem: PekkoActorSystem, wsClient: WSClient) ext
   }
 
   private implicit val bookLookupExecutionContext: ExecutionContext =
-    pekkoActorSystem.dispatchers.lookup("akka.actor.book-lookup")
+    pekkoActorSystem.dispatchers.lookup("pekko.actor.book-lookup")
 
   private final val circuitBreaker = new CircuitBreaker(
     scheduler = pekkoActorSystem.scheduler,

--- a/commercial/conf/application.conf
+++ b/commercial/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -43,7 +43,7 @@ trait FrontendComponents
   })
 
   lazy val jobScheduler = new JobScheduler(appContext)
-  lazy val akkaAsync = new AkkaAsync(environment, pekkoActorSystem)
+  lazy val pekkoAsync = new PekkoAsync(environment, pekkoActorSystem)
   lazy val appMetrics = ApplicationMetrics()
   lazy val guardianConf = new GuardianConfiguration
   lazy val mode = environment.mode

--- a/common/app/commercial/targeting/TargetingLifecycle.scala
+++ b/common/app/commercial/targeting/TargetingLifecycle.scala
@@ -1,12 +1,12 @@
 package commercial.targeting
 
 import app.LifecycleComponent
-import common.{JobScheduler, AkkaAsync}
+import common.{JobScheduler, PekkoAsync}
 import play.api.inject.ApplicationLifecycle
 import scala.concurrent.duration._
 import scala.concurrent.{Future, ExecutionContext}
 
-class TargetingLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, akkaAsync: AkkaAsync)(implicit
+class TargetingLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, pekkoAsync: PekkoAsync)(implicit
     executionContext: ExecutionContext,
 ) extends LifecycleComponent {
 
@@ -22,7 +22,7 @@ class TargetingLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler,
       CampaignAgent.refresh()
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       CampaignAgent.refresh()
     }
   }

--- a/common/app/common/Logback/KinesisAdapter.scala
+++ b/common/app/common/Logback/KinesisAdapter.scala
@@ -17,7 +17,7 @@ import scala.annotation.nowarn
 
 // LogbackOperationsPool must be wired as a singleton
 class LogbackOperationsPool(val pekkoActorSystem: PekkoActorSystem) {
-  val logbackOperations: MessageDispatcher = pekkoActorSystem.dispatchers.lookup("akka.logback-operations")
+  val logbackOperations: MessageDispatcher = pekkoActorSystem.dispatchers.lookup("pekko.logback-operations")
 }
 
 // The KinesisAppender[ILoggingEvent] blocks logging operations on putMessage. This overrides the KinesisAppender api, executing putMessage in an

--- a/common/app/common/akka.scala
+++ b/common/app/common/akka.scala
@@ -6,7 +6,7 @@ import play.api.{Environment => PlayEnv, Mode}
 import scala.concurrent.ExecutionContext
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 
-class AkkaAsync(env: PlayEnv, pekkoActorSystem: PekkoActorSystem) {
+class PekkoAsync(env: PlayEnv, pekkoActorSystem: PekkoActorSystem) {
   implicit val ec: ExecutionContext = pekkoActorSystem.dispatcher
 
   // "apply" isn't expressive and doesn't explain what it does.

--- a/common/app/common/dfp/DfpAgentLifecycle.scala
+++ b/common/app/common/dfp/DfpAgentLifecycle.scala
@@ -1,12 +1,12 @@
 package common.dfp
 
 import app.LifecycleComponent
-import common.{JobScheduler, AkkaAsync}
+import common.{JobScheduler, PekkoAsync}
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DfpAgentLifecycle(appLifeCycle: ApplicationLifecycle, jobs: JobScheduler, akkaAsync: AkkaAsync)(implicit
+class DfpAgentLifecycle(appLifeCycle: ApplicationLifecycle, jobs: JobScheduler, pekkoAsync: PekkoAsync)(implicit
     ec: ExecutionContext,
 ) extends LifecycleComponent {
 
@@ -25,15 +25,15 @@ class DfpAgentLifecycle(appLifeCycle: ApplicationLifecycle, jobs: JobScheduler, 
       Future.successful(())
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       refreshDfpAgent()
     }
   }
 }
 
-class FaciaDfpAgentLifecycle(appLifeCycle: ApplicationLifecycle, jobs: JobScheduler, akkaAsync: AkkaAsync)(implicit
+class FaciaDfpAgentLifecycle(appLifeCycle: ApplicationLifecycle, jobs: JobScheduler, pekkoAsync: PekkoAsync)(implicit
     ec: ExecutionContext,
-) extends DfpAgentLifecycle(appLifeCycle, jobs, akkaAsync) {
+) extends DfpAgentLifecycle(appLifeCycle, jobs, pekkoAsync) {
 
   override def refreshDfpAgent(): Unit = {
     DfpAgent.refresh()

--- a/common/app/concurrent/BlockingOperations.scala
+++ b/common/app/concurrent/BlockingOperations.scala
@@ -6,7 +6,7 @@ import org.apache.pekko.dispatch.MessageDispatcher
 import scala.concurrent.Future
 
 class BlockingOperations(pekkoActorSystem: PekkoActorSystem) {
-  private val blockingOperations: MessageDispatcher = pekkoActorSystem.dispatchers.lookup("akka.blocking-operations")
+  private val blockingOperations: MessageDispatcher = pekkoActorSystem.dispatchers.lookup("pekko.blocking-operations")
 
   def executeBlocking[T](block: => T): Future[T] = {
     Future(block)(blockingOperations)

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -208,7 +208,7 @@ abstract case class AnyGoodCachedHealthCheck(healthChecks: SingleHealthCheck*)(i
 class CachedHealthCheckLifeCycle(
     healthCheckController: CachedHealthCheck,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
 )(implicit executionContext: ExecutionContext)
     extends LifecycleComponent {
 
@@ -222,7 +222,7 @@ class CachedHealthCheckLifeCycle(
       }
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       healthCheckController.runChecks()
     }
   }

--- a/common/app/conf/switches/SwitchboardLifecycle.scala
+++ b/common/app/conf/switches/SwitchboardLifecycle.scala
@@ -7,7 +7,7 @@ import play.api.inject.ApplicationLifecycle
 import scala.concurrent.duration._
 import scala.concurrent.{Future, ExecutionContext}
 
-class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, akkaAsync: AkkaAsync)(implicit
+class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, pekkoAsync: PekkoAsync)(implicit
     ec: ExecutionContext,
 ) extends LifecycleComponent
     with GuLogging {
@@ -20,7 +20,7 @@ class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobSchedule
 
   override def start(): Unit = {
 
-    Switches.all.foreach(_.failInitializationAfter(2.minutes)(akkaAsync))
+    Switches.all.foreach(_.failInitializationAfter(2.minutes)(pekkoAsync))
 
     jobs.deschedule("SwitchBoardRefreshJob")
     //run every minute, 47 seconds after the minute
@@ -28,7 +28,7 @@ class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobSchedule
       refresh()
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       refresh()
     }
   }

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -51,8 +51,8 @@ trait Initializable[T] extends GuLogging {
 
   def initialize(t: T): Unit = initialized.trySuccess(t)
   def onInitialized: Future[T] = initialized.future
-  def failInitializationAfter(initializationTimeout: FiniteDuration)(akkaAsync: AkkaAsync): Unit = {
-    akkaAsync.after(initializationTimeout) {
+  def failInitializationAfter(initializationTimeout: FiniteDuration)(pekkoAsync: PekkoAsync): Unit = {
+    pekkoAsync.after(initializationTimeout) {
       initialized.tryFailure {
         new TimeoutException(s"Initialization timed out after $initializationTimeout")
       }

--- a/common/app/contentapi/SectionsLookUpLifecycle.scala
+++ b/common/app/contentapi/SectionsLookUpLifecycle.scala
@@ -9,7 +9,7 @@ import scala.concurrent.{Future, ExecutionContext}
 class SectionsLookUpLifecycle(
     appLifecycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     sectionsLookUp: SectionsLookUp,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent
@@ -35,7 +35,7 @@ class SectionsLookUpLifecycle(
     descheduleJobs()
     scheduleJobs()
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       sectionsLookUp.refresh()
     }
   }

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -139,7 +139,7 @@ object ConfigAgent extends GuLogging {
 
 }
 
-class ConfigAgentLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, akkaAsync: AkkaAsync)(implicit
+class ConfigAgentLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, pekkoAsync: PekkoAsync)(implicit
     ec: ExecutionContext,
 ) extends LifecycleComponent {
 
@@ -155,7 +155,7 @@ class ConfigAgentLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobSchedule
       ConfigAgent.refresh
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       ConfigAgent.refresh
     }
   }

--- a/common/app/services/ophan/SurgingContentAgent.scala
+++ b/common/app/services/ophan/SurgingContentAgent.scala
@@ -47,7 +47,7 @@ object SurgeUtils {
 class SurgingContentAgentLifecycle(
     appLifecycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     ophanApi: OphanApi,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent {
@@ -66,7 +66,7 @@ class SurgingContentAgentLifecycle(
       SurgingContentAgent.update(ophanApi, ec)
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       SurgingContentAgent.update(ophanApi, ec)
     }
   }

--- a/common/conf/test.conf
+++ b/common/conf/test.conf
@@ -1,4 +1,4 @@
-akka {
+pekko {
   blocking-operations {
     executor = "thread-pool-executor"
     throughput = 10

--- a/dev-build/conf/dev-build.application.conf
+++ b/dev-build/conf/dev-build.application.conf
@@ -1,5 +1,6 @@
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["org.apache.pekko.event.Logging$DefaultLogger"]
+  # , "org.apache.pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/discussion/conf/application.conf
+++ b/discussion/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/facia-press/conf/application.conf
+++ b/facia-press/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/facia/app/feed/DeeplyReadLifecycle.scala
+++ b/facia/app/feed/DeeplyReadLifecycle.scala
@@ -2,7 +2,7 @@ package feed
 
 import agents.DeeplyReadAgent
 import app.LifecycleComponent
-import common.{AkkaAsync, JobScheduler}
+import common.{PekkoAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
 
 import java.util.concurrent.Executors
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class DeeplyReadLifecycle(
     appLifecycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     deeplyReadAgent: DeeplyReadAgent,
 ) extends LifecycleComponent {
 
@@ -35,7 +35,7 @@ class DeeplyReadLifecycle(
       deeplyReadAgent.refresh()
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       deeplyReadAgent.refresh()
     }
   }

--- a/facia/app/feed/MostViewedLifecycle.scala
+++ b/facia/app/feed/MostViewedLifecycle.scala
@@ -4,7 +4,7 @@ import agents.MostViewedAgent
 
 import java.util.concurrent.Executors
 import app.LifecycleComponent
-import common.{AkkaAsync, JobScheduler}
+import common.{PekkoAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class MostViewedLifecycle(
     appLifecycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     mostViewedAgent: MostViewedAgent,
 ) extends LifecycleComponent {
 
@@ -36,7 +36,7 @@ class MostViewedLifecycle(
       mostViewedAgent.refresh()
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       mostViewedAgent.refresh()
     }
   }

--- a/facia/conf/application.conf
+++ b/facia/conf/application.conf
@@ -6,8 +6,8 @@
 "assets.cache./public/security.txt"="public, max-age=900"
 "assets.cache./public/security.txt.asc"="public, max-age=900"
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/identity/app/conf/IdentityLifecycle.scala
+++ b/identity/app/conf/IdentityLifecycle.scala
@@ -1,7 +1,7 @@
 package conf
 
 import app.LifecycleComponent
-import common.{JobScheduler, AkkaAsync}
+import common.{JobScheduler, PekkoAsync}
 import jobs.TorExitNodeList
 import model.PhoneNumbers
 import play.api.inject.ApplicationLifecycle
@@ -10,7 +10,7 @@ import scala.concurrent.{Future, ExecutionContext}
 
 class IdentityLifecycle(
     appLifecycle: ApplicationLifecycle,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     jobs: JobScheduler,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent {
@@ -35,7 +35,7 @@ class IdentityLifecycle(
     descheduleJobs()
     scheduleJobs()
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       TorExitNodeList.run()
       PhoneNumbers
     }

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -1,5 +1,5 @@
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -3,14 +3,14 @@ package feed
 import agents.DeeplyReadAgent
 import java.util.concurrent.Executors
 import app.LifecycleComponent
-import common.{AkkaAsync, JobScheduler}
+import common.{PekkoAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
 import scala.concurrent.{ExecutionContext, Future}
 
 class OnwardJourneyLifecycle(
     appLifecycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     mostReadAgent: MostReadAgent,
     geoMostPopularAgent: GeoMostPopularAgent,
     dayMostPopularAgent: DayMostPopularAgent,
@@ -56,7 +56,7 @@ class OnwardJourneyLifecycle(
       dayMostPopularAgent.refresh()
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       mostPopularAgent.refresh()
       deeplyReadAgent.refresh()
       geoMostPopularAgent.refresh()

--- a/onward/conf/application.conf
+++ b/onward/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/preview/conf/application.conf
+++ b/preview/conf/application.conf
@@ -1,5 +1,5 @@
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/rss/conf/application.conf
+++ b/rss/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -1,7 +1,7 @@
 package cricket.conf
 
 import app.LifecycleComponent
-import common.{AkkaAsync, JobScheduler}
+import common.{PekkoAsync, JobScheduler}
 import jobs.CricketStatsJob
 
 import java.time.LocalDate
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class CricketLifecycle(
     appLifeCycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     cricketStatsJob: CricketStatsJob,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent {
@@ -43,7 +43,7 @@ class CricketLifecycle(
     scheduleJobs()
 
     // ensure that we populate the cricket stats cache immediately
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       cricketStatsJob.run(fromDate = LocalDate.now.minusMonths(2), matchesToFetch = 10)
     }
   }

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -15,7 +15,7 @@ import java.time.Clock
 class FootballLifecycle(
     appLifeCycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     competitionsService: CompetitionsService,
     contentApiClient: ContentApiClient,
 )(implicit ec: ExecutionContext)
@@ -79,7 +79,7 @@ class FootballLifecycle(
     descheduleJobs()
     scheduleJobs()
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       val competitionUpdate = competitionsService.refreshCompetitionData()
       competitionUpdate.foreach { _ =>
         competitionsService.competitionIds.foreach(id => competitionsService.refreshCompetitionAgent(id, defaultClock))

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -1,7 +1,7 @@
 package rugby.conf
 
 import app.LifecycleComponent
-import common.{AkkaAsync, JobScheduler}
+import common.{PekkoAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
 import rugby.feed.CapiFeed
 import rugby.jobs.RugbyStatsJob
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 class RugbyLifecycle(
     appLifeCycle: ApplicationLifecycle,
     jobs: JobScheduler,
-    akkaAsync: AkkaAsync,
+    pekkoAsync: PekkoAsync,
     rugbyStatsJob: RugbyStatsJob,
     capiFeed: CapiFeed,
 )(implicit ec: ExecutionContext)
@@ -34,12 +34,12 @@ class RugbyLifecycle(
       rugbyStatsJob.sendMatchArticles(refreshedNavContent)
     }
 
-    akkaAsync.after1s {
+    pekkoAsync.after1s {
       rugbyStatsJob.fetchFixturesAndResults()
     }
 
     //delay to allow previous jobs to complete
-    akkaAsync.after(initializationTimeout) {
+    pekkoAsync.after(initializationTimeout) {
       val refreshedNavContent = capiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
       rugbyStatsJob.sendMatchArticles(refreshedNavContent)
     }

--- a/sport/conf/application.conf
+++ b/sport/conf/application.conf
@@ -1,6 +1,6 @@
 
-akka {
-  loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["pekko.event.Logging$DefaultLogger", "pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {


### PR DESCRIPTION
## What is the value of this and can you measure success?

Part of Akka migration due to licensing changes (#8783)

## What does this change?

Updates config for akka to pekko as mentioned in the [Pekko migration guide](https://pekko.apache.org/docs/pekko/current/project/migration-guides.html)

> Config names use “pekko” prefix instead of “akka”, e.g. pekko.actor.provider instead of akka.actor.provider

Also renames `akkaAsync` values to `pekkoAsync` to make it super clear it's using Pekko not Akka now.

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
