### PR TITLE
Start server-side liveblog ads AB test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -43,16 +43,6 @@ object Lightbox
       participationGroup = Perc0B,
     )
 
-object ServerSideLiveblogInlineAds
-    extends Experiment(
-      name = "server-side-liveblog-inline-ads",
-      description =
-        "Test whether we can load liveblog inline ads server-side without negative effects on user experience or revenue",
-      owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
-      sellByDate = LocalDate.of(2023, 11, 1),
-      participationGroup = Perc0C,
-    )
-
 object EuropeNetworkFront
     extends Experiment(
       name = "europe-network-front",
@@ -106,6 +96,16 @@ object OfferHttp3
       owners = Seq(Owner.withGithub("paulmr")),
       sellByDate = LocalDate.of(2023, 9, 29),
       participationGroup = Perc1E,
+    )
+
+object ServerSideLiveblogInlineAds
+    extends Experiment(
+      name = "server-side-liveblog-inline-ads",
+      description =
+        "Test whether we can load liveblog inline ads server-side without negative effects on user experience or revenue",
+      owners = Seq(Owner.withGithub("@guardian/commercial-dev")),
+      sellByDate = LocalDate.of(2023, 11, 1),
+      participationGroup = Perc5A,
     )
 
 object SectionFrontsBannerAds


### PR DESCRIPTION
## What is the value of this and can you measure success?

- Starts the server-side liveblog inline ads AB test. This test involves using [two sets of inline ad slots](https://github.com/guardian/dotcom-rendering/pull/8666), one for small screens and one for large screens, so that we can provide a better advert to viewport height ratio for a wider range of users.

## What does this change?

- Set the participation group of the ServerSideLiveblogInlineAds experiment to 5A
