### PR TITLE
Extend `OfferHttp3` switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -61,6 +61,6 @@ object OfferHttp3
       name = "offer-http3",
       description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
       owners = Seq(Owner.withGithub("paulmr")),
-      sellByDate = LocalDate.of(2024, 1, 3),
+      sellByDate = LocalDate.of(2024, 4, 3),
       participationGroup = Perc1E,
     )


### PR DESCRIPTION
## What does this change?
Extends `OfferHttp3` switch

## Why?
So that we have a clean build

