### PR TITLE
Constrain width of label to size of merch ad

### DIFF
--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -6,13 +6,14 @@
     refresh: Boolean = true,
     outOfPage: Boolean = false,
     optId: Option[String] = None,
-    optClassNames: Option[String] = None
+    optClassNames: Option[String] = None,
+    useFlexContainer: Boolean = false
 )(placeholderContent: Html)(implicit request: RequestHeader)
 
 @import views.support.Commercial
 @import implicits.Requests._
 
-<div class="ad-slot-container">
+<div class="ad-slot-container" @if(useFlexContainer) { style="display: flex; justify-content: center;" }>
     <div
         id="dfp-ad--@optId.getOrElse(name)"
         class="js-ad-slot ad-slot ad-slot--@name @adTypes.map{ adType =>ad-slot--@adType}.mkString(" ") @optClassNames"

--- a/common/app/views/fragments/commercial/commercialComponent.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponent.scala.html
@@ -1,9 +1,12 @@
 @()(implicit request: RequestHeader)
 
-@fragments.commercial.adSlot(
-    "merchandising",
-    Seq("commercial-component"),
-    Map(),
-    showLabel=true,
-    refresh=false
-){ }
+<div class="merchandising-wrapper">
+    @fragments.commercial.adSlot(
+        "merchandising",
+        Seq("commercial-component"),
+        Map(),
+        showLabel=true,
+        refresh=false,
+        useFlexContainer=true,
+    ){ }
+</div>

--- a/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
@@ -1,9 +1,12 @@
 @(isPaidContent: Boolean, hasPageSkin: Boolean = false)(implicit request: RequestHeader)
 
-@fragments.commercial.adSlot(
-    "merchandising-high",
-    Seq("commercial-component-high"),
-    Map(),
-    showLabel=true,
-    refresh=false
-){ }
+<div class="merchandising-high-wrapper">
+    @fragments.commercial.adSlot(
+        "merchandising-high",
+        Seq("commercial-component-high"),
+        Map(),
+        showLabel=true,
+        refresh=false,
+        useFlexContainer = true,
+    ){ }
+</div>

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -97,10 +97,6 @@
     }
 }
 
-.ad-slot-container {
-    width: 100%;
-}
-
 .ad-slot-container[top-above-nav-ad-rendered='true'],
 .ad-slot-container--centre-slot {
     width: fit-content;
@@ -110,6 +106,17 @@
 .ad-slot-container .ad-slot--mobile {
     margin-left: auto;
     margin-right: auto;
+}
+
+.merchandising-wrapper,
+.merchandising-high-wrapper {
+    position: relative;
+    margin: auto;
+    @each $breakpoint, $container-width in $breakpoints {
+        @include mq($breakpoint) {
+            max-width: $container-width + ($gs-gutter * 2);
+        }
+    }
 }
 
 .ad-slot--crossword-banner,
@@ -592,7 +599,7 @@
     visibility: hidden;
 }
 
-.ad-slot[data-label-show='true']:not(.ad-slot--dark):not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+.ad-slot[data-label-show='true']:not(.ad-slot--dark):not(.ad-slot--interscroller)::before {
     @include font-size(12, 20);
     content: attr(ad-label-text);
     display: block;
@@ -641,24 +648,6 @@
     top: 0px;
     left: 0px;
     right: 0px;
-}
-
-.ad-slot--merchandising[data-label-show='true']::before, .ad-slot--merchandising-high[data-label-show='true']::before {
-    @include font-size(12, 20);
-    content: attr(ad-label-text);
-    display: block;
-    visibility: visible;
-    position: relative;
-    height: $mpu-ad-label-height;
-    background-color: $brightness-97;
-    padding: 0 ($gs-baseline/3)*2;
-    border-top: 1px solid $brightness-86;
-    color: $brightness-46;
-    text-align: left;
-    box-sizing: border-box;
-    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
-    max-width: 970px;
-    margin: auto;
 }
 
 .ad-slot__adtest-cookie-clear-link {


### PR DESCRIPTION
_Credit to @emma-imber on this, just rebased and wrote up the PR._

## What is the value of this and can you measure success?

Fixes some visual issues encountered when running some large formats in merchandising slots via Opt Out Advertising - See the screenshots below.

## What does this change?

This PR ensures the label applied to advertising in merchandising slots matches the width of the creative. We do this by replicating the behaviour in DCR, and wrapping the slots in a flex container.

## Screenshots

The useful adtest here is https://m.code.dev-theguardian.com/uk?adtest=thirdparty

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| | ![after_two][] |
| | ![after_three][] |

[before]: https://github.com/guardian/frontend/assets/8000415/350287a9-c362-44e6-8fdb-0a8cd317d1fa
[after]: https://github.com/guardian/frontend/assets/8000415/7518ba46-7844-4639-8416-705d2b022ffd
[after_two]: https://github.com/guardian/frontend/assets/8000415/1cf3dfb2-85b9-41cd-913b-eb7e059c9142
[after_three]: https://github.com/guardian/frontend/assets/8000415/120af4eb-f772-4c21-9364-6e59a04b8477
