### PR TITLE
Upgrade `@guardian/commercial@14.1.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^16.3.0",
-		"@guardian/commercial": "13.0.0",
+		"@guardian/commercial": "14.1.0",
 		"@guardian/consent-management-platform": "13.7.3",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.0.1",
 		"@guardian/identity-auth-frontend": "3.0.0",
-		"@guardian/libs": "^15.6.4",
+		"@guardian/libs": "16.0.0",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "^13.2.1",
 		"@guardian/source-react-components": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,10 +2484,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-2.0.1.tgz#1164867ba84498058ad5d561337bc3c48dd30e6f"
   integrity sha512-5EQB3LWDLxDaTKk/RHBGwoGy5mT90ZEa56XzrBStfyFi2FYma9bCvGdEEcOPmf3tLhdVxh93ikuooPveq76siA==
 
-"@guardian/libs@^15.6.4":
-  version "15.6.4"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.4.tgz#13787065e5c58b884944c5c71d6e324c7f2e566a"
-  integrity sha512-oN+xN7FBuVKLCbbjvAMdWjgWqOtvR38acnqwAKsjUDkFsBzRWU/pueDSEGTCTTVSFcRdCKOsWnop+Vwh59P47g==
+"@guardian/libs@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-16.0.0.tgz#35c567039f3a2a8440e3f0520b1bd9d275e6ad97"
+  integrity sha512-2i9cN6htXnvABIGhfqJGb9Bh/DdQOayUjb5ruqBGTiXEeDBHztctdVsi7+rPfMlwyPxQ+0qYLhM19f6J94vvhQ==
 
 "@guardian/libs@^16.0.0":
   version "16.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,20 +2428,20 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-16.3.0.tgz#77e2c550507d4e5b86029bce716a9a102d7cc136"
   integrity sha512-JQ9MkrJx6+7OXxwqPy2lfFNKvvmFGTCbdOedC2KczdLKusKUSWIw3EzLwdoRpgMTXsQSVpqrJ5N/VM3wDsAAxQ==
 
-"@guardian/commercial@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-13.0.0.tgz#7e4de3773af2a8ac600267975419fe41324b1f14"
-  integrity sha512-LtRU1c4qu2WJvByDhAKOjD0U4nRxsv5dtaHqYJfq9ROmtenLTvPbIAAAqnNoUZDxv49mbjG9a5LSPv/DhJgbEw==
+"@guardian/commercial@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-14.1.0.tgz#c3a693e216c1f4f920b7638b03abd35ef4ad226f"
+  integrity sha512-ZrokNbBYbZm1HbD5+MvTKajWMqQND0i4moHMp3faTniGjTqrKE6S6ykwgqbMIz5ZU0+s34kqCPNwkTV7/xvtrw==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"
+    "@guardian/prebid.js" "8.34.0"
     "@octokit/core" "^4.0.5"
     fastdom "^1.0.11"
     lodash-es "^4.17.21"
-    prebid.js guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4
     process "^0.11.10"
     raven-js "^3.27.2"
-    tslib "^2.5.3"
+    tslib "^2.6.2"
     web-vitals "^3.3.2"
     wolfy87-eventemitter "^5.2.9"
 
@@ -2498,6 +2498,29 @@
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@guardian/ophan-tracker-js/-/ophan-tracker-js-2.0.4.tgz#899cf3b3d91d403fb5afb6842b258fff1c286c60"
   integrity sha512-kwUNUSfnL8SQwzTlVzInYh7a6VSMFy3zEq2A6Hm7cmKSbl8D7ed03y7ANqquViFuPffRZRQ0IrkJHSbMnsRmrA==
+
+"@guardian/prebid.js@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@guardian/prebid.js/-/prebid.js-8.34.0.tgz#6ab69684d254e52c44a0fe58ad5fc334ee133953"
+  integrity sha512-DLH/EuWGsM6oZcMVm+qsuWhYPl+TE4nqkDzAVJRjOkiP3AHHOZ7AnQaGzF9Y9tG3EeFU/iJwqJ43JlIjDBOt1A==
+  dependencies:
+    "@babel/core" "^7.23.2"
+    "@babel/plugin-transform-runtime" "^7.18.9"
+    "@babel/preset-env" "^7.16.8"
+    "@babel/runtime" "^7.18.9"
+    "@guardian/libs" "^16.0.0"
+    core-js "^3.13.0"
+    core-js-pure "^3.13.0"
+    criteo-direct-rsa-validate "^1.1.0"
+    crypto-js "^4.2.0"
+    dlv "1.1.3"
+    dset "3.1.2"
+    express "^4.15.4"
+    fun-hooks "^0.9.9"
+    just-clone "^1.0.2"
+    live-connect-js "^6.3.4"
+  optionalDependencies:
+    fsevents "^2.3.2"
 
 "@guardian/prettier@^3.0.0":
   version "3.0.0"
@@ -10105,17 +10128,17 @@ listr@^0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-live-connect-common@^v3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/live-connect-common/-/live-connect-common-3.0.3.tgz#720ca29a22d59c8b26a0dac894bb4863b1b69627"
-  integrity sha512-ZPycT04ROBUvPiksnLTunrKC3ROhBSeO99fQ+4qMIkgKwP2CvS44L7fK+0WFV4nAi+65KbzSng7JWcSlckfw8w==
+live-connect-common@^v3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/live-connect-common/-/live-connect-common-3.1.1.tgz#7d0474bce04d6c03fb7157abebd37b0deac437a6"
+  integrity sha512-sV0oUvJnaTN41f30hOo3wDjZL2y8TYu5BQKvlxmek7Agpe2AGGN/dsPA8i2sHkessRKpcTfrPjmpnG2bIxq7Gg==
 
-live-connect-js@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-6.3.0.tgz#032d6015969293774430872d4d22ca8bae8ff2c9"
-  integrity sha512-1SnXQZq9gxHIb0scXPX1Da1rQ0oY2sloMGgeRreTAwhCtdQEuip/IYwgOh3/ZeZ6yT6iG9FLb7+AjORC4pO46g==
+live-connect-js@^6.3.4:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-6.5.0.tgz#3731fd8a20d117235c843f5d14502961483accd9"
+  integrity sha512-gZOKtGjPjTf6JuUtA6OZgg8w/uEP2lEtlAKWSox+rTiTRmD4U6o28MB9WEgSJWlZWwUwmWu9dL8ByxBFbsWZyg==
   dependencies:
-    live-connect-common "^v3.0.2"
+    live-connect-common "^v3.1.1"
     tiny-hashes "1.0.1"
 
 load-json-file@^4.0.0:
@@ -11837,28 +11860,6 @@ preact@^10.5.13:
   version "10.13.2"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.13.2.tgz#2c40c73d57248b57234c4ae6cd9ab9d8186ebc0a"
   integrity sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==
-
-prebid.js@guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4:
-  version "8.24.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4"
-  dependencies:
-    "@babel/core" "^7.23.2"
-    "@babel/plugin-transform-runtime" "^7.18.9"
-    "@babel/preset-env" "^7.16.8"
-    "@babel/runtime" "^7.18.9"
-    "@guardian/libs" "^16.0.0"
-    core-js "^3.13.0"
-    core-js-pure "^3.13.0"
-    criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^4.2.0"
-    dlv "1.1.3"
-    dset "3.1.2"
-    express "^4.15.4"
-    fun-hooks "^0.9.9"
-    just-clone "^1.0.2"
-    live-connect-js "^6.3.0"
-  optionalDependencies:
-    fsevents "^2.3.2"
 
 precinct@^8.0.0, precinct@^8.1.0:
   version "8.3.1"
@@ -14110,7 +14111,7 @@ tslib@^2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
-tslib@^2.3.1, tslib@^2.5.0:
+tslib@^2.3.1, tslib@^2.5.0, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
## What does this change?

Upgrade @guardian/commercial@14.1.0
Upgrade @guardian/libs@16.0.0

This brings in the following commercial changes:

https://github.com/guardian/commercial/releases/tag/v14.1.0
  - now uses @guardian/prebid.js from a published package so we shouldn't see issues with the github prefix anymore such as yarn cache flip-flopping of dependencies, snyk and dependabot errors.

https://github.com/guardian/commercial/releases/tag/v14.0.0
