### PR TITLE
Swap DCR tag page endpoint

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -292,7 +292,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     )
 
     val json = DotcomTagFrontsRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.faciaBaseURL + "/TagFront", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.faciaBaseURL + "/TagPage", CacheTime.Facia)
   }
 
   def getInteractive(


### PR DESCRIPTION
## What is the value of this and can you measure success?

Starts sending requests to endpoint named consistently with the rest of the code, ahead of launching [the 1% test for tag pages](https://github.com/guardian/frontend/pull/26883)

## What does this change?

Updates the DCR endpoint for tag pages from `/TagFront` to `/TagPage` since [the terminology was updated in `dotcom-rendering`](https://github.com/guardian/dotcom-rendering/pull/10540)

_Does not update other terminology since this is already being done in #26883._

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] ~Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)~ N/A
  - [ ] ~[Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)~ N/A
  - [ ] ~[Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)~ N/A
  - [ ] ~[Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)~ N/A

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
