### PR TITLE
Extend experiment `offer-http3`

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -61,6 +61,6 @@ object OfferHttp3
       name = "offer-http3",
       description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
       owners = Seq(Owner.withGithub("paulmr")),
-      sellByDate = LocalDate.of(2023, 11, 30),
+      sellByDate = LocalDate.of(2024, 1, 3),
       participationGroup = Perc1E,
     )


### PR DESCRIPTION
Extends the `offer-http3` experiment, to fix failing tests.