### PR TITLE
Remove ads-in-merch AB test

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -432,14 +432,4 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
-
-  val adsInMerch: Switch = Switch(
-    group = Commercial,
-    name = "ads-in-merch",
-    description = "Enable showing adverts in merchandising-high and merchandising slots",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 12, 4)),
-    exposeClientSide = true,
-  )
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
-		"@guardian/commercial": "11.23.2",
+		"@guardian/commercial": "11.24.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-15.0.1.tgz#2c936c43e654f5ae28db254329eae1b4b5861641"
   integrity sha512-XNqYE9X/4aM5vZqiZInedvEZ9niPfdqwL7SjzNF0wnVbR+YObOC6QC68M521gTPcyca6r190qtnayv4GNO0peg==
 
-"@guardian/commercial@11.23.2":
-  version "11.23.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.23.2.tgz#4ae9dd847459c463808362ca3aca6507dacfff43"
-  integrity sha512-mP4qi+4uoJN0axeWovQlSsO9hjsolcHI/5dzgyD7K/yG7BrRb5u1HgKRG6ECrQXE4WeQmi8N9ONKSq4E6v+NFA==
+"@guardian/commercial@11.24.0":
+  version "11.24.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.24.0.tgz#b20b0baf559d14e3318d6056eb33c07faeb73762"
+  integrity sha512-DD4cDglyFTW4+R+syV3Bjrx1ijD4F9zo0AEAF5lbsK1C84vYtnnusbUlMUKK7kyTAHI2Mz2JJ4QhljoS+zHNYQ==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
## What is the value of this and can you measure success?

- We ran this test for Black Friday to test running ads in merchandising ad slots: `merchandising` and `merchandising-high`. We are happy with the results and want to keep running ads in these slots, allowing merchandising ads to compete with other non-Guardian ads

## What does this change?

- Removes the `ads-in-merch` AB test
- bumps commercial. Changes here: https://github.com/guardian/commercial/pull/1165

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
