### PR TITLE
bump cmp to 13.7.1 for babel-traverse issue and commercial to 11.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
 		"@guardian/commercial": "11.17.2",
-		"@guardian/consent-management-platform": "^13.7.1",
+		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",
 		"@guardian/identity-auth-frontend": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
-		"@guardian/commercial": "11.17.1",
+		"@guardian/commercial": "11.17.2",
 		"@guardian/consent-management-platform": "^13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
 		"@guardian/commercial": "11.17.1",
-		"@guardian/consent-management-platform": "^13.6.1",
+		"@guardian/consent-management-platform": "^13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",
 		"@guardian/identity-auth-frontend": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,7 +1925,7 @@
     web-vitals "^3.3.2"
     wolfy87-eventemitter "^5.2.9"
 
-"@guardian/consent-management-platform@^13.7.1":
+"@guardian/consent-management-platform@13.7.1":
   version "13.7.1"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.1.tgz#ba38f32de023775e615e79cfa97a3425f144eb89"
   integrity sha512-BtUNkuCqd++A0Wkk9CA4kI95yVZJk1YMjPdppEnmq3cG/ros4ElXN4cNG7pWifeTR5cUtJflAiRRO4L5ewASpQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,10 +1925,10 @@
     web-vitals "^3.3.2"
     wolfy87-eventemitter "^5.2.9"
 
-"@guardian/consent-management-platform@^13.6.1":
-  version "13.6.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
-  integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
+"@guardian/consent-management-platform@^13.7.1":
+  version "13.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.1.tgz#ba38f32de023775e615e79cfa97a3425f144eb89"
+  integrity sha512-BtUNkuCqd++A0Wkk9CA4kI95yVZJk1YMjPdppEnmq3cG/ros4ElXN4cNG7pWifeTR5cUtJflAiRRO4L5ewASpQ==
 
 "@guardian/core-web-vitals@^5.0.0":
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,10 +1908,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-15.0.1.tgz#2c936c43e654f5ae28db254329eae1b4b5861641"
   integrity sha512-XNqYE9X/4aM5vZqiZInedvEZ9niPfdqwL7SjzNF0wnVbR+YObOC6QC68M521gTPcyca6r190qtnayv4GNO0peg==
 
-"@guardian/commercial@11.17.1":
-  version "11.17.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.17.1.tgz#20d1995af590acf1ff5cb0422d77d50319daf241"
-  integrity sha512-XNkuPbpKgxYozjELlyloi0OgxCrPuwBVM+KS0VaeDypbn7SWCFt5Wt2maDGB3ss3NiwJ4YKq5/On7j5Z43yBrQ==
+"@guardian/commercial@11.17.2":
+  version "11.17.2"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.17.2.tgz#0745c0888925d6c880bc41f0cd7f0369d64d498d"
+  integrity sha512-vgijbkjLQ+9nr04Pim2XIDIlL/xpw6coFV7BDNzWqP5MBib1k2NeVqoHlp2geKGP+AbA77Rt1CZpB+5mh+f4iQ==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
## What is the value of this and can you measure success? 

Security patch and change to vendors for consent-management-platform
Security patch and centre video element for commercial

## What does this change?

### Consent-management-platform
Removes babel/traverse insecurity from consent-management-platform.
Update to vendor.ts to match the Sourcepoint Vendor List.
https://github.com/guardian/consent-management-platform/releases/tag/v13.7.1 

### Commercial
Removes babel/traverse insecurity and centre video element in the video interscroller template
https://github.com/guardian/commercial/releases/tag/v11.17.2 

## Screenshots



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
