### PR TITLE
Direct article requests to new rendering app

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -150,6 +150,7 @@ class GuardianConfiguration extends GuLogging {
 
   object rendering {
     lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
+    lazy val articleBaseURL = configuration.getMandatoryStringProperty("article-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -232,7 +232,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     }
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + path, page.metadata.cacheTime)
+    post(ws, json, Configuration.rendering.articleBaseURL + path, page.metadata.cacheTime)
   }
 
   def getBlocks(
@@ -243,7 +243,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomBlocksRenderingDataModel(page, request, blocks)
     val json = DotcomBlocksRenderingDataModel.toJson(dataModel)
 
-    postWithoutHandler(ws, json, Configuration.rendering.baseURL + "/Blocks")
+    postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/Blocks")
       .flatMap(response => {
         if (response.status == 200)
           Future.successful(response.body)
@@ -355,7 +355,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomRenderingDataModel.forImageContent(imageContent, request, pageType, mainBlock)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
   }
 
   def getAppsImageContent(
@@ -366,7 +366,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomRenderingDataModel.forImageContent(imageContent, request, pageType, mainBlock)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/AppsArticle", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsArticle", CacheTime.Facia)
   }
 
   def getMedia(
@@ -378,7 +378,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomRenderingDataModel.forMedia(mediaPage, request, pageType, blocks)
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
   }
 
   def getGallery(
@@ -390,7 +390,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomRenderingDataModel.forGallery(gallery, request, pageType, blocks)
 
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
   }
 }
 


### PR DESCRIPTION
Reverts guardian/frontend#26814

After trying to [implement this via a feature switch](https://github.com/guardian/frontend/pull/26816), the switch wasn't working as required.

Might be better to just reimplement this original PR since we have now increased the latency on the existing `rendering` app https://github.com/guardian/dotcom-rendering/pull/10235