### PR TITLE
Set printable crossword cache time to 60 secs

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -58,7 +58,7 @@ trait CrosswordController extends BaseController with GuLogging with ImplicitCon
       context: ApplicationContext,
   ): Future[Result] = {
     withCrossword(crosswordType, id) { (crossword, content) =>
-      Cached(60)(
+      Cached(60.seconds)(
         RevalidatableResult.Ok(
           CrosswordHtmlPage.html(
             CrosswordPageWithSvg(
@@ -87,7 +87,7 @@ class CrosswordPageController(val contentApiClient: ContentApiClient, val contro
   def accessibleCrossword(crosswordType: String, id: Int): Action[AnyContent] =
     Action.async { implicit request =>
       withCrossword(crosswordType, id) { (crossword, content) =>
-        Cached(60)(
+        Cached(60.seconds)(
           RevalidatableResult.Ok(
             CrosswordHtmlPage.html(
               AccessibleCrosswordPage(
@@ -107,7 +107,7 @@ class CrosswordPageController(val contentApiClient: ContentApiClient, val contro
   def printableCrossword(crosswordType: String, id: Int): Action[AnyContent] =
     Action.async { implicit request =>
       withCrossword(crosswordType, id) { (crossword, content) =>
-        Cached(60)(
+        Cached(60.seconds)(
           RevalidatableResult.Ok(
             PrintableCrosswordHtmlPage.html(
               CrosswordPageWithSvg(
@@ -127,7 +127,7 @@ class CrosswordPageController(val contentApiClient: ContentApiClient, val contro
 
         val globalStylesheet = Static(s"stylesheets/$ContentCSSFile.css")
 
-        Cached(60) {
+        Cached(60.seconds) {
           val body = s"""$xml"""
           RevalidatableResult(
             Cors {

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -107,7 +107,7 @@ class CrosswordPageController(val contentApiClient: ContentApiClient, val contro
   def printableCrossword(crosswordType: String, id: Int): Action[AnyContent] =
     Action.async { implicit request =>
       withCrossword(crosswordType, id) { (crossword, content) =>
-        Cached(3.days)(
+        Cached(60)(
           RevalidatableResult.Ok(
             PrintableCrosswordHtmlPage.html(
               CrosswordPageWithSvg(


### PR DESCRIPTION
Occasionally we need to update the crossword data after publication. This happened recently, and while the interactive/playable crossword was very fast to update, we received some comments (https://www.theguardian.com/crosswords/cryptic/29227#comment-165327727, and others) that the `/print` version remained out of date. I was able to request a cache purge for the page to correct it in this circumstance, but it would be preferable if the cache time was sufficiently short that updates propagated quickly without intervention.

## What is the value of this and can you measure success?

Users see the corrected page very quickly, and are not relying on developers watching comments to remember to purge the cache for the page. The new max-cache matches the value for other crossword pages, including the main page and accessible pages and the thumbnail endpoint. I don't believe these pages see a huge amount of traffic, so I wouldn't expect this to cause a significantly increased resource usage.

I looked through the commit history for this line, and it has been unchanged since the page was implemented and no rationale was given for this specific value.

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [-] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [-] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [-] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [-] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)


<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
