### PR TITLE
Add ability to forward DCR article traffic to new `article-rendering` app

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -150,6 +150,7 @@ class GuardianConfiguration extends GuLogging {
 
   object rendering {
     lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
+    lazy val articleBaseURL = configuration.getMandatoryStringProperty("article-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -551,6 +551,6 @@ trait FeatureSwitches {
     safeState = Off,
     // This is a random date in the future but this switch should be removed far before then
     sellByDate = Some(LocalDate.of(2024, 6, 5)),
-    exposeClientSide = false,
+    exposeClientSide = true,
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -542,4 +542,15 @@ trait FeatureSwitches {
     sellByDate = Some(LocalDate.of(2024, 6, 5)),
     exposeClientSide = true,
   )
+
+  val SplitRenderingStack = Switch(
+    SwitchGroup.Feature,
+    "split-rendering-stack",
+    "If this switch is on, we will split DCR traffic between rendering stacks",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    // This is a random date in the future but this switch should be removed far before then
+    sellByDate = Some(LocalDate.of(2024, 6, 5)),
+    exposeClientSide = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Add a switch which when on will send traffic to the new `article-rendering` app for `/Article` DCR endpoints so that we can begin splitting the DCR apps in order to scale better with varying traffic levels and types of requests.

See https://github.com/guardian/dotcom-rendering/issues/8351 for more information

## What does this change?

Re-implements https://github.com/guardian/frontend/pull/26789 but this time with a feature switch to easily switch on or off. Also changes fewer endpoints for first iteration