### PR TITLE
Force A Version Of `netty-codec-http2`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ val common = library("common")
       awsSqs,
       awsSsm,
       eTagCachingS3,
+      nettyCodecHttp2,
       contentApiClient,
       enumeratumPlayJson,
       filters,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,6 +124,10 @@ object Dependencies {
       jacksonDatabind,
     )
 
+  // Forcing a version of this to fix an issue with the dependency.
+  // This is a transitive dependency of the AWS SDK used by etag-caching library
+  val nettyCodecHttp2 = "io.netty" % "netty-codec-http2" % "4.1.100.Final"
+
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.7"
   val jquery = "org.webjars" % "jquery" % "3.2.1"


### PR DESCRIPTION
Fixes an issue with the dependency. This is a transitive dependency of the AWS SDK used by the `etag-caching` library.
