### PR TITLE
bump commercial package to 15.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "14.4.3",
+		"@guardian/commercial": "15.0.1",
 		"@guardian/consent-management-platform": "13.10.0",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/commercial@14.4.3":
-  version "14.4.3"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-14.4.3.tgz#41da4505064c882ca93d590d8a5a6619f9a7f6e6"
-  integrity sha512-Sems06ePcTgF6DYybStTERcGymr89TDONKBrCNq27IrhKsiTjwiDyZgTWnXipojQdOvxxIZNk6XWpTKVOdQbDw==
+"@guardian/commercial@15.0.1":
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-15.0.1.tgz#4f610a5431cf6e0290bb835dd3bf8f16fe6fb1a8"
+  integrity sha512-cJB3lOFyOdiPE6jmllUjK0nyQc7whz8QYi3xmI4Y6A7lCqHDnm4XnIJFC3n+ejsWtqCK3/Cr8MHN0JWR4dbPMw==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
Bumps commercial package to 15.0.1

Includes several bumps from commercial. The major bump may seem more major, but actually just removes redundant ad slots
The following changes are including in the updates:
https://github.com/guardian/commercial/releases/tag/v15.0.0
and
https://github.com/guardian/commercial/releases/tag/v15.0.1
