### PR TITLE
Stop sending alreadyVisited to SDC

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@guardian/source-foundations": "^13.0.0",
 		"@guardian/source-react-components": "^12.0.0",
 		"@guardian/source-react-components-development-kitchen": "^10.0.1",
-		"@guardian/support-dotcom-components": "1.0.8",
+		"@guardian/support-dotcom-components": "1.1.0",
 		"bean": "~1.0.14",
 		"bonzo": "~2.0.0",
 		"bootstrap-sass": "3.4.0",

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.ts
@@ -1,10 +1,5 @@
-import { storage } from '@guardian/libs';
-
-const getVisitCount = (): number =>
-	parseInt(storage.local.getRaw('gu.alreadyVisited') ?? '', 10) || 0;
-
 const pageShouldHideReaderRevenue = (): boolean =>
 	window.guardian.config.page.shouldHideReaderRevenue ??
 	window.guardian.config.page.sponsorshipType === 'paid-content';
 
-export { pageShouldHideReaderRevenue, getVisitCount };
+export { pageShouldHideReaderRevenue };

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -85,12 +85,6 @@ const clearBannerHistory = () => {
 const showMeTheBanner = (asExistingSupporter = false) => {
 	clearBannerHistory();
 
-	// The banner only displays after a certain number of pageviews. So let's get there quick!
-	storage.local.setRaw(
-		'gu.alreadyVisited',
-		minArticlesBeforeShowingBanner + 1,
-	);
-
 	clearCommonReaderRevenueStateAndReload(asExistingSupporter);
 };
 

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -13,7 +13,6 @@ import type React from 'react';
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import { submitComponentEvent } from 'common/modules/commercial/acquisitions-ophan';
-import { getVisitCount } from 'common/modules/commercial/contributions-utilities';
 import {
 	getLastOneOffContributionDate,
 	getPurchaseInfo,
@@ -138,7 +137,6 @@ const buildBannerPayload = async (
 	const browserId = window.guardian.config.ophan.browserId;
 
 	const targeting: BannerTargeting = {
-		alreadyVisitedCount: getVisitCount(),
 		shouldHideReaderRevenue: shouldHideReaderRevenue,
 		isPaidContent: isPaidContent,
 		showSupportMessaging: !(await shouldHideSupportMessaging()),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,10 +2502,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.13.0.tgz#4a40ac6e2bd62b8bf8ef634e9084fcc8c640d8c7"
   integrity sha512-tibmZHHu7TjN3DSphUhlGSLCAJvLqr8XLDpgdlWB8YO1ohwYacOPpVdIGSi0N7E0XxjUOfB757XWXgs3yNd0LQ==
 
-"@guardian/support-dotcom-components@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.8.tgz#1f1b3e11483e3f17a472ec1ad375100f96bed0ea"
-  integrity sha512-5Llcfv2DLfqGyjylJXtlyShhZJqImFHvMQBNKR0JxKZeGPX/rz8FZlyLKSmGuzaK0ommRUtvHgeumdxzzK9jfA==
+"@guardian/support-dotcom-components@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.1.0.tgz#c5236dc6427cbfac1c05a43c14e0fad455d71110"
+  integrity sha512-jdxhB2cNTP9nIFciFudlV4w3i5YnIIFrrjIi1Pbpmv4Y6O8vGR0k7KfyZfUiY9GVilcMPMMTv08En9I26Mz1vQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
Currently DCR and Frontend maintain a pageview counter in local storage called `gu.alreadyVisited`.
It's listed as essential, but wasn't really doing what Marketing needed, so we've [stopped using it in the Marketing API](https://github.com/guardian/support-dotcom-components/pull/1024).

With this PR we stop sending it to the API (SDC).

Still TODO later - change the logic that maintains `gu.alreadyVisited` to only do so if user has the right consent. It's still used for advertising.