### PR TITLE
ChartAtomBlockElement - Pass title to DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -187,8 +187,14 @@ object CartoonBlockElement {
 // contains all the css and js required to display the atom.
 // Note tha The CAPI answer also gives structured data, so maybe one day we could try and use that instead of
 // precompiled html.
-case class ChartAtomBlockElement(id: String, url: String, html: String, css: Option[String], js: Option[String])
-    extends PageElement
+case class ChartAtomBlockElement(
+    id: String,
+    url: String,
+    html: String,
+    css: Option[String],
+    js: Option[String],
+    title: String,
+) extends PageElement
 object ChartAtomBlockElement {
   implicit val ChartAtomBlockElementWrites: Writes[ChartAtomBlockElement] = Json.writes[ChartAtomBlockElement]
 }
@@ -1115,6 +1121,7 @@ object PageElement {
                 html = chart.html, // This is atom.defaultHtml
                 css = None, // hardcoded to None during experimental period
                 js = None, // hardcoded to None during experimental period
+                title = chart.title,
               ),
             )
           }


### PR DESCRIPTION
## What does this change?
Pass through the title property to the ChartAtomBlockElement in DCR, where it is required to set the proper title on the iframe