### PR TITLE
Extend kargo-prebid switch for a month

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -71,7 +71,7 @@ trait ABTestSwitches {
     "Test Kargo as a prebid bidder for US traffic.",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 11, 30)),
+    sellByDate = Some(LocalDate.of(2024, 1, 9)),
     exposeClientSide = true,
   )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Legal / Commercial depts are still in discussion with Kargo. We'll extend the test so the build continues to pass.

## What does this change?

Extend Kargo switch by a month.
