### PR TITLE
Check consents for gu.alreadyVisited

### DIFF
--- a/static/src/javascripts/bootstraps/standard/alreadyVisited.ts
+++ b/static/src/javascripts/bootstraps/standard/alreadyVisited.ts
@@ -1,0 +1,24 @@
+import { onConsent } from '@guardian/consent-management-platform';
+
+/**
+ * This local storage item is used to target ads if a user has the correct consents
+ */
+const AlreadyVisitedKey = 'gu.alreadyVisited';
+
+const getAlreadyVisitedCount = (): number => {
+	const alreadyVisited = parseInt(
+		localStorage.getItem(AlreadyVisitedKey) ?? '',
+		10,
+	);
+	return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
+};
+
+export const incrementAlreadyVisited = async (): Promise<void> => {
+	const { canTarget } = await onConsent();
+	if (canTarget) {
+		const alreadyVisited = getAlreadyVisitedCount() + 1;
+		localStorage.setItem(AlreadyVisitedKey, alreadyVisited.toString());
+	} else {
+		localStorage.removeItem(AlreadyVisitedKey);
+	}
+};

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -16,11 +16,8 @@
 import fastdom from 'fastdom';
 import raven from 'lib/raven';
 import userPrefs from 'common/modules/user-prefs';
-import { storage } from '@guardian/libs';
-import { fetchJson } from 'lib/fetch-json';
 import { mediator } from 'lib/mediator';
 import { addEventListener } from 'lib/events';
-import { addCookie } from 'lib/cookies';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import { isBreakpoint } from 'lib/detect';
@@ -35,6 +32,7 @@ import ophan from 'ophan/ng';
 import { initAtoms } from './atoms';
 import { initEmbedResize } from "./emailEmbeds";
 import { setAdFreeCookie } from 'common/modules/commercial/user-features';
+import { incrementAlreadyVisited } from "bootstraps/standard/alreadyVisited";
 
 const showHiringMessage = () => {
     try {
@@ -159,11 +157,8 @@ const bootStandard = () => {
         setAdFreeCookie(1);
     }
 
-    // set local storage: gu.alreadyVisited
     if (window.guardian.isEnhanced) {
-        const key = 'gu.alreadyVisited';
-        const alreadyVisited = parseInt(storage.local.getRaw(key), 10) || 0;
-        storage.local.setRaw(key, alreadyVisited + 1);
+        void incrementAlreadyVisited();
     }
 
     ophan.setEventEmitter(mediator);


### PR DESCRIPTION
In a [previous PR](https://github.com/guardian/dotcom-rendering/pull/9847) we stopped using the `alreadyVisited` local storage item for Marketing targeting. It can now be considered non-essential, as it's only used for ads targeting.

With this PR, the `alreadyVisited` counter will now only be maintained for users with the right consent.