### PR TITLE
It’s about time we use “Batter”

### DIFF
--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -9,7 +9,7 @@ object Team {
   implicit val writes: OWrites[Team] = Json.writes[Team]
 }
 
-case class InningsBatsman(
+case class InningsBatter(
     name: String,
     order: Int,
     ballsFaced: Int,
@@ -24,8 +24,8 @@ case class InningsBatsman(
   lazy val notOut: Boolean = !out
 }
 
-object InningsBatsman {
-  implicit val writes: OWrites[InningsBatsman] = Json.writes[InningsBatsman]
+object InningsBatter {
+  implicit val writes: OWrites[InningsBatter] = Json.writes[InningsBatter]
 }
 
 case class InningsBowler(name: String, order: Int, overs: Int, maidens: Int, runs: Int, wickets: Int)
@@ -48,7 +48,7 @@ case class Innings(
     declared: Boolean,
     forfeited: Boolean,
     description: String,
-    batsmen: List[InningsBatsman],
+    batsmen: List[InningsBatter],
     bowlers: List[InningsBowler],
     fallOfWicket: List[InningsWicket],
     byes: Int,
@@ -63,14 +63,14 @@ case class Innings(
   lazy val allOut = wickets == 10
   lazy val wickets = fallOfWicket.length
 
-  lazy val firstIn: Option[InningsBatsman] = batsmen.find(_.notOut)
-  lazy val secondIn: Option[InningsBatsman] = {
+  lazy val firstIn: Option[InningsBatter] = batsmen.find(_.notOut)
+  lazy val secondIn: Option[InningsBatter] = {
     batsmen.filter(_.notOut) match {
       case first :: second :: _ => Some(second)
       case _                    => None
     }
   }
-  lazy val lastOut: Option[InningsBatsman] = batsmen.filter(_.out).lastOption
+  lazy val lastOut: Option[InningsBatter] = batsmen.filter(_.out).lastOption
 }
 
 object Innings {
@@ -94,11 +94,11 @@ case class Match(
 
   def lastInnings: Option[Innings] = innings.lastOption
 
-  def firstInBatsman: Option[InningsBatsman] = lastInnings.flatMap(_.firstIn)
+  def firstInBatter: Option[InningsBatter] = lastInnings.flatMap(_.firstIn)
 
-  def secondInBatsman: Option[InningsBatsman] = lastInnings.flatMap(_.secondIn)
+  def secondInBatter: Option[InningsBatter] = lastInnings.flatMap(_.secondIn)
 
-  def lastOut: Option[InningsBatsman] = lastInnings.flatMap(_.lastOut)
+  def lastOut: Option[InningsBatter] = lastInnings.flatMap(_.lastOut)
 }
 
 object Match {

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -101,20 +101,20 @@ object Parser {
       .toList
       .sortBy(_.order)
 
-  private def parseInningsBatsmen(batsmen: NodeSeq): List[InningsBatsman] =
+  private def parseInningsBatsmen(batsmen: NodeSeq): List[InningsBatter] =
     batsmen
-      .map { batsman =>
-        InningsBatsman(
-          (batsman \ "player" \ "name").text,
-          (batsman \ "@order").text.toInt,
-          getStatistic(batsman, "balls-faced") toInt,
-          getStatistic(batsman, "runs-scored") toInt,
-          getStatistic(batsman, "fours") toInt,
-          getStatistic(batsman, "sixes") toInt,
-          (batsman \ "status").text == "batted",
-          (batsman \ "dismissal" \ "description").text,
-          getStatistic(batsman, "on-strike").toInt > 0,
-          getStatistic(batsman, "runs-scored").toInt > 0,
+      .map { batter =>
+        InningsBatter(
+          (batter \ "player" \ "name").text,
+          (batter \ "@order").text.toInt,
+          getStatistic(batter, "balls-faced") toInt,
+          getStatistic(batter, "runs-scored") toInt,
+          getStatistic(batter, "fours") toInt,
+          getStatistic(batter, "sixes") toInt,
+          (batter \ "status").text == "batted",
+          (batter \ "dismissal" \ "description").text,
+          getStatistic(batter, "on-strike").toInt > 0,
+          getStatistic(batter, "runs-scored").toInt > 0,
         )
       }
       .toList

--- a/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
+++ b/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
@@ -40,19 +40,19 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @for(batsman <- innings.batsmen) {
+                    @for(batter <- innings.batsmen) {
                         <tr>
                             <td class="table-column--importance-3">
-                                <b>@batsman.name</b>
+                                <b>@batter.name</b>
                                 <div class="mobile-only">
-                                    @batsman.howOut
+                                    @batter.howOut
                                 </div>
                             </td>
-                            <td class="table-column--importance-1">@batsman.howOut</td>
-                            <td class="table-column--importance-3">@batsman.runs</td>
-                            <td class="table-column--importance-3">@batsman.ballsFaced</td>
-                            <td class="table-column--importance-1">@batsman.fours</td>
-                            <td class="table-column--importance-1">@batsman.sixes</td>
+                            <td class="table-column--importance-1">@batter.howOut</td>
+                            <td class="table-column--importance-3">@batter.runs</td>
+                            <td class="table-column--importance-3">@batter.ballsFaced</td>
+                            <td class="table-column--importance-1">@batter.fours</td>
+                            <td class="table-column--importance-1">@batter.sixes</td>
                         </tr>
                     }
                     <tr class="table-row--divider">

--- a/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
+++ b/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
@@ -31,7 +31,7 @@
             <table class="table table--responsive-font">
                 <thead>
                     <tr>
-                        <th class="table-column--importance-3">Batsman</th>
+                        <th class="table-column--importance-3">Batter</th>
                         <th class="table-column--importance-1"></th>
                         <th class="table-column--importance-3">Runs</th>
                         <th class="table-column--importance-3">Balls</th>


### PR DESCRIPTION
## What is the value of this and can you measure success?

- “Batter” is the official, gender-neutral term [since September 2021](https://en.wikipedia.org/wiki/Batting_(cricket)), [despite having no entry in the style guide](https://www.theguardian.com/guardian-observer-style-guide-b).
- Brings [the batter full circle](https://github.com/guardian/frontend/blob/59c4759192e620a333e0a7282f41541841fc5850/docs/99-archives/crepes.md#L16-L28), a week on from Shrove Tuesday

## What does this change?

Remove all user-facing and developer instances of “Batsman” with ”Batter”.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/76776/be5c494b-3d87-4bad-8b75-4d9ce71a59d4
[after]: https://github.com/guardian/frontend/assets/76776/33114947-4046-4051-b994-825375afe38a

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)