### PR TITLE
Reinstate affiliate links and move the disclaimer to the top of the page

### DIFF
--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -13,10 +13,12 @@
             @fragments.contentMeta(gallery.item, gallery)
 
             @if(gallery.item.fields.standfirst.isDefined) {
-                <div class="tonal__standfirst" id="gallery__standfirst">
+                <div class="tonal__standfirst">
                     @fragments.standfirst(gallery.item)
                 </div>
             }
+
+            <div id="gallery__disclaimer" style="display: none"></div>
 
             <div class="content__meta-container gallery__meta-container">
                 @if(!gallery.item.content.hasTonalHeaderByline) {

--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -18,8 +18,6 @@
                 </div>
             }
 
-            <div id="gallery__disclaimer" style="display: none"></div>
-
             <div class="content__meta-container gallery__meta-container">
                 @if(!gallery.item.content.hasTonalHeaderByline) {
                     @fragments.meta.byline(gallery.item.trail.byline, gallery.item.tags)

--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -13,7 +13,7 @@
             @fragments.contentMeta(gallery.item, gallery)
 
             @if(gallery.item.fields.standfirst.isDefined) {
-                <div class="tonal__standfirst">
+                <div class="tonal__standfirst" id="gallery__standfirst">
                     @fragments.standfirst(gallery.item)
                 </div>
             }

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -47,7 +47,6 @@ object GalleryCaptionCleaners {
         "gallery",
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
-        page.gallery.content.fields.firstPublicationDate,
       ),
     )
 

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -1,7 +1,6 @@
 package views
 
 import common.Edition
-import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import model.{ApplicationContext, GalleryPage, Interactive}
 import org.jsoup.Jsoup
 import play.api.mvc.RequestHeader
@@ -48,7 +47,6 @@ object GalleryCaptionCleaners {
         "gallery",
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
-        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
       ),
     )
 

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -1,6 +1,7 @@
 package views
 
 import common.Edition
+import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import model.{ApplicationContext, GalleryPage, Interactive}
 import org.jsoup.Jsoup
 import play.api.mvc.RequestHeader
@@ -47,6 +48,7 @@ object GalleryCaptionCleaners {
         "gallery",
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
+        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
       ),
     )
 

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -48,7 +48,7 @@ object GalleryCaptionCleaners {
         "gallery",
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
-        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
+        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks),
       ),
     )
 

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -1,7 +1,6 @@
 package views
 
 import common.Edition
-import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import model.{ApplicationContext, GalleryPage, Interactive}
 import org.jsoup.Jsoup
 import play.api.mvc.RequestHeader
@@ -48,7 +47,6 @@ object GalleryCaptionCleaners {
         "gallery",
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
-        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks),
       ),
     )
 

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -1,7 +1,6 @@
 package views
 
 import common.Edition
-import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import layout.ContentWidths
 import layout.ContentWidths.{Inline, LiveBlogMedia, MainMedia, Showcase}
 import model.content.MediaWrapper
@@ -85,7 +84,6 @@ object BodyProcessor {
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         contentType = "article",
         tags = article.content.tags.tags.map(_.id),
-        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -1,6 +1,7 @@
 package views
 
 import common.Edition
+import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import layout.ContentWidths
 import layout.ContentWidths.{Inline, LiveBlogMedia, MainMedia, Showcase}
 import model.content.MediaWrapper
@@ -84,6 +85,7 @@ object BodyProcessor {
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         contentType = "article",
         tags = article.content.tags.tags.map(_.id),
+        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -1,7 +1,6 @@
 package views
 
 import common.Edition
-import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import layout.ContentWidths
 import layout.ContentWidths.{Inline, LiveBlogMedia, MainMedia, Showcase}
 import model.content.MediaWrapper
@@ -85,7 +84,6 @@ object BodyProcessor {
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         contentType = "article",
         tags = article.content.tags.tags.map(_.id),
-        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks),
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -85,7 +85,7 @@ object BodyProcessor {
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         contentType = "article",
         tags = article.content.tags.tags.map(_.id),
-        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
+        isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks),
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -84,7 +84,6 @@ object BodyProcessor {
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         contentType = "article",
         tags = article.content.tags.tags.map(_.id),
-        publishedDate = article.content.fields.firstPublicationDate,
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,7 +15,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       AdaptiveSite,
       OfferHttp3,
       DeeplyRead,
-      DisableAffiliateLinks
+      DisableAffiliateLinks,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,6 +15,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       AdaptiveSite,
       OfferHttp3,
       DeeplyRead,
+      DisableAffiliateLinks
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -69,7 +69,7 @@ object OfferHttp3
 object DisableAffiliateLinks
     extends Experiment(
       name = "disable-affiliate-links",
-      description = "Disable affiliate links for 5% of users so that we can measure differences in engagement",
+      description = "Disable affiliate links for 2% of users so that we can measure differences in engagement",
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2024, 1, 30),
       participationGroup = Perc2A,

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -72,5 +72,5 @@ object DisableAffiliateLinks
       description = "Disable affiliate links for 5% of users so that we can measure differences in engagement",
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2024, 1, 30),
-      participationGroup = Perc5A,
+      participationGroup = Perc2A,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -64,3 +64,12 @@ object OfferHttp3
       sellByDate = LocalDate.of(2024, 1, 3),
       participationGroup = Perc1E,
     )
+
+object DisableAffiliateLinks
+    extends Experiment(
+      name = "disable-affiliate-links",
+      description = "Disable affiliate links for 5% of users so that we can measure differences in engagement",
+      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+      sellByDate = LocalDate.of(2024, 1, 30),
+      participationGroup = Perc5A,
+    )

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -5,6 +5,7 @@ import com.gu.contentapi.client.model.v1.{Block => APIBlock}
 import common.Edition
 import common.commercial.EditionAdTargeting.adTargetParamValueWrites
 import conf.Configuration
+import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import model.dotcomrendering.pageElements.PageElement
 import model.{ContentFormat, ContentPage}
 import play.api.libs.json._
@@ -66,7 +67,8 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
+    val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, isInDisableAffiliateLinksTest)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 
     val edition = Edition(request)

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -68,7 +68,7 @@ object DotcomBlocksRenderingDataModel {
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
     val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)(request)
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, isInDisableAffiliateLinksTest)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 
     val edition = Edition(request)

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -67,7 +67,7 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
+    val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)(request)
     val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, isInDisableAffiliateLinksTest)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -7,7 +7,7 @@ import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
-import experiments.ActiveExperiments
+import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
@@ -461,7 +461,8 @@ object DotcomRenderingDataModel {
       blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
     }
 
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
+    val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, isInDisableAffiliateLinksTest)
     val shouldAddDisclaimer = hasAffiliateLinks(bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -7,7 +7,7 @@ import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
-import experiments.ActiveExperiments
+import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
@@ -461,7 +461,8 @@ object DotcomRenderingDataModel {
       blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
     }
 
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
+    val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)(request)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, isInDisableAffiliateLinksTest)
     val shouldAddDisclaimer = hasAffiliateLinks(bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -7,7 +7,7 @@ import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
-import experiments.{ActiveExperiments, DisableAffiliateLinks}
+import experiments.ActiveExperiments
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
@@ -461,8 +461,7 @@ object DotcomRenderingDataModel {
       blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
     }
 
-    val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, isInDisableAffiliateLinksTest)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
     val shouldAddDisclaimer = hasAffiliateLinks(bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -7,7 +7,7 @@ import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
-import experiments.{ActiveExperiments, DisableAffiliateLinks}
+import experiments.ActiveExperiments
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
@@ -461,8 +461,7 @@ object DotcomRenderingDataModel {
       blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
     }
 
-    val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)(request)
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, isInDisableAffiliateLinksTest)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
     val shouldAddDisclaimer = hasAffiliateLinks(bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -277,7 +277,7 @@ object DotcomRenderingUtils {
       defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
       alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
       tagPaths = content.content.tags.tags.map(_.id),
-      isInDisableAffiliateLinksTest = isInDisableAffiliateLinksTest
+      isInDisableAffiliateLinksTest = isInDisableAffiliateLinksTest,
     )
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -277,7 +277,6 @@ object DotcomRenderingUtils {
       defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
       alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
       tagPaths = content.content.tags.tags.map(_.id),
-      firstPublishedDate = content.content.fields.firstPublicationDate,
     )
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -268,7 +268,7 @@ object DotcomRenderingUtils {
     }
   }
 
-  def shouldAddAffiliateLinks(content: ContentType): Boolean = {
+  def shouldAddAffiliateLinks(content: ContentType, isInDisableAffiliateLinksTest: Boolean): Boolean = {
     AffiliateLinksCleaner.shouldAddAffiliateLinks(
       switchedOn = Switches.AffiliateLinks.isSwitchedOn,
       section = content.metadata.sectionId,
@@ -277,6 +277,7 @@ object DotcomRenderingUtils {
       defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
       alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
       tagPaths = content.content.tags.tags.map(_.id),
+      isInDisableAffiliateLinksTest = isInDisableAffiliateLinksTest
     )
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -268,7 +268,7 @@ object DotcomRenderingUtils {
     }
   }
 
-  def shouldAddAffiliateLinks(content: ContentType, isInDisableAffiliateLinksTest: Boolean): Boolean = {
+  def shouldAddAffiliateLinks(content: ContentType)(implicit request: RequestHeader): Boolean = {
     AffiliateLinksCleaner.shouldAddAffiliateLinks(
       switchedOn = Switches.AffiliateLinks.isSwitchedOn,
       section = content.metadata.sectionId,
@@ -277,7 +277,6 @@ object DotcomRenderingUtils {
       defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
       alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
       tagPaths = content.content.tags.tags.map(_.id),
-      isInDisableAffiliateLinksTest = isInDisableAffiliateLinksTest,
     )
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -938,7 +938,8 @@ object AffiliateLinksCleaner {
     element.tagName == "a" && SkimLinksCache.isSkimLink(element.attr("href"))
 
   def insertAffiliateDisclaimer(document: Document, contentType: String): Document = {
-    document.body().append(affiliateLinksDisclaimer(contentType).toString())
+    val standfirstElement = document.getElementByClass("tonal__standfirst")
+    standfirstElement.after(affiliateLinksDisclaimer(contentType).toString())
     document
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -938,7 +938,7 @@ object AffiliateLinksCleaner {
     element.tagName == "a" && SkimLinksCache.isSkimLink(element.attr("href"))
 
   def insertAffiliateDisclaimer(document: Document, contentType: String): Document = {
-    val standfirstElement = document.getElementsByClass("tonal__standfirst")[0]
+    val standfirstElement = document.getElementsByClass("tonal__standfirst").first()
     standfirstElement.after(affiliateLinksDisclaimer(contentType).toString())
     document
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -938,7 +938,7 @@ object AffiliateLinksCleaner {
     element.tagName == "a" && SkimLinksCache.isSkimLink(element.attr("href"))
 
   def insertAffiliateDisclaimer(document: Document, contentType: String): Document = {
-    val standfirstElement = document.getElementByClass("tonal__standfirst")
+    val standfirstElement = document.getElementsByClass("tonal__standfirst")[0]
     standfirstElement.after(affiliateLinksDisclaimer(contentType).toString())
     document
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -882,7 +882,6 @@ case class AffiliateLinksCleaner(
     contentType: String,
     appendDisclaimer: Option[Boolean] = None,
     tags: List[String],
-    publishedDate: Option[DateTime],
 ) extends HtmlCleaner
     with GuLogging {
 
@@ -896,7 +895,6 @@ case class AffiliateLinksCleaner(
         defaultOffTags,
         alwaysOffTags,
         tags,
-        publishedDate,
       )
     ) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, appendDisclaimer, contentType, skimlinksId)
@@ -961,15 +959,9 @@ object AffiliateLinksCleaner {
       defaultOffTags: Set[String],
       alwaysOffTags: Set[String],
       tagPaths: List[String],
-      firstPublishedDate: Option[DateTime],
   ): Boolean = {
-    val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
-
-    // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off
-    // date. The cut off date is temporary while we are working on improving the compliance of affiliate links
-    if (
-      !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && firstPublishedDate.exists(_.isBefore(publishedCutOffDate))
-    ) {
+    // Never include affiliate links if it is tagged with an always off tag
+    if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags)) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
       } else {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -961,9 +961,13 @@ object AffiliateLinksCleaner {
       defaultOffTags: Set[String],
       alwaysOffTags: Set[String],
       tagPaths: List[String],
+      isInDisableAffiliateLinksTest: Boolean,
   ): Boolean = {
     // Never include affiliate links if it is tagged with an always off tag
-    if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags)) {
+
+    if (
+      !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && !isInDisableAffiliateLinksTest
+    ) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
       } else {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -938,7 +938,9 @@ object AffiliateLinksCleaner {
     element.tagName == "a" && SkimLinksCache.isSkimLink(element.attr("href"))
 
   def insertAffiliateDisclaimer(document: Document, contentType: String): Document = {
-    document.body().prepend(affiliateLinksDisclaimer(contentType).toString())
+    if (contentType == "gallery") {
+      document.body().prepend(affiliateLinksDisclaimer(contentType).toString())
+    }
     document
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -967,9 +967,7 @@ object AffiliateLinksCleaner {
   ): Boolean = {
     // Never include affiliate links if it is tagged with an always off tag
 
-    if (
-      !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && !isInDisableAffiliateLinksTest
-    ) {
+    if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && !isInDisableAffiliateLinksTest) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
       } else {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -938,7 +938,7 @@ object AffiliateLinksCleaner {
     element.tagName == "a" && SkimLinksCache.isSkimLink(element.attr("href"))
 
   def insertAffiliateDisclaimer(document: Document, contentType: String): Document = {
-    document.getElementById(contentType + "__disclaimer").append(affiliateLinksDisclaimer(contentType).toString())
+    document.body().prepend(affiliateLinksDisclaimer(contentType).toString())
     document
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -895,6 +895,7 @@ case class AffiliateLinksCleaner(
         defaultOffTags,
         alwaysOffTags,
         tags,
+        isInDisableAffiliateLinksTest,
       )
     ) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, appendDisclaimer, contentType, skimlinksId)

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -938,8 +938,7 @@ object AffiliateLinksCleaner {
     element.tagName == "a" && SkimLinksCache.isSkimLink(element.attr("href"))
 
   def insertAffiliateDisclaimer(document: Document, contentType: String): Document = {
-    val standfirstElement = document.getElementById("gallery__standfirst")
-    standfirstElement.after(affiliateLinksDisclaimer(contentType).toString())
+    document.getElementById(contentType + "__disclaimer").append(affiliateLinksDisclaimer(contentType).toString())
     document
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -882,6 +882,7 @@ case class AffiliateLinksCleaner(
     contentType: String,
     appendDisclaimer: Option[Boolean] = None,
     tags: List[String],
+    isInDisableAffiliateLinksTest: Boolean,
 ) extends HtmlCleaner
     with GuLogging {
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -938,7 +938,7 @@ object AffiliateLinksCleaner {
     element.tagName == "a" && SkimLinksCache.isSkimLink(element.attr("href"))
 
   def insertAffiliateDisclaimer(document: Document, contentType: String): Document = {
-    val standfirstElement = document.getElementsByClass("tonal__standfirst").first()
+    val standfirstElement = document.getElementById("gallery__standfirst")
     standfirstElement.after(affiliateLinksDisclaimer(contentType).toString())
     document
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -897,7 +897,7 @@ case class AffiliateLinksCleaner(
         defaultOffTags,
         alwaysOffTags,
         tags,
-      )(request)
+      )
     ) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, appendDisclaimer, contentType, skimlinksId)
     } else document

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -26,7 +26,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -36,7 +35,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      isInDisableAffiliateLinksTest = False
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -46,7 +44,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -56,7 +53,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      isInDisableAffiliateLinksTest = False
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -66,7 +62,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("bereavement"),
-      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -76,7 +71,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -86,7 +80,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-      isInDisableAffiliateLinksTest = False
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -96,7 +89,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("bereavement"),
-      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -106,7 +98,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
-      isInDisableAffiliateLinksTest = False
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -116,7 +107,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
-      isInDisableAffiliateLinksTest = True
     ) should be(false)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -26,6 +26,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
+      isInDisableAffiliateLinksTest = false,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -35,6 +36,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
+      isInDisableAffiliateLinksTest = false,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -44,6 +46,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
+      isInDisableAffiliateLinksTest = false,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -53,6 +56,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
+      isInDisableAffiliateLinksTest = false,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -62,6 +66,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("bereavement"),
+      isInDisableAffiliateLinksTest = false,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -71,6 +76,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
+      isInDisableAffiliateLinksTest = false,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -80,6 +86,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
+      isInDisableAffiliateLinksTest = false,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -89,6 +96,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("bereavement"),
+      isInDisableAffiliateLinksTest = false,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -98,6 +106,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
+      isInDisableAffiliateLinksTest = false,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -107,6 +116,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
+      isInDisableAffiliateLinksTest = true,
     ) should be(false)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -26,6 +26,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
+      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -35,6 +36,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
+      isInDisableAffiliateLinksTest = False
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -44,6 +46,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
+      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -53,6 +56,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
+      isInDisableAffiliateLinksTest = False
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -62,6 +66,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("bereavement"),
+      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -71,6 +76,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
+      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -80,6 +86,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
+      isInDisableAffiliateLinksTest = False
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -89,6 +96,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("bereavement"),
+      isInDisableAffiliateLinksTest = False
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -98,6 +106,17 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
+      isInDisableAffiliateLinksTest = False
     ) should be(true)
+    shouldAddAffiliateLinks(
+      switchedOn = true,
+      "fashion",
+      Some(true),
+      supportedSections,
+      Set.empty,
+      Set("bereavement"),
+      List("tech"),
+      isInDisableAffiliateLinksTest = True
+    ) should be(false)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -17,8 +17,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
     val supportedSections = Set("film", "books", "fashion")
-    val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
-    val newPublishedDate = Some(new DateTime(2020, 8, 15, 0, 0))
 
     shouldAddAffiliateLinks(
       switchedOn = false,
@@ -28,7 +26,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -38,7 +35,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      oldPublishedDate,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -48,7 +44,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -58,7 +53,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      oldPublishedDate,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -68,7 +62,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("bereavement"),
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -78,7 +71,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -88,7 +80,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-      oldPublishedDate,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -98,7 +89,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("bereavement"),
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -108,17 +98,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
-      oldPublishedDate,
     ) should be(true)
-    shouldAddAffiliateLinks(
-      switchedOn = true,
-      "fashion",
-      Some(true),
-      supportedSections,
-      Set.empty,
-      Set("bereavement"),
-      List("tech"),
-      newPublishedDate,
-    ) should be(false)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -1,8 +1,10 @@
 package views.support.cleaner
 import conf.Configuration
+import conf.switches.Switches.ServerSideExperiments
 import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.test.FakeRequest
 import views.support.AffiliateLinksCleaner._
 
 class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
@@ -16,6 +18,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
   }
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
+    val fakeTestControlRequest = FakeRequest().withHeaders("X-GU-Experiment-2perc-A" -> "control")
+
     val supportedSections = Set("film", "books", "fashion")
 
     shouldAddAffiliateLinks(
@@ -26,8 +30,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      isInDisableAffiliateLinksTest = false,
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -36,8 +39,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      isInDisableAffiliateLinksTest = false,
-    ) should be(true)
+    )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -46,8 +48,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      isInDisableAffiliateLinksTest = false,
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -56,8 +57,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      isInDisableAffiliateLinksTest = false,
-    ) should be(true)
+    )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -66,8 +66,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("bereavement"),
-      isInDisableAffiliateLinksTest = false,
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -76,8 +75,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-      isInDisableAffiliateLinksTest = false,
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -86,8 +84,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-      isInDisableAffiliateLinksTest = false,
-    ) should be(true)
+    )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -96,8 +93,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("bereavement"),
-      isInDisableAffiliateLinksTest = false,
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -106,17 +102,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
-      isInDisableAffiliateLinksTest = false,
-    ) should be(true)
-    shouldAddAffiliateLinks(
-      switchedOn = true,
-      "fashion",
-      Some(true),
-      supportedSections,
-      Set.empty,
-      Set("bereavement"),
-      List("tech"),
-      isInDisableAffiliateLinksTest = true,
-    ) should be(false)
+    )(fakeTestControlRequest) should be(true)
   }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR contains the final changes needed to reinstate affiliate links for articles published after the cut-off date set a few years ago.

Also adds a server side test for 2% of users who won't see affiliate links. This will allow us to measure the impact of reintroducing affiliate links on metrics such as attention time.

See these PRs for the other changes made for affiliate links:
https://github.com/guardian/dotcom-rendering/pull/9724
https://github.com/guardian/frontend/pull/26753

## What does this change?
This PR removes the cut-off date for affiliate links, allowing them to be added to newly published articles.

We also now only use frontend to inject the disclaimer for galleries, because they're still rendered on frontend. The disclaimer now gets added to the first caption of a gallery, before any affiliate links.

Also adds a 2% server side test so that users in the test don't see affiliate links. This is so we can monitor the impact of reinstating affiliate links.

## Screenshots
How the disclaimer now appears on galleries:
### Desktop:
<img width="948" alt="Screenshot 2023-12-05 at 14 39 11" src="https://github.com/guardian/frontend/assets/108270776/2866a41f-70a2-4836-af97-c1301f604371">

### Mobile:
<img width="328" alt="Screenshot 2023-12-05 at 14 38 28" src="https://github.com/guardian/frontend/assets/108270776/ddef702c-f799-4ef8-9c8f-a3b0b89282ca">

Disclaimer disappears for those in the server side test
### In the test:
<img width="931" alt="Screenshot 2023-12-13 at 18 04 06" src="https://github.com/guardian/frontend/assets/108270776/97036c2d-d575-45b7-b7a2-2f680d4ff382">

### Not in the test:
<img width="925" alt="Screenshot 2023-12-13 at 18 03 55" src="https://github.com/guardian/frontend/assets/108270776/16f53fa7-f09c-4d20-807c-192daef854e4">


