### PR TITLE
bump commercial to 14.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^16.3.0",
-		"@guardian/commercial": "14.2.0",
+		"@guardian/commercial": "14.2.1",
 		"@guardian/consent-management-platform": "13.7.3",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,10 +2428,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-16.3.0.tgz#77e2c550507d4e5b86029bce716a9a102d7cc136"
   integrity sha512-JQ9MkrJx6+7OXxwqPy2lfFNKvvmFGTCbdOedC2KczdLKusKUSWIw3EzLwdoRpgMTXsQSVpqrJ5N/VM3wDsAAxQ==
 
-"@guardian/commercial@14.2.0":
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-14.2.0.tgz#bd0393df25907c03bd6b14e046602662cb6a2b22"
-  integrity sha512-D5yXKs+qefU07enkcnQ6ibhzyu5M2WaDL4KA97+3mCrnW3GtGefFGd2UPIR7I9srbtVngyFxemHXtHlOjJXWcQ==
+"@guardian/commercial@14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-14.2.1.tgz#47b83e03541252c4550cd8b224dc35ee3b9e9f04"
+  integrity sha512-VbzhwwyimLkUsG3v3gdfeIIHKQIVt1U6z1wSaJTTgjYb2oy++e8P3/7n5pUrLIqCAYJSSXnraQrafFcNzn8g+g==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"


### PR DESCRIPTION
## What does this change?

Bumps commercial to v14.2.1

#### Changes:
- https://github.com/guardian/commercial/pull/1248