### PR TITLE
Enable Lightbox for all

### DIFF
--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -62,4 +62,14 @@ trait JournalismSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
+
+  val Lightbox = Switch(
+    SwitchGroup.Journalism,
+    name = "lightbox",
+    description = "Enable lightbox for images",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      Lightbox,
       AdaptiveSite,
       OfferHttp3,
       DeeplyRead,
@@ -26,15 +25,6 @@ object DeeplyRead
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 1, 31),
       participationGroup = Perc0A,
-    )
-
-object Lightbox
-    extends Experiment(
-      name = "lightbox",
-      description = "Testing the impact lightbox might have on our CWVs",
-      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 1, 31),
-      participationGroup = Perc5A,
     )
 
 // Removing while we are still implementing this content type in DCR


### PR DESCRIPTION
## What is the value of this and can you measure success?

Make all our users who want the lighbox, including @paperboyo, happy!

## What does this change?

Turn the Lightbox experiment into a feature switch

- https://github.com/guardian/dotcom-rendering/pull/10329

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)