### PR TITLE
Add switch for rendering discussion in apps articles

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -532,4 +532,14 @@ trait FeatureSwitches {
     sellByDate = Some(LocalDate.of(2024, 6, 5)),
     exposeClientSide = true,
   )
+  val DiscussionInApps = Switch(
+    SwitchGroup.Feature,
+    "discussion-in-apps",
+    "If this switch is on, we will render discussion in apps articles",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    // This is a random date in the future but this switch should be removed far before then
+    sellByDate = Some(LocalDate.of(2024, 6, 5)),
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
So we can selectively enable it per environment.

Closes https://github.com/guardian/dotcom-rendering/issues/9871.

