### PR TITLE
Bump commercial to 11.19.0 and extend expiring switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -91,7 +91,7 @@ trait ABTestSwitches {
     "'Test the impact of running prebid earlier in the page load process.",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 11, 31)),
+    sellByDate = Some(LocalDate.of(2023, 11, 30)),
     exposeClientSide = true,
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "Test Kargo as a prebid bidder for US traffic.",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 10, 30)),
+    sellByDate = Some(LocalDate.of(2023, 11, 30)),
     exposeClientSide = true,
   )
 
@@ -91,7 +91,7 @@ trait ABTestSwitches {
     "'Test the impact of running prebid earlier in the page load process.",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 10, 31)),
+    sellByDate = Some(LocalDate.of(2023, 11, 31)),
     exposeClientSide = true,
   )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -27,7 +27,7 @@ object DeeplyRead
       name = "deeply-read",
       description = "When ON, deeply read footer section is displayed",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2023, 10, 31),
+      sellByDate = LocalDate.of(2023, 11, 30),
       participationGroup = Perc0A,
     )
 
@@ -36,7 +36,7 @@ object Lightbox
       name = "lightbox",
       description = "Testing the impact lightbox might have on our CWVs",
       owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2023, 10, 30),
+      sellByDate = LocalDate.of(2023, 11, 30),
       participationGroup = Perc0B,
     )
 
@@ -83,7 +83,7 @@ object OfferHttp3
       name = "offer-http3",
       description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
       owners = Seq(Owner.withGithub("paulmr")),
-      sellByDate = LocalDate.of(2023, 10, 30),
+      sellByDate = LocalDate.of(2023, 11, 30),
       participationGroup = Perc1E,
     )
 
@@ -92,6 +92,6 @@ object OphanEsm
       name = "ophan-esm",
       description = "Use ophan-tracker-js@2, which uses native ES Modules",
       owners = Seq(Owner.withGithub("@guardian/ophan")),
-      sellByDate = LocalDate.of(2023, 10, 31),
+      sellByDate = LocalDate.of(2023, 11, 30),
       participationGroup = Perc50,
     )

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
-    "@guardian/commercial": "11.18.0",
+		"@guardian/commercial": "11.19.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,18 +1908,17 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-15.0.1.tgz#2c936c43e654f5ae28db254329eae1b4b5861641"
   integrity sha512-XNqYE9X/4aM5vZqiZInedvEZ9niPfdqwL7SjzNF0wnVbR+YObOC6QC68M521gTPcyca6r190qtnayv4GNO0peg==
 
-
-"@guardian/commercial@11.18.0":
-  version "11.18.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.18.0.tgz#7c2be3351d448cc9a91edf5569fcf2f45124e86d"
-  integrity sha512-U1nhvCeIiFjt+TpK3wF6XZ6I3Sy/obNmaLanv8d4keULpHTF1rsfL0Mb4SfOOeUsDFz/RuHgDuo+lbKvbRQj4w==
+"@guardian/commercial@11.19.0":
+  version "11.19.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.19.0.tgz#dcb51eab371d2230bc5e0afde8d145a9af259dee"
+  integrity sha512-LbuX2dZM98QrUijaTPeI9wYARTD7o4xTCoX4EBeNnoJ4k5APOCl0OkxuBHlD06RCmNZ0ERMCQx7bse3rDFwaZQ==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"
     fastdom "^1.0.11"
     lodash-es "^4.17.21"
     ophan-tracker-js "^2.0.1"
-    prebid.js guardian/prebid.js#ddf4251
+    prebid.js guardian/prebid.js#0b4cccd
     process "^0.11.10"
     raven-js "^3.27.2"
     tslib "^2.5.3"
@@ -4927,10 +4926,10 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
-crypto-js@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
-  integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 css-color-names@0.0.1:
   version "0.0.1"
@@ -10966,9 +10965,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js#ddf4251:
+prebid.js@guardian/prebid.js#0b4cccd:
   version "7.54.5"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/ddf4251b19c95878af00f640211c0c31ac3e7ac2"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5"
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"
@@ -10978,7 +10977,7 @@ prebid.js@guardian/prebid.js#ddf4251:
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^3.3.0"
+    crypto-js "^4.2.0"
     dlv "1.1.3"
     dset "3.1.2"
     express "^4.15.4"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Bumps commercial to 11.19.0. This version has resolved a vulnerability caused by an older version of crypto-js in Prebid.

Also extends 6 switches that had expired, so that the build passes.