### PR TITLE
chore: remove unused resolver

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -51,9 +51,7 @@ object ProjectSettings {
       <dependencies>
         <exclude org="commons-logging" module="commons-logging"><!-- Conflicts with jcl-over-slf4j in Play. --></exclude>
       </dependencies>,
-    resolvers ++= Resolver.sonatypeOssRepos("releases") ++ Seq(
-      "Spy" at "https://files.couchbase.com/maven2/",
-    ),
+    resolvers ++= Resolver.sonatypeOssRepos("releases"),
     update / evictionWarningOptions := EvictionWarningOptions.default
       .withWarnTransitiveEvictions(false)
       .withWarnDirectEvictions(false)


### PR DESCRIPTION
## What is the value of this and can you measure success?

As a result of MavenGate, we are removing sbt resolvers that are not owned by Sonatype for security reasons. This PR removes the Spy resolver (for `spymemcached` dependency) which was added [10 years ago](https://github.com/guardian/frontend/blame/eef34baaa3b994358bf0b52f924bf92daa37e26d/project/Prototypes.scala). [`spymemcached` is available on Maven Central](https://mvnrepository.com/artifact/net.spy/spymemcached).

How to test

Running `sbt compile` locally on this branch completed successfully.