### PR TITLE
Bump AWS version to `1.12.638`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 
 object Dependencies {
   val identityLibVersion = "4.17"
-  val awsVersion = "1.12.205"
+  val awsVersion = "1.12.638"
   val capiVersion = "19.4.1"
   val faciaVersion = "4.0.6"
   val dispatchVersion = "0.13.1"


### PR DESCRIPTION
## What does this change?

- Bumps version of AWS libs to `1.12.638`
- Tested in [CODE](https://riffraff.gutools.co.uk/deployment/view/52ff485a-b1c9-4147-b77f-e2f7792d11d3)