### PR TITLE
add feature switch for user-features

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -532,4 +532,14 @@ trait FeatureSwitches {
     sellByDate = Some(LocalDate.of(2024, 6, 5)),
     exposeClientSide = false,
   )
+
+  val UserFeaturesDcr = Switch(
+    SwitchGroup.Feature,
+    "user-features-dcr",
+    "If this switch is on, we will load user-features from dcr",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 1, 15)),
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION

## What does this change?
This PR adds a simple feature switch that enables the `user-features` module introduced in https://github.com/guardian/dotcom-rendering/pull/9362.

It is defaulted to false and therefore need to be switched on in the switchboard.
