### PR TITLE
add AB test for mobile commercial banner

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     Set(
       AdaptiveSite,
       DeeplyRead,
+      CrosswordMobileBanner,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -43,4 +44,13 @@ object AdaptiveSite
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 4, 2),
       participationGroup = Perc1A,
+    )
+
+object CrosswordMobileBanner
+    extends Experiment(
+      name = "crossword-mobile-banner",
+      description = "Test banner advert in mobile crossword page",
+      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+      sellByDate = LocalDate.of(2024, 4, 2),
+      participationGroup = Perc0A,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?
This sets up an AB test for a new banner ad in the crosswords mobile pages.

## What does this change?
Add abTests to the `CanCheckExperiment` 
