### PR TITLE
add monitoring for DCAR rollout

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -134,6 +134,7 @@ class ArticleController(
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
       case AppsFormat =>
+        log.info("[ArticleRendering] path executing in dotcom rendering for apps (DCAR)")
         remoteRenderer.getAppsArticle(
           ws,
           article,

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -134,7 +134,6 @@ class ArticleController(
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
       case AppsFormat =>
-        log.info("[ArticleRendering] path executing in dotcom rendering for apps (DCAR)")
         remoteRenderer.getAppsArticle(
           ws,
           article,

--- a/article/app/services/dotcomrendering/ArticlePicker.scala
+++ b/article/app/services/dotcomrendering/ArticlePicker.scala
@@ -5,6 +5,7 @@ import implicits.Requests._
 import model.{ArticlePage, PageWithStoryPackage}
 import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
+import implicits.AppsFormat
 
 object ArticlePageChecks {
 
@@ -65,11 +66,30 @@ object ArticlePicker {
       ("pageTones" -> pageTones)
 
     if (tier == RemoteRender) {
-      DotcomponentsLogger.logger.logRequest(s"path executing in dotcomponents", features, page.article)
+      if (request.getRequestFormat == AppsFormat)
+        DotcomponentsLogger.logger.logRequest(
+          s"[ArticleRendering] path executing in dotcom rendering for apps (DCAR)",
+          features,
+          page.article,
+        )
+      else
+        DotcomponentsLogger.logger.logRequest(
+          s"[ArticleRendering] path executing in dotcomponents",
+          features,
+          page.article,
+        )
     } else if (tier == PressedArticle) {
-      DotcomponentsLogger.logger.logRequest(s"path executing from pressed content", features, page.article)
+      DotcomponentsLogger.logger.logRequest(
+        s"[ArticleRendering] path executing from pressed content",
+        features,
+        page.article,
+      )
     } else {
-      DotcomponentsLogger.logger.logRequest(s"path executing in web", features, page.article)
+      DotcomponentsLogger.logger.logRequest(
+        s"[ArticleRendering] path executing in web (frontend)",
+        features,
+        page.article,
+      )
     }
 
     tier


### PR DESCRIPTION
## What is the value of this and can you measure success?

Part of [dotcom-rendering/issues/8992](https://github.com/guardian/dotcom-rendering/issues/8992), alongside [mobile-apps-api/pull/2727](https://github.com/guardian/mobile-apps-api/pull/2727), to measure the rollout of DCAR

## What does this change?

Adds a log line to apps article requests to understand the volume of requests for DCAR rendered articles, in comparison with AR (apps rendering) and templates (legacy native rendering)

