### PR TITLE
Bump Identity libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,11 +155,11 @@ val identity = application("identity")
     libraryDependencies ++= Seq(
       filters,
       identityAuthPlay,
-      http4sCore,
       slf4jExt,
       libPhoneNumber,
       supportInternationalisation,
     ),
+    dependencyOverrides ++= jackson,
     PlayKeys.playDefaultPort := 9009,
     Test / testOptions += Tests.Argument("-oF"),
   )

--- a/identity/app/services/IdentityServices.scala
+++ b/identity/app/services/IdentityServices.scala
@@ -2,8 +2,8 @@ package services
 
 import java.util.concurrent.{Executors, ThreadPoolExecutor}
 import clients.DiscussionClient
+import com.gu.identity.auth.{IdapiAuthConfig, IdapiAuthService}
 import com.gu.identity.cookie.IdentityCookieService
-import com.gu.identity.play.IdentityPlayAuthService
 import com.softwaremill.macwire._
 import conf.IdentityConfigurationComponents
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
@@ -28,7 +28,7 @@ trait IdentityServices extends IdentityConfigurationComponents with IdApiCompone
   lazy val idRequestParser = wire[IdRequestParser]
   lazy val identityUrlBuilder = wire[IdentityUrlBuilder]
   lazy val playSigninService = wire[PlaySigninService]
-  lazy val identityAuthService: IdentityPlayAuthService = {
+  lazy val identityAuthService: IdapiAuthService = {
     val blockingThreads = 30
 
     val threadPool = Executors.newFixedThreadPool(blockingThreads).asInstanceOf[ThreadPoolExecutor]
@@ -36,10 +36,8 @@ trait IdentityServices extends IdentityConfigurationComponents with IdApiCompone
 
     val ec: ExecutionContext = ExecutionContext.fromExecutorService(threadPool)
 
-    IdentityPlayAuthService.unsafeInit(
-      Uri.unsafeFromString(identityConfiguration.apiRoot),
-      identityConfiguration.apiClientToken,
-      None,
+    IdapiAuthService.unsafeInit(
+      IdapiAuthConfig(Uri.unsafeFromString(identityConfiguration.apiRoot), identityConfiguration.apiClientToken),
     )(ec)
   }
   lazy val identityCookieService: IdentityCookieService =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,10 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  // Once we're able to upgrade identityLibVersion to >=4.10 we should
-  // remove the http4s-core dependency eviction below. (Unless we've
-  // started needing it for something else in the meantime.)
-  val identityLibVersion = "3.255"
+  val identityLibVersion = "4.17"
   val awsVersion = "1.12.205"
   val capiVersion = "19.4.0"
   val faciaVersion = "4.0.6"
@@ -40,9 +37,6 @@ object Dependencies {
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % identityLibVersion
-  // We're evicting the version of http4s-code used in the Identity packages
-  // Once we can upgrade Identity packages to >=4.10 we should remove this
-  val http4sCore = "org.http4s" %% "http4s-core" % "0.22.15"
   val mockWs = "de.leanovate.play-mockws" %% "play-mockws" % "2.6.2" % Test
   val jodaTime = "joda-time" % "joda-time" % "2.9.9"
   val jodaConvert = "org.joda" % "joda-convert" % "1.8.3"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Should eliminate any vulnerable transitive dependencies that the old Identity libraries may have been bringing in.  Also will make it easier to keep Identity libraries up to date in future as we don't expect to make so many breaking changes in future.

## What does this change?
Bumps Identity libraries from v3.255 to v4.17.

There will need to be some future work in the next few weeks to support Okta authorisation of endpoints or removing the authorised endpoints altogether if they prove to be redundant.

## Checklist

- [x] Tested locally, and on CODE
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
