### PR TITLE
Allow rendering apps version of image content

### DIFF
--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -1,21 +1,22 @@
 package controllers
 
-import com.gu.contentapi.client.model.{Direction, FollowingSearchQuery, SearchQuery}
 import com.gu.contentapi.client.model.v1.{Block, ItemResponse, Content => ApiContent}
+import com.gu.contentapi.client.model.{Direction, FollowingSearchQuery, SearchQuery}
 import common._
+import conf.Configuration.contentApi
 import conf.switches.Switches
 import contentapi.ContentApiClient
+import implicits.{AppsFormat, JsonFormat}
 import model._
+import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import pages.ContentHtmlPage
+import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
-import services.ImageQuery
-import views.support.RenderOtherStatus
-import play.api.libs.json._
-import conf.Configuration.contentApi
-import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import renderers.DotcomRenderingService
+import services.ImageQuery
 import services.dotcomrendering.{ImageContentPicker, RemoteRender}
+import views.support.RenderOtherStatus
 
 import scala.concurrent.Future
 
@@ -63,6 +64,27 @@ class ImageContentController(
       request: RequestHeader,
   ): Future[Result] = {
     val pageType = PageType(content, request, context)
+
+    request.getRequestFormat match {
+      case JsonFormat =>
+        Future.successful(
+          common.renderJson(getDCRJson(content, pageType, mainBlock), content).as("application/json"),
+        )
+      case AppsFormat =>
+        remoteRenderer.getAppsImageContent(
+          wsClient,
+          content,
+          pageType,
+          mainBlock,
+        )
+      case _ =>
+        remoteRenderer.getImageContent(
+          wsClient,
+          content,
+          pageType,
+          mainBlock,
+        )
+    }
 
     if (request.isJson) {
       Future.successful(

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -85,19 +85,6 @@ class ImageContentController(
           mainBlock,
         )
     }
-
-    if (request.isJson) {
-      Future.successful(
-        common.renderJson(getDCRJson(content, pageType, mainBlock), content).as("application/json"),
-      )
-    } else {
-      remoteRenderer.getImageContent(
-        wsClient,
-        content,
-        pageType,
-        mainBlock,
-      )
-    }
   }
 
   private def isSupported(c: ApiContent) = c.isImageContent

--- a/applications/app/services/dotcomrendering/ImageContentPicker.scala
+++ b/applications/app/services/dotcomrendering/ImageContentPicker.scala
@@ -2,6 +2,7 @@ package services.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.{Block, ElementType}
 import common.GuLogging
+import implicits.AppsFormat
 import model.Cors.RichRequestHeader
 import model.ImageContentPage
 import play.api.mvc.RequestHeader
@@ -26,9 +27,24 @@ object ImageContentPicker extends GuLogging {
     }
 
     if (tier == RemoteRender) {
-      DotcomponentsLogger.logger.logRequest(s"path executing in dotcomponents", Map.empty, imageContentPage.image)
+      if (request.getRequestFormat == AppsFormat)
+        DotcomponentsLogger.logger.logRequest(
+          s"[ArticleRendering] path executing in dotcom rendering for apps (DCAR)",
+          Map.empty,
+          imageContentPage.image,
+        )
+      else
+        DotcomponentsLogger.logger.logRequest(
+          s"[ArticleRendering] path executing in dotcomponents",
+          Map.empty,
+          imageContentPage.image,
+        )
     } else {
-      DotcomponentsLogger.logger.logRequest(s"path executing in web", Map.empty, imageContentPage.image)
+      DotcomponentsLogger.logger.logRequest(
+        s"[ArticleRendering] path executing in web (frontend)",
+        Map.empty,
+        imageContentPage.image,
+      )
     }
 
     tier

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -358,6 +358,17 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
   }
 
+  def getAppsImageContent(
+      ws: WSClient,
+      imageContent: ImageContentPage,
+      pageType: PageType,
+      mainBlock: Option[Block],
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = DotcomRenderingDataModel.forImageContent(imageContent, request, pageType, mainBlock)
+    val json = DotcomRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.baseURL + "/AppsArticle", CacheTime.Facia)
+  }
+
   def getMedia(
       ws: WSClient,
       mediaPage: MediaPage,


### PR DESCRIPTION
## What does this change?

This allows image content (aka picture content) to be rendered for apps, by respecting the ?dcr=apps parameter

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/1229808/e89762af-2300-44a8-b750-10babbda6b2c
[after]: https://github.com/guardian/frontend/assets/1229808/1530a85f-2893-4133-853f-e3ceec337c7b
