### PR TITLE
switch to new ami recipe with cdk-base role

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -58,5 +58,5 @@ deployments:
       cloudFormationStackName: frontend
       amiParametersToTags:
         AMI:
-          Recipe: ubuntu-focal-frontend-base-ARM-java11
+          Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
_Part of https://github.com/guardian/dotcom-rendering/issues/9825_

Follows initial attempt in #26744 to add the CDK base to frontend apps

This PR only switches the AMI recipe to one that has `cdk-base` in it

