### PR TITLE
Revert "Use new base URL for DCR article endpoints"

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -150,7 +150,6 @@ class GuardianConfiguration extends GuLogging {
 
   object rendering {
     lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
-    lazy val articleBaseURL = configuration.getMandatoryStringProperty("article-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -232,7 +232,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     }
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.articleBaseURL + path, page.metadata.cacheTime)
+    post(ws, json, Configuration.rendering.baseURL + path, page.metadata.cacheTime)
   }
 
   def getBlocks(
@@ -243,7 +243,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomBlocksRenderingDataModel(page, request, blocks)
     val json = DotcomBlocksRenderingDataModel.toJson(dataModel)
 
-    postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/Blocks")
+    postWithoutHandler(ws, json, Configuration.rendering.baseURL + "/Blocks")
       .flatMap(response => {
         if (response.status == 200)
           Future.successful(response.body)
@@ -355,7 +355,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomRenderingDataModel.forImageContent(imageContent, request, pageType, mainBlock)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
   }
 
   def getAppsImageContent(
@@ -366,7 +366,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomRenderingDataModel.forImageContent(imageContent, request, pageType, mainBlock)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsArticle", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.baseURL + "/AppsArticle", CacheTime.Facia)
   }
 
   def getMedia(
@@ -378,7 +378,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomRenderingDataModel.forMedia(mediaPage, request, pageType, blocks)
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
   }
 
   def getGallery(
@@ -390,7 +390,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomRenderingDataModel.forGallery(gallery, request, pageType, blocks)
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
   }
 }
 


### PR DESCRIPTION
Reverts guardian/frontend#26789

We are seeing increased latency for the existing `rendering` app which is causing the app to scale beyond its needs, since the scaling policy is set to double capacity for latency above 0.2s.

While we investigate why the latency has increased, we'll revert this PR and re-implement in more gradual stages rather than re-routing all article traffic at once.

Average latency graph for `rendering` app:

<img width="911" alt="image" src="https://github.com/guardian/frontend/assets/43961396/ae0b53c9-03a0-4fa9-a4c6-4f03f348c613">

P90 and P99 latency graph for `rendering app:

<img width="1012" alt="image" src="https://github.com/guardian/frontend/assets/43961396/84dc4015-5dcb-4598-85bb-04c8597b71e2">
