### PR TITLE
remove user-features feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -532,14 +532,4 @@ trait FeatureSwitches {
     sellByDate = Some(LocalDate.of(2024, 6, 5)),
     exposeClientSide = true,
   )
-
-  val UserFeaturesDcr = Switch(
-    SwitchGroup.Feature,
-    "user-features-dcr",
-    "If this switch is on, we will load user-features from dcr",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 1, 15)),
-    exposeClientSide = true,
-  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
We are now confident that user-features is loading the module successfully from `DCR` and no need to the the fallback of a switch to turn it back to `commercial` to provide the user-feature module.

This reverts the feature switch set in: https://github.com/guardian/frontend/pull/26687/files
## Screenshots

| Before | After |
|--------|-------|
| <img width="250" alt="Screenshot 2023-12-04 at 15 51 49" src="https://github.com/guardian/frontend/assets/49187886/1b309adf-e72c-4a2a-8e7d-f2cda5327ae1"> | <img width="250" alt="Screenshot 2023-12-04 at 15 55 00" src="https://github.com/guardian/frontend/assets/49187886/24910eda-1a4f-4013-9aae-ace806299416"> |


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
