### PR TITLE
Remove europe feature switch

### DIFF
--- a/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
+++ b/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
@@ -22,7 +22,7 @@
         @inputText(takeoverForm("url"), Symbol("_label")-> "Paste URL here:", Symbol("size") -> 100, Symbol("_help") -> "")
         @select(
             takeoverForm("editions"),
-            options = for(e <- Edition.allWithBetaEditions) yield { e.id -> e.displayName },
+            options = for(e <- Edition.allEditions) yield { e.id -> e.displayName },
             Symbol("multiple") -> true,
             Symbol("_label") -> "Editions this applies to (one or multiple):"
         )

--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -32,7 +32,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       using a Box structure.
      */
     Future
-      .sequence(Edition.all.map { edition =>
+      .sequence(Edition.allEditions.map { edition =>
         ophanApi.getDeeplyRead(edition).flatMap {
           ophanDeeplyReadItems =>
             log.info(s"ophanItems updated with: ${ophanDeeplyReadItems.size} new items")
@@ -66,7 +66,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
         }
       })
       .map(trailsList => {
-        val map = Edition.all.zip(trailsList).toMap
+        val map = Edition.allEditions.zip(trailsList).toMap
         deeplyReadItems.alter(map)
       })
   }

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -47,7 +47,6 @@ object Edition {
   implicit def edition(implicit request: RequestHeader): Edition = this(request)
 
   lazy val defaultEdition: Edition = editions.Uk
-
   def editionsSupportingSection(sectionId: String): Seq[Edition] =
     allEditions.filter(_.isEditionalised(sectionId))
 

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -1,6 +1,5 @@
 package common
 
-import conf.switches.Switches.EuropeNetworkFrontSwitch
 import navigation.EditionNavLinks
 
 import java.util.Locale
@@ -48,24 +47,21 @@ object Edition {
   implicit def edition(implicit request: RequestHeader): Edition = this(request)
 
   lazy val defaultEdition: Edition = editions.Uk
-  def editionsByRequest(implicit request: RequestHeader): List[Edition] = {
-    if (!EuropeNetworkFrontSwitch.isSwitchedOn) all else allWithBetaEditions
-  }
-  def editionsSupportingSection(sectionId: String): Seq[Edition] =
-    allWithBetaEditions.filter(_.isEditionalised(sectionId))
 
-  lazy val all = List(
+  def editionsSupportingSection(sectionId: String): Seq[Edition] =
+    allEditions.filter(_.isEditionalised(sectionId))
+
+  lazy val allEditions = List(
     editions.Uk,
     editions.Us,
     editions.Au,
     editions.International,
+    editions.Europe,
   )
-
-  lazy val allWithBetaEditions = all ++ List(editions.Europe)
 
   lazy val localeByEdition: Map[Edition, Locale] =
     (for {
-      edition <- allWithBetaEditions
+      edition <- allEditions
       locale <- edition.locale
     } yield edition -> locale).toMap
 
@@ -83,30 +79,23 @@ object Edition {
     editionFromParameter
       .orElse(editionFromHeader)
       .orElse(editionFromCookie)
-      // Fastly does not have switch information so we will always try and set the edition to Europe
-      // if a user is in CoE and then fallback to INT edition in Frontend if that user is not part of the experiment.
-      .map(edition =>
-        if (edition.equalsIgnoreCase(editions.Europe.id) && !EuropeNetworkFrontSwitch.isSwitchedOn)
-          editions.International.id
-        else edition,
-      )
       .getOrElse(defaultEdition.id)
   }
 
   def apply(request: RequestHeader): Edition = {
     val cookieValue = editionFromRequest(request)
-    editionsByRequest(request).find(_.matchesCookie(cookieValue)).getOrElse(defaultEdition)
+    allEditions.find(_.matchesCookie(cookieValue)).getOrElse(defaultEdition)
   }
 
   def others(implicit request: RequestHeader): Seq[Edition] = {
     val currentEdition = Edition(request)
-    editionsByRequest(request).filterNot(_ == currentEdition)
+    allEditions.filterNot(_ == currentEdition)
   }
 
-  def othersWithBetaEditions(edition: Edition): Seq[Edition] = allWithBetaEditions.filterNot(_ == edition)
+  def othersWithBetaEditions(edition: Edition): Seq[Edition] = allEditions.filterNot(_ == edition)
 
-  def byId(id: String): Option[Edition] = allWithBetaEditions.find(_.id.equalsIgnoreCase(id))
-  def byNetworkFrontId(id: String): Option[Edition] = allWithBetaEditions.find(_.networkFrontId == id)
+  def byId(id: String): Option[Edition] = allEditions.find(_.id.equalsIgnoreCase(id))
+  def byNetworkFrontId(id: String): Option[Edition] = allEditions.find(_.networkFrontId == id)
 
   implicit val editionWrites: Writes[Edition] = new Writes[Edition] {
     def writes(edition: Edition): JsValue = Json.obj("id" -> edition.id)
@@ -116,7 +105,7 @@ object Edition {
     (__ \ "id").read[String] map (Edition.byId(_).getOrElse(defaultEdition))
   }
 
-  lazy val editionRegex = allWithBetaEditions.map(_.homePagePath.replaceFirst("/", "")).mkString("|")
+  lazy val editionRegex = allEditions.map(_.homePagePath.replaceFirst("/", "")).mkString("|")
   private lazy val EditionalisedFront = s"""^/($editionRegex)$$""".r
 
   private lazy val EditionalisedId = s"^/($editionRegex)/([\\w\\d-]+)$$".r

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -40,7 +40,7 @@ case class CommercialProperties(
       .getOrElse(Set.empty)
 
   def perEdition: Map[Edition, EditionCommercialProperties] = {
-    Edition.allWithBetaEditions.map { edition =>
+    Edition.allEditions.map { edition =>
       (
         edition,
         EditionCommercialProperties(

--- a/common/app/common/commercial/EditionAdTargeting.scala
+++ b/common/app/common/commercial/EditionAdTargeting.scala
@@ -72,7 +72,7 @@ object EditionAdTargeting {
   )
 
   private def editionTargeting(targeting: Edition => Set[AdTargetParam]): Set[EditionAdTargeting] =
-    for (edition <- Edition.allWithBetaEditions.toSet[Edition])
+    for (edition <- Edition.allEditions.toSet[Edition])
       yield EditionAdTargeting(edition, paramSet = Some(targeting(edition)))
 
   def fromContent(item: Content): Set[EditionAdTargeting] =

--- a/common/app/common/commercial/EditionBranding.scala
+++ b/common/app/common/commercial/EditionBranding.scala
@@ -44,7 +44,7 @@ object EditionBranding {
 
   implicit val editionBrandingFormat = Json.format[EditionBranding]
 
-  val editions = Edition.allWithBetaEditions.toSet
+  val editions = Edition.allEditions.toSet
 
   def fromContent(item: Content): Set[EditionBranding] =
     editions map { edition =>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -542,13 +542,4 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val EuropeNetworkFrontSwitch = Switch(
-    SwitchGroup.Feature,
-    "europe-network-front-switch",
-    "Test new europe network front",
-    owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
 }

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -25,7 +25,7 @@ object PressedPage {
     def optionalMapEntry(key: String, o: Option[String]): Map[String, String] =
       o.map(value => Map(key -> value)).getOrElse(Map())
 
-    val isNetworkFront: Boolean = Edition.allWithBetaEditions.exists(_.networkFrontId == id)
+    val isNetworkFront: Boolean = Edition.allEditions.exists(_.networkFrontId == id)
     val keywordIds: Seq[String] = frontKeywordIds(id)
     val contentType: DotcomContentType =
       if (isNetworkFront) DotcomContentType.NetworkFront else DotcomContentType.Section
@@ -120,7 +120,7 @@ case class PressedPage(
   lazy val filterEmpty: PressedPage = copy(collections = collections.filterNot(_.isEmpty))
 
   override val metadata: MetaData = PressedPage.makeMetadata(id, seoData, frontProperties, collections)
-  val isNetworkFront: Boolean = Edition.allWithBetaEditions.exists(_.networkFrontId == id)
+  val isNetworkFront: Boolean = Edition.allEditions.exists(_.networkFrontId == id)
 
   /** If a Facia front is a tag or section page, it ought to exist as a tag or section ID for one of its pieces of
     * content.

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -18,7 +18,7 @@ case class SeoData(id: String, navSection: String, webTitle: String, title: Opti
 object SeoData extends GuLogging {
   implicit val seoFormatter = Json.format[SeoData]
 
-  val editions = Edition.allWithBetaEditions.map(_.id.toLowerCase)
+  val editions = Edition.allEditions.map(_.id.toLowerCase)
 
   def fromPath(path: String): SeoData =
     (path.split('/').toList: @unchecked) match { // split() never gives the empty list

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -34,7 +34,7 @@ object `package` {
   }
 
   def frontKeywordIds(pageId: String): Seq[String] = {
-    val editions = Edition.allWithBetaEditions.map(_.id.toLowerCase).toSet
+    val editions = Edition.allEditions.map(_.id.toLowerCase).toSet
 
     val parts = pageId.split("/").toList match {
       case edition :: rest if editions.contains(edition) => rest

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -742,7 +742,7 @@ object NavigationData {
   implicit val editionNavLinksWrites = Json.writes[EditionNavLinks]
 
   val nav: JsValue = toJson(
-    (Edition.all
+    (Edition.allEditions
       .map(e => e.networkFrontId -> toJson(e.navigationLinks)) :+ "tagPages" -> toJson(NavLinks.tagPages)).toMap,
   )
 }

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -13,7 +13,7 @@
     </button>
 
     <ul class="menu-group">
-        @Edition.editionsByRequest.map { edition =>
+        @Edition.allEditions.map { edition =>
              @if(edition != Edition(request)) {
                  <li class="menu-item">
                      <a data-link-name="nav3 : topbar : edition-picker: @edition.id"

--- a/common/test/agents/DeeplyReadAgentTest.scala
+++ b/common/test/agents/DeeplyReadAgentTest.scala
@@ -32,7 +32,7 @@ import test.{
       contentApiClient = contentApiClient,
       ophanApi = ophanApi,
     )
-    Edition.all.map(edition => {
+    Edition.allEditions.map(edition => {
       agent.getTrails(edition) shouldBe Seq.empty
     })
   }

--- a/common/test/common/EditionTest.scala
+++ b/common/test/common/EditionTest.scala
@@ -42,7 +42,7 @@ class EditionTest extends AnyFlatSpec with Matchers {
     // because they are used as defaults for other editions that do not override them
 
     val defaultSections = Edition.defaultEdition.editionalisedSections.sorted
-    val allSections = Edition.allWithBetaEditions.flatMap(_.editionalisedSections).distinct.sorted
+    val allSections = Edition.allEditions.flatMap(_.editionalisedSections).distinct.sorted
 
     allSections should equal(defaultSections)
   }

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1960,6 +1960,736 @@
             "classList" : [ ]
         } ]
     },
+    "europe" : {
+        "newsPillar" : {
+            "title" : "News",
+            "url" : "/",
+            "longTitle" : "Headlines",
+            "iconName" : "home",
+            "children" : [ {
+                "title" : "World",
+                "url" : "/world",
+                "longTitle" : "World news",
+                "children" : [ {
+                    "title" : "Europe",
+                    "url" : "/world/europe-news",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "US",
+                    "url" : "/us-news",
+                    "longTitle" : "US news",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Americas",
+                    "url" : "/world/americas",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Asia",
+                    "url" : "/world/asia",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Australia",
+                    "url" : "/australia-news",
+                    "longTitle" : "Australia news",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Middle East",
+                    "url" : "/world/middleeast",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Africa",
+                    "url" : "/world/africa",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Inequality",
+                    "url" : "/inequality",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Global development",
+                    "url" : "/global-development",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            }, {
+                "title" : "UK",
+                "url" : "/uk-news",
+                "longTitle" : "UK news",
+                "children" : [ {
+                    "title" : "UK politics",
+                    "url" : "/politics",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Education",
+                    "url" : "/education",
+                    "children" : [ {
+                        "title" : "Schools",
+                        "url" : "/education/schools",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    }, {
+                        "title" : "Teachers",
+                        "url" : "/teacher-network",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    }, {
+                        "title" : "Universities",
+                        "url" : "/education/universities",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    }, {
+                        "title" : "Students",
+                        "url" : "/education/students",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    } ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Media",
+                    "url" : "/media",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Society",
+                    "url" : "/society",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Law",
+                    "url" : "/law",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Scotland",
+                    "url" : "/uk/scotland",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Wales",
+                    "url" : "/uk/wales",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Northern Ireland",
+                    "url" : "/uk/northernireland",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            }, {
+                "title" : "Climate crisis",
+                "url" : "/environment/climate-crisis",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Environment",
+                "url" : "/environment",
+                "children" : [ {
+                    "title" : "Climate crisis",
+                    "url" : "/environment/climate-crisis",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Wildlife",
+                    "url" : "/environment/wildlife",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Energy",
+                    "url" : "/environment/energy",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Pollution",
+                    "url" : "/environment/pollution",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            }, {
+                "title" : "Science",
+                "url" : "/science",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Global development",
+                "url" : "/global-development",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Football",
+                "url" : "/football",
+                "children" : [ {
+                    "title" : "Live scores",
+                    "url" : "/football/live",
+                    "longTitle" : "football/live",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Tables",
+                    "url" : "/football/tables",
+                    "longTitle" : "football/tables",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Fixtures",
+                    "url" : "/football/fixtures",
+                    "longTitle" : "football/fixtures",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Results",
+                    "url" : "/football/results",
+                    "longTitle" : "football/results",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Competitions",
+                    "url" : "/football/competitions",
+                    "longTitle" : "football/competitions",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Clubs",
+                    "url" : "/football/teams",
+                    "longTitle" : "football/teams",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            }, {
+                "title" : "Tech",
+                "url" : "/technology",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Business",
+                "url" : "/business",
+                "children" : [ {
+                    "title" : "Economics",
+                    "url" : "/business/economics",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Banking",
+                    "url" : "/business/banking",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Money",
+                    "url" : "/money",
+                    "children" : [ {
+                        "title" : "Property",
+                        "url" : "/money/property",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    }, {
+                        "title" : "Pensions",
+                        "url" : "/money/pensions",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    }, {
+                        "title" : "Savings",
+                        "url" : "/money/savings",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    }, {
+                        "title" : "Borrowing",
+                        "url" : "/money/debt",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    }, {
+                        "title" : "Careers",
+                        "url" : "/money/work-and-careers",
+                        "children" : [ ],
+                        "classList" : [ ]
+                    } ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Markets",
+                    "url" : "/business/stock-markets",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Project Syndicate",
+                    "url" : "/business/series/project-syndicate-economists",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "B2B",
+                    "url" : "/business-to-business",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Retail",
+                    "url" : "/business/retail",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            }, {
+                "title" : "Obituaries",
+                "url" : "/obituaries",
+                "children" : [ ],
+                "classList" : [ ]
+            } ],
+            "classList" : [ ]
+        },
+        "opinionPillar" : {
+            "title" : "Opinion",
+            "url" : "/commentisfree",
+            "longTitle" : "Opinion home",
+            "iconName" : "home",
+            "children" : [ {
+                "title" : "The Guardian view",
+                "url" : "/profile/editorial",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Columnists",
+                "url" : "/index/contributors",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Cartoons",
+                "url" : "/cartoons/archive",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Opinion videos",
+                "url" : "/type/video+tone/comment",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Letters",
+                "url" : "/tone/letters",
+                "children" : [ ],
+                "classList" : [ ]
+            } ],
+            "classList" : [ ]
+        },
+        "sportPillar" : {
+            "title" : "Sport",
+            "url" : "/sport",
+            "longTitle" : "Sport home",
+            "iconName" : "home",
+            "children" : [ {
+                "title" : "Football",
+                "url" : "/football",
+                "children" : [ {
+                    "title" : "Live scores",
+                    "url" : "/football/live",
+                    "longTitle" : "football/live",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Tables",
+                    "url" : "/football/tables",
+                    "longTitle" : "football/tables",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Fixtures",
+                    "url" : "/football/fixtures",
+                    "longTitle" : "football/fixtures",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Results",
+                    "url" : "/football/results",
+                    "longTitle" : "football/results",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Competitions",
+                    "url" : "/football/competitions",
+                    "longTitle" : "football/competitions",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Clubs",
+                    "url" : "/football/teams",
+                    "longTitle" : "football/teams",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            }, {
+                "title" : "Cricket",
+                "url" : "/sport/cricket",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Rugby union",
+                "url" : "/sport/rugby-union",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Tennis",
+                "url" : "/sport/tennis",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Cycling",
+                "url" : "/sport/cycling",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "F1",
+                "url" : "/sport/formulaone",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Golf",
+                "url" : "/sport/golf",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "US sports",
+                "url" : "/sport/us-sport",
+                "children" : [ ],
+                "classList" : [ ]
+            } ],
+            "classList" : [ ]
+        },
+        "culturePillar" : {
+            "title" : "Culture",
+            "url" : "/culture",
+            "longTitle" : "Culture home",
+            "iconName" : "home",
+            "children" : [ {
+                "title" : "Books",
+                "url" : "/books",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Music",
+                "url" : "/music",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "TV & radio",
+                "url" : "/tv-and-radio",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Art & design",
+                "url" : "/artanddesign",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Film",
+                "url" : "/film",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Games",
+                "url" : "/games",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Classical",
+                "url" : "/music/classicalmusicandopera",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Stage",
+                "url" : "/stage",
+                "children" : [ ],
+                "classList" : [ ]
+            } ],
+            "classList" : [ ]
+        },
+        "lifestylePillar" : {
+            "title" : "Lifestyle",
+            "url" : "/lifeandstyle",
+            "longTitle" : "Lifestyle home",
+            "iconName" : "home",
+            "children" : [ {
+                "title" : "Fashion",
+                "url" : "/fashion",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Food",
+                "url" : "/food",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Recipes",
+                "url" : "/tone/recipes",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Love & sex",
+                "url" : "/lifeandstyle/love-and-sex",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Health & fitness",
+                "url" : "/lifeandstyle/health-and-wellbeing",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Home & garden",
+                "url" : "/lifeandstyle/home-and-garden",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Women",
+                "url" : "/lifeandstyle/women",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Men",
+                "url" : "/lifeandstyle/men",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Family",
+                "url" : "/lifeandstyle/family",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Travel",
+                "url" : "/travel",
+                "children" : [ {
+                    "title" : "UK",
+                    "url" : "/travel/uk",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Europe",
+                    "url" : "/travel/europe",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "US",
+                    "url" : "/travel/usa",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            }, {
+                "title" : "Money",
+                "url" : "/money",
+                "children" : [ {
+                    "title" : "Property",
+                    "url" : "/money/property",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Pensions",
+                    "url" : "/money/pensions",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Savings",
+                    "url" : "/money/savings",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Borrowing",
+                    "url" : "/money/debt",
+                    "children" : [ ],
+                    "classList" : [ ]
+                }, {
+                    "title" : "Careers",
+                    "url" : "/money/work-and-careers",
+                    "children" : [ ],
+                    "classList" : [ ]
+                } ],
+                "classList" : [ ]
+            } ],
+            "classList" : [ ]
+        },
+        "otherLinks" : [ {
+            "title" : "The Guardian app",
+            "url" : "https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Video",
+            "url" : "/video",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Podcasts",
+            "url" : "/podcasts",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Pictures",
+            "url" : "/inpictures",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Newsletters",
+            "url" : "/email-newsletters",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Today's paper",
+            "url" : "/theguardian",
+            "children" : [ {
+                "title" : "Obituaries",
+                "url" : "/obituaries",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "G2",
+                "url" : "/theguardian/g2",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Journal",
+                "url" : "/theguardian/journal",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Saturday",
+                "url" : "/theguardian/saturday",
+                "children" : [ ],
+                "classList" : [ ]
+            } ],
+            "classList" : [ ]
+        }, {
+            "title" : "Inside the Guardian",
+            "url" : "https://www.theguardian.com/membership",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "The Observer",
+            "url" : "/observer",
+            "children" : [ {
+                "title" : "Comment",
+                "url" : "/theobserver/news/comment",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "The New Review",
+                "url" : "/theobserver/new-review",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Observer Magazine",
+                "url" : "/theobserver/magazine",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Observer Food Monthly",
+                "url" : "/theobserver/foodmonthly",
+                "children" : [ ],
+                "classList" : [ ]
+            } ],
+            "classList" : [ ]
+        }, {
+            "title" : "Guardian Weekly",
+            "url" : "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Crosswords",
+            "url" : "/crosswords",
+            "children" : [ {
+                "title" : "Blog",
+                "url" : "/crosswords/crossword-blog",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Quick",
+                "url" : "/crosswords/series/quick",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Cryptic",
+                "url" : "/crosswords/series/cryptic",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Prize",
+                "url" : "/crosswords/series/prize",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Weekend",
+                "url" : "/crosswords/series/weekend-crossword",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Quiptic",
+                "url" : "/crosswords/series/quiptic",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Genius",
+                "url" : "/crosswords/series/genius",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Speedy",
+                "url" : "/crosswords/series/speedy",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Everyman",
+                "url" : "/crosswords/series/everyman",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Azed",
+                "url" : "/crosswords/series/azed",
+                "children" : [ ],
+                "classList" : [ ]
+            } ],
+            "classList" : [ ]
+        }, {
+            "title" : "Wordiply",
+            "url" : "https://www.wordiply.com",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Corrections",
+            "url" : "/theguardian/series/corrections-and-clarifications",
+            "children" : [ ],
+            "classList" : [ ]
+        } ],
+        "brandExtensions" : [ {
+            "title" : "Search jobs",
+            "url" : "https://jobs.theguardian.com",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Holidays",
+            "url" : "https://holidays.theguardian.com?INTCMP=holidays_int_web_newheader",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Digital Archive",
+            "url" : "https://theguardian.newspapers.com",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Guardian Puzzles app",
+            "url" : "https://puzzles.theguardian.com/download",
+            "children" : [ ],
+            "classList" : [ ]
+        }, {
+            "title" : "Guardian Licensing",
+            "url" : "https://licensing.theguardian.com/",
+            "children" : [ ],
+            "classList" : [ ]
+        } ]
+    },
     "tagPages" : [ "us-news/us-politics", "australia-news/australian-politics", "australia-news/australian-immigration-and-asylum", "australia-news/indigenous-australians", "uk/scotland", "uk/wales", "uk/northernireland", "world/europe-news", "world/americas", "world/asia", "world/africa", "world/middleeast", "business/economics", "business/banking", "business/retail", "business/stock-markets", "business/eurozone", "business/diversity-and-equality", "business/us-small-business", "environment/climate-change", "environment/climate-crisis", "environment/wildlife", "environment/energy", "environment/pollution", "money/property", "money/pensions", "money/savings", "money/debt", "money/work-and-careers", "cartoons/archive", "type/cartoon", "profile/editorial", "au/index/contributors", "index/contributors", "commentisfree/series/comment-is-free-weekly", "sport/rugby-union", "sport/cricket", "sport/tennis", "sport/cycling", "sport/golf", "sport/us-sport", "sport/horse-racing", "sport/rugbyleague", "sport/boxing", "sport/formulaone", "sport/nfl", "sport/mlb", "football/mls", "sport/nba", "sport/nhl", "sport/afl", "football/a-league", "sport/nrl", "music/classicalmusicandopera", "food", "tone/recipes", "lifeandstyle/health-and-wellbeing", "lifeandstyle/family", "lifeandstyle/home-and-garden", "lifeandstyle/love-and-sex", "au/lifeandstyle/fashion", "au/lifeandstyle/food-and-drink", "au/lifeandstyle/relationships", "au/lifeandstyle/health-and-wellbeing", "travel/uk", "travel/europe", "travel/usa", "travel/skiing", "travel/australasia", "travel/asia", "theguardian", "observer", "football/live", "football/tables", "football/competitions", "football/results", "football/fixtures", "crosswords/crossword-blog", "crosswords/series/crossword-editor-update", "crosswords/series/quick", "crosswords/series/cryptic", "crosswords/series/prize", "crosswords/series/weekend-crossword", "crosswords/series/quiptic", "crosswords/series/genius", "crosswords/series/speedy", "crosswords/series/everyman", "crosswords/series/azed", "fashion/beauty", "technology/motoring", "commentisfree/commentisfree", "education/education" ],
     "international" : {
         "newsPillar" : {

--- a/facia/app/agents/MostViewedAgent.scala
+++ b/facia/app/agents/MostViewedAgent.scala
@@ -104,7 +104,7 @@ class MostViewedAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, ws
 
   // Note that here we are in procedural land here (not functional)
   def refresh()(implicit ec: ExecutionContext): Future[(Option[Content], Option[Content])] = {
-    MostViewed.refreshAll(Edition.allWithBetaEditions)(refresh)
+    MostViewed.refreshAll(Edition.allEditions)(refresh)
     refreshGlobal()
   }
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -17,7 +17,7 @@ import services.{CollectionConfigWithId, ConfigAgent}
 import layout.slices._
 import views.html.fragments.containers.facia_cards.container
 import views.support.FaciaToMicroFormat2Helpers.getCollection
-import conf.switches.Switches.{EuropeNetworkFrontSwitch, InlineEmailStyles}
+import conf.switches.Switches.InlineEmailStyles
 import implicits.GUHeaders
 import pages.{FrontEmailHtmlPage, FrontHtmlPage}
 import utils.TargetedCollections
@@ -206,9 +206,6 @@ trait FaciaController
 
   import PressedPage.pressedPageFormat
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader): Future[Result] = {
-    if (path == "europe" && !EuropeNetworkFrontSwitch.isSwitchedOn) {
-      return successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
-    }
     val futureFaciaPage: Future[Option[(PressedPage, Boolean)]] = frontJsonFapi.get(path, liteRequestType).flatMap {
       case Some(faciaPage: PressedPage) =>
         val pageContainsTargetedCollections = TargetedCollections.pageContainsTargetedCollections(faciaPage)
@@ -230,7 +227,7 @@ trait FaciaController
       case None => Future.successful(None)
     }
 
-    val networkFrontEdition = Edition.allWithBetaEditions.find(_.networkFrontId == path)
+    val networkFrontEdition = Edition.allEditions.find(_.networkFrontId == path)
     val participatingInDeeplyReadTest = ActiveExperiments.isParticipating(DeeplyRead)
     val deeplyRead = if (participatingInDeeplyReadTest) {
       networkFrontEdition.map(deeplyReadAgent.getTrails)

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -77,7 +77,7 @@ class NavigationController(val controllerComponents: ControllerComponents) exten
               "topLevelSections" -> menu.pillars.map(section => topLevelNavItems(section)),
               "readerRevenueLinks" -> UrlHelpers.readerRevenueLinks.map(section => navSectionLink(section)),
               "secondarySections" -> navSecondarySections,
-              "editions" -> Edition.all,
+              "editions" -> Edition.allEditions,
             ),
           ),
         )

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -95,7 +95,7 @@ class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, w
 
   // Note that here we are in procedural land here (not functional)
   def refresh()(implicit ec: ExecutionContext): Unit = {
-    MostViewed.refreshAll(Edition.allWithBetaEditions)(refresh)
+    MostViewed.refreshAll(Edition.allEditions)(refresh)
     refreshGlobal()
   }
 }


### PR DESCRIPTION
## What does this change?

This removes all the logic and data structures added to handle hiding the Europe edition pre-launch given that the edition has now gone live. This includes:

- Removing the Europe feature switch introduced in #26570
- Removing all uses of the switch 
- Removing the `editionByRequest` function introduced in #25463 and consequently removing the `allWithBetaEditions` list and adding `Europe` to the `allEditions` list (renamed from `all` to make it less ambiguous)
- Updating the `reference-navigation.json` file used by DCR 

This won't be merged until references to the Feature switch are removed from DCR (Draft PR in progress [here](https://github.com/guardian/dotcom-rendering/pull/8893))
