### PR TITLE
Update PressedContent.scala

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -76,6 +76,7 @@ object PressedContent {
     "/us-news/2016/jun/02/chicago-water-lead-pipes-replacement",
     "/us-news/2016/jun/02/flint-water-crisis-tests-targeted-homes-far-from-lead-pipes",
     "/politics/ng-interactive/2016/jun/03/brexit-how-can-the-same-statistics-be-read-so-differently",
+    "/membership/ng-interactive/2016/jun/16/guardian-labour-liverpool-ewen-macaskill",
     "/membership/2016/jun/23/labour-liverpool-ewen-macaskill",
     "/global-development/2016/sep/06/poorest-countries-hit-hardest-world-lags-behind-global-education-goals-unesco-report",
     "/commentisfree/2016/jul/07/guardian-view-on-the-chilcot-report",


### PR DESCRIPTION
## What does this change?

Add the following interactive to pressed content so it is not served by DCR as requested by CP:
https://www.theguardian.com/membership/ng-interactive/2016/jun/16/guardian-labour-liverpool-ewen-macaskill

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
