### PR TITLE
Remove okhttp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,6 @@ val common = library("common")
       atomRenderer,
       identityModel,
       capiAws,
-      okhttp,
       pekkoActor,
       pekkoStream,
       pekkoSlf4j,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -99,7 +99,6 @@ object Dependencies {
   val atomRenderer = "com.gu" %% "atom-renderer" % "1.2.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7"
-  val okhttp = "com.squareup.okhttp3" % "okhttp" % "4.10.0"
 
   /*
     Note: Although frontend compiles and passes all the current tests when jackson is removed, be careful that this


### PR DESCRIPTION
## What does this change?
Removes okhttp package from Frontend. This doesn't seem to have been used since 2018 when it was removed in this PR [here](https://github.com/guardian/frontend/pull/20836) 


For context, this package was added here https://github.com/guardian/frontend/pull/19526
