### PR TITLE
Add `.tool-versions` To Version Control For Java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,3 @@ static/src/stylesheets/pasteup/.npmrc
 metals.sbt
 
 .java-version
-.tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.22.7.1


### PR DESCRIPTION
Allows us to specify the Java version for this project, for tools that recognise this file such as `asdf`. MAPI has already been doing this for a while: https://github.com/guardian/mobile-apps-api/pull/2316

We also already do something similar for Node in `frontend`:

https://github.com/guardian/frontend/blob/eb7fdfa7c41cd4a8644e71971e327aa97a68794f/.nvmrc#L1

We could also consider moving the Node version into `.tool-versions` at some point in the future, so one tool can manage both.

If anyone reading this PR thinks this may cause a problem for their workflow please comment! I've tagged several people who've committed to frontend over the last couple of weeks for this reason.
