### PR TITLE
Merchandising high label when ad

### DIFF
--- a/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
@@ -4,6 +4,6 @@
     "merchandising-high",
     Seq("commercial-component-high"),
     Map(),
-    showLabel=false,
+    showLabel=true,
     refresh=false
 ){ }


### PR DESCRIPTION
## What is the value of this and can you measure success?
When ads appear in merchandising-high a label should be visible.

## What does this change?

Setting `showLabel=true` on the merchandising-high slot when it it server rendered ([it isn't necessarily!](https://github.com/guardian/commercial/blob/main/src/lib/high-merch.ts)), this doesn't actually render the label unless a non-merch ad is present, because a merchanding ads are fluid and labels do not appear on fluid ads.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/1731150/6dba6698-b4ec-4baa-aa0f-0127a5b0bef7

[after]: https://github.com/guardian/frontend/assets/1731150/ba3f7291-8fb9-4621-99d8-df046db1bd8a


## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
