### PR TITLE
Rename ads in merch test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -57,8 +57,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-billboards-in-merch-high",
-    "Test the commercial impact of showing billboard adverts in merchandising-high slots",
+    "ab-ads-in-merch",
+    "Test the commercial impact of showing adverts in merchandising-high and merchandising slots",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
     sellByDate = Some(LocalDate.of(2023, 11, 30)),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
-		"@guardian/commercial": "11.19.1",
+		"@guardian/commercial": "^11.20.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,13 +1,13 @@
 import type { ABTest } from '@guardian/ab-core';
 import { getUrlVars } from 'lib/url';
 import { isInABTestSynchronous } from '../experiments/ab';
-import { billboardsInMerchHigh } from '../experiments/tests/billboards-in-merch-high';
+import { adsInMerch } from '../experiments/tests/ads-in-merch';
 import { integrateIma } from '../experiments/tests/integrate-ima';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
 	integrateIma,
-	billboardsInMerchHigh,
+	adsInMerch,
 ];
 
 /**

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,5 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
-import { billboardsInMerchHigh } from './tests/billboards-in-merch-high';
+import { adsInMerch } from './tests/ads-in-merch';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { elementsManager } from './tests/elements-manager';
@@ -18,7 +18,7 @@ export const concurrentTests: readonly ABTest[] = [
 	deeplyReadArticleFooterTest,
 	consentlessAds,
 	integrateIma,
-	billboardsInMerchHigh,
+	adsInMerch,
 	elementsManager,
 	prebidKargo,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/ads-in-merch.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/ads-in-merch.ts
@@ -1,7 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 
-export const billboardsInMerchHigh: ABTest = {
-	id: 'BillboardsInMerchHigh',
+export const adsInMerch: ABTest = {
+	id: 'AdsInMerch',
 	author: '@commercial-dev',
 	start: '2022-12-07',
 	expiry: '2023-11-30',
@@ -10,9 +10,9 @@ export const billboardsInMerchHigh: ABTest = {
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Opt in only',
 	successMeasure:
-		'Test the commercial impact of showing billboard adverts in merchandising-high slots',
+		'Test the commercial impact of showing adverts in merchandising-high and merchandising slots',
 	description:
-		'Show billboard adverts in merchandising-high slots to browsers in the variant',
+		'Show adverts in merchandising-high and merchandising slots to browsers in the variant',
 	variants: [
 		{
 			id: 'control',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,10 +1908,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-15.0.1.tgz#2c936c43e654f5ae28db254329eae1b4b5861641"
   integrity sha512-XNqYE9X/4aM5vZqiZInedvEZ9niPfdqwL7SjzNF0wnVbR+YObOC6QC68M521gTPcyca6r190qtnayv4GNO0peg==
 
-"@guardian/commercial@11.19.1":
-  version "11.19.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.19.1.tgz#390b24b3a0975c1501b1e329bcf64f1684f3240d"
-  integrity sha512-dJ1RVxaSKOxFL+CZ5fPWc728E+tfG8MDuFP0IW+HtFeYWq/aF3MCXlNr7dswyn9LP7qSEOkuv43YJJADNv3/KA==
+"@guardian/commercial@^11.20.0":
+  version "11.20.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.20.0.tgz#6a07246c157ba8ef365e790b8417fe6042be54dc"
+  integrity sha512-kA6hHf9o9u57qteMSmk8t9Eu2xWb6IvrnnS1hVBhvMum6b1pmzVqHUxSb3oKqb7AFz7Jq7zjweOiITfJpr3BNg==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
## What is the value of this and can you measure success?

We will soon be extending the scope of this test, so that ads of Billboard and MPU sizes will be added to `merchandising` and `merchandising-high` slots.

## What does this change?

Updates names of tests, descriptions and files to reflect new scope.

## TODO

- [x] Bump `@guardian/commercial` once published

## Related PRs

- guardian/commercial#1135
- guardian/dotcom-rendering#9454