### PR TITLE
Rename US Soccer Fixtures To "schedules"

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -103,19 +103,39 @@ object NavLinks {
 
   /* SPORT */
 
+  private val footballScores = NavLink("Live scores", "/football/live", Some("football/live"))
+  private val footballTables = NavLink("Tables", "/football/tables", Some("football/tables"))
+  private val footballFixtures = NavLink("Fixtures", "/football/fixtures", Some("football/fixtures"))
+  private val footballResults = NavLink("Results", "/football/results", Some("football/results"))
+  private val footballCompetitions = NavLink("Competitions", "/football/competitions", Some("football/competitions"))
+  private val footballClubs = NavLink("Clubs", "/football/teams", Some("football/teams"))
+
+  private val soccerSchedules = footballFixtures.copy(title = "Schedules")
+
   val football = NavLink(
     "Football",
     "/football",
     children = List(
-      NavLink("Live scores", "/football/live", Some("football/live")),
-      NavLink("Tables", "/football/tables", Some("football/tables")),
-      NavLink("Fixtures", "/football/fixtures", Some("football/fixtures")),
-      NavLink("Results", "/football/results", Some("football/results")),
-      NavLink("Competitions", "/football/competitions", Some("football/competitions")),
-      NavLink("Clubs", "/football/teams", Some("football/teams")),
+      footballScores,
+      footballTables,
+      footballFixtures,
+      footballResults,
+      footballCompetitions,
+      footballClubs,
     ),
   )
-  val soccer = football.copy(title = "Soccer", url = "/soccer")
+  val soccer = NavLink(
+    title = "Soccer",
+    url = "/soccer",
+    children = List(
+      footballScores,
+      footballTables,
+      soccerSchedules,
+      footballResults,
+      footballCompetitions,
+      footballClubs,
+    ),
+  )
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
   val rugbyUnion = NavLink("Rugby union", "/sport/rugby-union")

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1139,7 +1139,7 @@
 							"classList": []
 						},
 						{
-							"title": "Fixtures",
+							"title": "Schedules",
 							"url": "/football/fixtures",
 							"longTitle": "football/fixtures",
 							"children": [],
@@ -1291,7 +1291,7 @@
 							"classList": []
 						},
 						{
-							"title": "Fixtures",
+							"title": "Schedules",
 							"url": "/football/fixtures",
 							"longTitle": "football/fixtures",
 							"children": [],


### PR DESCRIPTION
On the US soccer subnav, the word "fixtures" has been replaced with the word "schedules". The links and placement are the same.

Includes a refactor of the way this part of the nav is constructed, to avoid brittleness that might have been caused by copying and modifying the nested `children` array.

## Screenshots

| | Before | After |
| - | - | - |
| US | ![us-nav-before] | ![us-nav-after] |
| UK | ![uk-nav-before] | ![uk-nav-after] |

[us-nav-before]: https://github.com/guardian/frontend/assets/53781962/45f20430-af8e-4113-8661-358b29ede551
[uk-nav-before]: https://github.com/guardian/frontend/assets/53781962/40c024a5-9e0f-48ac-85f1-31571ba672f4
[uk-nav-after]: https://github.com/guardian/frontend/assets/53781962/003f38ff-214a-48a5-b991-bfe2f7491d3d
[us-nav-after]: https://github.com/guardian/frontend/assets/53781962/8c762021-ecbb-4600-b92f-714fa6008c09
