### PR TITLE
Remove vertical video feature switches

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -522,14 +522,4 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val VerticalVideo = Switch(
-    SwitchGroup.Feature,
-    "vertical-video",
-    "When ON, shows the vertical video container",
-    owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -532,14 +532,4 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val VerticalVideoSurvey = Switch(
-    SwitchGroup.Feature,
-    "vertical-video-survey",
-    "When ON, shows the vertical video survey link",
-    owners = Seq(Owner.withGithub("@guardian/editorial-experience")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
 }

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -6,7 +6,7 @@
 @import views.html.fragments.containers.facia_cards._
 @import views.support.Commercial.container.shouldRenderAsPaidContainer
 @import views.support.GetClasses
-@import conf.switches.Switches.{MostViewedFronts, VerticalVideo => VerticalVideoSwitch}
+@import conf.switches.Switches.{MostViewedFronts}
 @import experiments.ActiveExperiments
 
 @import conf.audio.FlagshipFrontContainer

--- a/common/app/views/fragments/containers/facia_cards/verticalVideoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/verticalVideoContainer.scala.html
@@ -8,7 +8,6 @@
 @import model.VideoFaciaProperties
 @import layout.FaciaCardHeader
 @import model.Pillar.RichPillar
-@import conf.switches.Switches.{VerticalVideoSurvey}
 
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 
@@ -116,12 +115,4 @@ data-layout="vertical-video"
         @fragments.inlineSvg("chevron-right", "icon", Seq("vertical-video-playlist__icon", "vertical-video-playlist__icon--next"))
         </a>
     </div>
-    @if(VerticalVideoSurvey.isSwitchedOn) {
-        <div class="vertical-video__ext-link">
-            We're experimenting with vertical video.&nbsp;
-            <a href="https://guardiannewsandmedia.formstack.com/forms/vertical_video"
-            target="_blank"
-            rel="noopener noreferrer">Tell us what you think</a>
-        </div>
-    }
 </div>


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
Removes feature switches as these switches are no longer in use 🧹 
## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
