### PR TITLE
InteractiveAtomBlockElement - Pass title to DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -328,6 +328,7 @@ case class InteractiveAtomBlockElement(
     js: Option[String],
     placeholderUrl: Option[String],
     role: Option[String],
+    title: String,
 ) extends PageElement
 object InteractiveAtomBlockElement {
   implicit val InteractiveAtomBlockElementWrites: Writes[InteractiveAtomBlockElement] =
@@ -1158,6 +1159,7 @@ object PageElement {
                 js = interactive.mainJS,
                 placeholderUrl = interactive.placeholderUrl,
                 role = elementRole,
+                title = interactive.title,
               ),
             )
           }


### PR DESCRIPTION

## What does this change?
Pass through the title property to the InteractiveAtomBlockElement in DCR, where it is required to set the proper title on the iframe
