### PR TITLE
Enable deeply read: 50%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -25,7 +25,7 @@ object DeeplyRead
       description = "When ON, deeply read footer section is displayed",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 1, 31),
-      participationGroup = Perc0A,
+      participationGroup = Perc50,
     )
 
 object Lightbox


### PR DESCRIPTION
## What does this change?

Enables the deeply read test for 50% of audiences. 

## What is the value of this and can you measure success?

To understand if this type of onward journey drives greater engagement. We will look at: 
* any drop in over all clickthrough compared to current most viewed
* any uplift in time spent from clicks to deeply read vs most viewed

Fixes https://github.com/guardian/dotcom-rendering/issues/8807