### PR TITLE
Bump `@guardian/commercial@11.13.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
-		"@guardian/commercial": "11.12.0",
+		"@guardian/commercial": "11.13.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,10 +1556,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-15.0.1.tgz#2c936c43e654f5ae28db254329eae1b4b5861641"
   integrity sha512-XNqYE9X/4aM5vZqiZInedvEZ9niPfdqwL7SjzNF0wnVbR+YObOC6QC68M521gTPcyca6r190qtnayv4GNO0peg==
 
-"@guardian/commercial@11.12.0":
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.12.0.tgz#e801daa5fabca6177d9616fd347516b95d313104"
-  integrity sha512-I01xGg9kTT2sz22+9ebPba/195PZDXmVOa4Km5oHqat0n4AOaam9zhCqR9VG4d8pgGquMAjeB75zeZGwnl2dQw==
+"@guardian/commercial@11.13.0":
+  version "11.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.13.0.tgz#c6de9a72e23bf6150ce70d5cf43fe77d43bfb49e"
+  integrity sha512-o9Q6lDTMK2Qd0zAlaCXhkT4HN2leYuitHWnhGdjnMUi6d3cJtDMXeGGmcqL5A4r2PnkLULB0DbiJOfwCr5VaYg==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"
@@ -10494,7 +10494,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js#356f371:
+"prebid.js@github:guardian/prebid.js#356f371":
   version "7.54.5"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/356f3714fda0459b6740e90ff265055fe6d4f813"
   dependencies:


### PR DESCRIPTION
[Release notes](https://github.com/guardian/commercial/releases/tag/v11.13.0). Keeping things up to date.