### PR TITLE
Use new base URL for DCR article endpoints

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -150,6 +150,7 @@ class GuardianConfiguration extends GuLogging {
 
   object rendering {
     lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
+    lazy val articleBaseURL = configuration.getMandatoryStringProperty("article-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -232,7 +232,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     }
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + path, page.metadata.cacheTime)
+    post(ws, json, Configuration.rendering.articleBaseURL + path, page.metadata.cacheTime)
   }
 
   def getBlocks(
@@ -243,7 +243,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomBlocksRenderingDataModel(page, request, blocks)
     val json = DotcomBlocksRenderingDataModel.toJson(dataModel)
 
-    postWithoutHandler(ws, json, Configuration.rendering.baseURL + "/Blocks")
+    postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/Blocks")
       .flatMap(response => {
         if (response.status == 200)
           Future.successful(response.body)
@@ -355,7 +355,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomRenderingDataModel.forImageContent(imageContent, request, pageType, mainBlock)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
   }
 
   def getAppsImageContent(
@@ -366,7 +366,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomRenderingDataModel.forImageContent(imageContent, request, pageType, mainBlock)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/AppsArticle", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsArticle", CacheTime.Facia)
   }
 
   def getMedia(
@@ -378,7 +378,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomRenderingDataModel.forMedia(mediaPage, request, pageType, blocks)
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
   }
 
   def getGallery(
@@ -390,7 +390,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomRenderingDataModel.forGallery(gallery, request, pageType, blocks)
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
   }
 }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

For the new DCR stack in https://github.com/guardian/dotcom-rendering/pull/9955 (and with added scaling policies https://github.com/guardian/dotcom-rendering/pull/10127), adds new SSM param reference to start pointing traffic towards the split app for articles.

## What does this change?

Adds new config and replaces `baseURL` with `articleBaseURL` in the `DotcomRenderingService` to start pointing traffic towards the new DCR app for articles using an ALB and Gu CDK pattern.

The following requests will now be served by the new `article-rendering` app:
- Articles
- Live blogs
- Blocks (live blogs)
- Image content
- Apps image content
- Media
- Gallery

The above request one of the following DCR endpoints:
- `/Article`
- `/AppsArticle`
- `/Blocks`

This is part of solution to https://github.com/guardian/dotcom-rendering/issues/9374
