### PR TITLE
Remove expired test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -37,16 +37,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-deeply-read-article-footer",
-    "Test whether adding deeply read articles have negative impact on recirculation",
-    owners = Seq(Owner.withName("dotcom.platform")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2023, 12, 13)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-consentless-ads",
     "Use consentless ad stack rather than consented / standalone",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
This was introduced by mistake by me in my previous PR: https://github.com/guardian/frontend/pull/26736#issuecomment-1855562534 with a merge conflict. It is expired now so we want to remove it to fix the build. 
## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
