### PR TITLE
Switch to Play 3 and go all in Pekko

### DIFF
--- a/admin/app/http/AdminFilters.scala
+++ b/admin/app/http/AdminFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import GoogleAuthFilters.AuthFilterWithExemptions
 import googleAuth.FilterExemptions
 import model.ApplicationContext

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,10 @@ val common = library("common")
       pekkoSlf4j,
     ),
     TestAssets / mappings ~= filterAssets,
+//    excludeDependencies ++= Seq(
+//      // As of Play 3.0, groupId has changed to org.playframework; exclude transitive dependencies to the old artifacts
+//      ExclusionRule(organization = "com.typesafe.play")
+//    ),
   )
 
 val commonWithTests = withTests(common)

--- a/build.sbt
+++ b/build.sbt
@@ -71,10 +71,6 @@ val common = library("common")
       pekkoSlf4j,
     ),
     TestAssets / mappings ~= filterAssets,
-//    excludeDependencies ++= Seq(
-//      // As of Play 3.0, groupId has changed to org.playframework; exclude transitive dependencies to the old artifacts
-//      ExclusionRule(organization = "com.typesafe.play")
-//    ),
   )
 
 val commonWithTests = withTests(common)

--- a/build.sbt
+++ b/build.sbt
@@ -64,13 +64,12 @@ val common = library("common")
       playJson,
       playJsonJoda,
       jodaForms,
-      jacksonDataFormat,
       identityModel,
       capiAws,
       pekkoActor,
       pekkoStream,
       pekkoSlf4j,
-    ) ++ jackson,
+    ),
     TestAssets / mappings ~= filterAssets,
   )
 
@@ -154,7 +153,6 @@ val identity = application("identity")
       libPhoneNumber,
       supportInternationalisation,
     ),
-    dependencyOverrides ++= jackson,
     PlayKeys.playDefaultPort := 9009,
     Test / testOptions += Tests.Argument("-oF"),
   )
@@ -182,7 +180,6 @@ val dev = application("dev-build")
   .settings(
     RoutesKeys.routesImport += "bindables._",
     Runtime / javaOptions += "-Dconfig.file=dev-build/conf/dev-build.application.conf",
-    dependencyOverrides ++= jackson,
   )
 
 val preview = application("preview")
@@ -202,14 +199,6 @@ val rss = application("rss")
 
 
 val main = root()
-// This evicts the version of
-// "com.fasterxml.jackson.core:jackson-databind"
-// used by "com.typesafe.play:sbt-plugin"
-  .settings(
-    libraryDependencies ++= Seq(
-      jacksonDatabind,
-    ),
-  )
   .aggregate(
     common,
     facia,

--- a/common/app/dev/DevAssetsController.scala
+++ b/common/app/dev/DevAssetsController.scala
@@ -1,6 +1,6 @@
 package dev
 
-import akka.stream.scaladsl.StreamConverters
+import org.apache.pekko.stream.scaladsl.StreamConverters
 import common.Assets.AssetNotFoundException
 import common.ImplicitControllerExecutionContext
 import java.io.File

--- a/common/app/http/AmpFilter.scala
+++ b/common/app/http/AmpFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import conf.Configuration
 import play.api.mvc.{Filter, RequestHeader, Result}
 

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -1,7 +1,7 @@
 package http
 
 import javax.inject.Inject
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import app.FrontendBuildInfo
 import conf.switches.Switches
 import implicits.Responses._
@@ -144,7 +144,6 @@ object Filters {
 
 }
 
-//Note: still using akka (instead of pekko) materializer from Play as both filters extend Play's Filter, so the types need to match
 class CommonFilters(frontendBuildInfo: FrontendBuildInfo)(implicit
     mat: Materializer,
     applicationContext: ApplicationContext,

--- a/common/app/http/GoogleAuthFilters.scala
+++ b/common/app/http/GoogleAuthFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.gu.googleauth.{FilterExemption, UserIdentity}
 import googleAuth.AuthCookie
 import model.ApplicationContext

--- a/common/app/http/H2PreloadFilter.scala
+++ b/common/app/http/H2PreloadFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import common.Preload
 import model.ApplicationContext
 import play.api.mvc._

--- a/common/app/http/RequestLoggingFilter.scala
+++ b/common/app/http/RequestLoggingFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import common.{GuLogging, RequestLogger, StopWatch}
 import play.api.mvc.{Filter, RequestHeader, Result}
 

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -57,7 +57,7 @@ trait ConfiguredTestSuite extends TestSuite with ConfiguredServer with Configure
   }
 
   /**
-    * `HTMLUnit` doesn't support [[org.fluentlenium.core.domain.FluentWebElement.html]]
+    * `HTMLUnit` doesn't support [[io.fluentlenium.core.domain.FluentWebElement.html]]
     * via TestBrowser, so use [[WebClient]] to retrieve a [[WebResponse]] instead, so
     * we can use [[WebResponse.getContentAsString]]
     */

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -1,6 +1,6 @@
 package test
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.gargoylesoftware.htmlunit.{BrowserVersion, WebClient}
 import common.Lazy

--- a/dev-build/app/http/DevFilters.scala
+++ b/dev-build/app/http/DevFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import implicits.Requests
 import model.ApplicationContext
 import play.api.http.HttpFilters

--- a/facia/test/controllers/front/FrontHeadlineTest.scala
+++ b/facia/test/controllers/front/FrontHeadlineTest.scala
@@ -29,8 +29,8 @@ class FrontHeadlineTest extends AnyFunSuite with Matchers {
 
     val RevalidatableResult(result, _) = FrontHeadline.renderEmailHeadline(pressedPage)
     val resultFuture = Future.successful(result)
-    val headline = Helpers.contentAsString(resultFuture)
-    val status = Helpers.status(resultFuture)
+    val headline = Helpers.contentAsString(resultFuture)(timeout)
+    val status = Helpers.status(resultFuture)(timeout)
 
     headline shouldBe "webTitle 1"
     status shouldBe 200

--- a/identity/app/http/HeaderLoggingFilter.scala
+++ b/identity/app/http/HeaderLoggingFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 
 import play.api.mvc._
 import utils.SafeLogging

--- a/identity/app/http/IdentityFilters.scala
+++ b/identity/app/http/IdentityFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import model.ApplicationContext
 import play.api.http.HttpFilters
 

--- a/identity/app/http/StrictTransportSecurityHeaderFilter.scala
+++ b/identity/app/http/StrictTransportSecurityHeaderFilter.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
+++ b/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
@@ -1,6 +1,6 @@
 package filters
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import http.StrictTransportSecurityHeaderFilter
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/preview/app/http/PreviewFilters.scala
+++ b/preview/app/http/PreviewFilters.scala
@@ -1,6 +1,6 @@
 package http
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import GoogleAuthFilters.AuthFilterWithExemptions
 import controllers.HealthCheck
 import googleAuth.FilterExemptions

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,7 +88,7 @@ object Dependencies {
   // logback2  to prevent "error: reference to logback is ambiguous;"
 
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
-  val targetingClient = "com.gu" %% "targeting-client" % "1.1.4"
+  val targetingClient = "com.gu" %% "targeting-client" % "1.1.4" // TODO: Needs to be upgraded so it pulls in play-json with groupid org.playframework
   val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.8.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
   val scalaCollectionPlus = "com.madgag" %% "scala-collection-plus" % "0.11"
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "2.30.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11" % Test
-  val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test
+  val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test
   val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-4-11" % "3.2.17.0" % Test
   val scalaTestPlusScalacheck = "org.scalatestplus" %% "scalacheck-1-17" % "3.2.17.0" % Test
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "4.0.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
-  val playJsonVersion = "3.0.1"
+  val playJsonVersion = "3.0.2"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.11"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion
@@ -32,7 +32,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.2.0"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion 
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
-  val playJsonVersion = "2.9.4"
+  val playJsonVersion = "3.0.1"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.11"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion
@@ -70,8 +70,8 @@ object Dependencies {
   val scalaCollectionPlus = "com.madgag" %% "scala-collection-plus" % "0.11"
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "2.30.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11" % Test
-  val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.1" % Test
-  val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-4-11" % "3.2.16.0" % Test
+  val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test
+  val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-4-11" % "3.2.17.0" % Test
   val scalaTestPlusScalacheck = "org.scalatestplus" %% "scalacheck-1-17" % "3.2.17.0" % Test
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "4.8.1"
@@ -93,8 +93,8 @@ object Dependencies {
   val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.7.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.2"
-  val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
-  val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
+  val playJson = "org.playframework" %% "play-json" % playJsonVersion
+  val playJsonJoda = "org.playframework" %% "play-json-joda" % playJsonVersion
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,7 +88,7 @@ object Dependencies {
   // logback2  to prevent "error: reference to logback is ambiguous;"
 
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
-  val targetingClient = "com.gu" %% "targeting-client" % "1.1.4" // TODO: Needs to be upgraded so it pulls in play-json with groupid org.playframework
+  val targetingClient = "com.gu.targeting-client" %% "client-play-json-v30" % "1.1.9"
   val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.8.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,7 +73,7 @@ object Dependencies {
   val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test
   val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-4-11" % "3.2.17.0" % Test
   val scalaTestPlusScalacheck = "org.scalatestplus" %% "scalacheck-1-17" % "3.2.17.0" % Test
-  val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
+  val scalaUri = "io.lemonlabs" %% "scala-uri" % "4.0.3"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "4.8.1"
   val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.36"
   val jerseyCore = "com.sun.jersey" % "jersey-core" % jerseyVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -91,7 +91,7 @@ object Dependencies {
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val targetingClient = "com.gu" %% "targeting-client" % "1.1.4"
   val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
-  val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.7.0"
+  val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.8.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.2"
   val playJson = "org.playframework" %% "play-json" % playJsonVersion
   val playJsonJoda = "org.playframework" %% "play-json-joda" % playJsonVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,8 +32,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.2.0"
-
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play28" % faciaVersion
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion 
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -98,37 +98,6 @@ object Dependencies {
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7"
 
-  /*
-    Note: Although frontend compiles and passes all the current tests when jackson is removed, be careful that this
-    may break the fronts diagnostics tools. If we try to remove jackson one day after (for instance after other
-    dependencies have been upgraded), then do remember to check for regressions.
-
-    The versions are currently set as they are because of:
-    https://github.com/orgs/playframework/discussions/11222
-   */
-  val jacksonVersion = "2.13.4"
-  val jacksonDatabindVersion = "2.13.4.1"
-  val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
-  val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
-  val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
-  val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
-  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
-  val jacksonParameterName = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion
-  val jackModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
-  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
-
-  val jackson =
-    Seq(
-      jacksonCore,
-      jacksonAnnotations,
-      jacksonDataTypeJdk8,
-      jacksonDataType,
-      jacksonDataFormat,
-      jacksonParameterName,
-      jackModule,
-      jacksonDatabind,
-    )
-
   // Forcing a version of this to fix an issue with the dependency.
   // This is a transitive dependency of the AWS SDK used by etag-caching library
   val nettyCodecHttp2 = "io.netty" % "netty-codec-http2" % "4.1.100.Final"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,8 +59,8 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.5.7" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.7"
-  val playGoogleAuth = "com.gu.play-googleauth" %% "play-v28" % "4.0.0"
-  val playSecretRotation = "com.gu.play-secret-rotation" %% "play-v28" % "7.1.0"
+  val playGoogleAuth = "com.gu.play-googleauth" %% "play-v30" % "4.0.0"
+  val playSecretRotation = "com.gu.play-secret-rotation" %% "play-v30" % "7.1.0"
   val playSecretRotationAwsSdk = "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "7.1.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbt.packager.universal.UniversalPlugin
 import sbt._
 import sbt.Keys._
 import com.gu.Dependencies._
-import play.sbt.{PlayAkkaHttpServer, PlayNettyServer, PlayScala}
+import play.sbt.{PlayPekkoHttpServer, PlayNettyServer, PlayScala}
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys.packageName
 import sbtbuildinfo.{BuildInfoKey, BuildInfoOption, BuildInfoPlugin}
@@ -97,7 +97,7 @@ object ProjectSettings {
   def root(): Project =
     Project("root", base = file("."))
       .enablePlugins(PlayScala, PlayNettyServer)
-      .disablePlugins(PlayAkkaHttpServer)
+      .disablePlugins(PlayPekkoHttpServer)
       .settings(frontendCompilationSettings)
       .settings(frontendRootSettings)
 
@@ -129,7 +129,7 @@ object ProjectSettings {
   def library(applicationName: String): Project = {
     Project(applicationName, file(applicationName))
       .enablePlugins(PlayScala, PlayNettyServer)
-      .disablePlugins(PlayAkkaHttpServer)
+      .disablePlugins(PlayPekkoHttpServer)
       .settings(frontendDependencyManagementSettings)
       .settings(frontendCompilationSettings)
       .settings(frontendTestSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,9 +7,7 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.7",
 )
 
-resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
-  Classpaths.typesafeReleases,
-)
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
   Classpaths.typesafeReleases,
 )
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,4 +21,4 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
 addDependencyTreePlugin
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,6 +21,6 @@ addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addDependencyTreePlugin
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import football.controllers.ResultsController
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -28,12 +28,12 @@ class SportTestSuite
       new ResultsListTest,
       new TeamColoursTest,
       new CompetitionAgentTest,
-      new FixturesFeatureTest,
+//      new FixturesFeatureTest,
       new LeagueTablesFeatureTest,
       new LiveMatchesFeatureTest,
       new MatchFeatureTest,
-      new ResultsFeatureTest,
-      new FixturesAndResultsTest,
+//      new ResultsFeatureTest,
+//      new FixturesAndResultsTest,
     )
     with SingleServerSuite {}
 

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -28,12 +28,12 @@ class SportTestSuite
       new ResultsListTest,
       new TeamColoursTest,
       new CompetitionAgentTest,
-//      new FixturesFeatureTest,
+      new FixturesFeatureTest,
       new LeagueTablesFeatureTest,
       new LiveMatchesFeatureTest,
       new MatchFeatureTest,
-//      new ResultsFeatureTest,
-//      new FixturesAndResultsTest,
+      new ResultsFeatureTest,
+      new FixturesAndResultsTest,
     )
     with SingleServerSuite {}
 


### PR DESCRIPTION
Co-authored-by: @mkurz, @kelvin-chappell @mchv @mxdvl   

Re-raising @mkurz's PR:
* https://github.com/guardian/frontend/pull/26677 

It has to be raised by someone in The Guardian organisation for the build to run.

## What does this change?
* Switches to Pekko and Play 3
* Removes Jackson dependencies. Play 3 upgraded to Jackson 2.14. No need to upgrade explicitly anymore. See [comment](https://github.com/guardian/frontend/pull/26677#discussion_r1385208651).
* Upgrades the following dependencies and plugin to their latest versions: 
  - `scalatestplus-play` 
  - `mockito-4-11` 
  - `io.lemonlabs:scala-uri`
  - `sbt-buildinfo`
* Updates Scala version to latest `2.13.13`
* Removes a fruitless filtering in `PressedContent` https://github.com/guardian/frontend/commit/4f55a6987cfe5400995568c29d9e9634ac79cb58

### Previous PRs preparing for this upgrade:
* https://github.com/guardian/frontend/pull/27021
* https://github.com/guardian/frontend/pull/26983
* https://github.com/guardian/frontend/pull/26986
* https://github.com/guardian/frontend/pull/26796
* https://github.com/guardian/frontend/pull/26806
* https://github.com/guardian/frontend/pull/26783
* https://github.com/guardian/frontend/pull/27030
* https://github.com/guardian/frontend/pull/27031
* https://github.com/guardian/frontend/pull/27032

## Checklist

- [x] Tested locally, and on CODE if necessary