### PR TITLE
Expose `dark-mode-apps` switch on client side

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -530,7 +530,7 @@ trait FeatureSwitches {
     safeState = Off,
     // This is a random date in the future but this switch should be removed far before then
     sellByDate = Some(LocalDate.of(2024, 6, 5)),
-    exposeClientSide = false,
+    exposeClientSide = true,
   )
 
   val UserFeaturesDcr = Switch(

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -524,7 +524,7 @@ trait FeatureSwitches {
 
   val DarkModeInApps = Switch(
     SwitchGroup.Feature,
-    "dark-mode-apps",
+    "dark-mode-in-apps",
     "If this switch is on, we will allow dark mode in apps articles",
     owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
     safeState = Off,


### PR DESCRIPTION
Only switches with `exposeClientSide=true` are passed to DCR.

https://github.com/guardian/frontend/blob/ea78dc5f4fb054bdea5cd584dbea99e5cd10f2db/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala#L94-L98
