### PR TITLE
Lift affiliate links disclaimer out of page elements

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -32,6 +32,7 @@ import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import services.NewsletterData
 import views.support.{CamelCase, ContentLayout, JavaScriptPage}
+import views.html.fragments.affiliateLinksDisclaimer
 // -----------------------------------------------------------------
 // DCR DataModel
 // -----------------------------------------------------------------
@@ -40,6 +41,7 @@ case class DotcomRenderingDataModel(
     version: Int,
     headline: String,
     standfirst: String,
+    affiliateLinksDisclaimer: Option[String],
     webTitle: String,
     mainMediaElements: List[PageElement],
     main: String,
@@ -121,6 +123,7 @@ object DotcomRenderingDataModel {
         "version" -> model.version,
         "headline" -> model.headline,
         "standfirst" -> model.standfirst,
+        "affiliateLinksDisclaimer" -> model.affiliateLinksDisclaimer,
         "webTitle" -> model.webTitle,
         "mainMediaElements" -> model.mainMediaElements,
         "main" -> model.main,
@@ -545,6 +548,13 @@ object DotcomRenderingDataModel {
 
     val selectedTopics = topicResult.map(topic => Seq(Topic(topic.`type`, topic.name)))
 
+    def getAffiliateLinksDisclaimer(shouldAddAffiliateLinks: Boolean) = {
+      if (shouldAddAffiliateLinks) {
+        Some(affiliateLinksDisclaimer("article").body)
+      } else {
+        None
+      }
+    }
     DotcomRenderingDataModel(
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
@@ -598,6 +608,7 @@ object DotcomRenderingDataModel {
       showBottomSocialButtons = ContentLayout.showBottomSocialButtons(content),
       slotMachineFlags = request.slotMachineFlags,
       standfirst = TextCleaner.sanitiseLinks(edition)(content.fields.standfirst.getOrElse("")),
+      affiliateLinksDisclaimer = getAffiliateLinksDisclaimer(shouldAddAffiliateLinks),
       starRating = content.content.starRating,
       subMetaKeywordLinks = content.content.submetaLinks.keywords.map(SubMetaLink.apply),
       subMetaSectionLinks =

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -1,24 +1,27 @@
-@(contentType: String)
-
-
-@articleDisclaimer() = {
+@(contentType: String) @articleDisclaimer() = {
     <p><em><sup>
-        This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
-        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
-        By clicking on an affiliate link, you accept that third-party cookies will be set.
-        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">More information</a>.
+        The Guardian’s product and service reviews are independent and are
+        in no way influenced by any advertiser or commercial initiative. We
+        will earn a commission from the retailer if you buy something
+        through an affiliate link.
+        <a
+            href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
+            data-link-name="in body link"
+            class="u-underline"
+            >Learn more</a
+        >.
     </sup></em></p>
-}
-
-@galleryDisclaimer() = {
-    <br><em>This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
-        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
-        By clicking on an affiliate link, you accept that third-party cookies will be set.
-        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.
+} @galleryDisclaimer() = {
+    <br><em>
+        The Guardian’s product and service reviews are independent and are in no
+        way influenced by any advertiser or commercial initiative. We will earn a
+        commission from the retailer if you buy something through an affiliate link.
+	    <a
+		    href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
+		    >Learn more</a
+	    >.
     </em>
-}
-
-@{contentType match {
+} @{contentType match {
     case "gallery" => galleryDisclaimer()
     case "article" => articleDisclaimer()
     case _ => Html("")


### PR DESCRIPTION
## What is the value of this and can you measure success?

Part of a stream of work to reinstate our Skimlinks implementation, which was disabled in #22885 due to uncertainty around compliance.

On pages containing Skimlinks, there needs to be a disclaimer informing the user that we stand to earn a commission on purchases originating on this page. Previously, the disclaimer appeared at the end of the article, hence why it was added to page elements (see #21119). This change updates the wording of the disclaimer and moves the HTML out of page elements and to a new top-level property on the DotcomRenderingModel. Ultimately this will allow us to put the disclaimer below the standfirst.

## What does this change?

- updates the disclaimer
- moves disclaimer out of page elements into a new property on the model

## Related PRs

- [x] guardian/dotcom-rendering#9724
- [ ] Show the disclaimer below standfirst in galleries (frontend)
- [ ] Remove [cutoff date](https://github.com/guardian/frontend/blob/main/common/app/views/support/HtmlCleaner.scala#L968)

## TODO - following launch
- [ ]  Remove disclaimer from page elements in frontend's DotcomRenderingModel as no longer needed
- [ ] Delete DisclaimerBlockComponent, associated logic and types from DCR as no longer needed
