### PR TITLE
Switch to Play 3 and go all in on Pekko

### DIFF
--- a/admin/app/http/AdminFilters.scala
+++ b/admin/app/http/AdminFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import GoogleAuthFilters.AuthFilterWithExemptions
 import googleAuth.FilterExemptions
 import model.ApplicationContext

--- a/common/app/dev/DevAssetsController.scala
+++ b/common/app/dev/DevAssetsController.scala
@@ -1,6 +1,6 @@
 package dev
 
-import akka.stream.scaladsl.StreamConverters
+import org.apache.pekko.stream.scaladsl.StreamConverters
 import common.Assets.AssetNotFoundException
 import common.ImplicitControllerExecutionContext
 import java.io.File

--- a/common/app/http/AmpFilter.scala
+++ b/common/app/http/AmpFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import conf.Configuration
 import play.api.mvc.{Filter, RequestHeader, Result}
 

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -1,7 +1,7 @@
 package http
 
 import javax.inject.Inject
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import app.FrontendBuildInfo
 import conf.switches.Switches
 import implicits.Responses._
@@ -144,7 +144,6 @@ object Filters {
 
 }
 
-//Note: still using akka (instead of pekko) materializer from Play as both filters extend Play's Filter, so the types need to match
 class CommonFilters(frontendBuildInfo: FrontendBuildInfo)(implicit
     mat: Materializer,
     applicationContext: ApplicationContext,

--- a/common/app/http/GoogleAuthFilters.scala
+++ b/common/app/http/GoogleAuthFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.gu.googleauth.{FilterExemption, UserIdentity}
 import googleAuth.AuthCookie
 import model.ApplicationContext

--- a/common/app/http/H2PreloadFilter.scala
+++ b/common/app/http/H2PreloadFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import common.Preload
 import model.ApplicationContext
 import play.api.mvc._

--- a/common/app/http/RequestLoggingFilter.scala
+++ b/common/app/http/RequestLoggingFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import common.{GuLogging, RequestLogger, StopWatch}
 import play.api.mvc.{Filter, RequestHeader, Result}
 

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -1,6 +1,6 @@
 package test
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.gargoylesoftware.htmlunit.{BrowserVersion, WebClient}
 import common.Lazy

--- a/dev-build/app/http/DevFilters.scala
+++ b/dev-build/app/http/DevFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import implicits.Requests
 import model.ApplicationContext
 import play.api.http.HttpFilters

--- a/identity/app/http/HeaderLoggingFilter.scala
+++ b/identity/app/http/HeaderLoggingFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 
 import play.api.mvc._
 import utils.SafeLogging

--- a/identity/app/http/IdentityFilters.scala
+++ b/identity/app/http/IdentityFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import model.ApplicationContext
 import play.api.http.HttpFilters
 

--- a/identity/app/http/StrictTransportSecurityHeaderFilter.scala
+++ b/identity/app/http/StrictTransportSecurityHeaderFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
+++ b/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
@@ -1,6 +1,6 @@
 package filters
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import http.StrictTransportSecurityHeaderFilter
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/preview/app/http/PreviewFilters.scala
+++ b/preview/app/http/PreviewFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import GoogleAuthFilters.AuthFilterWithExemptions
 import controllers.HealthCheck
 import googleAuth.FilterExemptions

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
-  val playJsonVersion = "2.9.4"
+  val playJsonVersion = "3.0.1"
   val playJsonExtensionsVersion = "0.42.0"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.11"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
@@ -62,9 +62,9 @@ object Dependencies {
   val scalaCollectionPlus = "com.madgag" %% "scala-collection-plus" % "0.11"
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "2.30.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11" % Test
-  val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
-  val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-3-4" % "3.3.0.0-SNAP3" % Test
-  val scalaTestPlusScalacheck = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test
+  val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test
+  val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-4-11" % "3.2.17.0" % Test
+  val scalaTestPlusScalacheck = "org.scalatestplus" %% "scalacheck-1-17" % "3.2.17.0" % Test
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "2.44.0"
   val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.36"
@@ -85,9 +85,9 @@ object Dependencies {
   val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.7.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.8"
-  val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
+  val playJson = "org.playframework" %% "play-json" % playJsonVersion
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
-  val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
+  val playJsonJoda = "org.playframework" %% "play-json-joda" % playJsonVersion
   val atomRenderer = "com.gu" %% "atom-renderer" % "1.2.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,37 +93,6 @@ object Dependencies {
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "4.10.0"
 
-  /*
-    Note: Although frontend compiles and passes all the current tests when jackson is removed, be careful that this
-    may break the fronts diagnostics tools. If we try to remove jackson one day after (for instance after other
-    dependencies have been upgraded), then do remember to check for regressions.
-
-    The versions are currently set as they are because of:
-    https://github.com/orgs/playframework/discussions/11222
-   */
-  val jacksonVersion = "2.13.2"
-  val jacksonDatabindVersion = "2.13.2.2"
-  val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
-  val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
-  val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
-  val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
-  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
-  val jacksonParameterName = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion
-  val jackModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
-  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
-
-  val jackson =
-    Seq(
-      jacksonCore,
-      jacksonAnnotations,
-      jacksonDataTypeJdk8,
-      jacksonDataType,
-      jacksonDataFormat,
-      jacksonParameterName,
-      jackModule,
-      jacksonDatabind,
-    )
-
   // Forcing a version of this to fix an issue with the dependency.
   // This is a transitive dependency of the AWS SDK used by etag-caching library
   val nettyCodecHttp2 = "io.netty" % "netty-codec-http2" % "4.1.100.Final"

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -52,7 +52,6 @@ object ProjectSettings {
         <exclude org="commons-logging" module="commons-logging"><!-- Conflicts with jcl-over-slf4j in Play. --></exclude>
       </dependencies>,
     resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
-      Resolver.typesafeRepo("releases"),
       "Spy" at "https://files.couchbase.com/maven2/",
     ),
     update / evictionWarningOptions := EvictionWarningOptions.default

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbt.packager.universal.UniversalPlugin
 import sbt._
 import sbt.Keys._
 import com.gu.Dependencies._
-import play.sbt.{PlayAkkaHttpServer, PlayNettyServer, PlayScala}
+import play.sbt.{PlayPekkoHttpServer, PlayNettyServer, PlayScala}
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys.packageName
 import sbtbuildinfo.{BuildInfoKey, BuildInfoOption, BuildInfoPlugin}
@@ -98,7 +98,7 @@ object ProjectSettings {
   def root(): Project =
     Project("root", base = file("."))
       .enablePlugins(PlayScala, PlayNettyServer)
-      .disablePlugins(PlayAkkaHttpServer)
+      .disablePlugins(PlayPekkoHttpServer)
       .settings(frontendCompilationSettings)
       .settings(frontendRootSettings)
 
@@ -130,7 +130,7 @@ object ProjectSettings {
   def library(applicationName: String): Project = {
     Project(applicationName, file(applicationName))
       .enablePlugins(PlayScala, PlayNettyServer)
-      .disablePlugins(PlayAkkaHttpServer)
+      .disablePlugins(PlayPekkoHttpServer)
       .settings(frontendDependencyManagementSettings)
       .settings(frontendCompilationSettings)
       .settings(frontendTestSettings)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,23 +22,6 @@ addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addDependencyTreePlugin
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-
-/*
-   Without setting VersionScheme.Always here on `scala-xml`, sbt 1.8.0 will raise fatal 'version conflict' errors when
-   used with sbt plugins like `sbt-native-packager`, which currently use sort-of-incompatible versions of the `scala-xml`
-   library. sbt 1.8.0 has upgraded to Scala 2.12.17, which has itself upgraded to `scala-xml` 2.1.0
-   (see https://github.com/sbt/sbt/releases/tag/v1.8.0), but `sbt-native-packager` is currently using `scala-xml` 1.1.1,
-    and the `scala-xml` library declares that it uses specifically 'early-semver' version compatibility (see
-    https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#versionscheme-librarydependencyschemes-and-sbt-150 ),
-    meaning that for version x.y.z, `x` & `y` *must match exactly* for versions to be considered compatible by sbt.
-
-    By setting VersionScheme.Always here on `scala-xml`, we're overriding its declared version-compatability scheme,
-    choosing to tolerate the risk of binary incompatibility. We consider this to be safe because when set under
-    `projects/` (ie *not* in `build.sbt` itself) it only affects the compilation of build.sbt, not of the application
-    build itself. Once the build has succeeded, there is no further risk (ie of a runtime exception due to clashing
-    versions of `scala-xml`).
- */
-libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,10 +7,7 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.7",
 )
 
-resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
-  Classpaths.typesafeReleases,
-  Resolver.typesafeRepo("releases"),
-)
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,13 +12,13 @@ resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
   Resolver.typesafeRepo("releases"),
 )
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import football.controllers.ResultsController
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec


### PR DESCRIPTION
Hi!

Play maintainer here :wink: I see you switched most of the repo to Pekko already:
- #26563
- #26602

Not sure if you have seen it, we finally (thanks to your support!) released Play 3, which starts to use Pekko under the hood, more can be found here:
- https://twitter.com/playframework/status/1721576472047911007
- https://github.com/playframework/playframework/releases/tag/3.0.0

All the new features, release highlights and the migration guide from Play 2.9 apply to 3.0 as well:
- Highlights 2.9: https://www.playframework.com/documentation/latest/Highlights29
- Highlights 3.0: https://www.playframework.com/documentation/latest/Highlights30 ("just" the Pekko switch + groupId change)
- Migration guide for 2.9: https://www.playframework.com/documentation/latest/Migration29
- Migration guide for 3.0: https://www.playframework.com/documentation/latest/Migration30 (again "only" pekko + groupId)

I took a look at your repo and started the migration; it's probably not all that needs to be done, but to get started. I will try my best to help to get things working for you. I will see what fails and push more commits to this pull request.
E.g. it might be possible that webjars cause problems, since Play 3 uses sbt-web 1.5 now which was refactored a bit. We will see. Also I think some dependencies need to be upgraded, like https://github.com/bizzabo/play-json-extensions (?). If so, I am happy to help there also.

If you have any further questions I am available.

BTW: Thanks for your ongoing financial support for Play, without it we would *definitely* not have been able to push out those releases, thank you very much!