### PR TITLE
"Soccer schedules" Heading For US

### DIFF
--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -1,7 +1,7 @@
 package football.model
 
 import com.madgag.scala.collection.decorators.MapDecorator
-import common.Edition
+import common.{Edition, editions}
 import football.collections.RichList
 import football.datetime.DateHelpers
 import implicits.Football
@@ -90,13 +90,14 @@ trait MatchesList extends Football with RichList {
     nextMatchDate.map(s"$baseUrl/" + _.format(DateTimeFormatter.ofPattern("yyyy/MMM/dd")))
   }
 
-  def getPageTitle: String = {
+  def getPageTitle(edition: Edition): String = {
     pageType match {
-      case "live"     => "Live football scores"
-      case "matches"  => "Football scores"
-      case "fixtures" => "Football fixtures"
-      case "results"  => "Football results"
-      case _          => pageType
+      case "live"                                 => "Live football scores"
+      case "matches"                              => "Football scores"
+      case "fixtures" if (edition == editions.Us) => "Soccer schedules"
+      case "fixtures"                             => "Football fixtures"
+      case "results"                              => "Football results"
+      case _                                      => pageType
     }
   }
 }

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -16,7 +16,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     <h2 class="hide-on-mobile-if-localnav content__inline-section page-type--football">
-                    @matchesList.getPageTitle
+                    @matchesList.getPageTitle(Edition(request))
                     </h2>
 
                     <div class="page-sponsor--football">


### PR DESCRIPTION
Changed the fixtures page heading from "Football fixtures" to "Soccer schedules" for the US edition.

## Screenshots

| | Before | After |
| - | - | - |
| US | ![us-before] | ![us-after] |
| UK | ![uk-before] | ![uk-after] |

[uk-before]: https://github.com/guardian/frontend/assets/53781962/39f67b74-e83b-4550-ba6b-30d053c8b031
[uk-after]: https://github.com/guardian/frontend/assets/53781962/6baaeade-5c64-4c0d-acdd-a9522a5a1e34
[us-before]: https://github.com/guardian/frontend/assets/53781962/eea4a9db-b33f-47db-a094-5a6bd3f3bc5b
[us-after]: https://github.com/guardian/frontend/assets/53781962/f4815286-d839-4f4b-9611-2fa0bf290520
