### PR TITLE
Handle JSON from SNS topic when receiving messages from the fronts tool

### DIFF
--- a/common/app/common/SQSQueues.scala
+++ b/common/app/common/SQSQueues.scala
@@ -114,8 +114,7 @@ case class TextMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implici
 /** Utility class for SQS queues that use JSON to serialize their messages */
 case class JsonMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implicit executionContext: ExecutionContext)
     extends MessageQueue[A](client, queueUrl)(executionContext)
-    with GuLogging
-    {
+    with GuLogging {
 
   def send(a: A)(implicit writes: Writes[A]): Future[SendMessageResult] =
     sendMessage(new SendMessageRequest().withQueueUrl(queueUrl).withMessageBody(Json.stringify(Json.toJson(a))))
@@ -124,7 +123,8 @@ case class JsonMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implici
     receiveMessages(request) map { messages =>
       messages.toSeq map { message =>
         val body = Json.parse(message.getBody).as[JsObject]
-        val actualBody = body.value.get("Message").map(_.toString().replaceAll("\\\\", "")).map(Json.parse).getOrElse(body)
+        val actualBody =
+          body.value.get("Message").map(_.toString().replaceAll("\\\\", "")).map(Json.parse).getOrElse(body)
 
         log.info(s"Body: ${body.toString()}")
         log.info(s"Actual Body: ${actualBody.toString()}")

--- a/common/app/common/SQSQueues.scala
+++ b/common/app/common/SQSQueues.scala
@@ -125,9 +125,9 @@ case class JsonMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implici
         val body = Json.parse(message.getBody).as[JsObject]
         val actualBody =
           body.value.get("Message").map(_.toString().replaceAll("\\\\", "")).map(Json.parse).getOrElse(body)
-
-        log.info(s"Body: ${body.toString()}")
-        log.info(s"Actual Body: ${actualBody.toString()}")
+        val messageId = body.value.get("MessageId").map(_.toString()).getOrElse("no message id")
+        log.info(s"Body: ${messageId} ${body.toString()}")
+        log.info(s"Actual Body: ${messageId} ${actualBody.toString()}")
 
         Message(
           MessageId(message.getMessageId),

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -61,6 +61,6 @@ object OfferHttp3
       name = "offer-http3",
       description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
       owners = Seq(Owner.withGithub("paulmr")),
-      sellByDate = LocalDate.of(2024, 1, 3),
+      sellByDate = LocalDate.of(2024, 4, 3),
       participationGroup = Perc1E,
     )


### PR DESCRIPTION
We are putting `FrontsUpdateSNSTopic` in front of `FrontPressToolJobQueue` (separate PR in platform will follow). Until now the queue has been receiving messages from the fronts tool directly. Once we put the topic in front of the queue, the queue will be receiving for some time messages both from the topic and and the fronts tool. With this change we're adding a way to also handle the JSON in the format the SNS topic sends it.

## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
