### PR TITLE
Update configuration SSM paths to allow lookup from `{stage}/{stack}/{app}`

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -3,12 +3,11 @@ package common
 import java.io.{File, FileInputStream}
 import java.nio.charset.Charset
 import java.util.Map.Entry
-
 import com.amazonaws.AmazonClientException
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.typesafe.config.{ConfigException, ConfigFactory}
-import common.Environment.{app, awsRegion, stage}
+import common.Environment.{app, awsRegion, stack, stage}
 import conf.{Configuration, Static}
 import org.apache.commons.io.IOUtils
 import services.ParameterStore
@@ -93,9 +92,11 @@ object GuardianConfiguration extends GuLogging {
       val frontendConfig = configFromParameterStore("/frontend")
       val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
       val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
+      val frontendStageStackAppConfig = configFromParameterStore(s"/${stage.toUpperCase}/${stack}/${app.toLowerCase}")
 
       userPrivate
         .withFallback(runtimeOnly)
+        .withFallback(frontendStageStackAppConfig)
         .withFallback(frontendAppConfig)
         .withFallback(frontendStageConfig)
         .withFallback(frontendConfig)


### PR DESCRIPTION
## What is the value of this and can you measure success?

The frontend apps currently use old versions of config paths when looking up values in SSM ie. `{stack}/{stage}` or `{stack}/{stage}/{app}`.

The newer and more standard format for SSM params is `{stage}/{stack}/{app}`.

Allowing parameters to be looked up via this method allows us to begin to migrate towards a safer pattern for storing parameters as well as allowing us to prioritise new values over old values.

Part of https://github.com/guardian/platform/issues/1568

## What does this change?

Adds new config path in the common `configuration` file so that we can look up parameters at `{stage}/{stack}/{app}`. Also prioritises this lookup path over existing ones. Will still pick up parameters specified by the old method but if one exists that fits the new one, should pick this value first.
