### PR TITLE
Remove frontsBannerAds feature switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -158,16 +158,6 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
-
-  val frontsBannerAds: Switch = Switch(
-    group = Commercial,
-    name = "fronts-banner-ads",
-    description = "Enable banner ads to display instead of MPUs and merch-high on fronts pages.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
 }
 
 trait PrebidSwitches {


### PR DESCRIPTION
## What is the value of this and can you measure success?

- Switch is no longer used: https://github.com/guardian/dotcom-rendering/pull/9378

## What does this change?

- Removes the frontsBannerAds switch