### PR TITLE
Add facia baseURL to config and use in DCR service

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -151,6 +151,7 @@ class GuardianConfiguration extends GuLogging {
   object rendering {
     lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
     lazy val articleBaseURL = configuration.getMandatoryStringProperty("article-rendering.baseURL")
+    lazy val faciaBaseURL = configuration.getMandatoryStringProperty("facia-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -277,7 +277,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     )
 
     val json = DotcomFrontsRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Front", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.faciaBaseURL + "/Front", CacheTime.Facia)
   }
 
   def getTagFront(
@@ -292,7 +292,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     )
 
     val json = DotcomTagFrontsRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/TagFront", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.faciaBaseURL + "/TagFront", CacheTime.Facia)
   }
 
   def getInteractive(

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -115,6 +115,10 @@ pa.rugby.api.key=none
 # DCR
 rendering.endpoint=http://localhost:3030
 rendering.baseURL=http://localhost:3030
+article-rendering.baseURL=http://localhost:3030
+facia-rendering.baseURL=http://localhost:3030
+interactive-rendering.baseURL=http://localhost:3030
+misc-rendering.baseURL=http://localhost:3030
 
 # contributions
 contributionsService.url=https://contributions.code.dev-guardianapis.com


### PR DESCRIPTION
## What is the value of this and can you measure success?

Starts sending traffic to the new `facia-rendering` DCR app for fronts and tag pages

Resolves https://github.com/guardian/dotcom-rendering/issues/9323

> [!IMPORTANT]
> https://github.com/guardian/dotcom-rendering/pull/10386 must be merged first as it launches the app and sets the relevant parameter store configuration

## What does this change?

Adds value for `facia-rendering` base URL in the configuration and then uses this in the `DotcomRenderingService` for DCR requests to `/Front` and `/TagFront`


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] ~Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)~
  - [ ] ~[Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)~
  - [ ] ~[Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)~
  - [ ] ~[Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)~

