### PR TITLE
Fix dev-build 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,6 +187,7 @@ val dev = application("dev-build")
   .settings(
     RoutesKeys.routesImport += "bindables._",
     Runtime / javaOptions += "-Dconfig.file=dev-build/conf/dev-build.application.conf",
+    dependencyOverrides ++= jackson,
   )
 
 val preview = application("preview")


### PR DESCRIPTION
## What is the value of this and can you measure success?
Fixes dev-build. 
```
[error] com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.13.2 requires Jackson Databind version >= 2.13.0 and < 2.14.0 - Found jackson-databind version 2.14.0
```
That was caused I think by this change https://github.com/guardian/frontend/blob/368191b9ccec8e2793b8d1b805c8156dd29f585b/build.sbt#L162
## What does this change?
Changes the jackson version for dependencyOverrides to dev application
## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
