### PR TITLE
DCR support for rugby endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,7 @@ val sport = application("sport")
     libraryDependencies ++= Seq(
       paClient,
     ),
+    dependencyOverrides ++= jackson,
   )
 
 val discussion = application("discussion").dependsOn(commonWithTests).aggregate(common)
@@ -187,6 +188,7 @@ val dev = application("dev-build")
   .settings(
     RoutesKeys.routesImport += "bindables._",
     Runtime / javaOptions += "-Dconfig.file=dev-build/conf/dev-build.application.conf",
+    dependencyOverrides ++= jackson,
   )
 
 val preview = application("preview")

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -3,6 +3,7 @@ package rugby.controllers
 import common._
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, MetaData, SectionId, StandalonePage}
+import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import play.twirl.api.Html
 import rugby.jobs.RugbyStatsJob
@@ -40,7 +41,11 @@ class MatchesController(
 
           val page = MatchPage(aMatch)
           Cached(60) {
-            if (request.isJson)
+            if (request.isJson && request.forceDCR)
+              JsonComponent(
+                "liveScore" -> Json.toJson(page.liveScore),
+              )
+            else if (request.isJson)
               JsonComponent(
                 "matchSummary" -> rugby.views.html.fragments.matchSummary(page, aMatch).toString,
                 "dropdown" -> views.html.fragments.dropdown("", isClientSideTemplate = true)(Html("")),

--- a/sport/app/rugby/feed/PAFeed.scala
+++ b/sport/app/rugby/feed/PAFeed.scala
@@ -1,7 +1,7 @@
 package rugby.feed
 
 import common.GuLogging
-import play.api.libs.json.{JsBoolean, Json}
+import play.api.libs.json.{JsBoolean, Json, OWrites}
 import play.api.libs.ws.WSClient
 import rugby.model._
 
@@ -26,16 +26,26 @@ trait RugbyClient {
 case class JsonParseException(msg: String) extends RuntimeException(msg)
 case class PARugbyAPIException(msg: String) extends RuntimeException(msg)
 
-sealed trait Event {
+sealed trait RugbyEvent {
   def competition: String
   def season: String
   def hasGroupTable(stage: Stage.Value): Boolean
 }
 
-case object WorldCup2019 extends Event {
+object RugbyEvent {
+  implicit val rugbyEventWrites: OWrites[RugbyEvent] = Json.writes[RugbyEvent]
+}
+
+case object WorldCup2019 extends RugbyEvent {
   override val competition = "482"
   override val season = "2019"
   override def hasGroupTable(stage: Stage.Value): Boolean = stage == Stage.Group
+  implicit val worldCup2019Writes: OWrites[WorldCup2019.type] = OWrites { (wc: WorldCup2019.type) =>
+    Json.obj(
+      "competition" -> wc.competition,
+      "season" -> wc.season,
+    )
+  }
 }
 
 object WorldCupPAIDs {

--- a/sport/app/rugby/jobs/RugbyStatsJob.scala
+++ b/sport/app/rugby/jobs/RugbyStatsJob.scala
@@ -2,7 +2,7 @@ package rugby.jobs
 
 import common.{Box, GuLogging}
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-import rugby.feed.{Event, MatchNavigation, PARugbyAPIException, RugbyFeed}
+import rugby.feed.{RugbyEvent, MatchNavigation, PARugbyAPIException, RugbyFeed}
 import rugby.model._
 
 import scala.collection.immutable
@@ -13,7 +13,7 @@ class RugbyStatsJob(feed: RugbyFeed) extends GuLogging {
   protected val matchNavContent = Box[Map[String, MatchNavigation]](Map.empty)
   protected val pastScoreEvents = Box[Map[String, Seq[ScoreEvent]]](Map.empty)
   protected val pastMatchesStat = Box[Map[String, MatchStat]](Map.empty)
-  protected val groupTables = Box[Map[Event, Seq[GroupTable]]](Map.empty)
+  protected val groupTables = Box[Map[RugbyEvent, Seq[GroupTable]]](Map.empty)
 
   val dateFormat: DateTimeFormatter = DateTimeFormat.forPattern("yyyy/MM/dd")
 

--- a/sport/app/rugby/model/rugby.scala
+++ b/sport/app/rugby/model/rugby.scala
@@ -2,7 +2,8 @@ package rugby.model
 
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-import rugby.feed.Event
+import play.api.libs.json._
+import rugby.feed.RugbyEvent
 import rugby.model.Status._
 
 case class Match(
@@ -13,9 +14,10 @@ case class Match(
     venue: Option[String],
     competitionName: String,
     status: Status,
-    event: Event, // TODO rename to just RugbyEvent (as will soon be PA)
+    event: RugbyEvent,
     stage: Stage.Value,
 ) {
+
   def hasTeam(teamId: String): Boolean = homeTeam.id == teamId || awayTeam.id == teamId
 
   lazy val hasGroupTable = event.hasGroupTable(stage)
@@ -52,9 +54,20 @@ object Stage extends Enumeration(1) {
   type Stage = Value
   val Group, KnockOut = Value
 }
-
 object Match {
   val dateFormat: DateTimeFormatter = DateTimeFormat.forPattern("yyyy/MM/dd").withZoneUTC()
+  implicit val writes: OWrites[Match] = (m: Match) =>
+    Json.obj(
+      "date" -> dateFormat.print(m.date),
+      "id" -> m.id,
+      "homeTeam" -> m.homeTeam,
+      "awayTeam" -> m.awayTeam,
+      "venue" -> m.venue,
+      "competitionName" -> m.competitionName,
+      "status" -> m.status,
+      "event" -> m.event,
+      "stage" -> m.stage,
+    )
 }
 
 case class Team(
@@ -62,19 +75,27 @@ case class Team(
     name: String,
     score: Option[Int] = None,
 )
+object Team {
+  implicit val writes: OWrites[Team] = Json.writes[Team]
+}
 
 case class Player(
     id: String,
     name: String,
     team: Team,
 )
+object Player {
+  implicit val writes: OWrites[Player] = Json.writes[Player]
+}
 
 case class ScoreEvent(
     player: Player,
     minute: String,
     `type`: ScoreType.Value,
 )
-
+object ScoreEvent {
+  implicit val writes: OWrites[ScoreEvent] = Json.writes[ScoreEvent]
+}
 object ScoreType extends Enumeration {
   val `Try` = Value("Try")
   val Conversion = Value("Conversion")
@@ -86,27 +107,25 @@ object ScoreType extends Enumeration {
 trait Status
 
 object Status {
-  object Result extends Status // The match is finished
-  object Postponed extends Status // The match has been postponed before kick off
-  object Abandoned extends Status // The match started but has been abandoned before it was completed
-  object Fixture extends Status // The match has not started
-  object TeamIn extends Status // The teams for the match have been announced and are in the feed
-  object FirstHalf extends Status // The match is in progress in the first half
-  object HalfTime extends Status // The match is at half time
-  object SecondHalf extends Status // The second half is being played
-  object FullTime
+  case object Result extends Status // The match is finished
+  case object Postponed extends Status // The match has been postponed before kick off
+  case object Abandoned extends Status // The match started but has been abandoned before it was completed
+  case object Fixture extends Status // The match has not started
+  case object TeamIn extends Status // The teams for the match have been announced and are in the feed
+  case object FirstHalf extends Status // The match is in progress in the first half
+  case object HalfTime extends Status // The match is at half time
+  case object SecondHalf extends Status // The second half is being played
+  case object FullTime
       extends Status // The game has finished the 80 minutes. Please not that this does not mean the match has finished as there may be extra time.
-  object ExtraTimeFirstHalf extends Status // The first half of extra time is being played
-  object ExtraTimeHalfTime extends Status // The first half of extra time has been played and it is at half time
-  object ExtraTimeSecondHalf extends Status // The second half of extra time is being played
-  object SuddenDeath
+  case object ExtraTimeFirstHalf extends Status // The first half of extra time is being played
+  case object ExtraTimeHalfTime extends Status // The first half of extra time has been played and it is at half time
+  case object ExtraTimeSecondHalf extends Status // The second half of extra time is being played
+  case object SuddenDeath
       extends Status // Occurs after extra time and essentially means the first point scorer in this period wins
-  object ShootOut extends Status // This is after sudden death and involves players taking drop kicks
-}
+  case object ShootOut extends Status // This is after sudden death and involves players taking drop kicks
 
-case class MatchStat(
-    teams: Seq[TeamStat],
-)
+  implicit val statusWrites: OWrites[Status] = OWrites(status => Json.obj("status" -> status.toString))
+}
 
 case class TeamStat(
     name: String,
@@ -149,11 +168,65 @@ case class TeamStat(
     scrums_lost: Int,
     scrums_total: Int,
 )
+object TeamStat {
+  implicit val writes: OWrites[TeamStat] = (ts: TeamStat) =>
+    Json.obj(
+      "name" -> ts.name,
+      "id" -> ts.id,
+      "possession" -> ts.possession,
+      "territory" -> ts.territory,
+      "carries_metres" -> ts.carries_metres,
+      "tackles" -> ts.tackles,
+      "missed_tackles" -> ts.missed_tackles,
+      "tackle_success" -> ts.tackle_success,
+      "turnover_won" -> ts.turnover_won,
+      "turnovers_conceded" -> ts.turnovers_conceded,
+      "lineouts_won" -> ts.lineouts_won,
+      "lineouts_lost" -> ts.lineouts_lost,
+      "mauls_won" -> ts.mauls_won,
+      "mauls_lost" -> ts.mauls_lost,
+      "mauls_total" -> ts.mauls_total,
+      "penalties_conceded" -> ts.penalties_conceded,
+      "penalty_conceded_dissent" -> ts.penalty_conceded_dissent,
+      "penalty_conceded_delib_knock_on" -> ts.penalty_conceded_delib_knock_on,
+      "penalty_conceded_early_tackle" -> ts.penalty_conceded_early_tackle,
+      "penalty_conceded_handling_in_ruck" -> ts.penalty_conceded_handling_in_ruck,
+      "penalty_conceded_high_tackle" -> ts.penalty_conceded_high_tackle,
+      "penalty_conceded_lineout_offence" -> ts.penalty_conceded_lineout_offence,
+      "penalty_conceded_collapsing" -> ts.penalty_conceded_collapsing,
+      "penalty_conceded_collapsing_maul" -> ts.penalty_conceded_collapsing_maul,
+      "penalty_conceded_collapsing_offence" -> ts.penalty_conceded_collapsing_offence,
+      "penalty_conceded_obstruction" -> ts.penalty_conceded_obstruction,
+      "penalty_conceded_offside" -> ts.penalty_conceded_offside,
+      "penalty_conceded_opp_half" -> ts.penalty_conceded_opp_half,
+      "penalty_conceded_own_half" -> ts.penalty_conceded_own_half,
+      "penalty_conceded_other" -> ts.penalty_conceded_other,
+      "penalty_conceded_scrum_offence" -> ts.penalty_conceded_scrum_offence,
+      "penalty_conceded_stamping" -> ts.penalty_conceded_stamping,
+      "penalty_conceded_wrong_side" -> ts.penalty_conceded_wrong_side,
+      "rucks_won" -> ts.rucks_won,
+      "rucks_lost" -> ts.rucks_lost,
+      "rucks_total" -> ts.rucks_total,
+      "scrums_won" -> ts.scrums_won,
+      "scrums_lost" -> ts.scrums_lost,
+      "scrums_total" -> ts.scrums_total,
+    )
+}
+case class MatchStat(
+    teams: Seq[TeamStat],
+)
+object MatchStat {
+  implicit val teamStatSeqWrites: Writes[Seq[TeamStat]] = Writes.seq(TeamStat.writes)
+  implicit val writes: OWrites[MatchStat] = Json.writes[MatchStat]
+}
 
 case class GroupTable(
     name: String,
     teams: Seq[TeamRank],
 )
+object GroupTable {
+  implicit val writes: OWrites[GroupTable] = Json.writes[GroupTable]
+}
 
 case class TeamRank(
     id: String,
@@ -166,3 +239,6 @@ case class TeamRank(
     pointsdiff: Int,
     points: Int,
 )
+object TeamRank {
+  implicit val writes: OWrites[TeamRank] = Json.writes[TeamRank]
+}


### PR DESCRIPTION
## What does this change?
Adds support to send json data  to DCR.
Similar PR here https://github.com/guardian/frontend/pull/24883
## Screenshots

<img width="900" alt="image" src="https://github.com/guardian/frontend/assets/110032454/b09b755a-c2a9-41aa-9683-d769ce8ab8d1">

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
