### PR TITLE
Add feature switch to enable fronts banner ads.

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -158,6 +158,16 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val frontsBannerAds: Switch = Switch(
+    group = Commercial,
+    name = "fronts-banner-ads",
+    description = "Enable banner ads to display instead of MPUs and merch-high on fronts pages.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }
 
 trait PrebidSwitches {


### PR DESCRIPTION
## What is the value of this and can you measure success?

- This switch is so that we can enable fronts-banner ads when we are ready to launch. It may be useful to disable this switch if there is some misconfiguration after fronts-banner ads are enabled and we want a quick way to turn them off. This switch should be removed in due course.

## What does this change?

- Adds a feature switch that will enable fronts-banner ads on fronts pages. This is part of a strategy to display a new type of ad on fronts instead of MPUs and merchandising-high slots.