### PR TITLE
Bump commercial to 11.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^16.2.0",
-		"@guardian/commercial": "11.27.1",
+		"@guardian/commercial": "11.28.0",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,10 +2407,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-16.2.0.tgz#f65f93a38f3bd621cb43f5f11beba3c002c13a21"
   integrity sha512-+wRKpo0LChL0PUqgRkqg/LrDpnz5ufIML1VokPwjZtyHpDMacB3393L3pBmKH46SNyBddmkRG98opfv1hdjqVA==
 
-"@guardian/commercial@11.27.1":
-  version "11.27.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.27.1.tgz#4715aa59a09882cd6a3c01f5858404477ea6018a"
-  integrity sha512-1hV6NEcfvlA63t3UbKrfBRbdRBwMuxiYZQp3Cn35zoU/jJsuiVtSFmC6SmezsCfZXLTG92cwrUT/C5/RZDZjnw==
+"@guardian/commercial@11.28.0":
+  version "11.28.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-11.28.0.tgz#09f668bc49d90dd84be6d696e66fc167ef9997e9"
+  integrity sha512-NBUVJYLhRMathySWPfNxaURosGceD6jc2SOe5yuCyPck3lC0I59/Mvs2Jzp05ncKMz6MKX23+0UqFPWip4dVBw==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
Bring in the changes from [11.28.0](https://github.com/guardian/commercial/releases/tag/v11.28.0)