### PR TITLE
Flag to turn off AMP

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -542,4 +542,14 @@ trait FeatureSwitches {
     sellByDate = Some(LocalDate.of(2024, 1, 15)),
     exposeClientSide = true,
   )
+
+  val TurnOffAmp = Switch(
+    SwitchGroup.Feature,
+    "turn-off-amp",
+    "If this switch is on, the AMP domain will be turned off and we will stop serving AMP articles",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 6, 15)),
+    exposeClientSide = false,
+  )
 }

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -1,16 +1,17 @@
 package implicits
 
 import com.gu.facia.client.models.{
+  AUNewSouthWalesTerritory,
+  AUQueenslandTerritory,
+  AUVictoriaTerritory,
   EU27Territory,
   NZTerritory,
   TargetedTerritory,
   USEastCoastTerritory,
   USWestCoastTerritory,
-  AUVictoriaTerritory,
-  AUQueenslandTerritory,
-  AUNewSouthWalesTerritory,
 }
 import conf.Configuration
+import conf.switches.Switches.TurnOffAmp
 import play.api.mvc.RequestHeader
 
 sealed trait RequestFormat
@@ -69,9 +70,10 @@ trait Requests {
 
     lazy val isRss: Boolean = r.path.endsWith("/rss")
 
-    lazy val isAmp: Boolean = r
-      .getQueryString("amp")
-      .isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host) || r.getQueryString("dcr").contains("amp")
+    lazy val isAmp: Boolean = !TurnOffAmp.isSwitchedOn &&
+      (r.getQueryString("amp").isDefined ||
+        (r.host.nonEmpty && r.host == Configuration.amp.host) ||
+        r.getQueryString("dcr").contains("amp"))
 
     lazy val isApps: Boolean = r.getQueryString("dcr").contains("apps")
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

From Rhianna's email: 

"There have been a few conversations you may have heard about running another AMP test, and a few of us had a chat about how we could potentially run this. 

In summary: 
- We tested turning off AMP earlier this year to see if there was an impact from an audience point of view - we didn't notice anything that worried us however we did realise that we were making more ad revenue from google amp than we were from mobile web so we left things as they were. 
- This topic has come up again as our US team believes there could be a significant increase in reader revenue for the US if we switch off Amp.

We think this is worth testing as we didn't look at reader revenues the last time we tested. 

The proposed test is: 
- A 6 week test from January 15th 
- The 'test' is really just turning AMP off for one week, on for the next, and so on. 
- We can't target AMP by region, so it will have to be turned off for everyone. 
- We'll continuously monitor it so if by the end of the first week we can see useful results, we'll stop the test. 

## What does this change?

Adds a flag that will turn AMP off and instead serve the regular website. 
The flag is a feature switch called `turn-off-amp`
