### PR TITLE
Increase circuit breaker max failures for DCR

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -156,7 +156,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds
-    lazy val circuitBreakerMaxFailures = 10 // we should increase this as DCR sees increasing usage
+    lazy val circuitBreakerMaxFailures = 50 // we should increase this as DCR sees increasing usage
   }
 
   object contributionsService {


### PR DESCRIPTION
## What is the value of this and can you measure success?

DCR was implemented with a circuit breaker when it was introduced which may have made sense for the time when it was one destination but now that we send traffic to at least three different applications, it does not make sense to have one circuit breaker between all of them.

This PR is a work in progress to update this logic to a more sensible solution, and addresses the first part of the following items:

- Increase the maximum number of failures allowed before the circuit breaker opens
- Introduce a new type of circuit breaker feature switch for DCR. It's quite strange that we use the same feature switch for CAPI as we do for DCR
- Implement different circuit breakers for each of the DCR apps, if we feel that this feature is an important one that we need to keep (will gather information from the first step where we increase the maximum number of failures before it trips)


## What does this change?

Increases the maximum number of failures before the circuit breaker trips into the open state for DCR requests
