### PR TITLE
Use separate circuit breaker switch for DCR

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -156,7 +156,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds
-    lazy val circuitBreakerMaxFailures = 50 // we should increase this as DCR sees increasing usage
+    lazy val circuitBreakerMaxFailures = 50
   }
 
   object contributionsService {

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -71,7 +71,7 @@ trait PerformanceSwitches {
     "circuit-breaker",
     "If this switch is switched on then the DCR circuit breaker will be operational",
     owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
+    safeState = On,
     sellByDate = never,
     exposeClientSide = false,
   )

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -66,6 +66,16 @@ trait PerformanceSwitches {
     exposeClientSide = false,
   )
 
+  val DCRCircuitBreakerSwitch = Switch(
+    SwitchGroup.Performance,
+    "circuit-breaker",
+    "If this switch is switched on then the DCR circuit breaker will be operational",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
+
   val AutoRefreshSwitch = Switch(
     SwitchGroup.Performance,
     "auto-refresh",

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.v1.{Block, Blocks, Content}
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
-import conf.switches.Switches.CircuitBreakerSwitch
+import conf.switches.Switches.DCRCircuitBreakerSwitch
 import crosswords.CrosswordPageWithContent
 import http.{HttpPreconnections, ResultWithPreconnectPreload}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
@@ -133,7 +133,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       }
     }
 
-    if (CircuitBreakerSwitch.isSwitchedOn) {
+    if (DCRCircuitBreakerSwitch.isSwitchedOn) {
       circuitBreaker.withCircuitBreaker(postWithoutHandler(ws, payload, endpoint, timeout)).map(handler)
     } else {
       postWithoutHandler(ws, payload, endpoint, timeout).map(handler)


### PR DESCRIPTION
## What is the value of this and can you measure success?

As a follow-up PR from #26913, this addresses the second item to introduce a new circuit breaker switch for DCR since we shouldn't be using the same one for CAPI as we do for DCR since they are totally separate services.

## What does this change?

Adds a new feature switch for a DCR-specific circuit breaker and uses that in the DotcomRenderingService instead of the CAPI circuit breaker switch which was being used before.
