### PR TITLE
Ensure All Newsletters page is async

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -10,8 +10,8 @@ GET        /_healthcheck                                                        
 GET        /sitemaps/news.xml                                                   controllers.SiteMapController.renderNewsSiteMap()
 GET        /sitemaps/video.xml                                                  controllers.SiteMapController.renderVideoSiteMap()
 
-GET        /email-newsletters.json                                              controllers.SignupPageController.renderNewslettersJson()
-GET        /email-newsletters                                                   controllers.SignupPageController.renderNewslettersPage()
+GET        /email-newsletters.json                                              controllers.SignupPageController.renderNewsletters()
+GET        /email-newsletters                                                   controllers.SignupPageController.renderNewsletters()
 
 GET        /survey/:formName/show                                               controllers.SurveyPageController.renderFormStackSurvey(formName)
 GET        /survey/thankyou                                                     controllers.SurveyPageController.thankYou()

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -347,7 +347,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = DotcomNewslettersPageRenderingDataModel.apply(page, newsletters, request)
     val json = DotcomNewslettersPageRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.faciaBaseURL + "/EmailNewsletters", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.baseURL + "/EmailNewsletters", CacheTime.Facia)
   }
 
   def getImageContent(

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -347,7 +347,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = DotcomNewslettersPageRenderingDataModel.apply(page, newsletters, request)
     val json = DotcomNewslettersPageRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/EmailNewsletters", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.faciaBaseURL + "/EmailNewsletters", CacheTime.Facia)
   }
 
   def getImageContent(


### PR DESCRIPTION
## What is the value of this and can you measure success?

We're getting lots of errors on the `facia` app since [directing the DCR requests for `/EmailNewsletters` to `facia-rendering`](https://github.com/guardian/frontend/pull/26866), so this refactors the code to render the all newsletters page and (hopefully) fixes an issue with a blocking operation.

## What does this change?

- Updates the `SignupPageController` to be `Action.async` rather than just `Action` and as such, swaps the return types to be `Future[Result]` instead of just `Result`. 
- Removes [`Await`](https://www.scala-lang.org/api/2.12.8/scala/concurrent/Await$.html) from the DCR request code, along with the max duration of 3 seconds. 
  In the docs for `Await` it says:
  >  While occasionally useful, e.g. for testing, it is recommended that you avoid Await whenever possible— instead favoring combinators and/or callbacks. Await's result and ready methods will block the calling thread's execution until they return, which will cause performance degradation, and possibly, deadlock issues.




