### PR TITLE
Add time zones to fixtures

### DIFF
--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -44,7 +44,7 @@
                 <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub">
                     @if(theMatch.isFixture){
                         <time datetime="@theMatch.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZone(Edition(request).timezoneId))" data-timestamp="@theMatch.date.toInstant.toEpochMilli">
-                            @theMatch.date.format(DateTimeFormatter.ofPattern("HH:mm ").withZone(Edition(request).timezoneId))</time>
+                            @theMatch.date.format(DateTimeFormatter.ofPattern("HH:mm z").withZone(Edition(request).timezoneId))</time>
                     }else{
                         @MatchStatus(theMatch.matchStatus)
                     }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Make it more explicit for our European edition readers when matches happen.

Especially relevant for users in Portugal.

Discussed with @HarryFischer from design who agreed it is good!

## What does this change?

Add the time zone next to fixture times

## Screenshots

### UK Edition

<img width="644" alt="Screenshot 2023-11-03 at 11 59 02" src="https://github.com/guardian/frontend/assets/76776/1d7df742-b33d-4eb5-82a1-07bec31c4f25">

### Europe Edition

<img width="644" alt="Screenshot 2023-11-03 at 11 59 19" src="https://github.com/guardian/frontend/assets/76776/8b98951d-cd56-4e13-86bb-dbebfdfead6d">

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
