### PR TITLE
Use v4 of GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: yarn
           node-version-file: .nvmrc
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: corretto
           cache: sbt
@@ -39,7 +39,7 @@ jobs:
         env:
           NODE_ENV: production
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}


### PR DESCRIPTION
## What is the value of this and can you measure success?
Keeping up-to-date

## What does this change?
Upgrades to v4 the following GH actions used in the build:
* `actions/checkout`
* `actions/setup-node`
* `actions/setup-java`
* `aws-actions/configure-aws-credentials`




