### PR TITLE
Ignore `.tool-versions` File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ static/src/stylesheets/pasteup/.npmrc
 metals.sbt
 
 .java-version
+.tool-versions


### PR DESCRIPTION
Used to specify local versions of tools on dev machines; for example, the Java version.
