### PR TITLE
Add nav link to US elections 2024

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -19,6 +19,7 @@ object NavLinks {
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = Some("US news"))
   val usPolitics = NavLink("US Politics", "/us-news/us-politics", longTitle = Some("US politics"))
+  val usElections2024 = NavLink("US elections 2024", "/us-news/us-elections-2024")
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")
@@ -307,9 +308,9 @@ object NavLinks {
   val usNewsPillar = ukNewsPillar.copy(children =
     List(
       usNews,
+      usElections2024,
       world,
       usEnvironment,
-      usPolitics,
       ukraine,
       soccer,
       usBusiness,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1,4286 +1,3468 @@
 {
-	"uk": {
-		"newsPillar": {
-			"title": "News",
-			"url": "/",
-			"longTitle": "Headlines",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "UK",
-					"url": "/uk-news",
-					"longTitle": "UK news",
-					"children": [
-						{
-							"title": "UK politics",
-							"url": "/politics",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Education",
-							"url": "/education",
-							"children": [
-								{
-									"title": "Schools",
-									"url": "/education/schools",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Teachers",
-									"url": "/teacher-network",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Universities",
-									"url": "/education/universities",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Students",
-									"url": "/education/students",
-									"children": [],
-									"classList": []
-								}
-							],
-							"classList": []
-						},
-						{
-							"title": "Media",
-							"url": "/media",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Society",
-							"url": "/society",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Law",
-							"url": "/law",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Scotland",
-							"url": "/uk/scotland",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Wales",
-							"url": "/uk/wales",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Northern Ireland",
-							"url": "/uk/northernireland",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "World",
-					"url": "/world",
-					"longTitle": "World news",
-					"children": [
-						{
-							"title": "Europe",
-							"url": "/world/europe-news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/us-news",
-							"longTitle": "US news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Americas",
-							"url": "/world/americas",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Asia",
-							"url": "/world/asia",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Australia",
-							"url": "/australia-news",
-							"longTitle": "Australia news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Middle East",
-							"url": "/world/middleeast",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Africa",
-							"url": "/world/africa",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Inequality",
-							"url": "/inequality",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Global development",
-							"url": "/global-development",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Climate crisis",
-					"url": "/environment/climate-crisis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Ukraine",
-					"url": "/world/ukraine",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Football",
-					"url": "/football",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Fixtures",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Newsletters",
-					"url": "/email-newsletters",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Business",
-					"url": "/business",
-					"children": [
-						{
-							"title": "Economics",
-							"url": "/business/economics",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Banking",
-							"url": "/business/banking",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Money",
-							"url": "/money",
-							"children": [
-								{
-									"title": "Property",
-									"url": "/money/property",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Pensions",
-									"url": "/money/pensions",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Savings",
-									"url": "/money/savings",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Borrowing",
-									"url": "/money/debt",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Careers",
-									"url": "/money/work-and-careers",
-									"children": [],
-									"classList": []
-								}
-							],
-							"classList": []
-						},
-						{
-							"title": "Markets",
-							"url": "/business/stock-markets",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Project Syndicate",
-							"url": "/business/series/project-syndicate-economists",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "B2B",
-							"url": "/business-to-business",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Retail",
-							"url": "/business/retail",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Environment",
-					"url": "/environment",
-					"children": [
-						{
-							"title": "Climate crisis",
-							"url": "/environment/climate-crisis",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Wildlife",
-							"url": "/environment/wildlife",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Energy",
-							"url": "/environment/energy",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pollution",
-							"url": "/environment/pollution",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "UK politics",
-					"url": "/politics",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Education",
-					"url": "/education",
-					"children": [
-						{
-							"title": "Schools",
-							"url": "/education/schools",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Teachers",
-							"url": "/teacher-network",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Universities",
-							"url": "/education/universities",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Students",
-							"url": "/education/students",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Society",
-					"url": "/society",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Science",
-					"url": "/science",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Tech",
-					"url": "/technology",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Global development",
-					"url": "/global-development",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Obituaries",
-					"url": "/obituaries",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"opinionPillar": {
-			"title": "Opinion",
-			"url": "/commentisfree",
-			"longTitle": "Opinion home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "The Guardian view",
-					"url": "/profile/editorial",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Columnists",
-					"url": "/index/contributors",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cartoons",
-					"url": "/tone/cartoons",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Opinion videos",
-					"url": "/type/video+tone/comment",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Letters",
-					"url": "/tone/letters",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"sportPillar": {
-			"title": "Sport",
-			"url": "/sport",
-			"longTitle": "Sport home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Football",
-					"url": "/football",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Fixtures",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Cricket",
-					"url": "/sport/cricket",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Rugby union",
-					"url": "/sport/rugby-union",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Tennis",
-					"url": "/sport/tennis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cycling",
-					"url": "/sport/cycling",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "F1",
-					"url": "/sport/formulaone",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Golf",
-					"url": "/sport/golf",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Boxing",
-					"url": "/sport/boxing",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Rugby league",
-					"url": "/sport/rugbyleague",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Racing",
-					"url": "/sport/horse-racing",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "US sports",
-					"url": "/sport/us-sport",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"culturePillar": {
-			"title": "Culture",
-			"url": "/culture",
-			"longTitle": "Culture home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Film",
-					"url": "/film",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Music",
-					"url": "/music",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "TV & radio",
-					"url": "/tv-and-radio",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Books",
-					"url": "/books",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Art & design",
-					"url": "/artanddesign",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Stage",
-					"url": "/stage",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Games",
-					"url": "/games",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"lifestylePillar": {
-			"title": "Lifestyle",
-			"url": "/lifeandstyle",
-			"longTitle": "Lifestyle home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Fashion",
-					"url": "/fashion",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Food",
-					"url": "/food",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Recipes",
-					"url": "/tone/recipes",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Travel",
-					"url": "/travel",
-					"children": [
-						{
-							"title": "UK",
-							"url": "/travel/uk",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Europe",
-							"url": "/travel/europe",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/travel/usa",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Health & fitness",
-					"url": "/lifeandstyle/health-and-wellbeing",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Women",
-					"url": "/lifeandstyle/women",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Men",
-					"url": "/lifeandstyle/men",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Love & sex",
-					"url": "/lifeandstyle/love-and-sex",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Beauty",
-					"url": "/fashion/beauty",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Home & garden",
-					"url": "/lifeandstyle/home-and-garden",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Money",
-					"url": "/money",
-					"children": [
-						{
-							"title": "Property",
-							"url": "/money/property",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pensions",
-							"url": "/money/pensions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Savings",
-							"url": "/money/savings",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Borrowing",
-							"url": "/money/debt",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Careers",
-							"url": "/money/work-and-careers",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Cars",
-					"url": "/technology/motoring",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"otherLinks": [
-			{
-				"title": "The Guardian app",
-				"url": "https://app.adjust.com/16xt6hai",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Video",
-				"url": "/video",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Podcasts",
-				"url": "/podcasts",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Pictures",
-				"url": "/inpictures",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Newsletters",
-				"url": "/email-newsletters",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Today's paper",
-				"url": "/theguardian",
-				"children": [
-					{
-						"title": "Obituaries",
-						"url": "/obituaries",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "G2",
-						"url": "/theguardian/g2",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Journal",
-						"url": "/theguardian/journal",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Saturday",
-						"url": "/theguardian/saturday",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Inside the Guardian",
-				"url": "https://www.theguardian.com/membership",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "The Observer",
-				"url": "/observer",
-				"children": [
-					{
-						"title": "Comment",
-						"url": "/theobserver/news/comment",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "The New Review",
-						"url": "/theobserver/new-review",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Magazine",
-						"url": "/theobserver/magazine",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Food Monthly",
-						"url": "/theobserver/foodmonthly",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Guardian Weekly",
-				"url": "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Crosswords",
-				"url": "/crosswords",
-				"children": [
-					{
-						"title": "Blog",
-						"url": "/crosswords/crossword-blog",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quick",
-						"url": "/crosswords/series/quick",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Cryptic",
-						"url": "/crosswords/series/cryptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Prize",
-						"url": "/crosswords/series/prize",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Weekend",
-						"url": "/crosswords/series/weekend-crossword",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quiptic",
-						"url": "/crosswords/series/quiptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Genius",
-						"url": "/crosswords/series/genius",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Speedy",
-						"url": "/crosswords/series/speedy",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Everyman",
-						"url": "/crosswords/series/everyman",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Azed",
-						"url": "/crosswords/series/azed",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Wordiply",
-				"url": "https://www.wordiply.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Corrections",
-				"url": "/theguardian/series/corrections-and-clarifications",
-				"children": [],
-				"classList": []
-			}
-		],
-		"brandExtensions": [
-			{
-				"title": "Search jobs",
-				"url": "https://jobs.theguardian.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Hire with Guardian Jobs",
-				"url": "https://recruiters.theguardian.com/?utm_source=gdnwb&utm_medium=navbar&utm_campaign=Guardian_Navbar_Recruiters&CMP_TU=trdmkt&CMP_BUNIT=jobs",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Holidays",
-				"url": "https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Live events",
-				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "About Us",
-				"url": "/about",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Digital Archive",
-				"url": "https://theguardian.newspapers.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Print Shop",
-				"url": "/artanddesign/series/gnm-print-sales",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Patrons",
-				"url": "https://patrons.theguardian.com/?INTCMP=header_patrons",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Puzzles app",
-				"url": "https://puzzles.theguardian.com/download",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Licensing",
-				"url": "https://licensing.theguardian.com/",
-				"children": [],
-				"classList": []
-			}
-		]
-	},
-	"us": {
-		"newsPillar": {
-			"title": "News",
-			"url": "/",
-			"longTitle": "Headlines",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "US",
-					"url": "/us-news",
-					"longTitle": "US news",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "World",
-					"url": "/world",
-					"longTitle": "World news",
-					"children": [
-						{
-							"title": "Europe",
-							"url": "/world/europe-news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/us-news",
-							"longTitle": "US news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Americas",
-							"url": "/world/americas",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Asia",
-							"url": "/world/asia",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Australia",
-							"url": "/australia-news",
-							"longTitle": "Australia news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Middle East",
-							"url": "/world/middleeast",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Africa",
-							"url": "/world/africa",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Inequality",
-							"url": "/inequality",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Global development",
-							"url": "/global-development",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Environment",
-					"url": "/environment",
-					"children": [
-						{
-							"title": "Climate crisis",
-							"url": "/environment/climate-crisis",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Wildlife",
-							"url": "/environment/wildlife",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Energy",
-							"url": "/environment/energy",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pollution",
-							"url": "/environment/pollution",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Green light",
-							"url": "/environment/series/green-light",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "US Politics",
-					"url": "/us-news/us-politics",
-					"longTitle": "US politics",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Ukraine",
-					"url": "/world/ukraine",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Soccer",
-					"url": "/soccer",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Schedules",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Business",
-					"url": "/business",
-					"children": [
-						{
-							"title": "Economics",
-							"url": "/business/economics",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Diversity & equality in business",
-							"url": "/business/diversity-and-equality",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Small business",
-							"url": "/business/us-small-business",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Retail",
-							"url": "/business/retail",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Tech",
-					"url": "/technology",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Science",
-					"url": "/science",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Newsletters",
-					"url": "/email-newsletters",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Wellness",
-					"url": "/wellness",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"opinionPillar": {
-			"title": "Opinion",
-			"url": "/commentisfree",
-			"longTitle": "Opinion home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "The Guardian view",
-					"url": "/profile/editorial",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Columnists",
-					"url": "/index/contributors",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Letters",
-					"url": "/tone/letters",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Opinion videos",
-					"url": "/type/video+tone/comment",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cartoons",
-					"url": "/tone/cartoons",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"sportPillar": {
-			"title": "Sport",
-			"url": "/sport",
-			"longTitle": "Sport home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Soccer",
-					"url": "/soccer",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Schedules",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "NFL",
-					"url": "/sport/nfl",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Tennis",
-					"url": "/sport/tennis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "MLB",
-					"url": "/sport/mlb",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "MLS",
-					"url": "/football/mls",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "NBA",
-					"url": "/sport/nba",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "NHL",
-					"url": "/sport/nhl",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "F1",
-					"url": "/sport/formulaone",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Golf",
-					"url": "/sport/golf",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"culturePillar": {
-			"title": "Culture",
-			"url": "/culture",
-			"longTitle": "Culture home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Film",
-					"url": "/film",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Books",
-					"url": "/books",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Music",
-					"url": "/music",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Art & design",
-					"url": "/artanddesign",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "TV & radio",
-					"url": "/tv-and-radio",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Stage",
-					"url": "/stage",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Games",
-					"url": "/games",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"lifestylePillar": {
-			"title": "Lifestyle",
-			"url": "/lifeandstyle",
-			"longTitle": "Lifestyle home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Wellness",
-					"url": "/wellness",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Fashion",
-					"url": "/fashion",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Food",
-					"url": "/food",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Recipes",
-					"url": "/tone/recipes",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Love & sex",
-					"url": "/lifeandstyle/love-and-sex",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Home & garden",
-					"url": "/lifeandstyle/home-and-garden",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Health & fitness",
-					"url": "/lifeandstyle/health-and-wellbeing",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Family",
-					"url": "/lifeandstyle/family",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Travel",
-					"url": "/travel",
-					"children": [
-						{
-							"title": "US",
-							"url": "/travel/usa",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Europe",
-							"url": "/travel/europe",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "UK",
-							"url": "/travel/uk",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Money",
-					"url": "/money",
-					"children": [
-						{
-							"title": "Property",
-							"url": "/money/property",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pensions",
-							"url": "/money/pensions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Savings",
-							"url": "/money/savings",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Borrowing",
-							"url": "/money/debt",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Careers",
-							"url": "/money/work-and-careers",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"otherLinks": [
-			{
-				"title": "The Guardian app",
-				"url": "https://app.adjust.com/16xt6hai",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Video",
-				"url": "/video",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Podcasts",
-				"url": "/podcasts",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Pictures",
-				"url": "/inpictures",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Inside the Guardian",
-				"url": "https://www.theguardian.com/membership",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Weekly",
-				"url": "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_US",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Crosswords",
-				"url": "/crosswords",
-				"children": [
-					{
-						"title": "Blog",
-						"url": "/crosswords/crossword-blog",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quick",
-						"url": "/crosswords/series/quick",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Cryptic",
-						"url": "/crosswords/series/cryptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Prize",
-						"url": "/crosswords/series/prize",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Weekend",
-						"url": "/crosswords/series/weekend-crossword",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quiptic",
-						"url": "/crosswords/series/quiptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Genius",
-						"url": "/crosswords/series/genius",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Speedy",
-						"url": "/crosswords/series/speedy",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Everyman",
-						"url": "/crosswords/series/everyman",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Azed",
-						"url": "/crosswords/series/azed",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Wordiply",
-				"url": "https://www.wordiply.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Corrections",
-				"url": "/theguardian/series/corrections-and-clarifications",
-				"children": [],
-				"classList": []
-			}
-		],
-		"brandExtensions": [
-			{
-				"title": "Search jobs",
-				"url": "https://jobs.theguardian.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Digital Archive",
-				"url": "https://theguardian.newspapers.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Puzzles app",
-				"url": "https://puzzles.theguardian.com/download",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Licensing",
-				"url": "https://licensing.theguardian.com/",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "About Us",
-				"url": "/about",
-				"children": [],
-				"classList": []
-			}
-		]
-	},
-	"au": {
-		"newsPillar": {
-			"title": "News",
-			"url": "/",
-			"longTitle": "Headlines",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Australia",
-					"url": "/australia-news",
-					"longTitle": "Australia news",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "World",
-					"url": "/world",
-					"longTitle": "World news",
-					"children": [
-						{
-							"title": "Europe",
-							"url": "/world/europe-news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/us-news",
-							"longTitle": "US news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Americas",
-							"url": "/world/americas",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Asia",
-							"url": "/world/asia",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Australia",
-							"url": "/australia-news",
-							"longTitle": "Australia news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Middle East",
-							"url": "/world/middleeast",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Africa",
-							"url": "/world/africa",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Inequality",
-							"url": "/inequality",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Global development",
-							"url": "/global-development",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "AU politics",
-					"url": "/australia-news/australian-politics",
-					"longTitle": "Politics",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Environment",
-					"url": "/environment",
-					"children": [
-						{
-							"title": "Climate crisis",
-							"url": "/environment/climate-crisis",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Energy",
-							"url": "/environment/energy",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Wildlife",
-							"url": "/environment/wildlife",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Biodiversity",
-							"url": "/environment/biodiversity",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Oceans",
-							"url": "/environment/oceans",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pollution",
-							"url": "/environment/pollution",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Great Barrier Reef",
-							"url": "/environment/great-barrier-reef",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Climate crisis",
-					"url": "/environment/climate-crisis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Indigenous Australia",
-					"url": "/australia-news/indigenous-australians",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Immigration",
-					"url": "/australia-news/australian-immigration-and-asylum",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Media",
-					"url": "/media",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Business",
-					"url": "/business",
-					"children": [
-						{
-							"title": "Markets",
-							"url": "/business/stock-markets",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Money",
-							"url": "/money",
-							"children": [
-								{
-									"title": "Property",
-									"url": "/money/property",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Pensions",
-									"url": "/money/pensions",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Savings",
-									"url": "/money/savings",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Borrowing",
-									"url": "/money/debt",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Careers",
-									"url": "/money/work-and-careers",
-									"children": [],
-									"classList": []
-								}
-							],
-							"classList": []
-						},
-						{
-							"title": "Project Syndicate",
-							"url": "/business/series/project-syndicate-economists",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Retail",
-							"url": "/business/retail",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Science",
-					"url": "/science",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Tech",
-					"url": "/technology",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Podcasts",
-					"url": "/australia-podcasts",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Newsletters",
-					"url": "/email-newsletters",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"opinionPillar": {
-			"title": "Opinion",
-			"url": "/commentisfree",
-			"longTitle": "Opinion home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Columnists",
-					"url": "/au/index/contributors",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cartoons",
-					"url": "/tone/cartoons",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Indigenous",
-					"url": "/commentisfree/series/indigenousx",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Editorials",
-					"url": "/profile/editorial",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Letters",
-					"url": "/tone/letters",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"sportPillar": {
-			"title": "Sport",
-			"url": "/sport",
-			"longTitle": "Sport home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Football",
-					"url": "/football",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Fixtures",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "AFL",
-					"url": "/sport/afl",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "NRL",
-					"url": "/sport/nrl",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "A-League",
-					"url": "/football/a-league",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cricket",
-					"url": "/sport/cricket",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Rugby union",
-					"url": "/sport/rugby-union",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Tennis",
-					"url": "/sport/tennis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cycling",
-					"url": "/sport/cycling",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "F1",
-					"url": "/sport/formulaone",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"culturePillar": {
-			"title": "Culture",
-			"url": "/culture",
-			"longTitle": "Culture home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Film",
-					"url": "/film",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Music",
-					"url": "/music",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Books",
-					"url": "/books",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "TV & radio",
-					"url": "/tv-and-radio",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Art & design",
-					"url": "/artanddesign",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Stage",
-					"url": "/stage",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Games",
-					"url": "/games",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"lifestylePillar": {
-			"title": "Lifestyle",
-			"url": "/lifeandstyle",
-			"longTitle": "Lifestyle home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Travel",
-					"url": "/travel",
-					"children": [
-						{
-							"title": "Australasia",
-							"url": "/travel/australasia",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Asia",
-							"url": "/travel/asia",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "UK",
-							"url": "/travel/uk",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Europe",
-							"url": "/travel/europe",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/travel/usa",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Food",
-					"url": "/au/food",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Relationships",
-					"url": "/au/lifeandstyle/relationships",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Fashion",
-					"url": "/au/lifeandstyle/fashion",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Health & fitness",
-					"url": "/au/lifeandstyle/health-and-wellbeing",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Love & sex",
-					"url": "/lifeandstyle/love-and-sex",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Family",
-					"url": "/lifeandstyle/family",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Home & garden",
-					"url": "/lifeandstyle/home-and-garden",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"otherLinks": [
-			{
-				"title": "The Guardian app",
-				"url": "https://app.adjust.com/16xt6hai",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Video",
-				"url": "/video",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Podcasts",
-				"url": "/australia-podcasts",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Pictures",
-				"url": "/inpictures",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Newsletters",
-				"url": "/email-newsletters",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Inside the Guardian",
-				"url": "https://www.theguardian.com/membership",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Weekly",
-				"url": "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Aus",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Crosswords",
-				"url": "/crosswords",
-				"children": [
-					{
-						"title": "Blog",
-						"url": "/crosswords/crossword-blog",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quick",
-						"url": "/crosswords/series/quick",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Cryptic",
-						"url": "/crosswords/series/cryptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Prize",
-						"url": "/crosswords/series/prize",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Weekend",
-						"url": "/crosswords/series/weekend-crossword",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quiptic",
-						"url": "/crosswords/series/quiptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Genius",
-						"url": "/crosswords/series/genius",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Speedy",
-						"url": "/crosswords/series/speedy",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Everyman",
-						"url": "/crosswords/series/everyman",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Azed",
-						"url": "/crosswords/series/azed",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Wordiply",
-				"url": "https://www.wordiply.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Corrections",
-				"url": "/theguardian/series/corrections-and-clarifications",
-				"children": [],
-				"classList": []
-			}
-		],
-		"brandExtensions": [
-			{
-				"title": "Events",
-				"url": "/guardian-live-australia",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Digital Archive",
-				"url": "https://theguardian.newspapers.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Puzzles app",
-				"url": "https://puzzles.theguardian.com/download",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Australia Weekend",
-				"url": "/info/ng-interactive/2021/mar/17/make-sense-of-the-week-with-australia-weekend?INTCMP=header_au_weekend",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Licensing",
-				"url": "https://licensing.theguardian.com/",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "About Us",
-				"url": "/about",
-				"children": [],
-				"classList": []
-			}
-		]
-	},
-	"europe": {
-		"newsPillar": {
-			"title": "News",
-			"url": "/",
-			"longTitle": "Headlines",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "World",
-					"url": "/world",
-					"longTitle": "World news",
-					"children": [
-						{
-							"title": "Europe",
-							"url": "/world/europe-news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/us-news",
-							"longTitle": "US news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Americas",
-							"url": "/world/americas",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Asia",
-							"url": "/world/asia",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Australia",
-							"url": "/australia-news",
-							"longTitle": "Australia news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Middle East",
-							"url": "/world/middleeast",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Africa",
-							"url": "/world/africa",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Inequality",
-							"url": "/inequality",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Global development",
-							"url": "/global-development",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "UK",
-					"url": "/uk-news",
-					"longTitle": "UK news",
-					"children": [
-						{
-							"title": "UK politics",
-							"url": "/politics",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Education",
-							"url": "/education",
-							"children": [
-								{
-									"title": "Schools",
-									"url": "/education/schools",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Teachers",
-									"url": "/teacher-network",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Universities",
-									"url": "/education/universities",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Students",
-									"url": "/education/students",
-									"children": [],
-									"classList": []
-								}
-							],
-							"classList": []
-						},
-						{
-							"title": "Media",
-							"url": "/media",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Society",
-							"url": "/society",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Law",
-							"url": "/law",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Scotland",
-							"url": "/uk/scotland",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Wales",
-							"url": "/uk/wales",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Northern Ireland",
-							"url": "/uk/northernireland",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Climate crisis",
-					"url": "/environment/climate-crisis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Ukraine",
-					"url": "/world/ukraine",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Environment",
-					"url": "/environment",
-					"children": [
-						{
-							"title": "Climate crisis",
-							"url": "/environment/climate-crisis",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Wildlife",
-							"url": "/environment/wildlife",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Energy",
-							"url": "/environment/energy",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pollution",
-							"url": "/environment/pollution",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Science",
-					"url": "/science",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Global development",
-					"url": "/global-development",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Football",
-					"url": "/football",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Fixtures",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Tech",
-					"url": "/technology",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Business",
-					"url": "/business",
-					"children": [
-						{
-							"title": "Economics",
-							"url": "/business/economics",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Banking",
-							"url": "/business/banking",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Money",
-							"url": "/money",
-							"children": [
-								{
-									"title": "Property",
-									"url": "/money/property",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Pensions",
-									"url": "/money/pensions",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Savings",
-									"url": "/money/savings",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Borrowing",
-									"url": "/money/debt",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Careers",
-									"url": "/money/work-and-careers",
-									"children": [],
-									"classList": []
-								}
-							],
-							"classList": []
-						},
-						{
-							"title": "Markets",
-							"url": "/business/stock-markets",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Project Syndicate",
-							"url": "/business/series/project-syndicate-economists",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "B2B",
-							"url": "/business-to-business",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Retail",
-							"url": "/business/retail",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Obituaries",
-					"url": "/obituaries",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"opinionPillar": {
-			"title": "Opinion",
-			"url": "/commentisfree",
-			"longTitle": "Opinion home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "The Guardian view",
-					"url": "/profile/editorial",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Columnists",
-					"url": "/index/contributors",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cartoons",
-					"url": "/tone/cartoons",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Opinion videos",
-					"url": "/type/video+tone/comment",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Letters",
-					"url": "/tone/letters",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"sportPillar": {
-			"title": "Sport",
-			"url": "/sport",
-			"longTitle": "Sport home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Football",
-					"url": "/football",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Fixtures",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Cricket",
-					"url": "/sport/cricket",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Rugby union",
-					"url": "/sport/rugby-union",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Tennis",
-					"url": "/sport/tennis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cycling",
-					"url": "/sport/cycling",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "F1",
-					"url": "/sport/formulaone",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Golf",
-					"url": "/sport/golf",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "US sports",
-					"url": "/sport/us-sport",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"culturePillar": {
-			"title": "Culture",
-			"url": "/culture",
-			"longTitle": "Culture home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Books",
-					"url": "/books",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Music",
-					"url": "/music",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "TV & radio",
-					"url": "/tv-and-radio",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Art & design",
-					"url": "/artanddesign",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Film",
-					"url": "/film",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Games",
-					"url": "/games",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Stage",
-					"url": "/stage",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"lifestylePillar": {
-			"title": "Lifestyle",
-			"url": "/lifeandstyle",
-			"longTitle": "Lifestyle home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Fashion",
-					"url": "/fashion",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Food",
-					"url": "/food",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Recipes",
-					"url": "/tone/recipes",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Love & sex",
-					"url": "/lifeandstyle/love-and-sex",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Health & fitness",
-					"url": "/lifeandstyle/health-and-wellbeing",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Home & garden",
-					"url": "/lifeandstyle/home-and-garden",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Women",
-					"url": "/lifeandstyle/women",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Men",
-					"url": "/lifeandstyle/men",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Family",
-					"url": "/lifeandstyle/family",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Travel",
-					"url": "/travel",
-					"children": [
-						{
-							"title": "UK",
-							"url": "/travel/uk",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Europe",
-							"url": "/travel/europe",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/travel/usa",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Money",
-					"url": "/money",
-					"children": [
-						{
-							"title": "Property",
-							"url": "/money/property",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pensions",
-							"url": "/money/pensions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Savings",
-							"url": "/money/savings",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Borrowing",
-							"url": "/money/debt",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Careers",
-							"url": "/money/work-and-careers",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"otherLinks": [
-			{
-				"title": "The Guardian app",
-				"url": "https://app.adjust.com/16xt6hai",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Video",
-				"url": "/video",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Podcasts",
-				"url": "/podcasts",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Pictures",
-				"url": "/inpictures",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Newsletters",
-				"url": "/email-newsletters",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Today's paper",
-				"url": "/theguardian",
-				"children": [
-					{
-						"title": "Obituaries",
-						"url": "/obituaries",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "G2",
-						"url": "/theguardian/g2",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Journal",
-						"url": "/theguardian/journal",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Saturday",
-						"url": "/theguardian/saturday",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Inside the Guardian",
-				"url": "https://www.theguardian.com/membership",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "The Observer",
-				"url": "/observer",
-				"children": [
-					{
-						"title": "Comment",
-						"url": "/theobserver/news/comment",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "The New Review",
-						"url": "/theobserver/new-review",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Magazine",
-						"url": "/theobserver/magazine",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Food Monthly",
-						"url": "/theobserver/foodmonthly",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Guardian Weekly",
-				"url": "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Crosswords",
-				"url": "/crosswords",
-				"children": [
-					{
-						"title": "Blog",
-						"url": "/crosswords/crossword-blog",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quick",
-						"url": "/crosswords/series/quick",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Cryptic",
-						"url": "/crosswords/series/cryptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Prize",
-						"url": "/crosswords/series/prize",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Weekend",
-						"url": "/crosswords/series/weekend-crossword",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quiptic",
-						"url": "/crosswords/series/quiptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Genius",
-						"url": "/crosswords/series/genius",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Speedy",
-						"url": "/crosswords/series/speedy",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Everyman",
-						"url": "/crosswords/series/everyman",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Azed",
-						"url": "/crosswords/series/azed",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Wordiply",
-				"url": "https://www.wordiply.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Corrections",
-				"url": "/theguardian/series/corrections-and-clarifications",
-				"children": [],
-				"classList": []
-			}
-		],
-		"brandExtensions": [
-			{
-				"title": "Search jobs",
-				"url": "https://jobs.theguardian.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Holidays",
-				"url": "https://holidays.theguardian.com?INTCMP=holidays_int_web_newheader",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Digital Archive",
-				"url": "https://theguardian.newspapers.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Puzzles app",
-				"url": "https://puzzles.theguardian.com/download",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Licensing",
-				"url": "https://licensing.theguardian.com/",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "About Us",
-				"url": "/about",
-				"children": [],
-				"classList": []
-			}
-		]
-	},
-	"tagPages": [
-		"us-news/us-politics",
-		"australia-news/australian-politics",
-		"australia-news/australian-immigration-and-asylum",
-		"australia-news/indigenous-australians",
-		"uk/scotland",
-		"uk/wales",
-		"uk/northernireland",
-		"world/europe-news",
-		"world/americas",
-		"world/asia",
-		"world/africa",
-		"world/middleeast",
-		"business/economics",
-		"business/banking",
-		"business/retail",
-		"business/stock-markets",
-		"business/eurozone",
-		"business/diversity-and-equality",
-		"business/us-small-business",
-		"environment/climate-change",
-		"environment/climate-crisis",
-		"environment/wildlife",
-		"environment/energy",
-		"environment/pollution",
-		"money/property",
-		"money/pensions",
-		"money/savings",
-		"money/debt",
-		"money/work-and-careers",
-		"tone/cartoons",
-		"type/cartoon",
-		"profile/editorial",
-		"au/index/contributors",
-		"index/contributors",
-		"commentisfree/series/comment-is-free-weekly",
-		"sport/rugby-union",
-		"sport/cricket",
-		"sport/tennis",
-		"sport/cycling",
-		"sport/golf",
-		"sport/us-sport",
-		"sport/horse-racing",
-		"sport/rugbyleague",
-		"sport/boxing",
-		"sport/formulaone",
-		"sport/nfl",
-		"sport/mlb",
-		"football/mls",
-		"sport/nba",
-		"sport/nhl",
-		"sport/afl",
-		"football/a-league",
-		"sport/nrl",
-		"music/classicalmusicandopera",
-		"food",
-		"tone/recipes",
-		"lifeandstyle/health-and-wellbeing",
-		"lifeandstyle/family",
-		"lifeandstyle/home-and-garden",
-		"lifeandstyle/love-and-sex",
-		"au/lifeandstyle/fashion",
-		"au/lifeandstyle/food-and-drink",
-		"au/lifeandstyle/relationships",
-		"au/lifeandstyle/health-and-wellbeing",
-		"travel/uk",
-		"travel/europe",
-		"travel/usa",
-		"travel/skiing",
-		"travel/australasia",
-		"travel/asia",
-		"theguardian",
-		"observer",
-		"football/live",
-		"football/tables",
-		"football/competitions",
-		"football/results",
-		"football/fixtures",
-		"crosswords/crossword-blog",
-		"crosswords/series/crossword-editor-update",
-		"crosswords/series/quick",
-		"crosswords/series/cryptic",
-		"crosswords/series/prize",
-		"crosswords/series/weekend-crossword",
-		"crosswords/series/quiptic",
-		"crosswords/series/genius",
-		"crosswords/series/speedy",
-		"crosswords/series/everyman",
-		"crosswords/series/azed",
-		"fashion/beauty",
-		"technology/motoring",
-		"commentisfree/commentisfree",
-		"education/education"
-	],
-	"international": {
-		"newsPillar": {
-			"title": "News",
-			"url": "/",
-			"longTitle": "Headlines",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "World",
-					"url": "/world",
-					"longTitle": "World news",
-					"children": [
-						{
-							"title": "Europe",
-							"url": "/world/europe-news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/us-news",
-							"longTitle": "US news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Americas",
-							"url": "/world/americas",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Asia",
-							"url": "/world/asia",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Australia",
-							"url": "/australia-news",
-							"longTitle": "Australia news",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Middle East",
-							"url": "/world/middleeast",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Africa",
-							"url": "/world/africa",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Inequality",
-							"url": "/inequality",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Global development",
-							"url": "/global-development",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "UK",
-					"url": "/uk-news",
-					"longTitle": "UK news",
-					"children": [
-						{
-							"title": "UK politics",
-							"url": "/politics",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Education",
-							"url": "/education",
-							"children": [
-								{
-									"title": "Schools",
-									"url": "/education/schools",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Teachers",
-									"url": "/teacher-network",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Universities",
-									"url": "/education/universities",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Students",
-									"url": "/education/students",
-									"children": [],
-									"classList": []
-								}
-							],
-							"classList": []
-						},
-						{
-							"title": "Media",
-							"url": "/media",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Society",
-							"url": "/society",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Law",
-							"url": "/law",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Scotland",
-							"url": "/uk/scotland",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Wales",
-							"url": "/uk/wales",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Northern Ireland",
-							"url": "/uk/northernireland",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Climate crisis",
-					"url": "/environment/climate-crisis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Ukraine",
-					"url": "/world/ukraine",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Environment",
-					"url": "/environment",
-					"children": [
-						{
-							"title": "Climate crisis",
-							"url": "/environment/climate-crisis",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Wildlife",
-							"url": "/environment/wildlife",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Energy",
-							"url": "/environment/energy",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pollution",
-							"url": "/environment/pollution",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Science",
-					"url": "/science",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Global development",
-					"url": "/global-development",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Football",
-					"url": "/football",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Fixtures",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Tech",
-					"url": "/technology",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Business",
-					"url": "/business",
-					"children": [
-						{
-							"title": "Economics",
-							"url": "/business/economics",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Banking",
-							"url": "/business/banking",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Money",
-							"url": "/money",
-							"children": [
-								{
-									"title": "Property",
-									"url": "/money/property",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Pensions",
-									"url": "/money/pensions",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Savings",
-									"url": "/money/savings",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Borrowing",
-									"url": "/money/debt",
-									"children": [],
-									"classList": []
-								},
-								{
-									"title": "Careers",
-									"url": "/money/work-and-careers",
-									"children": [],
-									"classList": []
-								}
-							],
-							"classList": []
-						},
-						{
-							"title": "Markets",
-							"url": "/business/stock-markets",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Project Syndicate",
-							"url": "/business/series/project-syndicate-economists",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "B2B",
-							"url": "/business-to-business",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Retail",
-							"url": "/business/retail",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Obituaries",
-					"url": "/obituaries",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"opinionPillar": {
-			"title": "Opinion",
-			"url": "/commentisfree",
-			"longTitle": "Opinion home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "The Guardian view",
-					"url": "/profile/editorial",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Columnists",
-					"url": "/index/contributors",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cartoons",
-					"url": "/tone/cartoons",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Opinion videos",
-					"url": "/type/video+tone/comment",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Letters",
-					"url": "/tone/letters",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"sportPillar": {
-			"title": "Sport",
-			"url": "/sport",
-			"longTitle": "Sport home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Football",
-					"url": "/football",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Fixtures",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Cricket",
-					"url": "/sport/cricket",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Rugby union",
-					"url": "/sport/rugby-union",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Tennis",
-					"url": "/sport/tennis",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Cycling",
-					"url": "/sport/cycling",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "F1",
-					"url": "/sport/formulaone",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Golf",
-					"url": "/sport/golf",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "US sports",
-					"url": "/sport/us-sport",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"culturePillar": {
-			"title": "Culture",
-			"url": "/culture",
-			"longTitle": "Culture home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Books",
-					"url": "/books",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Music",
-					"url": "/music",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "TV & radio",
-					"url": "/tv-and-radio",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Art & design",
-					"url": "/artanddesign",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Film",
-					"url": "/film",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Games",
-					"url": "/games",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Stage",
-					"url": "/stage",
-					"children": [],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"lifestylePillar": {
-			"title": "Lifestyle",
-			"url": "/lifeandstyle",
-			"longTitle": "Lifestyle home",
-			"iconName": "home",
-			"children": [
-				{
-					"title": "Fashion",
-					"url": "/fashion",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Food",
-					"url": "/food",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Recipes",
-					"url": "/tone/recipes",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Love & sex",
-					"url": "/lifeandstyle/love-and-sex",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Health & fitness",
-					"url": "/lifeandstyle/health-and-wellbeing",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Home & garden",
-					"url": "/lifeandstyle/home-and-garden",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Women",
-					"url": "/lifeandstyle/women",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Men",
-					"url": "/lifeandstyle/men",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Family",
-					"url": "/lifeandstyle/family",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Travel",
-					"url": "/travel",
-					"children": [
-						{
-							"title": "UK",
-							"url": "/travel/uk",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Europe",
-							"url": "/travel/europe",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "US",
-							"url": "/travel/usa",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				},
-				{
-					"title": "Money",
-					"url": "/money",
-					"children": [
-						{
-							"title": "Property",
-							"url": "/money/property",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Pensions",
-							"url": "/money/pensions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Savings",
-							"url": "/money/savings",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Borrowing",
-							"url": "/money/debt",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Careers",
-							"url": "/money/work-and-careers",
-							"children": [],
-							"classList": []
-						}
-					],
-					"classList": []
-				}
-			],
-			"classList": []
-		},
-		"otherLinks": [
-			{
-				"title": "The Guardian app",
-				"url": "https://app.adjust.com/16xt6hai",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Video",
-				"url": "/video",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Podcasts",
-				"url": "/podcasts",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Pictures",
-				"url": "/inpictures",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Newsletters",
-				"url": "/email-newsletters",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Today's paper",
-				"url": "/theguardian",
-				"children": [
-					{
-						"title": "Obituaries",
-						"url": "/obituaries",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "G2",
-						"url": "/theguardian/g2",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Journal",
-						"url": "/theguardian/journal",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Saturday",
-						"url": "/theguardian/saturday",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Inside the Guardian",
-				"url": "https://www.theguardian.com/membership",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "The Observer",
-				"url": "/observer",
-				"children": [
-					{
-						"title": "Comment",
-						"url": "/theobserver/news/comment",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "The New Review",
-						"url": "/theobserver/new-review",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Magazine",
-						"url": "/theobserver/magazine",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Food Monthly",
-						"url": "/theobserver/foodmonthly",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Guardian Weekly",
-				"url": "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Crosswords",
-				"url": "/crosswords",
-				"children": [
-					{
-						"title": "Blog",
-						"url": "/crosswords/crossword-blog",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quick",
-						"url": "/crosswords/series/quick",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Cryptic",
-						"url": "/crosswords/series/cryptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Prize",
-						"url": "/crosswords/series/prize",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Weekend",
-						"url": "/crosswords/series/weekend-crossword",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Quiptic",
-						"url": "/crosswords/series/quiptic",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Genius",
-						"url": "/crosswords/series/genius",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Speedy",
-						"url": "/crosswords/series/speedy",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Everyman",
-						"url": "/crosswords/series/everyman",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Azed",
-						"url": "/crosswords/series/azed",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
-				"title": "Wordiply",
-				"url": "https://www.wordiply.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Corrections",
-				"url": "/theguardian/series/corrections-and-clarifications",
-				"children": [],
-				"classList": []
-			}
-		],
-		"brandExtensions": [
-			{
-				"title": "Search jobs",
-				"url": "https://jobs.theguardian.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Holidays",
-				"url": "https://holidays.theguardian.com?INTCMP=holidays_int_web_newheader",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Digital Archive",
-				"url": "https://theguardian.newspapers.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Puzzles app",
-				"url": "https://puzzles.theguardian.com/download",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Guardian Licensing",
-				"url": "https://licensing.theguardian.com/",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "About Us",
-				"url": "/about",
-				"children": [],
-				"classList": []
-			}
-		]
-	}
+  "uk" : {
+    "newsPillar" : {
+      "title" : "News",
+      "url" : "/",
+      "longTitle" : "Headlines",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "UK",
+        "url" : "/uk-news",
+        "longTitle" : "UK news",
+        "children" : [ {
+          "title" : "UK politics",
+          "url" : "/politics",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Education",
+          "url" : "/education",
+          "children" : [ {
+            "title" : "Schools",
+            "url" : "/education/schools",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Teachers",
+            "url" : "/teacher-network",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Universities",
+            "url" : "/education/universities",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Students",
+            "url" : "/education/students",
+            "children" : [ ],
+            "classList" : [ ]
+          } ],
+          "classList" : [ ]
+        }, {
+          "title" : "Media",
+          "url" : "/media",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Society",
+          "url" : "/society",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Law",
+          "url" : "/law",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Scotland",
+          "url" : "/uk/scotland",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Wales",
+          "url" : "/uk/wales",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Northern Ireland",
+          "url" : "/uk/northernireland",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "World",
+        "url" : "/world",
+        "longTitle" : "World news",
+        "children" : [ {
+          "title" : "Europe",
+          "url" : "/world/europe-news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/us-news",
+          "longTitle" : "US news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Americas",
+          "url" : "/world/americas",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Asia",
+          "url" : "/world/asia",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Australia",
+          "url" : "/australia-news",
+          "longTitle" : "Australia news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Middle East",
+          "url" : "/world/middleeast",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Africa",
+          "url" : "/world/africa",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Inequality",
+          "url" : "/inequality",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Global development",
+          "url" : "/global-development",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Climate crisis",
+        "url" : "/environment/climate-crisis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Ukraine",
+        "url" : "/world/ukraine",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Football",
+        "url" : "/football",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Fixtures",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Newsletters",
+        "url" : "/email-newsletters",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Business",
+        "url" : "/business",
+        "children" : [ {
+          "title" : "Economics",
+          "url" : "/business/economics",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Banking",
+          "url" : "/business/banking",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Money",
+          "url" : "/money",
+          "children" : [ {
+            "title" : "Property",
+            "url" : "/money/property",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Pensions",
+            "url" : "/money/pensions",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Savings",
+            "url" : "/money/savings",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Borrowing",
+            "url" : "/money/debt",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Careers",
+            "url" : "/money/work-and-careers",
+            "children" : [ ],
+            "classList" : [ ]
+          } ],
+          "classList" : [ ]
+        }, {
+          "title" : "Markets",
+          "url" : "/business/stock-markets",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Project Syndicate",
+          "url" : "/business/series/project-syndicate-economists",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "B2B",
+          "url" : "/business-to-business",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Retail",
+          "url" : "/business/retail",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Environment",
+        "url" : "/environment",
+        "children" : [ {
+          "title" : "Climate crisis",
+          "url" : "/environment/climate-crisis",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Wildlife",
+          "url" : "/environment/wildlife",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Energy",
+          "url" : "/environment/energy",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pollution",
+          "url" : "/environment/pollution",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "UK politics",
+        "url" : "/politics",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Education",
+        "url" : "/education",
+        "children" : [ {
+          "title" : "Schools",
+          "url" : "/education/schools",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Teachers",
+          "url" : "/teacher-network",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Universities",
+          "url" : "/education/universities",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Students",
+          "url" : "/education/students",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Society",
+        "url" : "/society",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Science",
+        "url" : "/science",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tech",
+        "url" : "/technology",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Global development",
+        "url" : "/global-development",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Obituaries",
+        "url" : "/obituaries",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "opinionPillar" : {
+      "title" : "Opinion",
+      "url" : "/commentisfree",
+      "longTitle" : "Opinion home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "The Guardian view",
+        "url" : "/profile/editorial",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Columnists",
+        "url" : "/index/contributors",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cartoons",
+        "url" : "/tone/cartoons",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Opinion videos",
+        "url" : "/type/video+tone/comment",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Letters",
+        "url" : "/tone/letters",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "sportPillar" : {
+      "title" : "Sport",
+      "url" : "/sport",
+      "longTitle" : "Sport home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Football",
+        "url" : "/football",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Fixtures",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cricket",
+        "url" : "/sport/cricket",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Rugby union",
+        "url" : "/sport/rugby-union",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tennis",
+        "url" : "/sport/tennis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cycling",
+        "url" : "/sport/cycling",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "F1",
+        "url" : "/sport/formulaone",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Golf",
+        "url" : "/sport/golf",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Boxing",
+        "url" : "/sport/boxing",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Rugby league",
+        "url" : "/sport/rugbyleague",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Racing",
+        "url" : "/sport/horse-racing",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "US sports",
+        "url" : "/sport/us-sport",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "culturePillar" : {
+      "title" : "Culture",
+      "url" : "/culture",
+      "longTitle" : "Culture home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Film",
+        "url" : "/film",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Music",
+        "url" : "/music",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "TV & radio",
+        "url" : "/tv-and-radio",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Books",
+        "url" : "/books",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Art & design",
+        "url" : "/artanddesign",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Stage",
+        "url" : "/stage",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Games",
+        "url" : "/games",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Classical",
+        "url" : "/music/classicalmusicandopera",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "lifestylePillar" : {
+      "title" : "Lifestyle",
+      "url" : "/lifeandstyle",
+      "longTitle" : "Lifestyle home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Fashion",
+        "url" : "/fashion",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Food",
+        "url" : "/food",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Recipes",
+        "url" : "/tone/recipes",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Travel",
+        "url" : "/travel",
+        "children" : [ {
+          "title" : "UK",
+          "url" : "/travel/uk",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Europe",
+          "url" : "/travel/europe",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/travel/usa",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Health & fitness",
+        "url" : "/lifeandstyle/health-and-wellbeing",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Women",
+        "url" : "/lifeandstyle/women",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Men",
+        "url" : "/lifeandstyle/men",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Love & sex",
+        "url" : "/lifeandstyle/love-and-sex",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Beauty",
+        "url" : "/fashion/beauty",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Home & garden",
+        "url" : "/lifeandstyle/home-and-garden",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Money",
+        "url" : "/money",
+        "children" : [ {
+          "title" : "Property",
+          "url" : "/money/property",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pensions",
+          "url" : "/money/pensions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Savings",
+          "url" : "/money/savings",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Borrowing",
+          "url" : "/money/debt",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Careers",
+          "url" : "/money/work-and-careers",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cars",
+        "url" : "/technology/motoring",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "otherLinks" : [ {
+      "title" : "The Guardian app",
+      "url" : "https://app.adjust.com/16xt6hai",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Video",
+      "url" : "/video",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Podcasts",
+      "url" : "/podcasts",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Pictures",
+      "url" : "/inpictures",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Newsletters",
+      "url" : "/email-newsletters",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Today's paper",
+      "url" : "/theguardian",
+      "children" : [ {
+        "title" : "Obituaries",
+        "url" : "/obituaries",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "G2",
+        "url" : "/theguardian/g2",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Journal",
+        "url" : "/theguardian/journal",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Saturday",
+        "url" : "/theguardian/saturday",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Inside the Guardian",
+      "url" : "https://www.theguardian.com/membership",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "The Observer",
+      "url" : "/observer",
+      "children" : [ {
+        "title" : "Comment",
+        "url" : "/theobserver/news/comment",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "The New Review",
+        "url" : "/theobserver/new-review",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Observer Magazine",
+        "url" : "/theobserver/magazine",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Observer Food Monthly",
+        "url" : "/theobserver/foodmonthly",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Weekly",
+      "url" : "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Crosswords",
+      "url" : "/crosswords",
+      "children" : [ {
+        "title" : "Blog",
+        "url" : "/crosswords/crossword-blog",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quick",
+        "url" : "/crosswords/series/quick",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cryptic",
+        "url" : "/crosswords/series/cryptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Prize",
+        "url" : "/crosswords/series/prize",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Weekend",
+        "url" : "/crosswords/series/weekend-crossword",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quiptic",
+        "url" : "/crosswords/series/quiptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Genius",
+        "url" : "/crosswords/series/genius",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Speedy",
+        "url" : "/crosswords/series/speedy",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Everyman",
+        "url" : "/crosswords/series/everyman",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Azed",
+        "url" : "/crosswords/series/azed",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Wordiply",
+      "url" : "https://www.wordiply.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Corrections",
+      "url" : "/theguardian/series/corrections-and-clarifications",
+      "children" : [ ],
+      "classList" : [ ]
+    } ],
+    "brandExtensions" : [ {
+      "title" : "Search jobs",
+      "url" : "https://jobs.theguardian.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Hire with Guardian Jobs",
+      "url" : "https://recruiters.theguardian.com/?utm_source=gdnwb&utm_medium=navbar&utm_campaign=Guardian_Navbar_Recruiters&CMP_TU=trdmkt&CMP_BUNIT=jobs",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Holidays",
+      "url" : "https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Live events",
+      "url" : "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "About Us",
+      "url" : "/about",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Digital Archive",
+      "url" : "https://theguardian.newspapers.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Print Shop",
+      "url" : "/artanddesign/series/gnm-print-sales",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Patrons",
+      "url" : "https://patrons.theguardian.com/?INTCMP=header_patrons",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Puzzles app",
+      "url" : "https://puzzles.theguardian.com/download",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Licensing",
+      "url" : "https://licensing.theguardian.com/",
+      "children" : [ ],
+      "classList" : [ ]
+    } ]
+  },
+  "us" : {
+    "newsPillar" : {
+      "title" : "News",
+      "url" : "/",
+      "longTitle" : "Headlines",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "US",
+        "url" : "/us-news",
+        "longTitle" : "US news",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "US elections 2024",
+        "url" : "/us-news/us-elections-2024",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "World",
+        "url" : "/world",
+        "longTitle" : "World news",
+        "children" : [ {
+          "title" : "Europe",
+          "url" : "/world/europe-news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/us-news",
+          "longTitle" : "US news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Americas",
+          "url" : "/world/americas",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Asia",
+          "url" : "/world/asia",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Australia",
+          "url" : "/australia-news",
+          "longTitle" : "Australia news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Middle East",
+          "url" : "/world/middleeast",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Africa",
+          "url" : "/world/africa",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Inequality",
+          "url" : "/inequality",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Global development",
+          "url" : "/global-development",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Environment",
+        "url" : "/environment",
+        "children" : [ {
+          "title" : "Climate crisis",
+          "url" : "/environment/climate-crisis",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Wildlife",
+          "url" : "/environment/wildlife",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Energy",
+          "url" : "/environment/energy",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pollution",
+          "url" : "/environment/pollution",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Green light",
+          "url" : "/environment/series/green-light",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Ukraine",
+        "url" : "/world/ukraine",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Soccer",
+        "url" : "/soccer",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Schedules",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Business",
+        "url" : "/business",
+        "children" : [ {
+          "title" : "Economics",
+          "url" : "/business/economics",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Diversity & equality in business",
+          "url" : "/business/diversity-and-equality",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Small business",
+          "url" : "/business/us-small-business",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Retail",
+          "url" : "/business/retail",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tech",
+        "url" : "/technology",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Science",
+        "url" : "/science",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Newsletters",
+        "url" : "/email-newsletters",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Wellness",
+        "url" : "/wellness",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "opinionPillar" : {
+      "title" : "Opinion",
+      "url" : "/commentisfree",
+      "longTitle" : "Opinion home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "The Guardian view",
+        "url" : "/profile/editorial",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Columnists",
+        "url" : "/index/contributors",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Letters",
+        "url" : "/tone/letters",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Opinion videos",
+        "url" : "/type/video+tone/comment",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cartoons",
+        "url" : "/tone/cartoons",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "sportPillar" : {
+      "title" : "Sport",
+      "url" : "/sport",
+      "longTitle" : "Sport home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Soccer",
+        "url" : "/soccer",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Schedules",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "NFL",
+        "url" : "/sport/nfl",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tennis",
+        "url" : "/sport/tennis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "MLB",
+        "url" : "/sport/mlb",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "MLS",
+        "url" : "/football/mls",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "NBA",
+        "url" : "/sport/nba",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "NHL",
+        "url" : "/sport/nhl",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "F1",
+        "url" : "/sport/formulaone",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Golf",
+        "url" : "/sport/golf",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "culturePillar" : {
+      "title" : "Culture",
+      "url" : "/culture",
+      "longTitle" : "Culture home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Film",
+        "url" : "/film",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Books",
+        "url" : "/books",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Music",
+        "url" : "/music",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Art & design",
+        "url" : "/artanddesign",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "TV & radio",
+        "url" : "/tv-and-radio",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Stage",
+        "url" : "/stage",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Classical",
+        "url" : "/music/classicalmusicandopera",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Games",
+        "url" : "/games",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "lifestylePillar" : {
+      "title" : "Lifestyle",
+      "url" : "/lifeandstyle",
+      "longTitle" : "Lifestyle home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Wellness",
+        "url" : "/wellness",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Fashion",
+        "url" : "/fashion",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Food",
+        "url" : "/food",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Recipes",
+        "url" : "/tone/recipes",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Love & sex",
+        "url" : "/lifeandstyle/love-and-sex",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Home & garden",
+        "url" : "/lifeandstyle/home-and-garden",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Health & fitness",
+        "url" : "/lifeandstyle/health-and-wellbeing",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Family",
+        "url" : "/lifeandstyle/family",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Travel",
+        "url" : "/travel",
+        "children" : [ {
+          "title" : "US",
+          "url" : "/travel/usa",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Europe",
+          "url" : "/travel/europe",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "UK",
+          "url" : "/travel/uk",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Money",
+        "url" : "/money",
+        "children" : [ {
+          "title" : "Property",
+          "url" : "/money/property",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pensions",
+          "url" : "/money/pensions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Savings",
+          "url" : "/money/savings",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Borrowing",
+          "url" : "/money/debt",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Careers",
+          "url" : "/money/work-and-careers",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "otherLinks" : [ {
+      "title" : "The Guardian app",
+      "url" : "https://app.adjust.com/16xt6hai",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Video",
+      "url" : "/video",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Podcasts",
+      "url" : "/podcasts",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Pictures",
+      "url" : "/inpictures",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Inside the Guardian",
+      "url" : "https://www.theguardian.com/membership",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Weekly",
+      "url" : "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_US",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Crosswords",
+      "url" : "/crosswords",
+      "children" : [ {
+        "title" : "Blog",
+        "url" : "/crosswords/crossword-blog",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quick",
+        "url" : "/crosswords/series/quick",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cryptic",
+        "url" : "/crosswords/series/cryptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Prize",
+        "url" : "/crosswords/series/prize",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Weekend",
+        "url" : "/crosswords/series/weekend-crossword",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quiptic",
+        "url" : "/crosswords/series/quiptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Genius",
+        "url" : "/crosswords/series/genius",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Speedy",
+        "url" : "/crosswords/series/speedy",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Everyman",
+        "url" : "/crosswords/series/everyman",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Azed",
+        "url" : "/crosswords/series/azed",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Wordiply",
+      "url" : "https://www.wordiply.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Corrections",
+      "url" : "/theguardian/series/corrections-and-clarifications",
+      "children" : [ ],
+      "classList" : [ ]
+    } ],
+    "brandExtensions" : [ {
+      "title" : "Search jobs",
+      "url" : "https://jobs.theguardian.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Digital Archive",
+      "url" : "https://theguardian.newspapers.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Puzzles app",
+      "url" : "https://puzzles.theguardian.com/download",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Licensing",
+      "url" : "https://licensing.theguardian.com/",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "About Us",
+      "url" : "/about",
+      "children" : [ ],
+      "classList" : [ ]
+    } ]
+  },
+  "au" : {
+    "newsPillar" : {
+      "title" : "News",
+      "url" : "/",
+      "longTitle" : "Headlines",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Australia",
+        "url" : "/australia-news",
+        "longTitle" : "Australia news",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "World",
+        "url" : "/world",
+        "longTitle" : "World news",
+        "children" : [ {
+          "title" : "Europe",
+          "url" : "/world/europe-news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/us-news",
+          "longTitle" : "US news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Americas",
+          "url" : "/world/americas",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Asia",
+          "url" : "/world/asia",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Australia",
+          "url" : "/australia-news",
+          "longTitle" : "Australia news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Middle East",
+          "url" : "/world/middleeast",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Africa",
+          "url" : "/world/africa",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Inequality",
+          "url" : "/inequality",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Global development",
+          "url" : "/global-development",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "AU politics",
+        "url" : "/australia-news/australian-politics",
+        "longTitle" : "Politics",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Environment",
+        "url" : "/environment",
+        "children" : [ {
+          "title" : "Climate crisis",
+          "url" : "/environment/climate-crisis",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Energy",
+          "url" : "/environment/energy",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Wildlife",
+          "url" : "/environment/wildlife",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Biodiversity",
+          "url" : "/environment/biodiversity",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Oceans",
+          "url" : "/environment/oceans",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pollution",
+          "url" : "/environment/pollution",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Great Barrier Reef",
+          "url" : "/environment/great-barrier-reef",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Climate crisis",
+        "url" : "/environment/climate-crisis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Indigenous Australia",
+        "url" : "/australia-news/indigenous-australians",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Immigration",
+        "url" : "/australia-news/australian-immigration-and-asylum",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Media",
+        "url" : "/media",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Business",
+        "url" : "/business",
+        "children" : [ {
+          "title" : "Markets",
+          "url" : "/business/stock-markets",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Money",
+          "url" : "/money",
+          "children" : [ {
+            "title" : "Property",
+            "url" : "/money/property",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Pensions",
+            "url" : "/money/pensions",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Savings",
+            "url" : "/money/savings",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Borrowing",
+            "url" : "/money/debt",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Careers",
+            "url" : "/money/work-and-careers",
+            "children" : [ ],
+            "classList" : [ ]
+          } ],
+          "classList" : [ ]
+        }, {
+          "title" : "Project Syndicate",
+          "url" : "/business/series/project-syndicate-economists",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Retail",
+          "url" : "/business/retail",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Science",
+        "url" : "/science",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tech",
+        "url" : "/technology",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Podcasts",
+        "url" : "/australia-podcasts",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Newsletters",
+        "url" : "/email-newsletters",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "opinionPillar" : {
+      "title" : "Opinion",
+      "url" : "/commentisfree",
+      "longTitle" : "Opinion home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Columnists",
+        "url" : "/au/index/contributors",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cartoons",
+        "url" : "/tone/cartoons",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Indigenous",
+        "url" : "/commentisfree/series/indigenousx",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Editorials",
+        "url" : "/profile/editorial",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Letters",
+        "url" : "/tone/letters",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "sportPillar" : {
+      "title" : "Sport",
+      "url" : "/sport",
+      "longTitle" : "Sport home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Football",
+        "url" : "/football",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Fixtures",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "AFL",
+        "url" : "/sport/afl",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "NRL",
+        "url" : "/sport/nrl",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "A-League",
+        "url" : "/football/a-league",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cricket",
+        "url" : "/sport/cricket",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Rugby union",
+        "url" : "/sport/rugby-union",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tennis",
+        "url" : "/sport/tennis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cycling",
+        "url" : "/sport/cycling",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "F1",
+        "url" : "/sport/formulaone",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "culturePillar" : {
+      "title" : "Culture",
+      "url" : "/culture",
+      "longTitle" : "Culture home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Film",
+        "url" : "/film",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Music",
+        "url" : "/music",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Books",
+        "url" : "/books",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "TV & radio",
+        "url" : "/tv-and-radio",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Art & design",
+        "url" : "/artanddesign",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Stage",
+        "url" : "/stage",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Games",
+        "url" : "/games",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Classical",
+        "url" : "/music/classicalmusicandopera",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "lifestylePillar" : {
+      "title" : "Lifestyle",
+      "url" : "/lifeandstyle",
+      "longTitle" : "Lifestyle home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Travel",
+        "url" : "/travel",
+        "children" : [ {
+          "title" : "Australasia",
+          "url" : "/travel/australasia",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Asia",
+          "url" : "/travel/asia",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "UK",
+          "url" : "/travel/uk",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Europe",
+          "url" : "/travel/europe",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/travel/usa",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Food",
+        "url" : "/au/food",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Relationships",
+        "url" : "/au/lifeandstyle/relationships",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Fashion",
+        "url" : "/au/lifeandstyle/fashion",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Health & fitness",
+        "url" : "/au/lifeandstyle/health-and-wellbeing",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Love & sex",
+        "url" : "/lifeandstyle/love-and-sex",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Family",
+        "url" : "/lifeandstyle/family",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Home & garden",
+        "url" : "/lifeandstyle/home-and-garden",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "otherLinks" : [ {
+      "title" : "The Guardian app",
+      "url" : "https://app.adjust.com/16xt6hai",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Video",
+      "url" : "/video",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Podcasts",
+      "url" : "/australia-podcasts",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Pictures",
+      "url" : "/inpictures",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Newsletters",
+      "url" : "/email-newsletters",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Inside the Guardian",
+      "url" : "https://www.theguardian.com/membership",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Weekly",
+      "url" : "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Aus",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Crosswords",
+      "url" : "/crosswords",
+      "children" : [ {
+        "title" : "Blog",
+        "url" : "/crosswords/crossword-blog",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quick",
+        "url" : "/crosswords/series/quick",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cryptic",
+        "url" : "/crosswords/series/cryptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Prize",
+        "url" : "/crosswords/series/prize",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Weekend",
+        "url" : "/crosswords/series/weekend-crossword",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quiptic",
+        "url" : "/crosswords/series/quiptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Genius",
+        "url" : "/crosswords/series/genius",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Speedy",
+        "url" : "/crosswords/series/speedy",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Everyman",
+        "url" : "/crosswords/series/everyman",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Azed",
+        "url" : "/crosswords/series/azed",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Wordiply",
+      "url" : "https://www.wordiply.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Corrections",
+      "url" : "/theguardian/series/corrections-and-clarifications",
+      "children" : [ ],
+      "classList" : [ ]
+    } ],
+    "brandExtensions" : [ {
+      "title" : "Events",
+      "url" : "/guardian-live-australia",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Digital Archive",
+      "url" : "https://theguardian.newspapers.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Puzzles app",
+      "url" : "https://puzzles.theguardian.com/download",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Australia Weekend",
+      "url" : "/info/ng-interactive/2021/mar/17/make-sense-of-the-week-with-australia-weekend?INTCMP=header_au_weekend",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Licensing",
+      "url" : "https://licensing.theguardian.com/",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "About Us",
+      "url" : "/about",
+      "children" : [ ],
+      "classList" : [ ]
+    } ]
+  },
+  "europe" : {
+    "newsPillar" : {
+      "title" : "News",
+      "url" : "/",
+      "longTitle" : "Headlines",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "World",
+        "url" : "/world",
+        "longTitle" : "World news",
+        "children" : [ {
+          "title" : "Europe",
+          "url" : "/world/europe-news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/us-news",
+          "longTitle" : "US news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Americas",
+          "url" : "/world/americas",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Asia",
+          "url" : "/world/asia",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Australia",
+          "url" : "/australia-news",
+          "longTitle" : "Australia news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Middle East",
+          "url" : "/world/middleeast",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Africa",
+          "url" : "/world/africa",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Inequality",
+          "url" : "/inequality",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Global development",
+          "url" : "/global-development",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "UK",
+        "url" : "/uk-news",
+        "longTitle" : "UK news",
+        "children" : [ {
+          "title" : "UK politics",
+          "url" : "/politics",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Education",
+          "url" : "/education",
+          "children" : [ {
+            "title" : "Schools",
+            "url" : "/education/schools",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Teachers",
+            "url" : "/teacher-network",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Universities",
+            "url" : "/education/universities",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Students",
+            "url" : "/education/students",
+            "children" : [ ],
+            "classList" : [ ]
+          } ],
+          "classList" : [ ]
+        }, {
+          "title" : "Media",
+          "url" : "/media",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Society",
+          "url" : "/society",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Law",
+          "url" : "/law",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Scotland",
+          "url" : "/uk/scotland",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Wales",
+          "url" : "/uk/wales",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Northern Ireland",
+          "url" : "/uk/northernireland",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Climate crisis",
+        "url" : "/environment/climate-crisis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Ukraine",
+        "url" : "/world/ukraine",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Environment",
+        "url" : "/environment",
+        "children" : [ {
+          "title" : "Climate crisis",
+          "url" : "/environment/climate-crisis",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Wildlife",
+          "url" : "/environment/wildlife",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Energy",
+          "url" : "/environment/energy",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pollution",
+          "url" : "/environment/pollution",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Science",
+        "url" : "/science",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Global development",
+        "url" : "/global-development",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Football",
+        "url" : "/football",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Fixtures",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tech",
+        "url" : "/technology",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Business",
+        "url" : "/business",
+        "children" : [ {
+          "title" : "Economics",
+          "url" : "/business/economics",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Banking",
+          "url" : "/business/banking",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Money",
+          "url" : "/money",
+          "children" : [ {
+            "title" : "Property",
+            "url" : "/money/property",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Pensions",
+            "url" : "/money/pensions",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Savings",
+            "url" : "/money/savings",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Borrowing",
+            "url" : "/money/debt",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Careers",
+            "url" : "/money/work-and-careers",
+            "children" : [ ],
+            "classList" : [ ]
+          } ],
+          "classList" : [ ]
+        }, {
+          "title" : "Markets",
+          "url" : "/business/stock-markets",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Project Syndicate",
+          "url" : "/business/series/project-syndicate-economists",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "B2B",
+          "url" : "/business-to-business",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Retail",
+          "url" : "/business/retail",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Obituaries",
+        "url" : "/obituaries",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "opinionPillar" : {
+      "title" : "Opinion",
+      "url" : "/commentisfree",
+      "longTitle" : "Opinion home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "The Guardian view",
+        "url" : "/profile/editorial",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Columnists",
+        "url" : "/index/contributors",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cartoons",
+        "url" : "/tone/cartoons",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Opinion videos",
+        "url" : "/type/video+tone/comment",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Letters",
+        "url" : "/tone/letters",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "sportPillar" : {
+      "title" : "Sport",
+      "url" : "/sport",
+      "longTitle" : "Sport home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Football",
+        "url" : "/football",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Fixtures",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cricket",
+        "url" : "/sport/cricket",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Rugby union",
+        "url" : "/sport/rugby-union",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tennis",
+        "url" : "/sport/tennis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cycling",
+        "url" : "/sport/cycling",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "F1",
+        "url" : "/sport/formulaone",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Golf",
+        "url" : "/sport/golf",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "US sports",
+        "url" : "/sport/us-sport",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "culturePillar" : {
+      "title" : "Culture",
+      "url" : "/culture",
+      "longTitle" : "Culture home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Books",
+        "url" : "/books",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Music",
+        "url" : "/music",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "TV & radio",
+        "url" : "/tv-and-radio",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Art & design",
+        "url" : "/artanddesign",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Film",
+        "url" : "/film",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Games",
+        "url" : "/games",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Classical",
+        "url" : "/music/classicalmusicandopera",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Stage",
+        "url" : "/stage",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "lifestylePillar" : {
+      "title" : "Lifestyle",
+      "url" : "/lifeandstyle",
+      "longTitle" : "Lifestyle home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Fashion",
+        "url" : "/fashion",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Food",
+        "url" : "/food",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Recipes",
+        "url" : "/tone/recipes",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Love & sex",
+        "url" : "/lifeandstyle/love-and-sex",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Health & fitness",
+        "url" : "/lifeandstyle/health-and-wellbeing",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Home & garden",
+        "url" : "/lifeandstyle/home-and-garden",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Women",
+        "url" : "/lifeandstyle/women",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Men",
+        "url" : "/lifeandstyle/men",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Family",
+        "url" : "/lifeandstyle/family",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Travel",
+        "url" : "/travel",
+        "children" : [ {
+          "title" : "UK",
+          "url" : "/travel/uk",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Europe",
+          "url" : "/travel/europe",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/travel/usa",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Money",
+        "url" : "/money",
+        "children" : [ {
+          "title" : "Property",
+          "url" : "/money/property",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pensions",
+          "url" : "/money/pensions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Savings",
+          "url" : "/money/savings",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Borrowing",
+          "url" : "/money/debt",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Careers",
+          "url" : "/money/work-and-careers",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "otherLinks" : [ {
+      "title" : "The Guardian app",
+      "url" : "https://app.adjust.com/16xt6hai",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Video",
+      "url" : "/video",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Podcasts",
+      "url" : "/podcasts",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Pictures",
+      "url" : "/inpictures",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Newsletters",
+      "url" : "/email-newsletters",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Today's paper",
+      "url" : "/theguardian",
+      "children" : [ {
+        "title" : "Obituaries",
+        "url" : "/obituaries",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "G2",
+        "url" : "/theguardian/g2",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Journal",
+        "url" : "/theguardian/journal",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Saturday",
+        "url" : "/theguardian/saturday",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Inside the Guardian",
+      "url" : "https://www.theguardian.com/membership",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "The Observer",
+      "url" : "/observer",
+      "children" : [ {
+        "title" : "Comment",
+        "url" : "/theobserver/news/comment",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "The New Review",
+        "url" : "/theobserver/new-review",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Observer Magazine",
+        "url" : "/theobserver/magazine",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Observer Food Monthly",
+        "url" : "/theobserver/foodmonthly",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Weekly",
+      "url" : "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Crosswords",
+      "url" : "/crosswords",
+      "children" : [ {
+        "title" : "Blog",
+        "url" : "/crosswords/crossword-blog",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quick",
+        "url" : "/crosswords/series/quick",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cryptic",
+        "url" : "/crosswords/series/cryptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Prize",
+        "url" : "/crosswords/series/prize",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Weekend",
+        "url" : "/crosswords/series/weekend-crossword",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quiptic",
+        "url" : "/crosswords/series/quiptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Genius",
+        "url" : "/crosswords/series/genius",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Speedy",
+        "url" : "/crosswords/series/speedy",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Everyman",
+        "url" : "/crosswords/series/everyman",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Azed",
+        "url" : "/crosswords/series/azed",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Wordiply",
+      "url" : "https://www.wordiply.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Corrections",
+      "url" : "/theguardian/series/corrections-and-clarifications",
+      "children" : [ ],
+      "classList" : [ ]
+    } ],
+    "brandExtensions" : [ {
+      "title" : "Search jobs",
+      "url" : "https://jobs.theguardian.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Holidays",
+      "url" : "https://holidays.theguardian.com?INTCMP=holidays_int_web_newheader",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Digital Archive",
+      "url" : "https://theguardian.newspapers.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Puzzles app",
+      "url" : "https://puzzles.theguardian.com/download",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Licensing",
+      "url" : "https://licensing.theguardian.com/",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "About Us",
+      "url" : "/about",
+      "children" : [ ],
+      "classList" : [ ]
+    } ]
+  },
+  "tagPages" : [ "us-news/us-politics", "australia-news/australian-politics", "australia-news/australian-immigration-and-asylum", "australia-news/indigenous-australians", "uk/scotland", "uk/wales", "uk/northernireland", "world/europe-news", "world/americas", "world/asia", "world/africa", "world/middleeast", "business/economics", "business/banking", "business/retail", "business/stock-markets", "business/eurozone", "business/diversity-and-equality", "business/us-small-business", "environment/climate-change", "environment/climate-crisis", "environment/wildlife", "environment/energy", "environment/pollution", "money/property", "money/pensions", "money/savings", "money/debt", "money/work-and-careers", "tone/cartoons", "type/cartoon", "profile/editorial", "au/index/contributors", "index/contributors", "commentisfree/series/comment-is-free-weekly", "sport/rugby-union", "sport/cricket", "sport/tennis", "sport/cycling", "sport/golf", "sport/us-sport", "sport/horse-racing", "sport/rugbyleague", "sport/boxing", "sport/formulaone", "sport/nfl", "sport/mlb", "football/mls", "sport/nba", "sport/nhl", "sport/afl", "football/a-league", "sport/nrl", "music/classicalmusicandopera", "food", "tone/recipes", "lifeandstyle/health-and-wellbeing", "lifeandstyle/family", "lifeandstyle/home-and-garden", "lifeandstyle/love-and-sex", "au/lifeandstyle/fashion", "au/lifeandstyle/food-and-drink", "au/lifeandstyle/relationships", "au/lifeandstyle/health-and-wellbeing", "travel/uk", "travel/europe", "travel/usa", "travel/skiing", "travel/australasia", "travel/asia", "theguardian", "observer", "football/live", "football/tables", "football/competitions", "football/results", "football/fixtures", "crosswords/crossword-blog", "crosswords/series/crossword-editor-update", "crosswords/series/quick", "crosswords/series/cryptic", "crosswords/series/prize", "crosswords/series/weekend-crossword", "crosswords/series/quiptic", "crosswords/series/genius", "crosswords/series/speedy", "crosswords/series/everyman", "crosswords/series/azed", "fashion/beauty", "technology/motoring", "commentisfree/commentisfree", "education/education" ],
+  "international" : {
+    "newsPillar" : {
+      "title" : "News",
+      "url" : "/",
+      "longTitle" : "Headlines",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "World",
+        "url" : "/world",
+        "longTitle" : "World news",
+        "children" : [ {
+          "title" : "Europe",
+          "url" : "/world/europe-news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/us-news",
+          "longTitle" : "US news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Americas",
+          "url" : "/world/americas",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Asia",
+          "url" : "/world/asia",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Australia",
+          "url" : "/australia-news",
+          "longTitle" : "Australia news",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Middle East",
+          "url" : "/world/middleeast",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Africa",
+          "url" : "/world/africa",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Inequality",
+          "url" : "/inequality",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Global development",
+          "url" : "/global-development",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "UK",
+        "url" : "/uk-news",
+        "longTitle" : "UK news",
+        "children" : [ {
+          "title" : "UK politics",
+          "url" : "/politics",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Education",
+          "url" : "/education",
+          "children" : [ {
+            "title" : "Schools",
+            "url" : "/education/schools",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Teachers",
+            "url" : "/teacher-network",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Universities",
+            "url" : "/education/universities",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Students",
+            "url" : "/education/students",
+            "children" : [ ],
+            "classList" : [ ]
+          } ],
+          "classList" : [ ]
+        }, {
+          "title" : "Media",
+          "url" : "/media",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Society",
+          "url" : "/society",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Law",
+          "url" : "/law",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Scotland",
+          "url" : "/uk/scotland",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Wales",
+          "url" : "/uk/wales",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Northern Ireland",
+          "url" : "/uk/northernireland",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Climate crisis",
+        "url" : "/environment/climate-crisis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Ukraine",
+        "url" : "/world/ukraine",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Environment",
+        "url" : "/environment",
+        "children" : [ {
+          "title" : "Climate crisis",
+          "url" : "/environment/climate-crisis",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Wildlife",
+          "url" : "/environment/wildlife",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Energy",
+          "url" : "/environment/energy",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pollution",
+          "url" : "/environment/pollution",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Science",
+        "url" : "/science",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Global development",
+        "url" : "/global-development",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Football",
+        "url" : "/football",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Fixtures",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tech",
+        "url" : "/technology",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Business",
+        "url" : "/business",
+        "children" : [ {
+          "title" : "Economics",
+          "url" : "/business/economics",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Banking",
+          "url" : "/business/banking",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Money",
+          "url" : "/money",
+          "children" : [ {
+            "title" : "Property",
+            "url" : "/money/property",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Pensions",
+            "url" : "/money/pensions",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Savings",
+            "url" : "/money/savings",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Borrowing",
+            "url" : "/money/debt",
+            "children" : [ ],
+            "classList" : [ ]
+          }, {
+            "title" : "Careers",
+            "url" : "/money/work-and-careers",
+            "children" : [ ],
+            "classList" : [ ]
+          } ],
+          "classList" : [ ]
+        }, {
+          "title" : "Markets",
+          "url" : "/business/stock-markets",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Project Syndicate",
+          "url" : "/business/series/project-syndicate-economists",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "B2B",
+          "url" : "/business-to-business",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Retail",
+          "url" : "/business/retail",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Obituaries",
+        "url" : "/obituaries",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "opinionPillar" : {
+      "title" : "Opinion",
+      "url" : "/commentisfree",
+      "longTitle" : "Opinion home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "The Guardian view",
+        "url" : "/profile/editorial",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Columnists",
+        "url" : "/index/contributors",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cartoons",
+        "url" : "/tone/cartoons",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Opinion videos",
+        "url" : "/type/video+tone/comment",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Letters",
+        "url" : "/tone/letters",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "sportPillar" : {
+      "title" : "Sport",
+      "url" : "/sport",
+      "longTitle" : "Sport home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Football",
+        "url" : "/football",
+        "children" : [ {
+          "title" : "Live scores",
+          "url" : "/football/live",
+          "longTitle" : "football/live",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Tables",
+          "url" : "/football/tables",
+          "longTitle" : "football/tables",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Fixtures",
+          "url" : "/football/fixtures",
+          "longTitle" : "football/fixtures",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Results",
+          "url" : "/football/results",
+          "longTitle" : "football/results",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Competitions",
+          "url" : "/football/competitions",
+          "longTitle" : "football/competitions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Clubs",
+          "url" : "/football/teams",
+          "longTitle" : "football/teams",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cricket",
+        "url" : "/sport/cricket",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Rugby union",
+        "url" : "/sport/rugby-union",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Tennis",
+        "url" : "/sport/tennis",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cycling",
+        "url" : "/sport/cycling",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "F1",
+        "url" : "/sport/formulaone",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Golf",
+        "url" : "/sport/golf",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "US sports",
+        "url" : "/sport/us-sport",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "culturePillar" : {
+      "title" : "Culture",
+      "url" : "/culture",
+      "longTitle" : "Culture home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Books",
+        "url" : "/books",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Music",
+        "url" : "/music",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "TV & radio",
+        "url" : "/tv-and-radio",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Art & design",
+        "url" : "/artanddesign",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Film",
+        "url" : "/film",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Games",
+        "url" : "/games",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Classical",
+        "url" : "/music/classicalmusicandopera",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Stage",
+        "url" : "/stage",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "lifestylePillar" : {
+      "title" : "Lifestyle",
+      "url" : "/lifeandstyle",
+      "longTitle" : "Lifestyle home",
+      "iconName" : "home",
+      "children" : [ {
+        "title" : "Fashion",
+        "url" : "/fashion",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Food",
+        "url" : "/food",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Recipes",
+        "url" : "/tone/recipes",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Love & sex",
+        "url" : "/lifeandstyle/love-and-sex",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Health & fitness",
+        "url" : "/lifeandstyle/health-and-wellbeing",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Home & garden",
+        "url" : "/lifeandstyle/home-and-garden",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Women",
+        "url" : "/lifeandstyle/women",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Men",
+        "url" : "/lifeandstyle/men",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Family",
+        "url" : "/lifeandstyle/family",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Travel",
+        "url" : "/travel",
+        "children" : [ {
+          "title" : "UK",
+          "url" : "/travel/uk",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Europe",
+          "url" : "/travel/europe",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "US",
+          "url" : "/travel/usa",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      }, {
+        "title" : "Money",
+        "url" : "/money",
+        "children" : [ {
+          "title" : "Property",
+          "url" : "/money/property",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Pensions",
+          "url" : "/money/pensions",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Savings",
+          "url" : "/money/savings",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Borrowing",
+          "url" : "/money/debt",
+          "children" : [ ],
+          "classList" : [ ]
+        }, {
+          "title" : "Careers",
+          "url" : "/money/work-and-careers",
+          "children" : [ ],
+          "classList" : [ ]
+        } ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    },
+    "otherLinks" : [ {
+      "title" : "The Guardian app",
+      "url" : "https://app.adjust.com/16xt6hai",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Video",
+      "url" : "/video",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Podcasts",
+      "url" : "/podcasts",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Pictures",
+      "url" : "/inpictures",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Newsletters",
+      "url" : "/email-newsletters",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Today's paper",
+      "url" : "/theguardian",
+      "children" : [ {
+        "title" : "Obituaries",
+        "url" : "/obituaries",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "G2",
+        "url" : "/theguardian/g2",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Journal",
+        "url" : "/theguardian/journal",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Saturday",
+        "url" : "/theguardian/saturday",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Inside the Guardian",
+      "url" : "https://www.theguardian.com/membership",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "The Observer",
+      "url" : "/observer",
+      "children" : [ {
+        "title" : "Comment",
+        "url" : "/theobserver/news/comment",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "The New Review",
+        "url" : "/theobserver/new-review",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Observer Magazine",
+        "url" : "/theobserver/magazine",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Observer Food Monthly",
+        "url" : "/theobserver/foodmonthly",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Weekly",
+      "url" : "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Crosswords",
+      "url" : "/crosswords",
+      "children" : [ {
+        "title" : "Blog",
+        "url" : "/crosswords/crossword-blog",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quick",
+        "url" : "/crosswords/series/quick",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Cryptic",
+        "url" : "/crosswords/series/cryptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Prize",
+        "url" : "/crosswords/series/prize",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Weekend",
+        "url" : "/crosswords/series/weekend-crossword",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Quiptic",
+        "url" : "/crosswords/series/quiptic",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Genius",
+        "url" : "/crosswords/series/genius",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Speedy",
+        "url" : "/crosswords/series/speedy",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Everyman",
+        "url" : "/crosswords/series/everyman",
+        "children" : [ ],
+        "classList" : [ ]
+      }, {
+        "title" : "Azed",
+        "url" : "/crosswords/series/azed",
+        "children" : [ ],
+        "classList" : [ ]
+      } ],
+      "classList" : [ ]
+    }, {
+      "title" : "Wordiply",
+      "url" : "https://www.wordiply.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Corrections",
+      "url" : "/theguardian/series/corrections-and-clarifications",
+      "children" : [ ],
+      "classList" : [ ]
+    } ],
+    "brandExtensions" : [ {
+      "title" : "Search jobs",
+      "url" : "https://jobs.theguardian.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Holidays",
+      "url" : "https://holidays.theguardian.com?INTCMP=holidays_int_web_newheader",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Digital Archive",
+      "url" : "https://theguardian.newspapers.com",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Puzzles app",
+      "url" : "https://puzzles.theguardian.com/download",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "Guardian Licensing",
+      "url" : "https://licensing.theguardian.com/",
+      "children" : [ ],
+      "classList" : [ ]
+    }, {
+      "title" : "About Us",
+      "url" : "/about",
+      "children" : [ ],
+      "classList" : [ ]
+    } ]
+  }
 }


### PR DESCRIPTION
Adds nav link to US elections 2024

Closes https://github.com/guardian/dotcom-rendering/issues/10301

## Screenshots

(weird formatting on "After" is something to do with the dev server!)

| Before      | After      |
|-------------|------------|
| <img width="322" alt="image" src="https://github.com/guardian/frontend/assets/705427/10829ae1-abcb-4ba3-9e80-b5f29727af26"> | <img width="315" alt="image" src="https://github.com/guardian/frontend/assets/705427/d6333779-0d7f-4c9f-b2cf-b42a0a39f8ec"> |

