### PR TITLE
fix: do not try to fetch number svg for football scores above 10 

### DIFF
--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -182,4 +182,10 @@ object CompetitionDisplayHelpers {
       .replace("Czech Republic", "Czech Rep.")
       .replace("Holland", "Netherlands")
   }
+
+  // We do not currently support scores above 10 so we default to a max
+  // number of goals to display if scores are above 10
+  def cleanScore(score: Int): Int = {
+    if (score > 10) 10 else score
+  }
 }

--- a/sport/app/football/views/fragments/matchSummary.scala.html
+++ b/sport/app/football/views/fragments/matchSummary.scala.html
@@ -5,6 +5,7 @@
 @import views.support.RenderClasses
 @import conf.Configuration
 @import model.CompetitionDisplayHelpers.cleanTeamName
+@import model.CompetitionDisplayHelpers.cleanScore
 @import football.model.GuTeamCodes
 
 @(theMatch: FootballMatch, competition: Option[Competition] = None, responsive: Boolean = false, link: Boolean = false)(implicit request: RequestHeader)
@@ -39,7 +40,7 @@
             </div>
 
             @if(theMatch.isLive || theMatch.isResult){
-                @homeTeam.score.map{score => @fragments.inlineSvg("number-" + score, "numbers", List("team__score")) }
+                @homeTeam.score.map{score => @fragments.inlineSvg("number-" + cleanScore(score), "numbers", List("team__score"))}
             }
         </div>
 
@@ -58,7 +59,7 @@
             </div>
 
             @if(theMatch.isLive || theMatch.isResult){
-                @awayTeam.score.map{score => @fragments.inlineSvg("number-" + score, "numbers", List("team__score")) }
+                @awayTeam.score.map{score => @fragments.inlineSvg("number-" + cleanScore(score), "numbers", List("team__score")) }
             }
         </div>
     </div>


### PR DESCRIPTION
## What is the value of this and can you measure success?

Prevents football match reports erroring for matches with scores above 10
Resolves #26718

## What does this change?

Adds a "cleanScore" helper to only try to fetch the SVG score for up to 10 goals.
For scores above 10 we default to showing 10


## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/43961396/53ab72c7-8fce-4c43-b6dc-1b65052cc181
[after]: https://github.com/guardian/frontend/assets/43961396/daed7085-bd65-445c-935b-c7d83e2f354d



#### NB
This PR does not address the fact that `10 != 14` but does stop the whole page erroring which is a slightly improved user experience than the incorrect score showing on the page 😄 


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)