### PR TITLE
Do not render tag combiners with DCR

### DIFF
--- a/applications/app/services/TagFrontPicker.scala
+++ b/applications/app/services/TagFrontPicker.scala
@@ -2,6 +2,7 @@ package services.dotcomrendering
 
 import common.GuLogging
 import implicits.Requests._
+import model.TagCombiner
 import play.api.mvc.RequestHeader
 import services.IndexPage
 
@@ -33,6 +34,7 @@ object TagFrontPicker extends GuLogging {
     Map(
       // until we complete https://github.com/guardian/dotcom-rendering/issues/5755
       ("isNotAccessibilityPage", tagPage.page.metadata.id != "help/accessibility-help"),
+      ("isNotTagCombiner", !tagPage.page.isInstanceOf[TagCombiner]),
     )
   }
 


### PR DESCRIPTION
## What does this change?

Prevents tag combiner pages (e.g. https://www.theguardian.com/tone/comment+profile/editorial) from being rendered with DCR. 

## Why

We don't yet support tag combiner pages in DCR, the model is a little different from regular tag pages.
Fixes https://github.com/guardian/dotcom-rendering/issues/9365
