### PR TITLE
Always render image content with DCR

### DIFF
--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -45,7 +45,7 @@ class ImageContentController(
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] =
     image(Edition(request), path).flatMap {
       case Right((content, mainBlock)) =>
-        val tier = ImageContentPicker.getTier(content, mainBlock)
+        val tier = ImageContentPicker.getTier(content)
 
         tier match {
           case RemoteRender => remoteRender(content, mainBlock)

--- a/applications/app/services/dotcomrendering/ImageContentPicker.scala
+++ b/applications/app/services/dotcomrendering/ImageContentPicker.scala
@@ -12,18 +12,13 @@ object ImageContentPicker extends GuLogging {
 
   def getTier(
       imageContentPage: ImageContentPage,
-      mainBlock: Option[Block],
   )(implicit
       request: RequestHeader,
   ): RenderType = {
-    val dcrCanRender =
-      mainBlock.exists(block => block.elements.forall(element => element.`type` == ElementType.Cartoon))
 
     val tier = {
       if (request.forceDCROff) LocalRender
-      else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender) RemoteRender
-      else LocalRender
+      else RemoteRender
     }
 
     if (tier == RemoteRender) {

--- a/applications/test/ImageContentControllerTest.scala
+++ b/applications/test/ImageContentControllerTest.scala
@@ -3,8 +3,8 @@ package test
 import controllers.ImageContentController
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import play.api.test.Helpers._
 
 @DoNotDiscover class ImageContentControllerTest
     extends AnyFlatSpec
@@ -23,12 +23,12 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
     new ImageContentController(testContentApiClient, play.api.test.Helpers.stubControllerComponents(), wsClient)
 
   "Image Content Controller" should "200 when content type is picture" in {
-    val result = imageContentController.render(pictureUrl)(TestRequest(pictureUrl))
+    val result = imageContentController.render(pictureUrl)(TestRequest(s"$pictureUrl?dcr=false"))
     status(result) should be(200)
   }
 
   "Image Content Controller" should "200 when content type is cartoon" in {
-    val result = imageContentController.render(cartoonUrl)(TestRequest(cartoonUrl))
+    val result = imageContentController.render(cartoonUrl)(TestRequest(s"$cartoonUrl?dcr=false"))
     status(result) should be(200)
   }
 

--- a/applications/test/ImageContentTemplateTest.scala
+++ b/applications/test/ImageContentTemplateTest.scala
@@ -1,20 +1,20 @@
 package test
+import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import org.scalatest.DoNotDiscover
-
 @DoNotDiscover class ImageContentTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
-  it should "render a cartoon" in goTo("/commentisfree/cartoon/2013/jul/15/iain-duncan-smith-benefits-cap") { browser =>
-    import browser._
-    el("[itemprop='headline']").html().toString.trim should be(
-      "Steve Bell on Iain Duncan Smith and the benefits cap – cartoon",
-    )
-    el(".media-primary img").attribute("src") should include("Steve-Bell-cartoon")
+  it should "render a cartoon" in goTo("/commentisfree/cartoon/2013/jul/15/iain-duncan-smith-benefits-cap?dcr=false") {
+    browser =>
+      import browser._
+      el("[itemprop='headline']").html().toString.trim should be(
+        "Steve Bell on Iain Duncan Smith and the benefits cap – cartoon",
+      )
+      el(".media-primary img").attribute("src") should include("Steve-Bell-cartoon")
   }
 
-  it should "render a picture" in goTo("/artanddesign/picture/2013/oct/08/photography") { browser =>
+  it should "render a picture" in goTo("/artanddesign/picture/2013/oct/08/photography?dcr=false") { browser =>
     import browser._
     $("[itemprop='headline']").first().text() should be("Early erotica - a picture from the past")
     el(".media-primary img").attribute("src") should include("French-Nude-in-Body-Stock")

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -27,16 +27,6 @@ object DeeplyRead
       participationGroup = Perc50,
     )
 
-// Removing while we are still implementing this content type in DCR
-//object DCRImageContent
-//    extends Experiment(
-//      name = "dcr-image-content",
-//      description = "Use DCR for image content",
-//      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-//      sellByDate = LocalDate.of(2024, 1, 1),
-//      participationGroup = Perc0E,
-//    )
-
 object AdaptiveSite
     extends Experiment(
       name = "adaptive-site",


### PR DESCRIPTION
## What does this change?

Renders all image articles with DCR, instead of just ones with cartoon elements

## Why

Now that we have lightbox in DCR there's no reason to render image articles with Frontend 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/1229808/faf96a37-2306-4969-b04c-4401d40565a9
[after]: https://github.com/guardian/frontend/assets/1229808/062da330-aca0-4058-a6d1-a857e6aaeae7
