### PR TITLE
add dark mode switch for dcar project

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -542,4 +542,14 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
+  val DarkModeInApps = Switch(
+    SwitchGroup.Feature,
+    "dark-mode-apps",
+    "If this switch is on, we will allow dark mode in apps articles",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    // This is a random date in the future but this switch should be removed far before then
+    sellByDate = Some(LocalDate.of(2024, 6, 5)),
+    exposeClientSide = false,
+  )
 }


### PR DESCRIPTION
## What does this change?

Adds a feature switch for dark mode in apps as part of the DCAR project (https://github.com/guardian/dotcom-rendering/issues/8729)

Resolves https://github.com/guardian/dotcom-rendering/issues/9111
