### PR TITLE
Add some missing setters from the A-Z list

### DIFF
--- a/applications/app/crosswords/CrosswordPage.scala
+++ b/applications/app/crosswords/CrosswordPage.scala
@@ -70,6 +70,7 @@ class CrosswordSearchPage extends StandalonePage {
   }
 
   val setters: Seq[String] = Seq(
+    "Algol",
     "Anto",
     "Arachne",
     "Araucaria",
@@ -105,6 +106,7 @@ class CrosswordSearchPage extends StandalonePage {
     "Imogen",
     "Jack",
     "Janus",
+    "Kite",
     "Kookaburra",
     "Logodaedalus",
     "Maskarade",
@@ -114,7 +116,9 @@ class CrosswordSearchPage extends StandalonePage {
     "Nutmeg",
     "Omnibus",
     "Orlando",
+    "Otterden",
     "Pan",
+    "Pangakupu",
     "Pasquale",
     "Paul",
     "Philistine",
@@ -134,5 +138,6 @@ class CrosswordSearchPage extends StandalonePage {
     "Troll",
     "Vlad",
     "Vulcan",
+    "Yank",
   )
 }


### PR DESCRIPTION
## What does this change?

An upcoming puzzle is from a new setter, Yank. I've taken this opportunity to add some of the other setters on the [A-Z list](https://www.theguardian.com/crosswords/2013/oct/28/crosswords-a-z) who weren't already appearing in this dropdown.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)