### PR TITLE
Add Europe Daily (Headlines) email front to list of special email fronts 

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -101,6 +101,7 @@ object EmailFrontPath {
       case "email/uk/daily" => Some(EmailFrontPath(path, "uk"))
       case "email/us/daily" => Some(EmailFrontPath(path, "us"))
       case "email/au/daily" => Some(EmailFrontPath(path, "au"))
+      case "email/europe/daily" => Some(EmailFrontPath(path, "europe"))
       case _                => None
     }
 }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -98,11 +98,11 @@ case class EmailFrontPath(path: String, edition: String)
 object EmailFrontPath {
   def fromPath(path: String): Option[EmailFrontPath] =
     path match {
-      case "email/uk/daily" => Some(EmailFrontPath(path, "uk"))
-      case "email/us/daily" => Some(EmailFrontPath(path, "us"))
-      case "email/au/daily" => Some(EmailFrontPath(path, "au"))
+      case "email/uk/daily"     => Some(EmailFrontPath(path, "uk"))
+      case "email/us/daily"     => Some(EmailFrontPath(path, "us"))
+      case "email/au/daily"     => Some(EmailFrontPath(path, "au"))
       case "email/europe/daily" => Some(EmailFrontPath(path, "europe"))
-      case _                => None
+      case _                    => None
     }
 }
 


### PR DESCRIPTION
## What does this change?

Includes the /email/europe/daily front to the list of special fronts. This means the buildExtraEmailCollections will add the headlines container, if the config is correct in the fronts tool. 

## Screenshots

Screeshots are comparing PROD to CODE, hence the content difference, but the important bit is the headlines container is rendered in CODE. 

| Before      | After      |
|-------------|------------|
| <img width="504" alt="Screenshot 2023-09-22 at 16 42 43" src="https://github.com/guardian/frontend/assets/1229808/87986e7d-bfc3-4178-aa5c-5a6887b3b04f"> | <img width="503" alt="Screenshot 2023-09-22 at 16 41 26" src="https://github.com/guardian/frontend/assets/1229808/48ed58a1-0e48-4c3b-877f-1a8e44a98258">|
