### PR TITLE
Remove text from crosswords

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -1,3 +1,4 @@
+@import views.html.fragments.crosswords.crosswordMeta
 @(crosswordPage: crosswords.CrosswordPageWithContent, gridVisable: Boolean = true)(implicit requestHeader: RequestHeader)
 @import common.LinkTo
 
@@ -27,10 +28,6 @@
                     @crosswordMeta(crosswordPage)
                 </div>
             }
-
-            <div class="hide-from-leftcol crossword__clues-header">Time on your hands? Stay connected and keep in touch with your friends with our new Puzzles mobile app. You can access more than 15,000 crosswords and sudoku and solve puzzles online together. <a href="https://puzzles.theguardian.com/download" data-link-name="crossword-mobile-link">Download and try it for free now.</a></div>
-
-            <div class="hide-until-leftcol crossword__clues-header">Time on your hands? Stay connected and keep in touch with your friends with our new Puzzles mobile app. You can access more than 15,000 crosswords and sudoku and solve puzzles online together. <a href="https://www.theguardian.com/info/2020/feb/10/the-guardian-puzzles-app?device=other" data-link-name="crossword-desktop-link">Download and try it for free now.</a></div>
 
             <div class="meta__extras meta__extras--crossword">
                 <div class="meta__social" data-component="share">


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/26922

## What does this change?
Removes text from crosswords

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/19683595/71d2ae5d-a9a6-4e19-bb88-da1358784bbc) | ![image](https://github.com/guardian/frontend/assets/19683595/448fece8-7ebe-4466-bba1-e380da700432) |

