### PR TITLE
Add new switchboard switch for public good

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -168,10 +168,11 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val publicGood: Switch = Switch(
+  val articleEndSlot: Switch = Switch(
     group = Commercial,
-    name = "public-good",
-    description = "Enable Public Good functionality",
+    name = "article-end-slot",
+    description =
+      "Enable the article end slot, this appears when the contributions epic does not. Currently only Public Good is served in this slot in the US.",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -167,6 +167,16 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val publicGood: Switch = Switch(
+    group = Commercial,
+    name = "public-good",
+    description = "Enable Public Good functionality",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }
 
 trait PrebidSwitches {


### PR DESCRIPTION
## What is the value of this and can you measure success?

We've AB tested public good a new advertising vendor in the US, [details here
](https://github.com/guardian/commercial/pull/961)

We're now preparing to go live, the AB test switch has already been remove, this adds a regular switch as is the convention for new third party integrations.

I've called it `article-end-slot` as the switch technically controls whether the `article-end` slot is shown when the epic doesn't, but it is only used for Public Good at the moment.

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
