### PR TITLE
Add Africa Cup Of Nations To Football Tables

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -29,6 +29,7 @@ class LeagueTableController(
   val tableOrder: Seq[String] = Seq(
     "World Cup 2022",
     "Premier League",
+    "Africa Cup of Nations",
     "Bundesliga",
     "Serie A",
     "La Liga",


### PR DESCRIPTION
Added to the football tables here: https://www.theguardian.com/football/tables

It will appear under "Internationals" in the dropdown, and second in the list of containers, between Premier League and Bundesliga.

| Before | After |
| - | - |
| ![football-tables-before] | ![football-tables] |

[football-tables]: https://github.com/guardian/frontend/assets/53781962/f33c58df-81ec-440e-8468-4d76f6bc6ebb
[football-tables-before]: https://github.com/guardian/frontend/assets/53781962/5b4e1d6b-1d36-4221-8823-6ccc43d9edf4
