### PR TITLE
Bump commercial to 11.26.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
-		"@guardian/commercial": "11.25.0",
+		"@guardian/commercial": "11.26.1",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-15.0.1.tgz#2c936c43e654f5ae28db254329eae1b4b5861641"
   integrity sha512-XNqYE9X/4aM5vZqiZInedvEZ9niPfdqwL7SjzNF0wnVbR+YObOC6QC68M521gTPcyca6r190qtnayv4GNO0peg==
 
-"@guardian/commercial@11.25.0":
-  version "11.25.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.25.0.tgz#6af524962dc73d54de6d1d6a38c658c649946a72"
-  integrity sha512-XRMty1F237iFWr10Nf2eFpkGxzw4cCDWOPFCFTrVNpVel9pMqHF9dR1UXIzPh84SOlFsJciBEAvAN0Z2KG9V9w==
+"@guardian/commercial@11.26.1":
+  version "11.26.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.26.1.tgz#96617214dd00b7405ed3257407a13520a235230b"
+  integrity sha512-aJ255CjnHawVGAufdQ5jaePTFpX1J7myBQXWE7s/u3riMsh0emXcHppjJZ+ptRC3cXbSDoh8kYaO7tqKua8ExQ==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
## What does this change?
Bringing in the changes to changes in: v[11.26.1](https://github.com/guardian/commercial/releases/tag/v11.26.1)
