### PR TITLE
The Crunch. Embed styling

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -275,6 +275,7 @@
 .email-sub__form--thrasher-cotton-capital,
 .email-sub__form--thrasher-five-great-reads,
 .email-sub__form--thrasher-this-is-europe,
+.email-sub__form--thrasher-the-crunch,
 .email-sub__form--thrasher-morning-briefing {
 
     .email-sub__thrasher-embed-label {


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

CSS update - use the blue button style for the embedded sign-up form to be used on a thrasher for a new newsletter (The Crunch.(not launched yet)).

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
