### PR TITLE
Revert "Reinstate affiliate links and move the disclaimer to the top of the page"

### DIFF
--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -47,6 +47,7 @@ object GalleryCaptionCleaners {
         "gallery",
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
+        page.gallery.content.fields.firstPublicationDate,
       ),
     )
 

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -84,6 +84,7 @@ object BodyProcessor {
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         contentType = "article",
         tags = article.content.tags.tags.map(_.id),
+        publishedDate = article.content.fields.firstPublicationDate,
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,7 +15,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       AdaptiveSite,
       OfferHttp3,
       DeeplyRead,
-      DisableAffiliateLinks,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -64,13 +63,4 @@ object OfferHttp3
       owners = Seq(Owner.withGithub("paulmr")),
       sellByDate = LocalDate.of(2024, 1, 3),
       participationGroup = Perc1E,
-    )
-
-object DisableAffiliateLinks
-    extends Experiment(
-      name = "disable-affiliate-links",
-      description = "Disable affiliate links for 2% of users so that we can measure differences in engagement",
-      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 1, 30),
-      participationGroup = Perc2A,
     )

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -5,7 +5,6 @@ import com.gu.contentapi.client.model.v1.{Block => APIBlock}
 import common.Edition
 import common.commercial.EditionAdTargeting.adTargetParamValueWrites
 import conf.Configuration
-import experiments.{ActiveExperiments, DisableAffiliateLinks}
 import model.dotcomrendering.pageElements.PageElement
 import model.{ContentFormat, ContentPage}
 import play.api.libs.json._
@@ -67,8 +66,7 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val isInDisableAffiliateLinksTest = ActiveExperiments.isParticipating(DisableAffiliateLinks)(request)
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 
     val edition = Edition(request)

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -461,7 +461,7 @@ object DotcomRenderingDataModel {
       blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
     }
 
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
     val shouldAddDisclaimer = hasAffiliateLinks(bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -268,7 +268,7 @@ object DotcomRenderingUtils {
     }
   }
 
-  def shouldAddAffiliateLinks(content: ContentType)(implicit request: RequestHeader): Boolean = {
+  def shouldAddAffiliateLinks(content: ContentType): Boolean = {
     AffiliateLinksCleaner.shouldAddAffiliateLinks(
       switchedOn = Switches.AffiliateLinks.isSwitchedOn,
       section = content.metadata.sectionId,
@@ -277,6 +277,7 @@ object DotcomRenderingUtils {
       defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
       alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
       tagPaths = content.content.tags.tags.map(_.id),
+      firstPublishedDate = content.content.fields.firstPublicationDate,
     )
   }
 

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -1,10 +1,8 @@
 package views.support.cleaner
 import conf.Configuration
-import conf.switches.Switches.ServerSideExperiments
 import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.test.FakeRequest
 import views.support.AffiliateLinksCleaner._
 
 class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
@@ -18,9 +16,9 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
   }
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
-    val fakeTestControlRequest = FakeRequest().withHeaders("X-GU-Experiment-2perc-A" -> "control")
-
     val supportedSections = Set("film", "books", "fashion")
+    val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
+    val newPublishedDate = Some(new DateTime(2020, 8, 15, 0, 0))
 
     shouldAddAffiliateLinks(
       switchedOn = false,
@@ -30,7 +28,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-    )(fakeTestControlRequest) should be(false)
+      oldPublishedDate,
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -39,7 +38,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-    )(fakeTestControlRequest) should be(true)
+      oldPublishedDate,
+    ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -48,7 +48,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-    )(fakeTestControlRequest) should be(false)
+      oldPublishedDate,
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -57,7 +58,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-    )(fakeTestControlRequest) should be(true)
+      oldPublishedDate,
+    ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -66,7 +68,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("bereavement"),
-    )(fakeTestControlRequest) should be(false)
+      oldPublishedDate,
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -75,7 +78,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-    )(fakeTestControlRequest) should be(false)
+      oldPublishedDate,
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -84,7 +88,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-    )(fakeTestControlRequest) should be(true)
+      oldPublishedDate,
+    ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -93,7 +98,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("bereavement"),
-    )(fakeTestControlRequest) should be(false)
+      oldPublishedDate,
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -102,6 +108,17 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
-    )(fakeTestControlRequest) should be(true)
+      oldPublishedDate,
+    ) should be(true)
+    shouldAddAffiliateLinks(
+      switchedOn = true,
+      "fashion",
+      Some(true),
+      supportedSections,
+      Set.empty,
+      Set("bereavement"),
+      List("tech"),
+      newPublishedDate,
+    ) should be(false)
   }
 }


### PR DESCRIPTION
Reverts guardian/frontend#26738

Editorial have asked us to switch this off ASAP