### PR TITLE
Add experiment for Ophan external click tracking

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,6 +14,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       AdaptiveSite,
       DeeplyRead,
       CrosswordMobileBanner,
+      OphanNext,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -53,4 +54,13 @@ object CrosswordMobileBanner
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2024, 4, 2),
       participationGroup = Perc0A,
+    )
+
+object OphanNext
+    extends Experiment(
+      name = "ophan-next",
+      description = "Use @guardian/ophan-tracker-js@2.1.0-next.1, which allows tracking of clicks on external links",
+      owners = Seq(Owner.withGithub("@guardian/ophan")),
+      sellByDate = LocalDate.of(2024, 4, 1),
+      participationGroup = Perc1B,
     )


### PR DESCRIPTION
## What does this change?

This adds a 1% server-side A/B test to deliver a version of the DCR client side bundle that incorporates a new version of Ophan that can track clicks on external links. See https://github.com/guardian/dotcom-rendering/pull/10425
