### PR TITLE
Remove super bowl from US main and sport nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -156,7 +156,6 @@ object NavLinks {
   val MLB = NavLink("MLB", "/sport/mlb")
   val NBA = NavLink("NBA", "/sport/nba")
   val NHL = NavLink("NHL", "/sport/nhl")
-  val superbowl = NavLink("Super Bowl", "/sport/super-bowl")
 
   /* CULTURE */
   val film = NavLink("Film", "/film")
@@ -319,7 +318,6 @@ object NavLinks {
       science,
       newsletters,
       wellness,
-      superbowl,
     ),
   )
   val intNewsPillar = ukNewsPillar.copy(
@@ -424,7 +422,6 @@ object NavLinks {
       NHL,
       formulaOne,
       golf,
-      superbowl,
     ),
   )
   val intSportPillar = ukSportPillar.copy(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1010,11 +1010,6 @@
                 "url" : "/wellness",
                 "children" : [ ],
                 "classList" : [ ]
-            }, {
-                "title" : "Super Bowl",
-                "url" : "/sport/super-bowl",
-                "children" : [ ],
-                "classList" : [ ]
             } ],
             "classList" : [ ]
         },
@@ -1135,11 +1130,6 @@
             }, {
                 "title" : "Golf",
                 "url" : "/sport/golf",
-                "children" : [ ],
-                "classList" : [ ]
-            }, {
-                "title" : "Super Bowl",
-                "url" : "/sport/super-bowl",
                 "children" : [ ],
                 "classList" : [ ]
             } ],


### PR DESCRIPTION
## What does this change?
Removes super bowl from US main and sport nav as it has finished.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/20416599/d88d2216-4412-482b-add8-fd17e55152d8
[after]: https://github.com/guardian/frontend/assets/20416599/83bd86b1-bfbd-46c2-8500-2a86af67e669

