### PR TITLE
Fix crossword-banner centring and label

### DIFF
--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -66,6 +66,12 @@
     margin-top: $gs-baseline;
     // 90px is the height of a leaderboard
     min-height: 90px + $mpu-ad-label-height + $gs-row-height / 2;
+    display: flex;
+    justify-content: center;
+
+    & .ad-slot-container {
+        width: fit-content;
+    }
 
     @include mq($until: desktop) {
         margin-left: -$gs-gutter;


### PR DESCRIPTION
## What is the value of this and can you measure success?
This ad looks a bit janky at the moment, this fixes that.

## What does this change?

Centre the ad and label

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/1731150/e451603c-d447-4638-9e9b-ad5dce1f7912"

[after]: https://github.com/guardian/frontend/assets/1731150/793520df-eae5-4435-a9ca-d1d472859089


## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
