### PR TITLE
Fix issue with banner ads on fronts not matching their appearance on DCR-rendered pages

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -26,6 +26,8 @@ $header-image-size-desktop: 100px;
 
 .fc-container--commercial {
     padding-bottom: 0;
+    background-color: $brightness-97;
+    z-index: 2;
 }
 
 .fc-container__inner,

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -20,6 +20,8 @@ $header-image-size-desktop: 100px;
 
 .fc-container--commercial {
     padding-bottom: 0;
+    background-color: $brightness-97;
+    z-index: 2;
 }
 
 .fc-container__inner,


### PR DESCRIPTION
## What does this change?

This adds a background colour to banner ad slots on frontend-rendered fronts to match their appearance on pages rendered with DCR. It also adds a z-index to hide the faux borders on the left and right of the page.

## Screenshots

### DCR appearance

![Screenshot 2024-02-07 at 15-43-50 News sport and opinion from the Guardian's global edition The Guardian](https://github.com/guardian/frontend/assets/29146931/f08f57df-a59f-4dd0-b5fc-8bc693a1121b)

### Fully in line with DCR

| Before      | After      |
|-------------|------------|
|  ![Screenshot 2024-02-07 at 15-38-44 Education news opinion and guides The Guardian](https://github.com/guardian/frontend/assets/29146931/4e0a7458-2a1f-4dd5-b1ec-3b0dcf064898) | ![Screenshot 2024-02-07 at 12-51-28 Education news opinion and guides The Guardian](https://github.com/guardian/frontend/assets/29146931/462e4847-c705-4932-a26d-7a5d6baff934) |

### Avoiding z-index changes

| Before      | After      |
|-------------|------------|
|  ![Screenshot 2024-02-07 at 15-38-44 Education news opinion and guides The Guardian](https://github.com/guardian/frontend/assets/29146931/4e0a7458-2a1f-4dd5-b1ec-3b0dcf064898) | ![Screenshot 2024-02-07 at 12-50-52 Education news opinion and guides The Guardian](https://github.com/guardian/frontend/assets/29146931/8e2b9399-f68f-4a0e-9d42-520a0db7781f) |

