### PR TITLE
Update age warning for social posts

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -136,8 +136,21 @@ final case class Content(
       .flatMap(_.url)
       .getOrElse(Configuration.images.fallbackLogo)
 
+  private val tagsWithoutAgeWarning = Seq(
+    "tone/help",
+    "info/info",
+    "tone/recipes",
+    "lifeandstyle/series/sudoku",
+    "type/crossword",
+    "lifeandstyle/series/kakuro",
+    "the-scott-trust/the-scott-trust",
+    "type/signup",
+    "info/newsletter-sign-up",
+    "guardian-live-events/guardian-live-events",
+  )
   def shareImageCategory: ShareImageCategory = {
-    val isOldNews = tags.tags.exists(_.id == "tone/news") &&
+
+    val isOldNews = !tags.tags.exists(tag => tagsWithoutAgeWarning.contains(tag.id)) &&
       trail.webPublicationDate.isBefore(DateTime.now().minusYears(1))
 
     val isOldOpinion = tags.tags.exists(_.id == "tone/comment") &&

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -178,6 +178,70 @@ class ContentTest
     contentWithShortUrl("https://www.theguardian.com/p/4t2c6").fields.shortUrlId should be("/p/4t2c6")
   }
 
+  it should "show age warning in social post when article is 1 year old" in {
+    val oneYearOld = Some(
+      jodaToJavaInstant(new DateTime(DateTime.now().minusYears(1))).atOffset(ZoneOffset.UTC).toCapiDateTime,
+    )
+
+    val contentWithNewsTag = Content(
+      article.copy(
+        webPublicationDate = oneYearOld,
+        fields = Some(ContentFields(sensitive = Some(false), shouldHideReaderRevenue = Some(false))),
+        tags = List(tag(s"tone/news")),
+      ),
+    )
+    val shareImageCategory = contentWithNewsTag.content.shareImageCategory
+    shareImageCategory.getClass.getSimpleName should be("GuardianOldContent")
+  }
+
+  it should "not show age warning in social post when article is less than 1 year old" in {
+    val threeMonthsOld = Some(
+      jodaToJavaInstant(new DateTime(DateTime.now().minusMonths(3))).atOffset(ZoneOffset.UTC).toCapiDateTime,
+    )
+
+    val contentWithNewsTag = Content(
+      article.copy(
+        webPublicationDate = threeMonthsOld,
+        fields = Some(ContentFields(sensitive = Some(false), shouldHideReaderRevenue = Some(false))),
+        tags = List(tag(s"tone/news")),
+      ),
+    )
+    contentWithNewsTag.content.shareImageCategory.getClass.getSimpleName should be("GuardianDefault$")
+  }
+
+  it should "show special opinion style overlay for age warning when article is tone/comment and is 1 year ago" in {
+    val oneYearOld = Some(
+      jodaToJavaInstant(new DateTime(DateTime.now().minusYears(1))).atOffset(ZoneOffset.UTC).toCapiDateTime,
+    )
+
+    val contentWithCommentTag = Content(
+      article.copy(
+        webPublicationDate = oneYearOld,
+        fields = Some(ContentFields(sensitive = Some(false), shouldHideReaderRevenue = Some(false))),
+        tags = List(tag(s"tone/comment")),
+      ),
+    )
+    contentWithCommentTag.content.shareImageCategory.getClass.getSimpleName should be("CommentGuardianOldContent")
+  }
+
+  it should "not show age warning when article is 1 year old and has any of the tags excluded from age warning" in {
+    val oneYearOld = Some(
+      jodaToJavaInstant(new DateTime(DateTime.now().minusYears(1))).atOffset(ZoneOffset.UTC).toCapiDateTime,
+    )
+
+    val contentWithTagThatShouldNotHaveAgeWarning = Content(
+      article.copy(
+        webPublicationDate = oneYearOld,
+        fields = Some(ContentFields(sensitive = Some(false), shouldHideReaderRevenue = Some(false))),
+        tags = List(tag(s"tone/recipes")),
+      ),
+    )
+
+    contentWithTagThatShouldNotHaveAgeWarning.content.shareImageCategory.getClass.getSimpleName should be(
+      "GuardianDefault$",
+    )
+  }
+
   val dateBeforeCutoff = Some(
     jodaToJavaInstant(new DateTime("2017-07-02T12:00:00.000Z")).atOffset(ZoneOffset.UTC).toCapiDateTime,
   )


### PR DESCRIPTION
Closes: https://github.com/guardian/dotcom-rendering/issues/10411

## What does this change?
* Keeps the special opinion style overlay
* We default to the simple yellow overlay for the rest of the tags, not just "tone/news" which was previously the case
* Adds a list of tags that should not have age warning

## Screenshots

| Article | Before | After |
|---------|--------|-------|
| ["tone/news" and 4 years old](https://m.code.dev-theguardian.com/politics/2020/jul/08/boris-johnson-refuses-to-apologise-to-care-workers-at-pmqs) | <img width="500" alt="image" src="https://github.com/guardian/frontend/assets/19683595/d06a032a-7242-4508-aea7-0acbad4f7954"> | <img width="516" alt="image" src="https://github.com/guardian/frontend/assets/19683595/a0f99480-77f9-4f87-be49-0493078e54e3"> |
| ["tone/comment" and 4 years old](https://m.code.dev-theguardian.com/commentisfree/2020/jul/14/labour-defeat-super-rich-conservatives-calling-higher-taxes-starmer) | <img width="493" alt="image" src="https://github.com/guardian/frontend/assets/19683595/4e7244db-1bf3-46ba-9a7d-38c67e343f08"> | <img width="499" alt="image" src="https://github.com/guardian/frontend/assets/19683595/5b431bd2-235c-4878-aad1-6342fa3ca019"> |
| ["tone/feature" and 4 years old](https://m.code.dev-theguardian.com/politics/2020/jul/13/i-feel-theres-hope-now-readers-on-100-days-of-keir-starmer-labour-leadership) | <img width="496" alt="image" src="https://github.com/guardian/frontend/assets/19683595/7e9470b6-ee5f-4264-a9c9-0fa1378d5528"> | <img width="496" alt="image" src="https://github.com/guardian/frontend/assets/19683595/b8acfaf0-70a5-42fe-b5c0-e8692d8a54dd"> |
| ["tone/recipes" 4 years old](https://m.code.dev-theguardian.com/food/2020/sep/12/meera-sodha-vegan-recipe-for-shaoxing-and-soy-braised-tofu-with-pak-choi) | <img width="488" alt="image" src="https://github.com/guardian/frontend/assets/19683595/816e1b52-7825-4aa0-b0c1-5013aa6f4ed7"> | <img width="495" alt="image" src="https://github.com/guardian/frontend/assets/19683595/e7550afc-5b0b-46b2-9384-b695b56745b6"> |
| ["tone/news" and recent](https://m.code.dev-theguardian.com/politics/2024/feb/12/starmer-urged-to-discipline-rochdale-candidate-over-israel-gaza-remarks) | <img width="492" alt="image" src="https://github.com/guardian/frontend/assets/19683595/6d5ee3c7-c117-41ff-8c33-03c13ec96298"> | <img width="493" alt="image" src="https://github.com/guardian/frontend/assets/19683595/d5adc87c-e3c7-42ab-b894-3e3f8a399e85"> |


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
