### PR TITLE
Increase prebid kargo test to 8%

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^16.3.0",
-		"@guardian/commercial": "12.1.0",
+		"@guardian/commercial": "12.1.1",
 		"@guardian/consent-management-platform": "13.7.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "1.1.1",

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-kargo.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-kargo.ts
@@ -5,7 +5,7 @@ export const prebidKargo: ABTest = {
 	author: '@commercial-dev',
 	start: '2023-12-05',
 	expiry: '2024-02-29',
-	audience: 4 / 100,
+	audience: 8 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'USA only',
 	successMeasure: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,10 +2428,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-16.3.0.tgz#77e2c550507d4e5b86029bce716a9a102d7cc136"
   integrity sha512-JQ9MkrJx6+7OXxwqPy2lfFNKvvmFGTCbdOedC2KczdLKusKUSWIw3EzLwdoRpgMTXsQSVpqrJ5N/VM3wDsAAxQ==
 
-"@guardian/commercial@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-12.1.0.tgz#4145ee167c43e12e209b7f5d387b785fc1438632"
-  integrity sha512-2x7kq5AifCAmnJ/hf67zxem/zXqC+/sSfdhkFbBgaZYxAQoXZlahr16o+lsmI0hVRk/V6V1ViVZ6csssslqnlA==
+"@guardian/commercial@12.1.1":
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-12.1.1.tgz#888f169ee23ffb74ae1628c3a75750b6dedc65d7"
+  integrity sha512-JHt1dl2tTytNThqn4vKB/Z9gGiYT1FIFRrbhBoAxJ3Ed580djEwwckddemAhBeMaladwd8PjhQrmBywidaMSsw==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@octokit/core" "^4.0.5"


### PR DESCRIPTION
## What does this change?
We increased from 2->4% recently but we're still not getting the data volumes that we expect for this test, if 8% doesn't do it we may need to dig deeper.
