### PR TITLE
Bump braze-components dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/braze-components": "^16.1.1",
+		"@guardian/braze-components": "^16.2.0",
 		"@guardian/commercial": "11.27.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/braze-components": "^15.0.1",
+		"@guardian/braze-components": "^16.1.1",
 		"@guardian/commercial": "11.27.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",

--- a/static/src/javascripts/projects/common/modules/commercial/braze/brazeBanner.tsx
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/brazeBanner.tsx
@@ -82,13 +82,12 @@ const renderBanner = (
 					: {};
 
 			const fetchEmail = (): Promise<string | null> => {
-				return new Promise ((resolve) => {
+				return new Promise((resolve) => {
 					getUserFromApiOrOkta()
 						.then((res) => {
 							if (
-								res &&
-								res.primaryEmailAddress &&
-								res.statusFields?.userEmailValidated
+								res?.primaryEmailAddress &&
+								res.statusFields.userEmailValidated
 							) {
 								resolve(res.primaryEmailAddress);
 							}

--- a/static/src/javascripts/projects/common/modules/commercial/braze/brazeBanner.tsx
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/brazeBanner.tsx
@@ -5,6 +5,7 @@ import { reportError } from '../../../../../lib/report-error';
 import {
 	getAuthStatus,
 	getOptionsHeadersWithOkta,
+	getUserFromApiOrOkta,
 } from '../../../modules/identity/api';
 import { submitComponentEvent, submitViewEvent } from '../acquisitions-ophan';
 import type { BrazeMessageInterface } from './brazeMessageInterface';
@@ -80,8 +81,18 @@ const renderBanner = (
 					? getOptionsHeadersWithOkta(authStatus)
 					: {};
 
-			const fetchEmail = (): Promise<string | null> =>
-				Promise.resolve(null);
+			const fetchEmail = (): Promise<string | null> => {
+				return new Promise ((resolve) => {
+					getUserFromApiOrOkta()
+						.then(res => {
+							if (res?.primaryEmailAddress && res?.statusFields?.userEmailValidated) {
+								resolve(res.primaryEmailAddress);
+							}
+							resolve(null);
+						})
+						.catch(err => resolve(null));
+				});
+			};
 
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- IE does not support shadow DOM, so instead we just render
 			if (!container.attachShadow) {

--- a/static/src/javascripts/projects/common/modules/commercial/braze/brazeBanner.tsx
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/brazeBanner.tsx
@@ -84,13 +84,17 @@ const renderBanner = (
 			const fetchEmail = (): Promise<string | null> => {
 				return new Promise ((resolve) => {
 					getUserFromApiOrOkta()
-						.then(res => {
-							if (res?.primaryEmailAddress && res?.statusFields?.userEmailValidated) {
+						.then((res) => {
+							if (
+								res &&
+								res.primaryEmailAddress &&
+								res.statusFields?.userEmailValidated
+							) {
 								resolve(res.primaryEmailAddress);
 							}
 							resolve(null);
 						})
-						.catch(err => resolve(null));
+						.catch(() => resolve(null));
 				});
 			};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,10 +2402,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^16.1.1":
-  version "16.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-16.1.1.tgz#c6e3e8c8e491f5cc95ab1b08ac64420623070a34"
-  integrity sha512-2c8i7yzcqUk/fzXJ9WsHOU5PqQ5EOt26Juk3V0p0YyFpffd/zBOgIwBVpFZyAFLBO+DL+JZ6QPjDEGJ3gJeUgA==
+"@guardian/braze-components@^16.2.0":
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-16.2.0.tgz#f65f93a38f3bd621cb43f5f11beba3c002c13a21"
+  integrity sha512-+wRKpo0LChL0PUqgRkqg/LrDpnz5ufIML1VokPwjZtyHpDMacB3393L3pBmKH46SNyBddmkRG98opfv1hdjqVA==
 
 "@guardian/commercial@11.27.0":
   version "11.27.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,10 +2402,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^15.0.1":
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-15.0.1.tgz#2c936c43e654f5ae28db254329eae1b4b5861641"
-  integrity sha512-XNqYE9X/4aM5vZqiZInedvEZ9niPfdqwL7SjzNF0wnVbR+YObOC6QC68M521gTPcyca6r190qtnayv4GNO0peg==
+"@guardian/braze-components@^16.1.1":
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-16.1.1.tgz#c6e3e8c8e491f5cc95ab1b08ac64420623070a34"
+  integrity sha512-2c8i7yzcqUk/fzXJ9WsHOU5PqQ5EOt26Juk3V0p0YyFpffd/zBOgIwBVpFZyAFLBO+DL+JZ6QPjDEGJ3gJeUgA==
 
 "@guardian/commercial@11.27.0":
   version "11.27.0"


### PR DESCRIPTION
## What does this change?
Bump the braze components dependency to latest v16.2.0.

We have updated the optional one-click contributions reminder button in the Braze epic, and added the button to the styleable Braze banner. The updated button uses the same functionality as exists for RRCP banners, to set a contribution reminder email flag for a reader.

## Screenshots
The changes to the relevant Braze banner and epic components are minor, and have been tested/approved in the braze-components repo.
