### PR TITLE
Embed button colours for Saturday Edition thrasher

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -268,6 +268,7 @@
     }
 }
 
+.email-sub__form--thrasher-saturday-edition,
 .email-sub__form--thrasher-us-morning-newsletter,
 .email-sub__form--thrasher-morning-mail,
 .email-sub__form--thrasher-afternoon-update,


### PR DESCRIPTION
## What does this change?

CSS update - use the blue button style for the embedded sign-up form to be used on a thrasher for Saturday Edition newsletter thrasher.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Visuals - the new newsletter will have this styling rather than the default with a white button

| before | after |
|---|---|
| <img width="1332" alt="Screenshot 2024-01-12 at 16 56 44" src="https://github.com/guardian/frontend/assets/30567854/3c14e3d6-6c85-40cc-b262-8a241432b9bb"> | <img width="1332" alt="Screenshot 2024-01-12 at 16 58 02" src="https://github.com/guardian/frontend/assets/30567854/aa059fdc-4d89-4c0f-8f23-22a418ce4ef3"> |





