### PR TITLE
Add Europe to ophan API Edition list

### DIFF
--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -1,6 +1,6 @@
 package services
 
-import common.editions.{Au, Uk, Us, International}
+import common.editions.{Au, Europe, International, Uk, Us}
 
 import java.net.URLEncoder
 import java.time.LocalDate
@@ -39,6 +39,7 @@ class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
       case Uk            => "gb"
       case Us            => "us"
       case International => "international"
+      case Europe        => "international"
     }
 
   // getBody is the general function that queries Ophan


### PR DESCRIPTION
## What is the value of this and can you measure success?
Adds Europe edition to the ophan api edition list as this was missing and was subsequently breaking the most viewed agent
## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
