### PR TITLE
Revert "Lift affiliate links disclaimer out of page elements"

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -32,7 +32,6 @@ import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import services.NewsletterData
 import views.support.{CamelCase, ContentLayout, JavaScriptPage}
-import views.html.fragments.affiliateLinksDisclaimer
 // -----------------------------------------------------------------
 // DCR DataModel
 // -----------------------------------------------------------------
@@ -41,7 +40,6 @@ case class DotcomRenderingDataModel(
     version: Int,
     headline: String,
     standfirst: String,
-    affiliateLinksDisclaimer: Option[String],
     webTitle: String,
     mainMediaElements: List[PageElement],
     main: String,
@@ -123,7 +121,6 @@ object DotcomRenderingDataModel {
         "version" -> model.version,
         "headline" -> model.headline,
         "standfirst" -> model.standfirst,
-        "affiliateLinksDisclaimer" -> model.affiliateLinksDisclaimer,
         "webTitle" -> model.webTitle,
         "mainMediaElements" -> model.mainMediaElements,
         "main" -> model.main,
@@ -548,13 +545,6 @@ object DotcomRenderingDataModel {
 
     val selectedTopics = topicResult.map(topic => Seq(Topic(topic.`type`, topic.name)))
 
-    def getAffiliateLinksDisclaimer(shouldAddAffiliateLinks: Boolean) = {
-      if (shouldAddAffiliateLinks) {
-        Some(affiliateLinksDisclaimer("article").body)
-      } else {
-        None
-      }
-    }
     DotcomRenderingDataModel(
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
@@ -608,7 +598,6 @@ object DotcomRenderingDataModel {
       showBottomSocialButtons = ContentLayout.showBottomSocialButtons(content),
       slotMachineFlags = request.slotMachineFlags,
       standfirst = TextCleaner.sanitiseLinks(edition)(content.fields.standfirst.getOrElse("")),
-      affiliateLinksDisclaimer = getAffiliateLinksDisclaimer(shouldAddAffiliateLinks),
       starRating = content.content.starRating,
       subMetaKeywordLinks = content.content.submetaLinks.keywords.map(SubMetaLink.apply),
       subMetaSectionLinks =

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -1,27 +1,24 @@
-@(contentType: String) @articleDisclaimer() = {
+@(contentType: String)
+
+
+@articleDisclaimer() = {
     <p><em><sup>
-        The Guardian’s product and service reviews are independent and are
-        in no way influenced by any advertiser or commercial initiative. We
-        will earn a commission from the retailer if you buy something
-        through an affiliate link.
-        <a
-            href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
-            data-link-name="in body link"
-            class="u-underline"
-            >Learn more</a
-        >.
+        This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
+        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
+        By clicking on an affiliate link, you accept that third-party cookies will be set.
+        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">More information</a>.
     </sup></em></p>
-} @galleryDisclaimer() = {
-    <br><em>
-        The Guardian’s product and service reviews are independent and are in no
-        way influenced by any advertiser or commercial initiative. We will earn a
-        commission from the retailer if you buy something through an affiliate link.
-	    <a
-		    href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
-		    >Learn more</a
-	    >.
+}
+
+@galleryDisclaimer() = {
+    <br><em>This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
+        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
+        By clicking on an affiliate link, you accept that third-party cookies will be set.
+        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.
     </em>
-} @{contentType match {
+}
+
+@{contentType match {
     case "gallery" => galleryDisclaimer()
     case "article" => articleDisclaimer()
     case _ => Html("")


### PR DESCRIPTION
Reverts guardian/frontend#26727

We are adding the disclaimer when the article is eligible for affiliate links, rather than when the article has affiliate links.

Let's revert now, fix next week