### PR TITLE
Upgrade sbt plugins to avoid repo.scala-sbt.org

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -52,7 +52,6 @@ object ProjectSettings {
         <exclude org="commons-logging" module="commons-logging"><!-- Conflicts with jcl-over-slf4j in Play. --></exclude>
       </dependencies>,
     resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
-      Resolver.typesafeRepo("releases"),
       "Spy" at "https://files.couchbase.com/maven2/",
     ),
     update / evictionWarningOptions := EvictionWarningOptions.default

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,36 +9,18 @@ libraryDependencies ++= Seq(
 
 resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
   Classpaths.typesafeReleases,
-  Resolver.typesafeRepo("releases"),
 )
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-
-/*
-   Without setting VersionScheme.Always here on `scala-xml`, sbt 1.8.0 will raise fatal 'version conflict' errors when
-   used with sbt plugins like `sbt-native-packager`, which currently use sort-of-incompatible versions of the `scala-xml`
-   library. sbt 1.8.0 has upgraded to Scala 2.12.17, which has itself upgraded to `scala-xml` 2.1.0
-   (see https://github.com/sbt/sbt/releases/tag/v1.8.0), but `sbt-native-packager` is currently using `scala-xml` 1.1.1,
-    and the `scala-xml` library declares that it uses specifically 'early-semver' version compatibility (see
-    https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#versionscheme-librarydependencyschemes-and-sbt-150 ),
-    meaning that for version x.y.z, `x` & `y` *must match exactly* for versions to be considered compatible by sbt.
-
-    By setting VersionScheme.Always here on `scala-xml`, we're overriding its declared version-compatability scheme,
-    choosing to tolerate the risk of binary incompatibility. We consider this to be safe because when set under
-    `projects/` (ie *not* in `build.sbt` itself) it only affects the compilation of build.sbt, not of the application
-    build itself. Once the build has succeeded, there is no further risk (ie of a runtime exception due to clashing
-    versions of `scala-xml`).
- */
-libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
Last year repo.scala-sbt.org was going down for a day:
- https://github.com/sbt/sbt/issues/7202

Meanwhile basically all sbt plugins and related libraries were published to maven central. I now started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts` (and delete any local artifacts from those repo in my local ivy and coursier cache).
With those repos blocked I tried to compile / run tests for your frontend repo and unfortunately you still pull in three outdated sbt plugins which are still only hosted on repo.scala-sbt.org.

This pull request finally upgrades those plugins, so you are now completely independent from above mentioned repos, fetching all your dependencies slolely from Maven Central.
I was now able to compile and tests with this PR applied.