### PR TITLE
Lift affiliate links disclaimer out of page elements (again)

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -188,7 +188,7 @@ object DotcomRenderingUtils {
         elem.`type` match {
           case Text =>
             val textString = elem.textTypeData.toList.mkString("\n") // just concat all the elems here for this test
-            AffiliateLinksCleaner.stringContainsAffiliateableLinks(textString)
+            stringContainsAffiliateableLinks(textString)
           case _ => false
         },
       )
@@ -199,6 +199,10 @@ object DotcomRenderingUtils {
         elems
       }
     } else elems
+  }
+
+  def stringContainsAffiliateableLinks(textString: String): Boolean = {
+    AffiliateLinksCleaner.stringContainsAffiliateableLinks(textString)
   }
 
   def blockElementsToPageElements(

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -2,20 +2,29 @@
 
 
 @articleDisclaimer() = {
-    <p><em><sup>
-        This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
-        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
-        By clicking on an affiliate link, you accept that third-party cookies will be set.
-        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">More information</a>.
-    </sup></em></p>
+    <p><sup>
+        The Guardian’s product and service reviews are independent and are
+        in no way influenced by any advertiser or commercial initiative. We
+        will earn a commission from the retailer if you buy something
+        through an affiliate link.
+        <a
+            href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
+            data-link-name="in body link"
+            class="u-underline"
+            >Learn more</a
+        >.
+    </sup></p>
 }
 
 @galleryDisclaimer() = {
-    <br><em>This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
-        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
-        By clicking on an affiliate link, you accept that third-party cookies will be set.
-        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.
-    </em>
+    <br>
+        The Guardian’s product and service reviews are independent and are in no
+        way influenced by any advertiser or commercial initiative. We will earn a
+        commission from the retailer if you buy something through an affiliate link.
+	    <a
+		    href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
+		    >Learn more</a
+	    >.
 }
 
 @{contentType match {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -916,11 +916,9 @@ object AffiliateLinksCleaner {
       contentType: String,
       skimlinksId: String,
   ): Document = {
-
     val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(html)
     linksToReplace.foreach { el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId)) }
-
-    // respect appendDisclaimer, or if it's not set then always add the disclaimer if affilate links have been added
+    // respect appendDisclaimer (for Galleries), or if it's not set then always add the disclaimer if affilate links have been added
     val shouldAppendDisclaimer = appendDisclaimer.getOrElse(linksToReplace.nonEmpty)
     if (shouldAppendDisclaimer) insertAffiliateDisclaimer(html, contentType)
     else html


### PR DESCRIPTION
## What is the value of this and can you measure success?

Reimplementation of #26727 (reverted in #26749)

Part of a stream of work to reinstate our Skimlinks implementation, which was disabled in #22885 due to uncertainty around compliance.

On pages containing Skimlinks, there needs to be a disclaimer informing the user that we stand to earn a commission on purchases originating on this page. Previously, the disclaimer appeared at the end of the article, hence why it was added to page elements (see #21119). This change updates the wording of the disclaimer and moves the HTML out of page elements and to a new top-level property on the DotcomRenderingModel. Ultimately this will allow us to put the disclaimer below the standfirst.

In the previous (reverted) implementation, the disclaimer was added to pages that _may_ have affiliate links (i.e. the article has the correct tags), but didn't check whether the page actually contained affiliate links. Therefore the disclaimer was being needlessly added to pages that did not have affiliate links. This change checks to ensure affiliate links are on the page before adding the disclaimer.

## What does this change?

- updates the disclaimer
- moves disclaimer out of page elements into a new property on the model

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering (once merged, reinstate Cyrpress test disabled in guardian/dotcom-rendering#9829)
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
