### PR TITLE
Extend MPU when no epic test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -61,7 +61,7 @@ trait ABTestSwitches {
     "Test MPU when there is no epic at the end of Article on the page.",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 1, 31)),
+    sellByDate = Some(LocalDate.of(2024, 2, 29)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mpu-when-no-epic.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mpu-when-no-epic.ts
@@ -4,7 +4,7 @@ export const mpuWhenNoEpic: ABTest = {
 	id: 'MpuWhenNoEpic',
 	author: '@commercial-dev',
 	start: '2023-11-22',
-	expiry: '2024-01-31',
+	expiry: '2024-02-29',
 	audience: 10 / 100,
 	audienceOffset: 5 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
## What is the value of this and can you measure success?

This test has not yet started, as we are waiting on Teads to make some changes first

## What does this change?

Extend the test by 1 month
