### PR TITLE
Remove age warning from articles with `gnm-archive` tag in social posts

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -147,6 +147,7 @@ final case class Content(
     "type/signup",
     "info/newsletter-sign-up",
     "guardian-live-events/guardian-live-events",
+    "gnm-archive/gnm-archive",
   )
   def shareImageCategory: ShareImageCategory = {
 


### PR DESCRIPTION
Part of [#10667](https://github.com/guardian/dotcom-rendering/issues/10667)

## What is the value of this and can you measure success?

## What does this change?
Add `gnm-archive/gnm-archive` tag in `tagsWithoutAgeWarning`

## Why?
Request from CP

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="491" alt="image" src="https://github.com/guardian/frontend/assets/19683595/b742f193-896d-4eb5-82cb-300a62a96cab"> | <img width="497" alt="image" src="https://github.com/guardian/frontend/assets/19683595/aed635c1-fdba-4057-8834-970d6f551ca9"> |

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
