### PR TITLE
Upgrade to Scala `2.13.12` 

### DIFF
--- a/admin/app/model/deploys/ApiResults.scala
+++ b/admin/app/model/deploys/ApiResults.scala
@@ -6,7 +6,7 @@ import play.api.mvc._
 object ApiResults extends Results {
 
   case class ApiError(message: String, statusCode: Int)
-  object ApiError { implicit val format = Json.format[ApiError] }
+  object ApiError { implicit val format: OFormat[ApiError] = Json.format[ApiError] }
 
   case class ApiErrors(errors: List[ApiError]) {
     def statusCode: Int = errors.map(_.statusCode).max

--- a/admin/app/model/deploys/RiffRaff.scala
+++ b/admin/app/model/deploys/RiffRaff.scala
@@ -2,12 +2,12 @@ package model.deploys
 
 import conf.Configuration
 import model.deploys.ApiResults.{ApiError, ApiErrors, ApiResponse}
-import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.json.{JsError, JsSuccess, Json, OFormat}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 case class RiffRaffDeployTags(vcsRevision: Option[String])
-object RiffRaffDeployTags { implicit val format = Json.format[RiffRaffDeployTags] }
+object RiffRaffDeployTags { implicit val format: OFormat[RiffRaffDeployTags] = Json.format[RiffRaffDeployTags] }
 
 case class RiffRaffDeploy(
     uuid: String,
@@ -19,7 +19,7 @@ case class RiffRaffDeploy(
     time: String,
     tags: RiffRaffDeployTags,
 )
-object RiffRaffDeploy { implicit val format = Json.format[RiffRaffDeploy] }
+object RiffRaffDeploy { implicit val format: OFormat[RiffRaffDeploy] = Json.format[RiffRaffDeploy] }
 
 class RiffRaffService(httpClient: HttpLike) {
 

--- a/admin/app/services/Fastly.scala
+++ b/admin/app/services/Fastly.scala
@@ -3,9 +3,10 @@ package services
 import common.GuLogging
 import conf.AdminConfiguration.fastly
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum}
+
 import java.util.Date
 import play.api.libs.ws.WSClient
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsValue, Json, OFormat}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -33,7 +34,7 @@ class FastlyStatisticService(wsClient: WSClient) extends GuLogging {
       start_time: Long,
   )
 
-  private implicit val FastlyApiStatFormat = Json.format[FastlyApiStat]
+  private implicit val FastlyApiStatFormat: OFormat[FastlyApiStat] = Json.format[FastlyApiStat]
 
   private val regions = List("usa", "europe", "ausnz")
 

--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -190,10 +190,10 @@ object FormattedChart {
 
   case class Cell(v: String)
 
-  implicit val cellReads = Json.writes[Cell]
-  implicit val rowReads = Json.writes[Row]
-  implicit val columnReads = Json.writes[Column]
-  implicit val tableReads = Json.writes[DataTable]
+  implicit val cellReads: OWrites[Cell] = Json.writes[Cell]
+  implicit val rowReads: OWrites[Row] = Json.writes[Row]
+  implicit val columnReads: OWrites[Column] = Json.writes[Column]
+  implicit val tableReads: OWrites[DataTable] = Json.writes[DataTable]
 }
 
 // A variation of Chart that can be easily serialised into a Google Visualization DataTable Json object.

--- a/article/test/AnalyticsFeatureTest.scala
+++ b/article/test/AnalyticsFeatureTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.matchers.should.Matchers
     with GivenWhenThen
     with Matchers
     with ConfiguredTestSuite {
-  implicit val config = Configuration
+  implicit val config: Configuration.type = Configuration
 
   Feature("Analytics") {
 

--- a/commercial/app/CommercialLifecycle.scala
+++ b/commercial/app/CommercialLifecycle.scala
@@ -1,16 +1,15 @@
 package commercial
 
 import java.util.concurrent.Executors
-
 import commercial.model.merchandise.jobs.Industries
 import app.LifecycleComponent
 import commercial.model.feeds._
 import common.LoggingField._
-import common.{PekkoAsync, JobScheduler, GuLogging}
+import common.{GuLogging, JobScheduler, PekkoAsync}
 import metrics.MetricUploader
 import play.api.inject.ApplicationLifecycle
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.util.control.NonFatal
 
 object CommercialMetrics {
@@ -28,7 +27,7 @@ class CommercialLifecycle(
     with GuLogging {
 
   // This class does work that should be kept separate from the EC used to serve requests
-  implicit private val ec = ExecutionContext.fromExecutorService(
+  implicit private val ec: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(
     Executors.newFixedThreadPool(10),
   )
 

--- a/commercial/app/controllers/JobsController.scala
+++ b/commercial/app/controllers/JobsController.scala
@@ -12,7 +12,7 @@ class JobsController(jobsAgent: JobsAgent, val controllerComponents: ControllerC
     extends BaseController
     with implicits.Requests {
 
-  implicit val codec = Codec.utf_8
+  implicit val codec: Codec = Codec.utf_8
 
   private def jobSample(specificIds: Seq[String], segment: Segment): Seq[Job] =
     (jobsAgent.specificJobs(specificIds) ++ jobsAgent.jobsTargetedAt(segment)).distinct.take(2)

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success, Try}
 
 trait GuLogging {
 
-  lazy implicit val log = Logger(getClass)
+  lazy implicit val log: Logger = Logger(getClass)
 
   protected def logException(e: Exception): Unit = {
     log.error(ExceptionUtils.getStackTrace(e))

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -31,7 +31,7 @@ case class RequestLoggerFields(request: RequestHeader, response: Option[Result],
 
     val allowListedHeaders = (for {
       headerName <- allowListedHeaderNames
-      value <- allHeadersFields.get(headerName)
+      value <- allHeadersFields.map { case (key, value) => (key.toLowerCase, value) }.get(headerName.toLowerCase)
     } yield headerName -> value).toMap
 
     val guardianSpecificHeaders = allHeadersFields.view.filterKeys(_.toUpperCase.startsWith("X-GU-")).toMap

--- a/common/app/common/SNSNotification.scala
+++ b/common/app/common/SNSNotification.scala
@@ -1,9 +1,9 @@
 package common
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 object SNSNotification {
-  implicit val jsonFormats = Json.format[SNSNotification]
+  implicit val jsonFormats: OFormat[SNSNotification] = Json.format[SNSNotification]
 }
 
 case class SNSNotification(

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -6,14 +6,14 @@ import com.gu.contentapi.client.model.v1.{Content, Section, Tag}
 import common.Edition
 import common.Edition.defaultEdition
 import common.dfp.DfpAgent
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json, OFormat}
 
 case class EditionCommercialProperties(branding: Option[Branding], adTargeting: Set[AdTargetParam])
 
 object EditionCommercialProperties {
-  implicit val thirdNeedlessFormatter = EditionAdTargeting.adTargetParamFormat
-  implicit val secondNeedlessFormatter = EditionBranding.brandingFormat
-  implicit val firstNeedlessFormatter = Json.format[EditionCommercialProperties]
+  implicit val thirdNeedlessFormatter: Format[AdTargetParam] = EditionAdTargeting.adTargetParamFormat
+  implicit val secondNeedlessFormatter: Format[Branding] = EditionBranding.brandingFormat
+  implicit val firstNeedlessFormatter: OFormat[EditionCommercialProperties] = Json.format[EditionCommercialProperties]
 
 }
 case class CommercialProperties(
@@ -54,7 +54,7 @@ case class CommercialProperties(
 
 object CommercialProperties {
 
-  implicit val commercialPropertiesFormat = Json.format[CommercialProperties]
+  implicit val commercialPropertiesFormat: OFormat[CommercialProperties] = Json.format[CommercialProperties]
 
   val empty = CommercialProperties(
     editionBrandings = Set.empty,

--- a/common/app/common/commercial/EditionAdTargeting.scala
+++ b/common/app/common/commercial/EditionAdTargeting.scala
@@ -64,7 +64,7 @@ object EditionAdTargeting {
       }
   }
 
-  implicit val editionAdTargetingFormat = Json.format[EditionAdTargeting]
+  implicit val editionAdTargetingFormat: OFormat[EditionAdTargeting] = Json.format[EditionAdTargeting]
 
   private val adTargeter = new AdTargeter(
     platform = "ng",

--- a/common/app/common/commercial/EditionBranding.scala
+++ b/common/app/common/commercial/EditionBranding.scala
@@ -11,7 +11,7 @@ case class EditionBranding(edition: Edition, branding: Option[Branding])
 
 object EditionBranding {
 
-  implicit val brandingFormat = {
+  implicit val brandingFormat: Format[Branding] = {
 
     implicit val dimensionsFormat = Json.format[Dimensions]
 
@@ -42,7 +42,7 @@ object EditionBranding {
     Format(brandingReads, Json.writes[Branding])
   }
 
-  implicit val editionBrandingFormat = Json.format[EditionBranding]
+  implicit val editionBrandingFormat: OFormat[EditionBranding] = Json.format[EditionBranding]
 
   val editions = Edition.allEditions.toSet
 

--- a/common/app/common/commercial/PrebidIndexSite.scala
+++ b/common/app/common/commercial/PrebidIndexSite.scala
@@ -12,7 +12,7 @@ case class PrebidIndexSite(bp: Breakpoint, id: Int)
 
 object PrebidIndexSite {
 
-  implicit val breakpointFormat = new Format[Breakpoint] {
+  implicit val breakpointFormat: Format[Breakpoint] = new Format[Breakpoint] {
     def reads(json: JsValue): JsResult[Breakpoint] =
       json match {
         case JsString("D") => JsSuccess(Desktop)
@@ -28,7 +28,7 @@ object PrebidIndexSite {
         case _       => JsString("D")
       }
   }
-  implicit val format = Json.format[PrebidIndexSite]
+  implicit val format: OFormat[PrebidIndexSite] = Json.format[PrebidIndexSite]
 
   private val defaultSiteIds = Set(
     PrebidIndexSite(Desktop, 208283),

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -24,7 +24,7 @@ case class HostedVideoPage(
 }
 
 object HostedVideoPage extends GuLogging {
-  private implicit val ordering = EncodingOrdering
+  private implicit val ordering: EncodingOrdering.type = EncodingOrdering
 
   def fromContent(content: Content): Option[HostedVideoPage] = {
     log.info(s"Building hosted video ${content.id} ...")

--- a/common/app/common/dfp/AdSize.scala
+++ b/common/app/common/dfp/AdSize.scala
@@ -7,13 +7,11 @@ case class AdSize(width: Int, height: Int)
 
 object AdSize {
 
-  implicit val writes = new Writes[AdSize] {
-    def writes(size: AdSize): JsValue = {
-      Json.obj(
-        "width" -> size.width,
-        "height" -> size.height,
-      )
-    }
+  implicit val writes: Writes[AdSize] = (size: AdSize) => {
+    Json.obj(
+      "width" -> size.width,
+      "height" -> size.height,
+    )
   }
 
   implicit val reads: Reads[AdSize] = (

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -6,6 +6,7 @@ import org.joda.time.DateTime
 import org.joda.time.DateTime.now
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.functional.syntax._
+import play.api.libs.json
 import play.api.libs.json._
 import play.api.libs.json.JodaReads._
 
@@ -30,13 +31,9 @@ object GuLineItemType {
       case otherLineItemType    => Other(otherLineItemType)
     }
 
-  implicit val guLineItemWrites = new Writes[GuLineItemType] {
-    def writes(lineItemType: GuLineItemType): JsValue = {
-      lineItemType match {
-        case Sponsorship                 => JsString("sponsorship")
-        case Other(lineItemTypeAsString) => JsString(lineItemTypeAsString)
-      }
-    }
+  implicit val guLineItemWrites: Writes[GuLineItemType] = {
+    case Sponsorship                 => JsString("sponsorship")
+    case Other(lineItemTypeAsString) => JsString(lineItemTypeAsString)
   }
 
   implicit val guLineItemTypeReads: Reads[GuLineItemType] =
@@ -62,11 +59,11 @@ case class GuCustomTargetingValue(
 )
 
 object GuCustomTargetingValue {
-  implicit val format = Json.format[GuCustomTargetingValue]
+  implicit val format: OFormat[GuCustomTargetingValue] = Json.format[GuCustomTargetingValue]
 }
 
 object GuCustomTargeting {
-  implicit val format = Json.format[GuCustomTargeting]
+  implicit val format: OFormat[GuCustomTargeting] = Json.format[GuCustomTargeting]
 }
 
 case class CustomTarget(name: String, op: String, values: Seq[String]) {
@@ -168,7 +165,7 @@ case class GuAdUnit(id: String, path: Seq[String], status: String) {
 
 object GuAdUnit {
 
-  implicit val adUnitFormats = Json.format[GuAdUnit]
+  implicit val adUnitFormats: OFormat[GuAdUnit] = Json.format[GuAdUnit]
 
   val ACTIVE = "ACTIVE"
   val INACTIVE = "INACTIVE"
@@ -296,24 +293,22 @@ object GuLineItem {
 
   private val timeFormatter = ISODateTimeFormat.dateTime().withZoneUTC()
 
-  implicit val lineItemWrites = new Writes[GuLineItem] {
-    def writes(lineItem: GuLineItem): JsValue = {
-      Json.obj(
-        "id" -> lineItem.id,
-        "orderId" -> lineItem.orderId,
-        "name" -> lineItem.name,
-        "lineItemType" -> lineItem.lineItemType,
-        "startTime" -> timeFormatter.print(lineItem.startTime),
-        "endTime" -> lineItem.endTime.map(timeFormatter.print(_)),
-        "isPageSkin" -> lineItem.isPageSkin,
-        "sponsor" -> lineItem.sponsor,
-        "status" -> lineItem.status,
-        "costType" -> lineItem.costType,
-        "creativePlaceholders" -> lineItem.creativePlaceholders,
-        "targeting" -> lineItem.targeting,
-        "lastModified" -> timeFormatter.print(lineItem.lastModified),
-      )
-    }
+  implicit val lineItemWrites: Writes[GuLineItem] = (lineItem: GuLineItem) => {
+    Json.obj(
+      "id" -> lineItem.id,
+      "orderId" -> lineItem.orderId,
+      "name" -> lineItem.name,
+      "lineItemType" -> lineItem.lineItemType,
+      "startTime" -> timeFormatter.print(lineItem.startTime),
+      "endTime" -> lineItem.endTime.map(timeFormatter.print(_)),
+      "isPageSkin" -> lineItem.isPageSkin,
+      "sponsor" -> lineItem.sponsor,
+      "status" -> lineItem.status,
+      "costType" -> lineItem.costType,
+      "creativePlaceholders" -> lineItem.creativePlaceholders,
+      "targeting" -> lineItem.targeting,
+      "lastModified" -> timeFormatter.print(lineItem.lastModified),
+    )
   }
 
   implicit val lineItemReads: Reads[GuLineItem] = (
@@ -356,8 +351,8 @@ case class GuCreativeTemplateParameter(
 
 object GuCreativeTemplateParameter {
 
-  implicit val GuCreativeTemplateParameterWrites = new Writes[GuCreativeTemplateParameter] {
-    def writes(param: GuCreativeTemplateParameter): JsValue = {
+  implicit val GuCreativeTemplateParameterWrites: Writes[GuCreativeTemplateParameter] =
+    (param: GuCreativeTemplateParameter) => {
       Json.obj(
         "type" -> param.parameterType,
         "label" -> param.label,
@@ -365,7 +360,6 @@ object GuCreativeTemplateParameter {
         "description" -> param.description,
       )
     }
-  }
 
   implicit val GuCreativeTemplateParameterReads: Reads[GuCreativeTemplateParameter] = (
     (JsPath \ "type").read[String] and
@@ -397,7 +391,8 @@ object GuCreative {
     (mapById(old) ++ mapById(recent)).values.toSeq
   }
 
-  implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
+  implicit val dateToTimestampWrites: json.JodaWrites.JodaDateTimeNumberWrites.type =
+    play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
   implicit val guCreativeFormats: Format[GuCreative] = Json.format[GuCreative]
 }
 

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -5,17 +5,16 @@ import model.Tag
 import play.api.libs.json._
 
 object InlineMerchandisingTagSet {
-  implicit val jsonReads = Json.reads[InlineMerchandisingTagSet]
+  implicit val jsonReads: Reads[InlineMerchandisingTagSet] = Json.reads[InlineMerchandisingTagSet]
 
-  implicit val inlineMerchandisingTagSetWrites = new Writes[InlineMerchandisingTagSet] {
-    def writes(tagSet: InlineMerchandisingTagSet): JsValue = {
+  implicit val inlineMerchandisingTagSetWrites: Writes[InlineMerchandisingTagSet] =
+    (tagSet: InlineMerchandisingTagSet) => {
       Json.obj(
         "keywords" -> tagSet.keywords,
         "series" -> tagSet.series,
         "contributors" -> tagSet.contributors,
       )
     }
-  }
 
 }
 
@@ -42,16 +41,15 @@ case class InlineMerchandisingTagSet(
 }
 
 object InlineMerchandisingTargetedTagsReport {
-  implicit val jsonReads = Json.reads[InlineMerchandisingTargetedTagsReport]
+  implicit val jsonReads: Reads[InlineMerchandisingTargetedTagsReport] =
+    Json.reads[InlineMerchandisingTargetedTagsReport]
 
-  implicit val inlineMerchandisingTargetedTagsReportWrites =
-    new Writes[InlineMerchandisingTargetedTagsReport] {
-      def writes(report: InlineMerchandisingTargetedTagsReport): JsValue = {
-        Json.obj(
-          "updatedTimeStamp" -> report.updatedTimeStamp,
-          "targetedTags" -> report.targetedTags,
-        )
-      }
+  implicit val inlineMerchandisingTargetedTagsReportWrites: Writes[InlineMerchandisingTargetedTagsReport] =
+    (report: InlineMerchandisingTargetedTagsReport) => {
+      Json.obj(
+        "updatedTimeStamp" -> report.updatedTimeStamp,
+        "targetedTags" -> report.targetedTags,
+      )
     }
 }
 
@@ -68,8 +66,8 @@ object InlineMerchandisingTargetedTagsReportParser extends GuLogging {
 }
 
 object HighMerchandisingLineItems {
-  implicit val lineItemFormat = Json.format[HighMerchandisingLineItem]
-  implicit val lineItemsFormat = Json.format[HighMerchandisingLineItems]
+  implicit val lineItemFormat: OFormat[HighMerchandisingLineItem] = Json.format[HighMerchandisingLineItem]
+  implicit val lineItemsFormat: OFormat[HighMerchandisingLineItems] = Json.format[HighMerchandisingLineItems]
 }
 
 case class HighMerchandisingLineItems(items: Seq[HighMerchandisingLineItem] = Seq.empty) {
@@ -110,7 +108,8 @@ case class HighMerchandisingLineItem(
 }
 
 object HighMerchandisingTargetedTagsReport {
-  implicit val jsonFormat = Json.format[HighMerchandisingTargetedTagsReport]
+  implicit val jsonFormat: OFormat[HighMerchandisingTargetedTagsReport] =
+    Json.format[HighMerchandisingTargetedTagsReport]
 }
 
 case class HighMerchandisingTargetedTagsReport(updatedTimeStamp: String, lineItems: HighMerchandisingLineItems)

--- a/common/app/common/dfp/TakeoverWithEmptyMPUs.scala
+++ b/common/app/common/dfp/TakeoverWithEmptyMPUs.scala
@@ -23,15 +23,13 @@ object TakeoverWithEmptyMPUs {
 
   val timeViewFormatter = DateTimeFormat.forPattern("d MMM YYYY HH:mm:ss z").withZoneUTC()
 
-  implicit val writes = new Writes[TakeoverWithEmptyMPUs] {
-    def writes(takeover: TakeoverWithEmptyMPUs): JsValue = {
-      Json.obj(
-        "url" -> takeover.url,
-        "editions" -> takeover.editions,
-        "startTime" -> timeJsonFormatter.print(takeover.startTime),
-        "endTime" -> timeJsonFormatter.print(takeover.endTime),
-      )
-    }
+  implicit val writes: Writes[TakeoverWithEmptyMPUs] = (takeover: TakeoverWithEmptyMPUs) => {
+    Json.obj(
+      "url" -> takeover.url,
+      "editions" -> takeover.editions,
+      "startTime" -> timeJsonFormatter.print(takeover.startTime),
+      "endTime" -> timeJsonFormatter.print(takeover.endTime),
+    )
   }
 
   val mustBeAtLeastOneDirectoryDeep = Constraint[String] { s: String =>
@@ -54,7 +52,7 @@ object TakeoverWithEmptyMPUs {
       (JsPath \ "endTime").read[String].map(timeJsonFormatter.parseDateTime)
   )(TakeoverWithEmptyMPUs.apply _)
 
-  implicit val editionFormatter = new Formatter[Edition] {
+  implicit val editionFormatter: Formatter[Edition] = new Formatter[Edition] {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Edition] = {
       val editionId = data(key)
       Edition.byId(editionId) map (Right(_)) getOrElse

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -23,5 +23,5 @@ object Au
       ),
     ) {
 
-  implicit val AU = Au
+  implicit val AU: Au.type = Au
 }

--- a/common/app/common/editions/Europe.scala
+++ b/common/app/common/editions/Europe.scala
@@ -16,5 +16,5 @@ object Europe
       navigationLinks = International.navigationLinks,
     ) {
 
-  implicit val EUR = Europe
+  implicit val EUR: Europe.type = Europe
 }

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -24,5 +24,5 @@ object International
       ),
     ) {
 
-  implicit val INT = International
+  implicit val INT: International.type = International
 }

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -23,5 +23,5 @@ object Uk
       ),
     ) {
 
-  implicit val UK = Uk
+  implicit val UK: Uk.type = Uk
 }

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -23,5 +23,5 @@ object Us
       ),
     ) {
 
-  implicit val US = Us
+  implicit val US: Us.type = Us
 }

--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -5,13 +5,14 @@ import model.ApplicationContext
 import org.quartz.impl.StdSchedulerFactory
 import org.quartz._
 import play.api.Mode.Test
+
 import scala.collection.mutable
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}
 
 object JobsState {
-  implicit val global = scala.concurrent.ExecutionContext.global
+  implicit val global: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
   val jobs = mutable.Map[String, () => Future[_]]()
   val outstanding = Box(Map[String, Int]().withDefaultValue(0))
 }

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -129,7 +129,7 @@ final case class CircuitBreakingContentApiClient(
 )(implicit executionContext: ExecutionContext)
     extends MonitoredContentApiClientLogic
     with RetryableContentApiClient {
-  override implicit val executor = ScheduledExecutor()
+  override implicit val executor: ScheduledExecutor = ScheduledExecutor()
   val retryDuration = Duration(250L, TimeUnit.MILLISECONDS)
   val retryAttempts = 3
   override val backoffStrategy: Retryable = BackoffStrategy.constantStrategy(retryDuration, retryAttempts)

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,7 +16,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       OfferHttp3,
       DeeplyRead,
     )
-  implicit val canCheckExperiment = new CanCheckExperiment(this)
+  implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
 
 object DeeplyRead

--- a/common/app/layout/slices/ContainerJsonConfig.scala
+++ b/common/app/layout/slices/ContainerJsonConfig.scala
@@ -1,6 +1,6 @@
 package layout.slices
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ContainerJsonConfig(
     name: String,
@@ -8,5 +8,5 @@ case class ContainerJsonConfig(
 )
 
 object ContainerJsonConfig {
-  implicit val jsonFormat = Json.format[ContainerJsonConfig]
+  implicit val jsonFormat: OFormat[ContainerJsonConfig] = Json.format[ContainerJsonConfig]
 }

--- a/common/app/layout/slices/Story.scala
+++ b/common/app/layout/slices/Story.scala
@@ -2,7 +2,7 @@ package layout.slices
 
 import common.Maps._
 import model.pressed.PressedContent
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 import scala.util.Try
 
@@ -12,9 +12,9 @@ case class Story(
 )
 
 object Story {
-  implicit val jsonFormat = Json.format[Story]
+  implicit val jsonFormat: OFormat[Story] = Json.format[Story]
 
-  implicit val ordering = Ordering.by[Story, Int](_.group)
+  implicit val ordering: Ordering[Story] = Ordering.by[Story, Int](_.group)
 
   def unboosted(n: Int): Story = Story(n, isBoosted = false)
 

--- a/common/app/model/CrosswordData.scala
+++ b/common/app/model/CrosswordData.scala
@@ -6,12 +6,13 @@ import crosswords.CrosswordGridColumnNotation
 import org.joda.time.DateTime
 import play.api.libs.json._
 import implicits.Dates.CapiRichDateTime
+import play.api.libs.json
 
 case class CrosswordPosition(x: Int, y: Int)
 
 object Entry {
-  implicit val positionWrites = Json.writes[CrosswordPosition]
-  implicit val jsonWrites = Json.writes[Entry]
+  implicit val positionWrites: OWrites[CrosswordPosition] = Json.writes[CrosswordPosition]
+  implicit val jsonWrites: OWrites[Entry] = Json.writes[Entry]
 
   def formatHumanNumber(numbers: String): Option[String] = {
 
@@ -77,13 +78,14 @@ case class CrosswordDimensions(
 
 object CrosswordData {
 
-  implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
+  implicit val dateToTimestampWrites: json.JodaWrites.JodaDateTimeNumberWrites.type =
+    play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
 
-  implicit val creatorWrites = Json.writes[CrosswordCreator]
+  implicit val creatorWrites: OWrites[CrosswordCreator] = Json.writes[CrosswordCreator]
 
-  implicit val dimensionsWrites = Json.writes[CrosswordDimensions]
+  implicit val dimensionsWrites: OWrites[CrosswordDimensions] = Json.writes[CrosswordDimensions]
 
-  implicit val jsonWrites = Json.writes[CrosswordData]
+  implicit val jsonWrites: OWrites[CrosswordData] = Json.writes[CrosswordData]
 
   def fromCrossword(crossword: Crossword, content: contentapi.Content): CrosswordData = {
     // For entry groups, all separator locations for entries within the

--- a/common/app/model/CrosswordGridModel.scala
+++ b/common/app/model/CrosswordGridModel.scala
@@ -11,7 +11,8 @@ import model.{CrosswordPosition, Entry}
 import Function.const
 
 trait CrosswordGridDataOrdering {
-  implicit val positionOrdering = Ordering.by[CrosswordPosition, (Int, Int)](position => (position.y, position.x))
+  implicit val positionOrdering: Ordering[CrosswordPosition] =
+    Ordering.by[CrosswordPosition, (Int, Int)](position => (position.y, position.x))
 }
 
 trait CrosswordGridColumnNotation {

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -98,7 +98,7 @@ object VideoMedia {
     )
 }
 final case class VideoMedia(videoAssets: List[VideoAsset]) {
-  private implicit val ordering = EncodingOrdering
+  private implicit val ordering: EncodingOrdering.type = EncodingOrdering
 
   val blockVideoAds = videoAssets.exists(_.blockVideoAds)
 
@@ -136,7 +136,7 @@ object AudioMedia {
     )
 }
 final case class AudioMedia(audioAssets: List[AudioAsset]) {
-  private implicit val ordering = EncodingOrdering
+  private implicit val ordering: EncodingOrdering.type = EncodingOrdering
 
   val duration: Int = audioAssets.headOption.map(_.duration).getOrElse(0)
   val encodings: Seq[Encoding] = {

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -6,6 +6,9 @@ import json.ObjectDeduplication.deduplicate
 import model.content._
 import model.facia.PressedCollection
 import model.pressed._
+import play.api
+import play.api.libs
+import play.api.libs.json
 import play.api.libs.json._
 import play.api.libs.json.JodaReads._
 
@@ -213,12 +216,13 @@ object PressedContentFormat {
       }
   }
 
-  implicit val pillarFormat = Json.format[Pillar]
-  implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
-  implicit val paginationFormat = Json.format[Pagination]
-  implicit val podcastFormat = Json.format[Podcast]
-  implicit val referenceFormat = Json.format[Reference]
-  implicit val tagPropertiesFormat = Json.format[TagProperties]
+  implicit val pillarFormat: OFormat[Pillar] = Json.format[Pillar]
+  implicit val dateToTimestampWrites: json.JodaWrites.JodaDateTimeNumberWrites.type =
+    play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
+  implicit val paginationFormat: OFormat[Pagination] = Json.format[Pagination]
+  implicit val podcastFormat: OFormat[Podcast] = Json.format[Podcast]
+  implicit val referenceFormat: OFormat[Reference] = Json.format[Reference]
+  implicit val tagPropertiesFormat: OFormat[TagProperties] = Json.format[TagProperties]
   implicit val tagFormat: Format[Tag] =
     deduplicate(
       Json.format[Tag],
@@ -226,31 +230,31 @@ object PressedContentFormat {
       _.maximumSize(20000) // average Tag retains ~8KB in memory, so 20000 cached Tags retain only 160MB
         .expireAfterAccess(1.hour),
     )
-  implicit val tagsFormat = Json.format[Tags]
-  implicit val elementPropertiesFormat = Json.format[ElementProperties]
-  implicit val imageAssetFormat = Json.format[ImageAsset]
-  implicit val videoAssetFormat = Json.format[VideoAsset]
-  implicit val imageMediaFormat = Json.format[ImageMedia]
-  implicit val videoMediaFormat = Json.format[VideoMedia]
-  implicit val videoElementFormat = Json.format[VideoElement]
-  implicit val mediaAssetFormat = Json.format[MediaAsset]
-  implicit val mediaAtomFormat = Json.format[MediaAtom]
-  implicit val mediaTypeFormat = MediaTypeFormat
-  implicit val cardStyleFormat = CardStyleFormat
-  implicit val faciaImageFormat = FaciaImageFormat.format
-  implicit val itemKickerFormat = ItemKickerFormat.format
-  implicit val tagKickerFormat = ItemKickerFormat.tagKickerFormat
-  implicit val pressedCardHeader = Json.format[PressedCardHeader]
-  implicit val pressedDisplaySettings = Json.format[PressedDisplaySettings]
-  implicit val pressedDiscussionSettings = Json.format[PressedDiscussionSettings]
-  implicit val pressedCard = Json.format[PressedCard]
-  implicit val pressedFields = Json.format[PressedFields]
-  implicit val pressedTrail = Json.format[PressedTrail]
-  implicit val pressedMetadata = Json.format[PressedMetadata]
-  implicit val pressedElements = Json.format[PressedElements]
-  implicit val pressedStory = Json.format[PressedStory]
-  implicit val pressedPropertiesFormat = Json.format[PressedProperties]
-  implicit val enrichedContentFormat = Json.format[EnrichedContent]
+  implicit val tagsFormat: OFormat[Tags] = Json.format[Tags]
+  implicit val elementPropertiesFormat: OFormat[ElementProperties] = Json.format[ElementProperties]
+  implicit val imageAssetFormat: OFormat[ImageAsset] = Json.format[ImageAsset]
+  implicit val videoAssetFormat: OFormat[VideoAsset] = Json.format[VideoAsset]
+  implicit val imageMediaFormat: OFormat[ImageMedia] = Json.format[ImageMedia]
+  implicit val videoMediaFormat: OFormat[VideoMedia] = Json.format[VideoMedia]
+  implicit val videoElementFormat: OFormat[VideoElement] = Json.format[VideoElement]
+  implicit val mediaAssetFormat: OFormat[MediaAsset] = Json.format[MediaAsset]
+  implicit val mediaAtomFormat: OFormat[MediaAtom] = Json.format[MediaAtom]
+  implicit val mediaTypeFormat: MediaTypeFormat.type = MediaTypeFormat
+  implicit val cardStyleFormat: CardStyleFormat.type = CardStyleFormat
+  implicit val faciaImageFormat: FaciaImageFormat.format.type = FaciaImageFormat.format
+  implicit val itemKickerFormat: ItemKickerFormat.format.type = ItemKickerFormat.format
+  implicit val tagKickerFormat: OFormat[TagKicker] = ItemKickerFormat.tagKickerFormat
+  implicit val pressedCardHeader: OFormat[PressedCardHeader] = Json.format[PressedCardHeader]
+  implicit val pressedDisplaySettings: OFormat[PressedDisplaySettings] = Json.format[PressedDisplaySettings]
+  implicit val pressedDiscussionSettings: OFormat[PressedDiscussionSettings] = Json.format[PressedDiscussionSettings]
+  implicit val pressedCard: OFormat[PressedCard] = Json.format[PressedCard]
+  implicit val pressedFields: OFormat[PressedFields] = Json.format[PressedFields]
+  implicit val pressedTrail: OFormat[PressedTrail] = Json.format[PressedTrail]
+  implicit val pressedMetadata: OFormat[PressedMetadata] = Json.format[PressedMetadata]
+  implicit val pressedElements: OFormat[PressedElements] = Json.format[PressedElements]
+  implicit val pressedStory: OFormat[PressedStory] = Json.format[PressedStory]
+  implicit val pressedPropertiesFormat: OFormat[PressedProperties] = Json.format[PressedProperties]
+  implicit val enrichedContentFormat: OFormat[EnrichedContent] = Json.format[EnrichedContent]
 
   val latestSnapFormat = Json.format[LatestSnap]
   val linkSnapFormat = Json.format[LinkSnap]
@@ -259,9 +263,9 @@ object PressedContentFormat {
 }
 
 object ItemKickerFormat {
-  implicit val kickerPropertiesFormat = Json.format[KickerProperties]
-  implicit val seriesFormat = Json.format[Series]
-  val tagKickerFormat = Json.format[TagKicker]
+  implicit val kickerPropertiesFormat: OFormat[KickerProperties] = Json.format[KickerProperties]
+  implicit val seriesFormat: OFormat[Series] = Json.format[Series]
+  val tagKickerFormat: OFormat[TagKicker] = Json.format[TagKicker]
 
   private val podcastKickerFormat = Json.format[PodcastKicker]
   private val sectionKickerFormat = Json.format[SectionKicker]
@@ -317,9 +321,9 @@ object ItemKickerFormat {
 }
 
 object FaciaImageFormat {
-  implicit val cutoutFormat = Json.format[Cutout]
-  implicit val replaceFormat = Json.format[Replace]
-  implicit val slideshowFormat = Json.format[ImageSlideshow]
+  implicit val cutoutFormat: OFormat[Cutout] = Json.format[Cutout]
+  implicit val replaceFormat: OFormat[Replace] = Json.format[Replace]
+  implicit val slideshowFormat: OFormat[ImageSlideshow] = Json.format[ImageSlideshow]
 
   object format extends Format[Image] {
     def reads(json: JsValue): JsResult[Image] = {
@@ -343,15 +347,17 @@ object FaciaImageFormat {
 }
 
 object PressedCollectionFormat {
-  implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
-  implicit val displayHintsFormat = Json.format[DisplayHints]
-  implicit val collectionConfigFormat = Json.format[CollectionConfig]
-  implicit val pressedContentFormat = PressedContentFormat.format
-  val format = Json.format[PressedCollection]
+  implicit val dateToTimestampWrites: libs.json.JodaWrites.JodaDateTimeNumberWrites.type =
+    play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
+  implicit val displayHintsFormat: OFormat[DisplayHints] = Json.format[DisplayHints]
+  implicit val collectionConfigFormat: OFormat[CollectionConfig] = Json.format[CollectionConfig]
+  implicit val pressedContentFormat: PressedContentFormat.format.type = PressedContentFormat.format
+  val format: OFormat[PressedCollection] = Json.format[PressedCollection]
 }
 
 object PressedPageFormat {
-  implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
-  implicit val pressedCollection = PressedCollectionFormat.format
-  val format = Json.format[PressedPage]
+  implicit val dateToTimestampWrites: api.libs.json.JodaWrites.JodaDateTimeNumberWrites.type =
+    play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
+  implicit val pressedCollection: OFormat[PressedCollection] = PressedCollectionFormat.format
+  val format: OFormat[PressedPage] = Json.format[PressedPage]
 }

--- a/common/app/model/MessageUsDataModel.scala
+++ b/common/app/model/MessageUsDataModel.scala
@@ -79,9 +79,9 @@ sealed trait FieldFormats {
     }
   }
 
-  implicit val nameFieldWrite = Json.writes[NameField]
-  implicit val emailFieldWrite = Json.writes[EmailField]
-  implicit val textAreaFieldWrite = Json.writes[TextAreaField]
+  implicit val nameFieldWrite: OWrites[NameField] = Json.writes[NameField]
+  implicit val emailFieldWrite: OWrites[EmailField] = Json.writes[EmailField]
+  implicit val textAreaFieldWrite: OWrites[TextAreaField] = Json.writes[TextAreaField]
 
   implicit val fieldWriteFmt: Writes[Field] = Json.writes[Field]
 }

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -8,13 +8,13 @@ import contentapi.Paths
 import model.facia.PressedCollection
 import model.pressed.PressedContent
 import navigation.GuardianFoundationHelper
-import play.api.libs.json.{JsBoolean, JsString, JsValue}
+import play.api.libs.json.{JsBoolean, JsString, JsValue, OFormat}
 
 import scala.language.postfixOps
 
 object PressedPage {
 
-  implicit val pressedPageFormat = PressedPageFormat.format
+  implicit val pressedPageFormat: OFormat[PressedPage] = PressedPageFormat.format
 
   def makeMetadata(
       id: String,

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.{Section => ApiSection}
 import common.Pagination
 import common.commercial.CommercialProperties
 import navigation.GuardianFoundationHelper
-import play.api.libs.json.{JsString, JsValue, Json}
+import play.api.libs.json.{JsString, JsValue, Json, OFormat}
 
 object Section {
   def make(section: ApiSection, pagination: Option[Pagination] = None): Section = {
@@ -61,7 +61,7 @@ case class SectionId(value: String) extends AnyVal
 
 object SectionId {
 
-  implicit val jsonFormat = Json.format[SectionId]
+  implicit val jsonFormat: OFormat[SectionId] = Json.format[SectionId]
 
   def fromCapiSection(section: ApiSection): SectionId = SectionId(section.id)
 

--- a/common/app/model/TagIndexPage.scala
+++ b/common/app/model/TagIndexPage.scala
@@ -6,7 +6,7 @@ import common.Strings./
 import play.api.libs.json._
 
 object SectionDefinition {
-  implicit val jsonFormat = Json.format[SectionDefinition]
+  implicit val jsonFormat: OFormat[SectionDefinition] = Json.format[SectionDefinition]
 }
 
 case class SectionDefinition(
@@ -15,7 +15,7 @@ case class SectionDefinition(
 )
 
 object TagDefinition {
-  implicit val jsonFormat = Json.format[TagDefinition]
+  implicit val jsonFormat: OFormat[TagDefinition] = Json.format[TagDefinition]
 
   def fromContentApiTag(apiTag: ApiTag): TagDefinition =
     TagDefinition(
@@ -54,7 +54,7 @@ case class TagDefinition(
 }
 
 object TagIndexListing {
-  implicit val jsonFormat = Json.format[TagIndexListing]
+  implicit val jsonFormat: OFormat[TagIndexListing] = Json.format[TagIndexListing]
 
   def fromTagIndex(tagIndex: TagIndex): TagIndexListing =
     TagIndexListing(tagIndex.id, tagIndex.title)
@@ -66,7 +66,7 @@ case class TagIndexListing(
 )
 
 object TagIndexListings {
-  implicit val jsonFormat = Json.format[TagIndexListings]
+  implicit val jsonFormat: OFormat[TagIndexListings] = Json.format[TagIndexListings]
 
   def fromTagIndexPages(pages: Seq[TagIndex]): TagIndexListings =
     TagIndexListings(pages.map(TagIndexListing.fromTagIndex).sortBy(_.title))
@@ -75,7 +75,7 @@ object TagIndexListings {
 case class TagIndexListings(pages: Seq[TagIndexListing])
 
 object TagIndex {
-  implicit val jsonFormat = Json.format[TagIndex]
+  implicit val jsonFormat: OFormat[TagIndex] = Json.format[TagIndex]
 }
 
 case class TagIndex(

--- a/common/app/model/content/Atom.scala
+++ b/common/app/model/content/Atom.scala
@@ -15,7 +15,7 @@ import model.{ImageAsset, ImageMedia, ShareLinkMeta}
 import org.apache.commons.lang3.time.DurationFormatUtils
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone, Duration}
-import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.json.{JsError, JsSuccess, Json, OFormat}
 import quiz._
 import views.support.GoogleStructuredData
 
@@ -331,8 +331,8 @@ final case class QuizAtom(
 
 object QuizAtom extends common.GuLogging {
 
-  implicit val assetFormat = Json.format[Asset]
-  implicit val imageFormat = Json.format[Image]
+  implicit val assetFormat: OFormat[Asset] = Json.format[Asset]
+  implicit val imageFormat: OFormat[Image] = Json.format[Image]
 
   private def transformAssets(quizAsset: Option[atomapi.quiz.Asset]): Option[QuizImageMedia] =
     quizAsset.flatMap { asset =>

--- a/common/app/model/dotcomrendering/Contributor.scala
+++ b/common/app/model/dotcomrendering/Contributor.scala
@@ -1,9 +1,9 @@
 package model.dotcomrendering
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OWrites}
 
 case class Contributor(name: String, imageUrl: Option[String], largeImageUrl: Option[String])
 
 object Contributor {
-  implicit val writes = Json.writes[Contributor]
+  implicit val writes: OWrites[Contributor] = Json.writes[Contributor]
 }

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -34,9 +34,9 @@ case class DotcomBlocksRenderingDataModel(
 
 object DotcomBlocksRenderingDataModel {
 
-  implicit val pageElementWrites = PageElement.pageElementWrites
+  implicit val pageElementWrites: Writes[PageElement] = PageElement.pageElementWrites
 
-  implicit val writes = new Writes[DotcomBlocksRenderingDataModel] {
+  implicit val writes: Writes[DotcomBlocksRenderingDataModel] = new Writes[DotcomBlocksRenderingDataModel] {
     def writes(model: DotcomBlocksRenderingDataModel) = {
       val obj = Json.obj(
         "blocks" -> model.blocks,

--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -9,7 +9,7 @@ import experiments.ActiveExperiments
 import layout.ContentCard
 import model.{PressedPage, RelatedContentItem}
 import navigation.{FooterLinks, Nav}
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{JsObject, JsValue, Json, OWrites}
 import play.api.mvc.RequestHeader
 import views.support.{CamelCase, JavaScriptPage}
 
@@ -35,7 +35,7 @@ case class DotcomFrontsRenderingDataModel(
 )
 
 object DotcomFrontsRenderingDataModel {
-  implicit val writes = Json.writes[DotcomFrontsRenderingDataModel]
+  implicit val writes: OWrites[DotcomFrontsRenderingDataModel] = Json.writes[DotcomFrontsRenderingDataModel]
 
   def apply(
       page: PressedPage,

--- a/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
@@ -7,9 +7,9 @@ import conf.Configuration
 import com.gu.contentapi.client.model.v1.Content
 import experiments.ActiveExperiments
 import layout.ContentCard
-import model.{SimplePage, RelatedContentItem}
+import model.{RelatedContentItem, SimplePage}
 import navigation.{FooterLinks, Nav}
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{JsObject, JsValue, Json, OWrites}
 import play.api.mvc.RequestHeader
 import views.support.{CamelCase, JavaScriptPage}
 import services.newsletters.model.NewsletterResponseV2
@@ -36,7 +36,8 @@ case class DotcomNewslettersPageRenderingDataModel(
 )
 
 object DotcomNewslettersPageRenderingDataModel {
-  implicit val writes = Json.writes[DotcomNewslettersPageRenderingDataModel]
+  implicit val writes: OWrites[DotcomNewslettersPageRenderingDataModel] =
+    Json.writes[DotcomNewslettersPageRenderingDataModel]
 
   def apply(
       page: SimplePage,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -112,9 +112,9 @@ case class DotcomRenderingDataModel(
 
 object DotcomRenderingDataModel {
 
-  implicit val pageElementWrites = PageElement.pageElementWrites
+  implicit val pageElementWrites: Writes[PageElement] = PageElement.pageElementWrites
 
-  implicit val writes = new Writes[DotcomRenderingDataModel] {
+  implicit val writes: Writes[DotcomRenderingDataModel] = new Writes[DotcomRenderingDataModel] {
     def writes(model: DotcomRenderingDataModel) = {
       val obj = Json.obj(
         "availableTopics" -> model.availableTopics,

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -28,7 +28,7 @@ case class Tag(
 )
 
 object Tag {
-  implicit val writes = Json.writes[Tag]
+  implicit val writes: OWrites[Tag] = Json.writes[Tag]
 
   def apply(t: model.Tag): Tag = {
     Tag(
@@ -60,8 +60,8 @@ case class Block(
 )
 
 object Block {
-  implicit val pageElementWrites = PageElement.pageElementWrites
-  implicit val writes = Json.writes[Block]
+  implicit val pageElementWrites: Writes[PageElement] = PageElement.pageElementWrites
+  implicit val writes: OWrites[Block] = Json.writes[Block]
 
   // TODO simplify date fields when DCR is ready
   def apply(
@@ -151,7 +151,7 @@ case class Pagination(
 )
 
 object Pagination {
-  implicit val writes = Json.writes[Pagination]
+  implicit val writes: OWrites[Pagination] = Json.writes[Pagination]
 }
 
 case class Commercial(
@@ -162,7 +162,7 @@ case class Commercial(
 )
 
 object Commercial {
-  implicit val writes = Json.writes[Commercial]
+  implicit val writes: OWrites[Commercial] = Json.writes[Commercial]
 }
 
 case class Config(
@@ -175,7 +175,7 @@ case class Config(
 )
 
 object Config {
-  implicit val writes = Json.writes[Config]
+  implicit val writes: OWrites[Config] = Json.writes[Config]
 }
 
 case class SubMetaLink(
@@ -184,7 +184,7 @@ case class SubMetaLink(
 )
 
 object SubMetaLink {
-  implicit val format = Json.format[SubMetaLink]
+  implicit val format: OFormat[SubMetaLink] = Json.format[SubMetaLink]
 
   def apply(sml: model.SubMetaLink): SubMetaLink = {
     SubMetaLink(
@@ -200,13 +200,13 @@ case class Author(
 )
 
 object Author {
-  implicit val writes = Json.writes[Author]
+  implicit val writes: OWrites[Author] = Json.writes[Author]
 }
 
 case class DCRBadge(seriesTag: String, imageUrl: String)
 
 object DCRBadge {
-  implicit val writes = Json.writes[DCRBadge]
+  implicit val writes: OWrites[DCRBadge] = Json.writes[DCRBadge]
 }
 
 case class PageFooter(
@@ -215,5 +215,5 @@ case class PageFooter(
 
 object PageFooter {
   implicit val footerLinkWrites: Writes[FooterLink] = Json.writes[FooterLink]
-  implicit val writes = Json.writes[PageFooter]
+  implicit val writes: OWrites[PageFooter] = Json.writes[PageFooter]
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -32,10 +32,8 @@ import java.net.URLEncoder
 sealed trait DotcomRenderingMatchType
 
 object DotcomRenderingMatchType {
-  implicit val matchTypesWrites = new Writes[DotcomRenderingMatchType] {
-    def writes(matchType: DotcomRenderingMatchType) =
-      JsString(matchType.toString)
-  }
+  implicit val matchTypesWrites: Writes[DotcomRenderingMatchType] = (matchType: DotcomRenderingMatchType) =>
+    JsString(matchType.toString)
 }
 
 case object CricketMatchType extends DotcomRenderingMatchType

--- a/common/app/model/dotcomrendering/DotcomTagFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomTagFrontsRenderingDataModel.scala
@@ -36,7 +36,7 @@ case class DotcomTagFrontsRenderingDataModel(
 )
 
 object DotcomTagFrontsRenderingDataModel {
-  implicit val writes = new Writes[DotcomTagFrontsRenderingDataModel] {
+  implicit val writes: Writes[DotcomTagFrontsRenderingDataModel] = new Writes[DotcomTagFrontsRenderingDataModel] {
     def writes(model: DotcomTagFrontsRenderingDataModel) = {
       Json.obj(
         "contents" -> model.contents,

--- a/common/app/model/dotcomrendering/MostPopular.scala
+++ b/common/app/model/dotcomrendering/MostPopular.scala
@@ -7,7 +7,7 @@ case class OnwardCollectionResponse(
     trails: Seq[Trail],
 )
 object OnwardCollectionResponse {
-  implicit val collectionWrites = Json.writes[OnwardCollectionResponse]
+  implicit val collectionWrites: OWrites[OnwardCollectionResponse] = Json.writes[OnwardCollectionResponse]
 }
 
 case class OnwardCollectionResponseDCR(
@@ -16,7 +16,8 @@ case class OnwardCollectionResponseDCR(
     mostShared: Option[Trail],
 )
 object OnwardCollectionResponseDCR {
-  implicit val onwardCollectionResponseForDRCWrites = Json.writes[OnwardCollectionResponseDCR]
+  implicit val onwardCollectionResponseForDRCWrites: OWrites[OnwardCollectionResponseDCR] =
+    Json.writes[OnwardCollectionResponseDCR]
 }
 
 case class MostPopularGeoResponse(
@@ -25,10 +26,11 @@ case class MostPopularGeoResponse(
     trails: Seq[Trail],
 )
 object MostPopularGeoResponse {
-  implicit val popularGeoWrites = Json.writes[MostPopularGeoResponse]
+  implicit val popularGeoWrites: OWrites[MostPopularGeoResponse] = Json.writes[MostPopularGeoResponse]
 }
 
 case class MostPopularCollectionResponse(heading: String, section: String, trails: Seq[Trail])
 object MostPopularCollectionResponse {
-  implicit val MostPopularCollectionResponseWrites = Json.writes[MostPopularCollectionResponse]
+  implicit val MostPopularCollectionResponseWrites: OWrites[MostPopularCollectionResponse] =
+    Json.writes[MostPopularCollectionResponse]
 }

--- a/common/app/model/dotcomrendering/PageType.scala
+++ b/common/app/model/dotcomrendering/PageType.scala
@@ -2,7 +2,7 @@ package model.dotcomrendering
 
 import common.Edition
 import model.{ApplicationContext, Page}
-import play.api.libs.json.{JsBoolean, Json}
+import play.api.libs.json.{JsBoolean, Json, OWrites}
 import play.api.mvc.RequestHeader
 import views.support.JavaScriptPage.getMap
 
@@ -17,7 +17,7 @@ case class PageType(
 )
 
 object PageType {
-  implicit val writes = Json.writes[PageType]
+  implicit val writes: OWrites[PageType] = Json.writes[PageType]
 
   def apply(page: Page, request: RequestHeader, context: ApplicationContext): PageType = {
     PageType(

--- a/common/app/model/dotcomrendering/Trail.scala
+++ b/common/app/model/dotcomrendering/Trail.scala
@@ -7,7 +7,7 @@ import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
 import layout.{ContentCard, DiscussionSettings}
 import model.{Article, ContentFormat, ImageMedia, InlineImage, Pillar}
 import model.pressed.PressedContent
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, OWrites, Writes}
 import play.api.mvc.RequestHeader
 import views.support.{ImageProfile, ImgSrc, Item300, Item460, RemoveOuterParaHtml}
 
@@ -37,7 +37,7 @@ case class Trail(
 
 object Trail {
 
-  implicit val brandingTypeWrites = new Writes[BrandingType] {
+  implicit val brandingTypeWrites: Writes[BrandingType] = new Writes[BrandingType] {
     def writes(bt: BrandingType) = {
       Json.obj(
         "name" -> bt.name,
@@ -45,15 +45,15 @@ object Trail {
     }
   }
 
-  implicit val dimensionsWrites = Json.writes[Dimensions]
+  implicit val dimensionsWrites: OWrites[Dimensions] = Json.writes[Dimensions]
 
-  implicit val logoWrites = Json.writes[CommercialLogo]
+  implicit val logoWrites: OWrites[CommercialLogo] = Json.writes[CommercialLogo]
 
-  implicit val brandingWrites = Json.writes[Branding]
+  implicit val brandingWrites: OWrites[Branding] = Json.writes[Branding]
 
-  implicit val discussionWrites = Json.writes[DiscussionSettings]
+  implicit val discussionWrites: OWrites[DiscussionSettings] = Json.writes[DiscussionSettings]
 
-  implicit val OnwardItemWrites = Json.writes[Trail]
+  implicit val OnwardItemWrites: OWrites[Trail] = Json.writes[Trail]
 
   private def contentCardToAvatarUrl(contentCard: ContentCard): Option[String] = {
 

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -3,7 +3,7 @@ package model
 import com.gu.commercial.branding.Branding
 import common.commercial.{CommercialProperties, EditionBranding}
 import common.{Edition, GuLogging}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class SeoDataJson(
     id: String,
@@ -16,7 +16,7 @@ case class SeoDataJson(
 case class SeoData(id: String, navSection: String, webTitle: String, title: Option[String], description: Option[String])
 
 object SeoData extends GuLogging {
-  implicit val seoFormatter = Json.format[SeoData]
+  implicit val seoFormatter: OFormat[SeoData] = Json.format[SeoData]
 
   val editions = Edition.allEditions.map(_.id.toLowerCase)
 
@@ -60,7 +60,7 @@ case class FrontProperties(
 }
 
 object FrontProperties {
-  implicit val jsonFormat = Json.format[FrontProperties]
+  implicit val jsonFormat: OFormat[FrontProperties] = Json.format[FrontProperties]
 
   val empty = FrontProperties(
     onPageDescription = None,

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -8,6 +8,7 @@ import model.liveblog.BodyBlock._
 import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.jsoup.Jsoup
+import play.api.libs.json
 import play.api.libs.json._
 
 object Blocks {
@@ -72,8 +73,9 @@ object BodyBlock {
   case object SummaryEvent extends EventType
   case object UnclassifiedEvent extends EventType
 
-  implicit val dateWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
-  implicit val blockElementWrites = BlockElement.blockElementWrites
+  implicit val dateWrites: json.JodaWrites.JodaDateTimeNumberWrites.type =
+    play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
+  implicit val blockElementWrites: Writes[BlockElement] = BlockElement.blockElementWrites
   implicit val bodyBlockWrites: Writes[BodyBlock] = Json.writes[BodyBlock]
 }
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -242,14 +242,12 @@ object ContentFormat {
   def fromFapiContentFormat(fapiContentFormat: fapiContentFormat): ContentFormat =
     ContentFormat(fapiContentFormat.design, fapiContentFormat.theme, fapiContentFormat.display)
 
-  implicit val contentFormatWrites = new Writes[ContentFormat] {
-    def writes(format: ContentFormat) =
-      Json.obj(
-        "design" -> format.design.toString,
-        "theme" -> format.theme.toString,
-        "display" -> format.display.toString,
-      )
-  }
+  implicit val contentFormatWrites: Writes[ContentFormat] = (format: ContentFormat) =>
+    Json.obj(
+      "design" -> format.design.toString,
+      "theme" -> format.theme.toString,
+      "display" -> format.display.toString,
+    )
 
   // TODO I am sure these should be in shared code, but not aware of any at time
   //  of writing. Let's move it somewhere common in the future.
@@ -308,7 +306,7 @@ object ContentFormat {
       (JsPath \ "theme").read[String].map(parseTheme) and
       (JsPath \ "display").readNullable[String].map(_.map(parseDisplay).getOrElse(StandardDisplay))
 
-  implicit val contentFormatReads = contentFormatBuilder.apply(ContentFormat.apply _)
+  implicit val contentFormatReads: Reads[ContentFormat] = contentFormatBuilder.apply(ContentFormat.apply _)
 }
 
 case class MetaData(

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -9,7 +9,7 @@ object LinkedData {
   import org.json4s._
   import org.json4s.native.Serialization.write
 
-  implicit val formats = DefaultFormats + FieldSerializer[LinkedData]()
+  implicit val formats: Formats = DefaultFormats + FieldSerializer[LinkedData]()
 
   def toJson(list: LinkedData): String = write(list)
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.{v1 => contentapi}
 import implicits.Dates._
 import org.joda.time.DateTime
 import com.github.nscala_time.time.Implicits._
-import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
+import play.api.libs.json.{JodaWrites, JsBoolean, JsString, JsValue, Json}
 import play.api.mvc.RequestHeader
 import views.support.{ImgSrc, Naked}
 
@@ -113,7 +113,8 @@ final case class Trail(
     }
   }
 
-  implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
+  implicit val dateToTimestampWrites: JodaWrites.JodaDateTimeNumberWrites.type =
+    play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
   def javascriptConfig: Map[String, JsValue] =
     Map(
       ("sectionName", JsString(sectionName)),

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -3,15 +3,15 @@ package navigation
 import common.Edition
 import model.Page
 import navigation.ReaderRevenueSite.{
+  PrintCTA,
+  PrintCTAWeekly,
   Support,
   SupportContribute,
   SupportSubscribe,
   SupporterCTA,
-  PrintCTA,
-  PrintCTAWeekly,
 }
 import navigation.UrlHelpers._
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, OWrites, Writes}
 
 case class ReaderRevenueLink(
     contribute: String,
@@ -21,7 +21,7 @@ case class ReaderRevenueLink(
 )
 
 object ReaderRevenueLink {
-  implicit val writes = Json.writes[ReaderRevenueLink]
+  implicit val writes: OWrites[ReaderRevenueLink] = Json.writes[ReaderRevenueLink]
 }
 
 case class ReaderRevenueLinks(
@@ -33,7 +33,7 @@ case class ReaderRevenueLinks(
 )
 
 object ReaderRevenueLinks {
-  implicit val writes = Json.writes[ReaderRevenueLinks]
+  implicit val writes: OWrites[ReaderRevenueLinks] = Json.writes[ReaderRevenueLinks]
 
   val headerReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
     getReaderRevenueUrl(SupportContribute, Header),
@@ -91,14 +91,14 @@ case class Nav(
 )
 
 object Nav {
-  implicit val flatSubnavWrites = Json.writes[FlatSubnav]
-  implicit val parentSubnavWrites = Json.writes[ParentSubnav]
-  implicit val subnavWrites = Writes[Subnav] {
+  implicit val flatSubnavWrites: OWrites[FlatSubnav] = Json.writes[FlatSubnav]
+  implicit val parentSubnavWrites: OWrites[ParentSubnav] = Json.writes[ParentSubnav]
+  implicit val subnavWrites: Writes[Subnav] = Writes[Subnav] {
     case nav: FlatSubnav   => flatSubnavWrites.writes(nav)
     case nav: ParentSubnav => parentSubnavWrites.writes(nav)
   }
 
-  implicit val writes = Json.writes[Nav]
+  implicit val writes: OWrites[Nav] = Json.writes[Nav]
 
   def apply(page: Page, edition: Edition): Nav = {
     val navMenu = NavMenu(page, edition)

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -1,6 +1,6 @@
 package navigation
 
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsValue, Json, OWrites}
 import common.Edition
 import play.api.libs.json.Json.toJson
 
@@ -735,8 +735,8 @@ case class EditionNavLinks(
 )
 
 object NavigationData {
-  implicit val navlinkWrites = Json.writes[NavLink]
-  implicit val editionNavLinksWrites = Json.writes[EditionNavLinks]
+  implicit val navlinkWrites: OWrites[NavLink] = Json.writes[NavLink]
+  implicit val editionNavLinksWrites: OWrites[EditionNavLinks] = Json.writes[EditionNavLinks]
 
   val nav: JsValue = toJson(
     (Edition.allEditions

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -62,14 +62,14 @@ case class NavMenu(
 
 object NavMenu {
 
-  implicit val navlinkWrites = Json.writes[NavLink]
-  implicit val flatSubnavWrites = Json.writes[FlatSubnav]
-  implicit val parentSubnavWrites = Json.writes[ParentSubnav]
-  implicit val subnavWrites = Writes[Subnav] {
+  implicit val navlinkWrites: OWrites[NavLink] = Json.writes[NavLink]
+  implicit val flatSubnavWrites: OWrites[FlatSubnav] = Json.writes[FlatSubnav]
+  implicit val parentSubnavWrites: OWrites[ParentSubnav] = Json.writes[ParentSubnav]
+  implicit val subnavWrites: Writes[Subnav] = Writes[Subnav] {
     case nav: FlatSubnav   => flatSubnavWrites.writes(nav)
     case nav: ParentSubnav => parentSubnavWrites.writes(nav)
   }
-  implicit val writes = Json.writes[NavMenu]
+  implicit val writes: OWrites[NavMenu] = Json.writes[NavMenu]
 
   private[navigation] case class NavRoot(
       children: Seq[NavLink],
@@ -291,5 +291,5 @@ object SimpleMenu {
     SimpleMenu(root.children, root.otherLinks, root.brandExtensions, ReaderRevenueLinks.all)
   }
 
-  implicit val writes = Json.writes[SimpleMenu]
+  implicit val writes: OWrites[SimpleMenu] = Json.writes[SimpleMenu]
 }

--- a/common/app/pagepresser/PollsHtmlCleaner.scala
+++ b/common/app/pagepresser/PollsHtmlCleaner.scala
@@ -1,7 +1,7 @@
 package pagepresser
 
 import org.jsoup.nodes.Document
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 import play.api.libs.ws.WSClient
 
 import scala.jdk.CollectionConverters._
@@ -9,9 +9,9 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
 object PollDeserializer {
-  implicit val jsonAnswers = Json.reads[Answer]
-  implicit val jsonQuestions = Json.reads[Question]
-  implicit val jsonPoll = Json.reads[Poll]
+  implicit val jsonAnswers: Reads[Answer] = Json.reads[Answer]
+  implicit val jsonQuestions: Reads[Question] = Json.reads[Question]
+  implicit val jsonPoll: Reads[Poll] = Json.reads[Poll]
 }
 
 case class Poll(pollId: String, questions: List[Question])

--- a/common/app/services/NewsletterService.scala
+++ b/common/app/services/NewsletterService.scala
@@ -2,10 +2,10 @@ package services
 import services.newsletters.NewsletterSignupAgent
 import services.newsletters.model.NewsletterResponseV2
 import common._
-import model.{ArticlePage, PageWithStoryPackage, LiveBlogPage, Tag}
+import model.{ArticlePage, LiveBlogPage, PageWithStoryPackage, Tag}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OWrites, Reads}
 import com.gu.contentapi.client.utils.format.NewsletterSignupDesign
 import com.gu.contentapi.client.model.v1.TagType
 
@@ -23,8 +23,8 @@ case class NewsletterData(
 )
 
 object NewsletterData {
-  implicit val newsletterDataReads = Json.reads[NewsletterData]
-  implicit val newsletterDataWrites = Json.writes[NewsletterData]
+  implicit val newsletterDataReads: Reads[NewsletterData] = Json.reads[NewsletterData]
+  implicit val newsletterDataWrites: OWrites[NewsletterData] = Json.writes[NewsletterData]
 }
 
 class NewsletterService(newsletterSignupAgent: NewsletterSignupAgent) {

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -17,13 +17,13 @@ import scala.concurrent.duration.DurationInt
 // Base on this response: https://dashboard.ophan.co.uk/api/mostread
 case class OphanMostReadItem(url: String, count: Int)
 object OphanMostReadItem {
-  implicit val jsonReads = Json.reads[OphanMostReadItem]
+  implicit val jsonReads: Reads[OphanMostReadItem] = Json.reads[OphanMostReadItem]
 }
 
 // Based on this response: https://dashboard.ophan.co.uk/api/deeplyread
 case class OphanDeeplyReadItem(path: String, benchmarkedAttentionTime: Int)
 object OphanDeeplyReadItem {
-  implicit val jsonReads = Json.reads[OphanDeeplyReadItem]
+  implicit val jsonReads: Reads[OphanDeeplyReadItem] = Json.reads[OphanDeeplyReadItem]
 }
 
 class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)

--- a/common/app/services/RedirectService.scala
+++ b/common/app/services/RedirectService.scala
@@ -40,16 +40,17 @@ object RedirectService {
     }
   }
 
-  implicit val destinationFormat = DynamoFormat.xmap[Destination, Map[String, String]] {
-    // map -> destination (i.e. reads)
-    case m if m.contains("destination") => Right(PermanentRedirect(m("source"), m("destination")))
-    case m if m.contains("archive")     => Right(ArchiveRedirect(m("source"), m("archive")))
-    case _                              => Left(MissingProperty)
-  } {
-    // destination -> map (i.e. writes)
-    case PermanentRedirect(source, destination) => Map("source" -> source, "destination" -> destination)
-    case ArchiveRedirect(source, archive)       => Map("source" -> source, "archive" -> archive)
-  }
+  implicit val destinationFormat: AnyRef with DynamoFormat[Destination] =
+    DynamoFormat.xmap[Destination, Map[String, String]] {
+      // map -> destination (i.e. reads)
+      case m if m.contains("destination") => Right(PermanentRedirect(m("source"), m("destination")))
+      case m if m.contains("archive")     => Right(ArchiveRedirect(m("source"), m("archive")))
+      case _                              => Left(MissingProperty)
+    } {
+      // destination -> map (i.e. writes)
+      case PermanentRedirect(source, destination) => Map("source" -> source, "destination" -> destination)
+      case ArchiveRedirect(source, archive)       => Map("source" -> source, "archive" -> archive)
+    }
 
   // This is a permanent 3XX redirect - it could be guardian/non-guardian address
   case class PermanentRedirect(source: String, location: String) extends Destination

--- a/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
+++ b/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
@@ -2,7 +2,7 @@ package services.newsletters
 
 import com.typesafe.scalalogging.LazyLogging
 import conf.Configuration
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 import play.api.libs.ws.{WSClient, WSResponse}
 import utils.RemoteAddress
 
@@ -21,5 +21,5 @@ class GoogleRecaptchaValidationService(wsClient: WSClient) extends LazyLogging w
 case class GoogleResponse(success: Boolean, `error-codes`: Option[Seq[String]])
 
 object GoogleResponse {
-  implicit val googleResponseReads = Json.reads[GoogleResponse]
+  implicit val googleResponseReads: Reads[GoogleResponse] = Json.reads[GoogleResponse]
 }

--- a/common/app/services/newsletters/model/NewsletterResponse.scala
+++ b/common/app/services/newsletters/model/NewsletterResponse.scala
@@ -1,6 +1,6 @@
 package services.newsletters.model
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OWrites, Reads}
 
 case class NewsletterResponse(
     identityName: String,
@@ -26,12 +26,12 @@ case class NewsletterResponse(
 )
 
 object NewsletterResponse {
-  implicit val emailEmbedReads = Json.reads[EmailEmbed]
-  implicit val emailEmbedWrites = Json.writes[EmailEmbed]
-  implicit val newsletterIllustrationReads = Json.reads[NewsletterIllustration]
-  implicit val newsletterIllustrationWrites = Json.writes[NewsletterIllustration]
-  implicit val newsletterResponseReads = Json.reads[NewsletterResponse]
-  implicit val newsletterResponseWrites = Json.writes[NewsletterResponse]
+  implicit val emailEmbedReads: Reads[EmailEmbed] = Json.reads[EmailEmbed]
+  implicit val emailEmbedWrites: OWrites[EmailEmbed] = Json.writes[EmailEmbed]
+  implicit val newsletterIllustrationReads: Reads[NewsletterIllustration] = Json.reads[NewsletterIllustration]
+  implicit val newsletterIllustrationWrites: OWrites[NewsletterIllustration] = Json.writes[NewsletterIllustration]
+  implicit val newsletterResponseReads: Reads[NewsletterResponse] = Json.reads[NewsletterResponse]
+  implicit val newsletterResponseWrites: OWrites[NewsletterResponse] = Json.writes[NewsletterResponse]
 }
 
 case class NewsletterResponseV2(
@@ -57,8 +57,8 @@ case class NewsletterResponseV2(
 )
 
 object NewsletterResponseV2 {
-  implicit val newsletterResponseV2Reads = Json.reads[NewsletterResponseV2]
-  implicit val newsletterResponseV2Writes = Json.writes[NewsletterResponseV2]
+  implicit val newsletterResponseV2Reads: Reads[NewsletterResponseV2] = Json.reads[NewsletterResponseV2]
+  implicit val newsletterResponseV2Writes: OWrites[NewsletterResponseV2] = Json.writes[NewsletterResponseV2]
 }
 
 case class NewslettersGetResponseV2Body(
@@ -68,6 +68,8 @@ case class NewslettersGetResponseV2Body(
 )
 
 object NewslettersGetResponseV2Body {
-  implicit val newslettersGetResponseV2BodyReads = Json.reads[NewslettersGetResponseV2Body]
-  implicit val newslettersGetResponseV2BodyWrites = Json.writes[NewslettersGetResponseV2Body]
+  implicit val newslettersGetResponseV2BodyReads: Reads[NewslettersGetResponseV2Body] =
+    Json.reads[NewslettersGetResponseV2Body]
+  implicit val newslettersGetResponseV2BodyWrites: OWrites[NewslettersGetResponseV2Body] =
+    Json.writes[NewslettersGetResponseV2Body]
 }

--- a/common/test/common/ExperimentsTest.scala
+++ b/common/test/common/ExperimentsTest.scala
@@ -104,7 +104,7 @@ class ExperimentsTest extends AnyFlatSpec with Matchers {
    */
   object AllExperiments extends ExperimentsDefinition {
     val allExperiments: Set[Experiment] = TestCases.experiments
-    implicit val canCheckExperiment = new CanCheckExperiment(this)
+    implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
   }
 
   object TestCases {

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -3,14 +3,15 @@ package common
 import org.scalatest.matchers.should.Matchers
 import common.editions.{Au, Europe, International, Uk, Us}
 import org.scalatest.flatspec.AnyFlatSpec
+import play.api.mvc.AnyContentAsEmpty
 import test._
 import play.api.test.FakeRequest
 
 class LinkToTest extends AnyFlatSpec with Matchers with implicits.FakeRequests {
 
-  implicit val edition = Uk
-  implicit val editions = Seq(Uk, Us, Au)
-  implicit val request = FakeRequest("GET", "/")
+  implicit val edition: Uk.type = Uk
+  implicit val editions: Seq[Edition] = Seq(Uk, Us, Au)
+  implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
 
   object TestLinkTo extends LinkTo {
     override lazy val host = "http://www.foo.com"

--- a/common/test/common/TagLinkerTest.scala
+++ b/common/test/common/TagLinkerTest.scala
@@ -13,6 +13,7 @@ import org.jsoup.nodes.Document
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import views.support.TagLinker
 
@@ -20,11 +21,11 @@ import scala.jdk.CollectionConverters._
 
 class TagLinkerTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
-  implicit val edition = Uk
-  implicit val request = FakeRequest("GET", "/")
+  implicit val edition: Uk.type = Uk
+  implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
 
   private implicit class Document2FirstPara(d: Document) {
-    val firstPara = d.select("p").asScala.head.html
+    val firstPara: String = d.select("p").asScala.head.html
   }
 
   "TagLinker" should "link tag at the start of the paragraph" in {

--- a/common/test/layout/package.scala
+++ b/common/test/layout/package.scala
@@ -48,7 +48,7 @@ package object layout {
 
   val columnGen = Gen.oneOf(singleItemGen, rowGen, splitColumnGen, mpuGen)
 
-  implicit val arbitrarySlice = Arbitrary {
+  implicit val arbitrarySlice: Arbitrary[SliceLayout] = Arbitrary {
     for {
       id <- arbitrary[String]
       numberOfCols <- Gen.choose(1, 4)

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -114,7 +114,8 @@ trait WithTestExecutionContext {
 }
 
 trait WithTestApplicationContext {
-  implicit val testApplicationContext = ApplicationContext(Environment.simple(), ApplicationIdentity("tests"))
+  implicit val testApplicationContext: ApplicationContext =
+    ApplicationContext(Environment.simple(), ApplicationIdentity("tests"))
 }
 
 trait WithMaterializer {

--- a/common/test/views/support/TitleTest.scala
+++ b/common/test/views/support/TitleTest.scala
@@ -10,11 +10,12 @@ import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 
 class TitleTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
-  implicit val request = FakeRequest()
+  implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
 
   it should "should create a 'default' title" in {
     val page = SimplePage(MetaData.make("", None, "The title", None))

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -90,7 +90,7 @@ final case class EmbedJsonHtml(
 )
 
 object EmbedJsonHtml {
-  implicit val format = Json.format[EmbedJsonHtml]
+  implicit val format: OFormat[EmbedJsonHtml] = Json.format[EmbedJsonHtml]
 }
 
 case class EmailFrontPath(path: String, edition: String)

--- a/facia-press/app/frontpress/StatusNotification.scala
+++ b/facia-press/app/frontpress/StatusNotification.scala
@@ -1,7 +1,6 @@
 package frontpress
 
 import java.nio.ByteBuffer
-
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.kinesis.{AmazonKinesisAsync, AmazonKinesisAsyncClient}
 import com.amazonaws.services.kinesis.model.{PutRecordRequest, PutRecordResult}
@@ -9,10 +8,10 @@ import com.gu.facia.api.ApiError
 import conf.Configuration
 import conf.switches.Switches.FaciaPressStatusNotifications
 import play.api.Logger
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 object StatusNotificationMessage {
-  implicit val jsonFormat = Json.format[StatusNotificationMessage]
+  implicit val jsonFormat: OFormat[StatusNotificationMessage] = Json.format[StatusNotificationMessage]
 }
 case class StatusNotificationMessage(
     status: String,

--- a/facia/app/agents/MostViewedAgent.scala
+++ b/facia/app/agents/MostViewedAgent.scala
@@ -31,7 +31,7 @@ class MostViewedAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, ws
   }
 
   private object MostDiscussedItem {
-    implicit val format = Json.format[MostDiscussedItem]
+    implicit val format: OFormat[MostDiscussedItem] = Json.format[MostDiscussedItem]
   }
 
   private def refreshGlobal()(implicit ec: ExecutionContext): Future[(Option[Content], Option[Content])] = {

--- a/facia/app/feed/DeeplyReadLifecycle.scala
+++ b/facia/app/feed/DeeplyReadLifecycle.scala
@@ -2,11 +2,11 @@ package feed
 
 import agents.DeeplyReadAgent
 import app.LifecycleComponent
-import common.{PekkoAsync, JobScheduler}
+import common.{JobScheduler, PekkoAsync}
 import play.api.inject.ApplicationLifecycle
 
 import java.util.concurrent.Executors
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 
 class DeeplyReadLifecycle(
     appLifecycle: ApplicationLifecycle,
@@ -15,7 +15,7 @@ class DeeplyReadLifecycle(
     deeplyReadAgent: DeeplyReadAgent,
 ) extends LifecycleComponent {
 
-  implicit val executionContext = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+  implicit val executionContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/facia/app/feed/DeeplyReadLifecycle.scala
+++ b/facia/app/feed/DeeplyReadLifecycle.scala
@@ -15,7 +15,8 @@ class DeeplyReadLifecycle(
     deeplyReadAgent: DeeplyReadAgent,
 ) extends LifecycleComponent {
 
-  implicit val executionContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+  implicit val executionContext: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/facia/app/feed/MostViewedLifecycle.scala
+++ b/facia/app/feed/MostViewedLifecycle.scala
@@ -4,10 +4,10 @@ import agents.MostViewedAgent
 
 import java.util.concurrent.Executors
 import app.LifecycleComponent
-import common.{PekkoAsync, JobScheduler}
+import common.{JobScheduler, PekkoAsync}
 import play.api.inject.ApplicationLifecycle
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 
 class MostViewedLifecycle(
     appLifecycle: ApplicationLifecycle,
@@ -16,7 +16,7 @@ class MostViewedLifecycle(
     mostViewedAgent: MostViewedAgent,
 ) extends LifecycleComponent {
 
-  implicit val executionContext = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+  implicit val executionContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/facia/app/feed/MostViewedLifecycle.scala
+++ b/facia/app/feed/MostViewedLifecycle.scala
@@ -16,7 +16,8 @@ class MostViewedLifecycle(
     mostViewedAgent: MostViewedAgent,
 ) extends LifecycleComponent {
 
-  implicit val executionContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+  implicit val executionContext: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/facia/app/model/OnwardItem.scala
+++ b/facia/app/model/OnwardItem.scala
@@ -1,7 +1,7 @@
 package model
 
 import model.facia.PressedCollection
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OWrites}
 import play.api.mvc.RequestHeader
 import model.dotcomrendering.{Trail => DCRTrail}
 
@@ -13,7 +13,7 @@ case class OnwardCollection(
 
 object OnwardCollection {
 
-  implicit def writes = Json.writes[OnwardCollection]
+  implicit def writes: OWrites[OnwardCollection] = Json.writes[OnwardCollection]
 
   def pressedCollectionToOnwardCollection(
       collection: PressedCollection,

--- a/identity/app/form/IdFormHelpers.scala
+++ b/identity/app/form/IdFormHelpers.scala
@@ -5,7 +5,7 @@ import views.html.fragments.form.fieldConstructors.{frontendFieldConstructor, mu
 import play.api.data.Field
 
 object IdFormHelpers {
-  implicit val fields = FieldConstructor(frontendFieldConstructor.f)
+  implicit val fields: FieldConstructor = FieldConstructor(frontendFieldConstructor.f)
 
   val nonInputFields = FieldConstructor(multiInputFieldConstructor.f)
 

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -9,6 +9,7 @@ import idapiclient.parser.IdApiJsonBodyParser
 import net.liftweb.json.Serialization.write
 import utils.SafeLogging
 import idapiclient.requests.{AutoSignInToken, DeletionBody}
+import net.liftweb.json.Formats
 import org.slf4j.LoggerFactory
 import play.api.libs.ws.WSClient
 
@@ -22,7 +23,7 @@ class IdApiClient(idJsonBodyParser: IdApiJsonBodyParser, conf: IdConfig, httpCli
 
   import idJsonBodyParser.{extractUnit, extract, jsonField}
 
-  private implicit val formats = idJsonBodyParser.formats
+  private implicit val formats: Formats = idJsonBodyParser.formats
 
   private def extractUser: (Response[HttpResponse]) => Response[User] = extract(jsonField("user"))
 

--- a/identity/app/idapiclient/parser/IdApiJsonBodyParser.scala
+++ b/identity/app/idapiclient/parser/IdApiJsonBodyParser.scala
@@ -2,11 +2,12 @@ package idapiclient.parser
 
 import com.gu.identity.model.{LiftJsonConfig, Error => IdApiError}
 import idapiclient.responses.Error
+import net.liftweb.json.Formats
 import net.liftweb.json.JsonAST.JValue
 import utils.SafeLogging
 
 class IdApiJsonBodyParser extends JsonBodyParser with SafeLogging {
-  override implicit val formats = LiftJsonConfig.formats + JodaJsonSerializer
+  override implicit val formats: Formats = LiftJsonConfig.formats + JodaJsonSerializer
 
   override def extractErrorFromResponse(json: JValue, statusCode: Int): List[Error] = {
     try {

--- a/identity/app/idapiclient/responses/Error.scala
+++ b/identity/app/idapiclient/responses/Error.scala
@@ -1,6 +1,6 @@
 package idapiclient.responses
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 /**
   * FIXME:
@@ -10,5 +10,5 @@ import play.api.libs.json.Json
 case class Error(message: String, description: String, statusCode: Int = 500, context: Option[String] = None)
 
 object Error {
-  implicit val errorFormat = Json.format[Error]
+  implicit val errorFormat: OFormat[Error] = Json.format[Error]
 }

--- a/identity/app/implicits/Forms.scala
+++ b/identity/app/implicits/Forms.scala
@@ -12,7 +12,7 @@ trait Forms extends I18nSupport {
   val httpConfiguration: HttpConfiguration
   private val formKey = "form-data"
 
-  private implicit val errorReads = new Reads[Seq[FormError]] {
+  private implicit val errorReads: Reads[Seq[FormError]] = new Reads[Seq[FormError]] {
     override def reads(js: JsValue): JsResult[Seq[FormError]] =
       Json.fromJson[Map[String, Seq[String]]](js).map {
         _.toSeq.map { case (k, v) => FormError(k, v) }
@@ -56,7 +56,7 @@ trait Forms extends I18nSupport {
     }
   }
 
-  implicit val formErrorWrites = new Writes[FormError] {
+  implicit val formErrorWrites: Writes[FormError] = new Writes[FormError] {
     def writes(formError: FormError) =
       Json.obj(
         "key" -> formError.key,

--- a/identity/test/idapiclient/parser/JsonBodyParserTest.scala
+++ b/identity/test/idapiclient/parser/JsonBodyParserTest.scala
@@ -18,7 +18,7 @@ class JsonBodyParserTest extends PathAnyFreeSpec with Matchers {
 
   object TestJsonBodyParser extends JsonBodyParser {
 
-    implicit val formats = new DefaultFormats {}
+    implicit val formats: DefaultFormats = new DefaultFormats {}
 
     def extractErrorFromResponse(json: JValue, statusCode: Int): List[Error] = testErrors
   }

--- a/onward/app/business/massagedModels.scala
+++ b/onward/app/business/massagedModels.scala
@@ -1,12 +1,12 @@
 package business
 
 import common.GuLogging
-import play.api.libs.json.{Json, JsString, JsValue, Writes}
+import play.api.libs.json.{JsString, JsValue, Json, OWrites, Writes}
 
 import scala.util.Try
 
 object Trend {
-  implicit val jsonWrites = new Writes[Trend] {
+  implicit val jsonWrites: Writes[Trend] = new Writes[Trend] {
     override def writes(o: Trend): JsValue =
       o match {
         case Negative => JsString("negative")
@@ -30,7 +30,7 @@ case object Positive extends Trend
 case object Level extends Trend
 
 object StockValue {
-  implicit val jsonWrites = Json.writes[StockValue]
+  implicit val jsonWrites: OWrites[StockValue] = Json.writes[StockValue]
 }
 
 case class StockValue(
@@ -42,7 +42,7 @@ case class StockValue(
 )
 
 object Stocks extends GuLogging {
-  implicit val jsonWrites = Json.writes[Stocks]
+  implicit val jsonWrites: OWrites[Stocks] = Json.writes[Stocks]
 
   private val Commas = """,+""".r
 

--- a/onward/app/business/rawModels.scala
+++ b/onward/app/business/rawModels.scala
@@ -1,6 +1,6 @@
 package business
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 
 /** Basic deserialization for the data exactly as it's given to us by Fingerpost.
   *
@@ -8,7 +8,7 @@ import play.api.libs.json.Json
   */
 
 object IndexChange {
-  implicit val jsonReads = Json.reads[IndexChange]
+  implicit val jsonReads: Reads[IndexChange] = Json.reads[IndexChange]
 }
 
 case class IndexChange(
@@ -18,7 +18,7 @@ case class IndexChange(
 )
 
 object IndexValue {
-  implicit val jsonReads = Json.reads[IndexValue]
+  implicit val jsonReads: Reads[IndexValue] = Json.reads[IndexValue]
 }
 
 case class IndexValue(
@@ -33,7 +33,7 @@ case class IndexValue(
 )
 
 object Index {
-  implicit val jsonReads = Json.reads[Index]
+  implicit val jsonReads: Reads[Index] = Json.reads[Index]
 }
 
 case class Index(
@@ -47,7 +47,7 @@ case class Index(
 )
 
 object Indices {
-  implicit val jsonReads = Json.reads[Indices]
+  implicit val jsonReads: Reads[Indices] = Json.reads[Indices]
 }
 
 case class Indices(

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -5,13 +5,13 @@ import conf.Configuration
 import model.Cached.RevalidatableResult
 import model.{Cached, Cors}
 import navigation.{NavLink, SimpleMenu, UrlHelpers}
-import play.api.libs.json.{JsValue, Json, Writes}
+import play.api.libs.json.{JsValue, Json, OWrites, Writes}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 case class ApiError(message: String, statusCode: Int)
 
 object ApiError {
-  implicit val writes = Json.writes[ApiError]
+  implicit val writes: OWrites[ApiError] = Json.writes[ApiError]
 }
 
 class NavigationController(val controllerComponents: ControllerComponents) extends BaseController {

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -26,7 +26,7 @@ class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, w
   }
 
   private object MostDiscussedItem {
-    implicit val format = Json.format[MostDiscussedItem]
+    implicit val format: OFormat[MostDiscussedItem] = Json.format[MostDiscussedItem]
   }
 
   private def refreshGlobal()(implicit ec: ExecutionContext): Future[Map[String, Content]] = {

--- a/onward/app/feed/MostViewedVideoAgent.scala
+++ b/onward/app/feed/MostViewedVideoAgent.scala
@@ -15,7 +15,7 @@ class MostViewedVideoAgent(contentApiClient: ContentApiClient, ophanApi: OphanAp
 
   private val agent = Box[Seq[Video]](Nil)
 
-  implicit val ophanQueryReads = Json.reads[QueryResult]
+  implicit val ophanQueryReads: Reads[QueryResult] = Json.reads[QueryResult]
 
   def mostViewedVideo(): Seq[Video] = agent()
 

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -1,11 +1,13 @@
 package feed
 
 import agents.DeeplyReadAgent
+
 import java.util.concurrent.Executors
 import app.LifecycleComponent
-import common.{PekkoAsync, JobScheduler}
+import common.{JobScheduler, PekkoAsync}
 import play.api.inject.ApplicationLifecycle
-import scala.concurrent.{ExecutionContext, Future}
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 
 class OnwardJourneyLifecycle(
     appLifecycle: ApplicationLifecycle,
@@ -21,7 +23,7 @@ class OnwardJourneyLifecycle(
     deeplyReadAgent: DeeplyReadAgent,
 ) extends LifecycleComponent {
 
-  implicit val capiClientExecutionContext = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+  implicit val capiClientExecutionContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -23,7 +23,8 @@ class OnwardJourneyLifecycle(
     deeplyReadAgent: DeeplyReadAgent,
 ) extends LifecycleComponent {
 
-  implicit val capiClientExecutionContext: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+  implicit val capiClientExecutionContext: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/onward/app/models/NewsAlertType.scala
+++ b/onward/app/models/NewsAlertType.scala
@@ -31,7 +31,7 @@ object NewsAlertType {
       case "sport"         => Sport
     }
 
-  implicit val jf = new Format[NewsAlertType] {
+  implicit val jf: Format[NewsAlertType] = new Format[NewsAlertType] {
     def reads(json: JsValue): JsResult[NewsAlertType] =
       json match {
         case JsString(s) => fromString(s) map { JsSuccess(_) } getOrElse JsError(s"$s is not a valid news alert type")

--- a/onward/app/models/Series.scala
+++ b/onward/app/models/Series.scala
@@ -27,7 +27,7 @@ case class SeriesStoriesDCR(
 )
 
 object SeriesStoriesDCR {
-  implicit val seriesStoriesDCRWrites = Json.writes[SeriesStoriesDCR]
+  implicit val seriesStoriesDCRWrites: OWrites[SeriesStoriesDCR] = Json.writes[SeriesStoriesDCR]
   def fromSeries(series: Series)(implicit request: RequestHeader): SeriesStoriesDCR = {
     SeriesStoriesDCR(
       id = series.id,

--- a/onward/app/models/URIFormats.scala
+++ b/onward/app/models/URIFormats.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 object URIFormats {
 
   // URI serializer/deserializer
-  implicit val uf = new Format[URI] {
+  implicit val uf: Format[URI] = new Format[URI] {
     override def writes(uri: URI): JsValue = JsString(uri.toString)
     override def reads(json: JsValue): JsResult[URI] = {
       val error = JsError("Value is expected to convert to URI")

--- a/onward/app/models/dotcomrendering/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomrendering/DotcomponentsOnwardsModels.scala
@@ -1,7 +1,7 @@
 package models.dotcomrendering
 
 import model.{ContentFormat, DotcomContentType, ImageAsset}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OWrites}
 
 // duplicated in dotcomponentsdatamodel
 case class RichLinkTag(
@@ -11,7 +11,7 @@ case class RichLinkTag(
 )
 
 object RichLinkTag {
-  implicit val writes = Json.writes[RichLinkTag]
+  implicit val writes: OWrites[RichLinkTag] = Json.writes[RichLinkTag]
 }
 
 case class RichLink(
@@ -30,5 +30,5 @@ case class RichLink(
 )
 
 object RichLink {
-  implicit val writes = Json.writes[RichLink]
+  implicit val writes: OWrites[RichLink] = Json.writes[RichLink]
 }

--- a/onward/app/weather/models/CityResponse.scala
+++ b/onward/app/weather/models/CityResponse.scala
@@ -2,13 +2,13 @@ package weather.models
 
 import common.Edition
 import common.editions.{Au, Uk, Us}
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, Reads, Writes}
 import weather.models.accuweather.LocationResponse
 
 object CityResponse {
-  implicit val jsonReads = Json.reads[CityResponse]
+  implicit val jsonReads: Reads[CityResponse] = Json.reads[CityResponse]
 
-  implicit val writes = new Writes[CityResponse] {
+  implicit val writes: Writes[CityResponse] = new Writes[CityResponse] {
     def writes(model: CityResponse) = {
       Json.obj(
         "id" -> model.id,

--- a/onward/app/weather/models/Temperatures.scala
+++ b/onward/app/weather/models/Temperatures.scala
@@ -1,11 +1,11 @@
 package weather.models
 
-import play.api.libs.json.{JsValue, Json, Writes}
+import play.api.libs.json.{JsValue, Json, Reads, Writes}
 
 object Temperatures {
-  implicit val jsonReads = Json.reads[Temperatures]
+  implicit val jsonReads: Reads[Temperatures] = Json.reads[Temperatures]
 
-  implicit val jsonWrites = new Writes[Temperatures] {
+  implicit val jsonWrites: Writes[Temperatures] = new Writes[Temperatures] {
     override def writes(o: Temperatures): JsValue = {
 
       Json.obj(

--- a/onward/app/weather/models/Weather.scala
+++ b/onward/app/weather/models/Weather.scala
@@ -1,11 +1,11 @@
 package weather.models
 
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, Reads, Writes}
 
 object Weather {
-  implicit val jsonReads = Json.reads[Weather]
+  implicit val jsonReads: Reads[Weather] = Json.reads[Weather]
 
-  implicit val writes = new Writes[Weather] {
+  implicit val writes: Writes[Weather] = new Writes[Weather] {
     def writes(model: Weather) = {
       Json.obj(
         "location" -> model.location,

--- a/onward/app/weather/models/WeatherResponse.scala
+++ b/onward/app/weather/models/WeatherResponse.scala
@@ -1,11 +1,11 @@
 package weather.models
 
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, Reads, Writes}
 
 object WeatherResponse {
-  implicit val jsonReads = Json.reads[WeatherResponse]
+  implicit val jsonReads: Reads[WeatherResponse] = Json.reads[WeatherResponse]
 
-  implicit val writes = new Writes[WeatherResponse] {
+  implicit val writes: Writes[WeatherResponse] = new Writes[WeatherResponse] {
     def writes(model: WeatherResponse) = {
       Json.obj(
         "description" -> model.weatherText,

--- a/onward/app/weather/models/accuweather/ForecastResponse.scala
+++ b/onward/app/weather/models/accuweather/ForecastResponse.scala
@@ -1,11 +1,11 @@
 package weather.models.accuweather
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 /** Not all the fields AccuWeather provides, but the ones we want */
 
 object Temperature {
-  implicit val jsonFormat = Json.format[Temperature]
+  implicit val jsonFormat: OFormat[Temperature] = Json.format[Temperature]
 }
 
 case class Temperature(
@@ -14,7 +14,7 @@ case class Temperature(
 )
 
 object ForecastResponse {
-  implicit val jsonFormat = Json.format[ForecastResponse]
+  implicit val jsonFormat: OFormat[ForecastResponse] = Json.format[ForecastResponse]
 }
 
 case class ForecastResponse(

--- a/onward/app/weather/models/accuweather/LocationResponse.scala
+++ b/onward/app/weather/models/accuweather/LocationResponse.scala
@@ -1,11 +1,11 @@
 package weather.models.accuweather
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 
 /* Not all the fields the AccuWeather API returns, but the ones we care about */
 
 object LocationName {
-  implicit val jsonReads = Json.reads[LocationName]
+  implicit val jsonReads: Reads[LocationName] = Json.reads[LocationName]
 }
 
 case class LocationName(
@@ -14,7 +14,7 @@ case class LocationName(
 )
 
 object LocationResponse {
-  implicit val jsonReads = Json.reads[LocationResponse]
+  implicit val jsonReads: Reads[LocationResponse] = Json.reads[LocationResponse]
 }
 
 case class LocationResponse(

--- a/onward/app/weather/models/accuweather/WeatherResponse.scala
+++ b/onward/app/weather/models/accuweather/WeatherResponse.scala
@@ -3,12 +3,12 @@ package weather.models.accuweather
 import common.Edition
 import common.editions.Us
 import model.dotcomrendering.{DotcomRenderingDataModel, ElementsEnhancer}
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, Reads, Writes}
 
 /** Not all the fields AccuWeather supplies, just the ones we care about */
 
 object WeatherResponse {
-  implicit val jsonReads = Json.reads[WeatherResponse]
+  implicit val jsonReads: Reads[WeatherResponse] = Json.reads[WeatherResponse]
 }
 
 case class WeatherResponse(

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -32,7 +32,7 @@ object ProjectSettings {
     Compile / packageDoc / publishArtifact := false,
     Compile / doc / sources := Seq.empty,
     Compile / doc := target.map(_ / "none").value,
-    scalaVersion := "2.13.10",
+    scalaVersion := "2.13.12",
     initialize := {
       val _ = initialize.value
       assert(

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 case class Team(name: String, id: String, home: Boolean, lineup: List[String])
 
 object Team {
-  implicit val writes = Json.writes[Team]
+  implicit val writes: OWrites[Team] = Json.writes[Team]
 }
 
 case class InningsBatsman(
@@ -25,19 +25,19 @@ case class InningsBatsman(
 }
 
 object InningsBatsman {
-  implicit val writes = Json.writes[InningsBatsman]
+  implicit val writes: OWrites[InningsBatsman] = Json.writes[InningsBatsman]
 }
 
 case class InningsBowler(name: String, order: Int, overs: Int, maidens: Int, runs: Int, wickets: Int)
 
 object InningsBowler {
-  implicit val writes = Json.writes[InningsBowler]
+  implicit val writes: OWrites[InningsBowler] = Json.writes[InningsBowler]
 }
 
 case class InningsWicket(order: Int, name: String, runs: Int)
 
 object InningsWicket {
-  implicit val writes = Json.writes[InningsWicket]
+  implicit val writes: OWrites[InningsWicket] = Json.writes[InningsWicket]
 }
 
 case class Innings(
@@ -58,7 +58,7 @@ case class Innings(
     wides: Int,
     extras: Int,
 ) {
-  implicit val writes = Json.writes[Innings]
+  implicit val writes: OWrites[Innings] = Json.writes[Innings]
   lazy val closed = declared || forfeited || allOut
   lazy val allOut = wickets == 10
   lazy val wickets = fallOfWicket.length
@@ -74,7 +74,7 @@ case class Innings(
 }
 
 object Innings {
-  implicit val writes = Json.writes[Innings]
+  implicit val writes: OWrites[Innings] = Json.writes[Innings]
 }
 
 case class Match(
@@ -102,5 +102,5 @@ case class Match(
 }
 
 object Match {
-  implicit val writes = Json.writes[Match]
+  implicit val writes: OWrites[Match] = Json.writes[Match]
 }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -23,7 +23,7 @@ class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materialize
   private val paEndpoint = "https://cricket-api.guardianapis.com/v1"
   private val credentials = conf.SportConfiguration.pa.cricketKey.map { ("Apikey", _) }
   private val xmlContentType = ("Accept", "application/xml")
-  private implicit val throttler = new CricketThrottler(pekkoActorSystem, materializer)
+  private implicit val throttler: CricketThrottler = new CricketThrottler(pekkoActorSystem, materializer)
 
   private def getMatchPaResponse(apiMethod: String)(implicit executionContext: ExecutionContext): Future[String] = {
     credentials

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -1,5 +1,6 @@
 package feed
 
+import com.github.nscala_time.time.Imports
 import com.github.nscala_time.time.Imports._
 import common._
 import conf.FootballClient
@@ -390,7 +391,7 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
     with GuLogging
     with implicits.Football {
 
-  private implicit val dateOrdering = Ordering.comparatorToOrdering(
+  private implicit val dateOrdering: Ordering[Imports.DateTime] = Ordering.comparatorToOrdering(
     DateTimeComparator.getInstance.asInstanceOf[Comparator[DateTime]],
   )
 

--- a/sport/app/rugby/model/paRugby.scala
+++ b/sport/app/rugby/model/paRugby.scala
@@ -2,7 +2,7 @@ package rugby.feed
 
 import common.GuLogging
 import org.joda.time.DateTime
-import play.api.libs.json.{JsError, JsResult, JsSuccess, Json}
+import play.api.libs.json.{JsError, JsResult, JsSuccess, Json, Reads}
 import rugby.model.Stage.Stage
 import rugby.model._
 import PAReads._
@@ -16,17 +16,17 @@ case class PAResult(
 )
 
 object PAReads {
-  implicit val dtReads = play.api.libs.json.JodaReads.DefaultJodaDateTimeReads
+  implicit val dtReads: Reads[DateTime] = play.api.libs.json.JodaReads.DefaultJodaDateTimeReads
 
-  implicit val resultReads = Json.reads[PAResult]
-  implicit val playerReads = Json.reads[PAPlayer]
-  implicit val nestedParticipantReads = Json.reads[NestedParticipant]
-  implicit val participantReads = Json.reads[Participant]
-  implicit val teamReads = Json.reads[PATeam]
-  implicit val venueReads = Json.reads[Venue]
-  implicit val tournamentReads = Json.reads[Tournament]
-  implicit val matchReads = Json.reads[PAMatch]
-  implicit val matchesReads = Json.reads[PAMatchesResponse]
+  implicit val resultReads: Reads[PAResult] = Json.reads[PAResult]
+  implicit val playerReads: Reads[PAPlayer] = Json.reads[PAPlayer]
+  implicit val nestedParticipantReads: Reads[NestedParticipant] = Json.reads[NestedParticipant]
+  implicit val participantReads: Reads[Participant] = Json.reads[Participant]
+  implicit val teamReads: Reads[PATeam] = Json.reads[PATeam]
+  implicit val venueReads: Reads[Venue] = Json.reads[Venue]
+  implicit val tournamentReads: Reads[Tournament] = Json.reads[Tournament]
+  implicit val matchReads: Reads[PAMatch] = Json.reads[PAMatch]
+  implicit val matchesReads: Reads[PAMatchesResponse] = Json.reads[PAMatchesResponse]
 }
 
 case class PAPlayer(

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -36,7 +36,7 @@ import scala.concurrent.duration._
     super.afterAll()
   }
 
-  override implicit val patienceConfig =
+  override implicit val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(3000, Millis)), interval = scaled(Span(100, Millis)))
 
   lazy val seasonStart = Some(LocalDate.of(2012, 8, 1))

--- a/sport/test/football/containers/FixturesAndResultsTest.scala
+++ b/sport/test/football/containers/FixturesAndResultsTest.scala
@@ -3,6 +3,8 @@ package football.containers
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
 import test._
 
 @DoNotDiscover class FixturesAndResultsTest
@@ -20,7 +22,7 @@ import test._
   lazy val fixturesAndResults = new FixturesAndResults(
     testCompetitionsService.competitionsWithTodaysMatchesAndFutureFixtures,
   )
-  implicit val fakeRequest = TestRequest()
+  implicit val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = TestRequest()
 
   "Creating container for a given team" should "be successful" in {
 


### PR DESCRIPTION
## What does this change?
Upgrades scala version to `2.13.12`.

## What is the value of this and can you measure success?
* Keeping up-to-date with the latest Scala 2.13 version
* Addresses "Implicit definition should have explicit type" warnings which in our case become errors because we have `-Xfatal-warnings` flag enabled. This also helps to ease migration to Scala 3.
* Unblocks:
  * https://github.com/guardian/frontend/pull/26783 
With Scala `2.13.10` the compiler was crashing.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/19683595/e498f86d-bb52-4354-a706-2d7aa84b2746) | ![image](https://github.com/guardian/frontend/assets/19683595/5e1b590b-55c0-4413-a7f5-fed733c27a38) |

Instead of crashing the compiler is producing a compilation error which we can now work on fixing in #26783 

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
