### PR TITLE
Send interactives DCR traffic to new `interactive-rendering` app

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -152,6 +152,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
     lazy val articleBaseURL = configuration.getMandatoryStringProperty("article-rendering.baseURL")
     lazy val faciaBaseURL = configuration.getMandatoryStringProperty("facia-rendering.baseURL")
+    lazy val interactiveBaseURL = configuration.getMandatoryStringProperty("interactive-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -308,7 +308,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     // Nb. interactives have a longer timeout because some of them are very
     // large unfortunately. E.g.
     // https://www.theguardian.com/education/ng-interactive/2018/may/29/university-guide-2019-league-table-for-computer-science-information.
-    post(ws, json, Configuration.rendering.baseURL + "/Interactive", page.metadata.cacheTime, 4.seconds)
+    post(ws, json, Configuration.rendering.interactiveBaseURL + "/Interactive", page.metadata.cacheTime, 4.seconds)
   }
 
   def getAMPInteractive(
@@ -320,7 +320,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = DotcomRenderingDataModel.forInteractive(page, blocks, request, pageType)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/AMPInteractive", page.metadata.cacheTime)
+    post(ws, json, Configuration.rendering.interactiveBaseURL + "/AMPInteractive", page.metadata.cacheTime)
   }
 
   def getAppsInteractive(
@@ -336,7 +336,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     // Nb. interactives have a longer timeout because some of them are very
     // large unfortunately. E.g.
     // https://www.theguardian.com/education/ng-interactive/2018/may/29/university-guide-2019-league-table-for-computer-science-information.
-    post(ws, json, Configuration.rendering.baseURL + "/AppsInteractive", page.metadata.cacheTime, 4.seconds)
+    post(ws, json, Configuration.rendering.interactiveBaseURL + "/AppsInteractive", page.metadata.cacheTime, 4.seconds)
   }
 
   def getEmailNewsletters(
@@ -347,7 +347,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = DotcomNewslettersPageRenderingDataModel.apply(page, newsletters, request)
     val json = DotcomNewslettersPageRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/EmailNewsletters", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.faciaBaseURL + "/EmailNewsletters", CacheTime.Facia)
   }
 
   def getImageContent(


### PR DESCRIPTION
## What is the value of this and can you measure success?

Continues [work to split out the DCR apps](https://github.com/guardian/dotcom-rendering/issues/8351) by sending DCR traffic for interactives to the [new `interactive-rendering` app](https://github.com/guardian/dotcom-rendering/pull/10458)

Resolves https://github.com/guardian/dotcom-rendering/issues/9324

## What does this change?

- Adds new config value for the `interactive-rendering` app base URL
- Swaps the general `rendering` baseURL for the interactive one for interactives requests
- Additionally swaps the `rendering` baseURL for `/EmailNewsletters` to go to the `facia-rendering` app instead as this is the most appropriate of the three apps to send this request to