### PR TITLE
Only require frontPressToolQueue and frontPressCronQueue if used

### DIFF
--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -23,13 +23,17 @@ class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorke
     }
   }
 
-  override lazy val queue: JsonMessageQueue[SNSNotification] = (Configuration.faciatool.frontPressCronQueue map { queueUrl =>
-    val credentials = Configuration.aws.mandatoryCredentials
+  override lazy val queue: JsonMessageQueue[SNSNotification] = (Configuration.faciatool.frontPressCronQueue map {
+    queueUrl =>
+      val credentials = Configuration.aws.mandatoryCredentials
 
-    JsonMessageQueue[SNSNotification](
-      AmazonSQSAsyncClient.asyncBuilder.withCredentials(credentials).withRegion(conf.Configuration.aws.region).build(),
-      queueUrl,
-    )
+      JsonMessageQueue[SNSNotification](
+        AmazonSQSAsyncClient.asyncBuilder
+          .withCredentials(credentials)
+          .withRegion(conf.Configuration.aws.region)
+          .build(),
+        queueUrl,
+      )
   }) getOrElse {
     throw new RuntimeException("Required property 'frontpress.sqs.cron_queue_url' not set")
   }

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -23,7 +23,7 @@ class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorke
     }
   }
 
-  override val queue: JsonMessageQueue[SNSNotification] = (Configuration.faciatool.frontPressCronQueue map { queueUrl =>
+  override lazy val queue: JsonMessageQueue[SNSNotification] = (Configuration.faciatool.frontPressCronQueue map { queueUrl =>
     val credentials = Configuration.aws.mandatoryCredentials
 
     JsonMessageQueue[SNSNotification](

--- a/facia-press/app/frontpress/JsonQueueWorker.scala
+++ b/facia-press/app/frontpress/JsonQueueWorker.scala
@@ -63,7 +63,7 @@ object JsonQueueWorker {
 abstract class JsonQueueWorker[A: Reads]()(implicit executionContext: ExecutionContext) extends GuLogging {
   import JsonQueueWorker._
 
-  val queue: JsonMessageQueue[A]
+  def queue: JsonMessageQueue[A]
   val deleteOnFailure: Boolean = false
 
   final private val lastSuccessfulReceipt = DateTimeRecorder()

--- a/facia-press/app/lifecycle/FaciaPressLifecycle.scala
+++ b/facia-press/app/lifecycle/FaciaPressLifecycle.scala
@@ -21,7 +21,9 @@ class FaciaPressLifecycle(
   }
 
   override def start(): Unit = {
-    toolPressQueueWorker.start()
+    if (Configuration.faciatool.frontPressToolQueue.isDefined) {
+      toolPressQueueWorker.start()
+    }
     if (Configuration.faciatool.frontPressCronQueue.isDefined) {
       frontPressCron.start()
     }


### PR DESCRIPTION
## What is the value of this and can you measure success?

This change allows you to run facia-press locally with less config.

## What does this change?

Makes a `val` lazy to avoid config being read unless it actually needs to be. This means that in the dev environment you can omit queue configuration and have facia-press run for manual pressing rather than queue-triggered presses.