### PR TITLE
Remove Europe experiment

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -7,7 +7,7 @@ import java.util.Locale
 import org.joda.time.DateTimeZone
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import experiments.{ActiveExperiments, EuropeNetworkFront}
+import experiments.ActiveExperiments
 
 import java.time.ZoneId
 
@@ -49,9 +49,7 @@ object Edition {
 
   lazy val defaultEdition: Edition = editions.Uk
   def editionsByRequest(implicit request: RequestHeader): List[Edition] = {
-    val participatingInTest =
-      ActiveExperiments.isParticipating(EuropeNetworkFront) || EuropeNetworkFrontSwitch.isSwitchedOn
-    if (!participatingInTest) all else allWithBetaEditions
+    if (!EuropeNetworkFrontSwitch.isSwitchedOn) all else allWithBetaEditions
   }
   def editionsSupportingSection(sectionId: String): Seq[Edition] =
     allWithBetaEditions.filter(_.isEditionalised(sectionId))
@@ -82,16 +80,13 @@ object Edition {
     // in production no cookies make it this far
     val editionFromCookie = request.cookies.get("GU_EDITION").map(_.value)
 
-    val participatingInTest =
-      ActiveExperiments.isParticipating(EuropeNetworkFront)(request) || EuropeNetworkFrontSwitch.isSwitchedOn
-
     editionFromParameter
       .orElse(editionFromHeader)
       .orElse(editionFromCookie)
       // Fastly does not have switch information so we will always try and set the edition to Europe
       // if a user is in CoE and then fallback to INT edition in Frontend if that user is not part of the experiment.
       .map(edition =>
-        if (edition.equalsIgnoreCase(editions.Europe.id) && !participatingInTest) editions.International.id else edition,
+        if (edition.equalsIgnoreCase(editions.Europe.id) && !EuropeNetworkFrontSwitch.isSwitchedOn) editions.International.id else edition,
       )
       .getOrElse(defaultEdition.id)
   }

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -86,7 +86,9 @@ object Edition {
       // Fastly does not have switch information so we will always try and set the edition to Europe
       // if a user is in CoE and then fallback to INT edition in Frontend if that user is not part of the experiment.
       .map(edition =>
-        if (edition.equalsIgnoreCase(editions.Europe.id) && !EuropeNetworkFrontSwitch.isSwitchedOn) editions.International.id else edition,
+        if (edition.equalsIgnoreCase(editions.Europe.id) && !EuropeNetworkFrontSwitch.isSwitchedOn)
+          editions.International.id
+        else edition,
       )
       .getOrElse(defaultEdition.id)
   }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,7 +14,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       FrontsBannerAdsDcr,
       Lightbox,
       ServerSideLiveblogInlineAds,
-      EuropeNetworkFront,
       OphanEsm,
       SectionFrontsBannerAds,
       HeaderTopBarSearchCapi,
@@ -41,15 +40,6 @@ object Lightbox
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2023, 9, 29),
       participationGroup = Perc0B,
-    )
-
-object EuropeNetworkFront
-    extends Experiment(
-      name = "europe-network-front",
-      description = "Test new europe network front",
-      owners = Seq(Owner.withGithub("rowannekabalan")),
-      sellByDate = LocalDate.of(2023, 9, 29),
-      participationGroup = Perc0D,
     )
 
 object FrontsBannerAdsDcr

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -27,7 +27,7 @@ import contentapi.ContentApiClient
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
-import experiments.{ActiveExperiments, DeeplyRead, EuropeNetworkFront}
+import experiments.{ActiveExperiments, DeeplyRead}
 import play.api.http.ContentTypes.JSON
 import http.HttpPreconnections
 import services.dotcomrendering.{FaciaPicker, RemoteRender}
@@ -206,9 +206,7 @@ trait FaciaController
 
   import PressedPage.pressedPageFormat
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader): Future[Result] = {
-    val participatingInTest =
-      ActiveExperiments.isParticipating(EuropeNetworkFront) || EuropeNetworkFrontSwitch.isSwitchedOn
-    if (path == "europe" && !participatingInTest) {
+    if (path == "europe" && !EuropeNetworkFrontSwitch.isSwitchedOn) {
       return successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
     }
     val futureFaciaPage: Future[Option[(PressedPage, Boolean)]] = frontJsonFapi.get(path, liteRequestType).flatMap {


### PR DESCRIPTION
## What is the value of this and can you measure success?

This removes the Europe experiment introduced in #25444 as we have launched the edition and the experiment is no longer needed. A follow-up PR will remove the Europe feature switch and all conditional logic that uses it.

