### PR TITLE
Remove scheduler switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -186,14 +186,4 @@ trait PerformanceSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
-
-  val Scheduler = Switch(
-    SwitchGroup.Performance,
-    "scheduler",
-    "Schedule JavaScript tasks using a centralised scheduler in dotcom-rendering",
-    owners = Seq(Owner.withGithub("@guardian/open-journalism")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

It’s not going to be used – https://github.com/guardian/dotcom-rendering/pull/8905

## What does this change?

Remove the `Scheduler` switch