### PR TITLE
Enable Lightbox for 5% of users

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -34,7 +34,7 @@ object Lightbox
       description = "Testing the impact lightbox might have on our CWVs",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 1, 31),
-      participationGroup = Perc0B,
+      participationGroup = Perc5A,
     )
 
 // Removing while we are still implementing this content type in DCR


### PR DESCRIPTION
## What is the value of this and can you measure success?

This feature is currently missing from the DCR migration

## What does this change?

Increase the lightbox test to 5% of users

## Screenshots

<img width="1718" alt="image" src="https://github.com/guardian/frontend/assets/76776/080d2034-2b83-4f11-8cfb-9fde5852e855">


## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
