### PR TITLE
Fix circuit breaker config name

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -68,7 +68,7 @@ trait PerformanceSwitches {
 
   val DCRCircuitBreakerSwitch = Switch(
     SwitchGroup.Performance,
-    "circuit-breaker",
+    "dcr-circuit-breaker",
     "If this switch is switched on then the DCR circuit breaker will be operational",
     owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
     safeState = On,


### PR DESCRIPTION
## What does this change?

Made a mistake in https://github.com/guardian/frontend/pull/26914 and forgot to change the switch name. This PR fixes that to ensure both CAPI and DCR circuit breaker switches have different names/IDs