### PR TITLE
Extend `header-top-bar-search-capi` switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -85,7 +85,7 @@ object HeaderTopBarSearchCapi
       name = "header-top-bar-search-capi",
       description = "Adds CAPI search to the top nav",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2023, 10, 10),
+      sellByDate = LocalDate.of(2023, 11, 10),
       participationGroup = Perc1B,
     )
 


### PR DESCRIPTION
Until 2023-11-10.

