### PR TITLE
Bump CAPI Scala Client To v19.4.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   // started needing it for something else in the meantime.)
   val identityLibVersion = "3.255"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.4.0"
+  val capiVersion = "19.4.1"
   val faciaVersion = "4.0.6"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
To prioritise picture designs over print shop designs: https://github.com/guardian/content-api-scala-client/pull/394
