### PR TITLE
Extend the IMA test and switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,7 +51,7 @@ trait ABTestSwitches {
     "Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos",
     owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 11, 30)),
+    sellByDate = Some(LocalDate.of(2024, 2, 28)),
     exposeClientSide = true,
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -4,7 +4,7 @@ import { noop } from '../../../../../lib/noop';
 export const integrateIma: ABTest = {
 	id: 'IntegrateIma',
 	start: '2022-07-14',
-	expiry: '2023-07-10',
+	expiry: '2024-02-28',
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',


### PR DESCRIPTION
## What does this change?

Extend the IMA AB test and corresponding switch definition until end of Feb next year.

## Why?

This was about to expire, and we'd like to keep it around before we roll out.
