### PR TITLE
Bump Commercial v11.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^15.0.1",
-		"@guardian/commercial": "11.26.1",
+		"@guardian/commercial": "11.27.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11787,7 +11787,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-"prebid.js@github:guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b":
+prebid.js@guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b:
   version "8.24.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/ee7f43c7c85a5245bbe51920cfed18818866ea7b"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-15.0.1.tgz#2c936c43e654f5ae28db254329eae1b4b5861641"
   integrity sha512-XNqYE9X/4aM5vZqiZInedvEZ9niPfdqwL7SjzNF0wnVbR+YObOC6QC68M521gTPcyca6r190qtnayv4GNO0peg==
 
-"@guardian/commercial@11.26.1":
-  version "11.26.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.26.1.tgz#96617214dd00b7405ed3257407a13520a235230b"
-  integrity sha512-aJ255CjnHawVGAufdQ5jaePTFpX1J7myBQXWE7s/u3riMsh0emXcHppjJZ+ptRC3cXbSDoh8kYaO7tqKua8ExQ==
+"@guardian/commercial@11.27.0":
+  version "11.27.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.27.0.tgz#42ac7b2ddbf206b03512e98350b7747a433bdde2"
+  integrity sha512-BEU4aPnEks/ognztdSTAcowKPU9VO4Wj1S7vPrIy6l5JrJrf8p426riHGoV7CDOUvOq6ae3hhUzmQlermHE02w==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"
@@ -11787,7 +11787,7 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
 
-prebid.js@guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b:
+"prebid.js@github:guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b":
   version "8.24.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/ee7f43c7c85a5245bbe51920cfed18818866ea7b"
   dependencies:


### PR DESCRIPTION
## What does this change?

Introduce changes in @guardian/commercial@11.27.0

### Minor Changes

- https://github.com/guardian/commercial/commit/1055092bf1ad98c7b8ffeb3500ea8e5db2424c8b: Add mobile-sticky to ROW
- https://github.com/guardian/commercial/commit/16c4358c727e7a5bdbd4e85aea8a08ac3aa80c0b: More commercial metrics
