### PR TITLE
Add Women's Nations League to the League Table Controller

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -37,6 +37,7 @@ class LeagueTableController(
     "Champions League",
     "Euro 2024 qualifying",
     "Women's Champions League",
+    "Women's Nations League",
     "Europa League",
     "Carabao Cup",
     "International friendlies",


### PR DESCRIPTION
## What is the value of this and can you measure success?
The Women's Nations League was missing from the Football Tables

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| <img width="928" alt="image" src="https://github.com/guardian/frontend/assets/26366706/47f10bc3-6b7f-4240-b2c8-34a0c732764c"> |<img width="938" alt="image" src="https://github.com/guardian/frontend/assets/26366706/62448a32-a181-4b69-84bd-426400c24972"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
