### PR TITLE
Send `abTests` to DCR Blocks endpoint

### DIFF
--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -10,6 +10,7 @@ import model.{ContentFormat, ContentPage}
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.CamelCase
+import experiments.ActiveExperiments
 
 // -----------------------------------------------------------------
 // DCR Blocks DataModel
@@ -28,6 +29,7 @@ case class DotcomBlocksRenderingDataModel(
     sharedAdTargeting: Map[String, AdTargetParamValue],
     adUnit: String,
     switches: Map[String, Boolean],
+    abTests: Map[String, String],
 )
 
 object DotcomBlocksRenderingDataModel {
@@ -49,6 +51,7 @@ object DotcomBlocksRenderingDataModel {
         "sharedAdTargeting" -> Json.toJson(model.sharedAdTargeting),
         "adUnit" -> model.adUnit,
         "switches" -> model.switches,
+        "abTests" -> model.abTests,
       )
 
       ElementsEnhancer.enhanceBlocks(obj)
@@ -111,6 +114,7 @@ object DotcomBlocksRenderingDataModel {
         content.metadata.commercial.map(_.adTargeting(edition)).getOrElse(Set.empty).map(f => (f.name, f.value)).toMap,
       adUnit = content.metadata.adUnitSuffix,
       switches = switches,
+      abTests = ActiveExperiments.getJsMap(request),
     )
   }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

We can vary blocks based on the current experiments (server-side A/B tests)

Related to https://github.com/guardian/dotcom-rendering/pull/10112

## What does this change?

Add `abTests` to the `DotcomBlocksRenderingDataModel`

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
