### PR TITLE
Display line items targeted to the im slot on the inline merch admin page

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -167,9 +167,10 @@ class DfpDataCacheJob(
     if (data.hasValidLineItems) {
       val now = printLondonTime(DateTime.now())
 
+      val lineItems = data.inlineMerchandisingTargetedLineItems
       val inlineMerchandisingTargetedTags = data.inlineMerchandisingTargetedTags
       Store.putInlineMerchandisingSponsorships(
-        stringify(toJson(InlineMerchandisingTargetedTagsReport(now, inlineMerchandisingTargetedTags))),
+        stringify(toJson(InlineMerchandisingTargetedTagsReport(now, inlineMerchandisingTargetedTags, lineItems))),
       )
     }
   }

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -7,6 +7,22 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[Gu
 
   val hasValidLineItems: Boolean = lineItems.nonEmpty
 
+  val inlineMerchandisingTargetedLineItems: InlineMerchandisingLineItems = {
+    val targetedLineItems = lineItems
+      .filter(_.targetsInlineMerchandising)
+      .foldLeft(Seq.empty[InlineMerchandisingLineItem]) { (soFar, lineItem) =>
+        soFar :+ InlineMerchandisingLineItem(
+          name = lineItem.name,
+          id = lineItem.id,
+          keywords = lineItem.inlineMerchandisingTargetedKeywords,
+          series = lineItem.inlineMerchandisingTargetedSeries,
+          contributors = lineItem.inlineMerchandisingTargetedContributors,
+        )
+      }
+
+    InlineMerchandisingLineItems(items = targetedLineItems)
+  }
+
   val inlineMerchandisingTargetedTags: InlineMerchandisingTagSet = {
     lineItems.foldLeft(InlineMerchandisingTagSet()) { (soFar, lineItem) =>
       soFar.copy(

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -62,7 +62,7 @@ trait Store extends GuLogging with Dates {
 
   def getDfpInlineMerchandisingTargetedTagsReport(): InlineMerchandisingTargetedTagsReport = {
     S3.get(dfpInlineMerchandisingTagsDataKey) flatMap (InlineMerchandisingTargetedTagsReportParser(_))
-  } getOrElse InlineMerchandisingTargetedTagsReport(now, InlineMerchandisingTagSet())
+  } getOrElse InlineMerchandisingTargetedTagsReport(now, InlineMerchandisingTagSet(), InlineMerchandisingLineItems())
 
   def getDfpHighMerchandisingTargetedTagsReport(): HighMerchandisingTargetedTagsReport = {
     S3.get(dfpHighMerchandisingTagsDataKey) flatMap (HighMerchandisingTargetedTagsReportParser(_))

--- a/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
@@ -1,5 +1,5 @@
 @import common.dfp.InlineMerchandisingTargetedTagsReport
-@import tools.{CapiLink, SiteLink}
+@import tools.{CapiLink, SiteLink, DfpLink}
 
 @(report: InlineMerchandisingTargetedTagsReport)(implicit request: RequestHeader, context: model.ApplicationContext)
 
@@ -50,4 +50,30 @@
         </ol>
     }
 
+    <h2>Line Items</h2>
+    <p>Line items that target the <em>im</em> slot:</p>
+    @if(report.lineItems.items.isEmpty) {<p>None</p>} else {
+        <table class="table table-striped table-bordered table-condensed">
+            <thead>
+                <tr>
+                    <th class="col-md-3">Name</th>
+                    <th class="col-md-1">DFP link</th>
+                    <th class="col-md-2">Keyword Targeting</th>
+                    <th class="col-md-2">Series Targeting</th>
+                    <th class="col-md-2">Contributor Targeting</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for(lineItem <- report.lineItems.sortedItems) {
+                    <tr>
+                        <td>@{lineItem.name}</td>
+                        <td><a href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a></td>
+                        <td>@{lineItem.keywords.mkString(", ")}</td>
+                        <td>@{lineItem.series.mkString(", ")}</td>
+                        <td>@{lineItem.contributors.mkString(", ")}</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
 }

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -261,6 +261,15 @@ case class GuLineItem(
     targetSlotIsHighMerch.nonEmpty
   }
 
+  val targetsInlineMerchandising: Boolean = {
+    val targetSlotIsInlineMerch = for {
+      targetSet <- targeting.customTargetSets
+      target <- targetSet.targets
+      if target.name == "slot" && target.values.contains("im")
+    } yield target
+    targetSlotIsInlineMerch.nonEmpty
+  }
+
   lazy val targetsNetworkOrSectionFrontDirectly: Boolean = {
     targeting.adUnitsIncluded.exists { adUnit =>
       val path = adUnit.path

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -40,6 +40,38 @@ case class InlineMerchandisingTagSet(
   def nonEmpty: Boolean = keywords.nonEmpty || series.nonEmpty || contributors.nonEmpty
 }
 
+object InlineMerchandisingLineItem {
+  implicit val jsonReads: Reads[InlineMerchandisingLineItem] = Json.reads[InlineMerchandisingLineItem]
+
+  implicit val inlineMerchandisingLineItemWrites: Writes[InlineMerchandisingLineItem] =
+    (lineItem: InlineMerchandisingLineItem) => {
+      Json.obj(
+        "name" -> lineItem.name,
+        "id" -> lineItem.id,
+        "keywords" -> lineItem.keywords,
+        "series" -> lineItem.series,
+        "contributors" -> lineItem.contributors,
+      )
+    }
+}
+
+case class InlineMerchandisingLineItem(
+    name: String,
+    id: Long,
+    keywords: Seq[String],
+    series: Seq[String],
+    contributors: Seq[String],
+) {}
+
+object InlineMerchandisingLineItems {
+  implicit val lineItemFormat: OFormat[InlineMerchandisingLineItem] = Json.format[InlineMerchandisingLineItem]
+  implicit val lineItemsFormat: OFormat[InlineMerchandisingLineItems] = Json.format[InlineMerchandisingLineItems]
+}
+
+case class InlineMerchandisingLineItems(items: Seq[InlineMerchandisingLineItem] = Seq.empty) {
+  val sortedItems = items.sortBy(_.name)
+}
+
 object InlineMerchandisingTargetedTagsReport {
   implicit val jsonReads: Reads[InlineMerchandisingTargetedTagsReport] =
     Json.reads[InlineMerchandisingTargetedTagsReport]
@@ -49,11 +81,16 @@ object InlineMerchandisingTargetedTagsReport {
       Json.obj(
         "updatedTimeStamp" -> report.updatedTimeStamp,
         "targetedTags" -> report.targetedTags,
+        "lineItems" -> report.lineItems,
       )
     }
 }
 
-case class InlineMerchandisingTargetedTagsReport(updatedTimeStamp: String, targetedTags: InlineMerchandisingTagSet)
+case class InlineMerchandisingTargetedTagsReport(
+    updatedTimeStamp: String,
+    targetedTags: InlineMerchandisingTagSet,
+    lineItems: InlineMerchandisingLineItems,
+)
 
 object InlineMerchandisingTargetedTagsReportParser extends GuLogging {
   def apply(jsonString: String): Option[InlineMerchandisingTargetedTagsReport] = {


### PR DESCRIPTION
## What is the value of this and can you measure success?
I keep seeing pages that have `hasInlineMerchandising` set to true but no ad is served.

It's quite tough to figure out why this is because you can't search for line items by their targeting (as far as I know).

This should make it easier to figure out why this happens sometimes!

## What does this change?

I've added a section to the admin that displays the line items currently targeting the im slot.

This required updating the DFP job for inline merch to also grab and cache the targeted line items.

## Screenshots
<img width="1401" alt="Screenshot 2024-02-23 at 14 00 15" src="https://github.com/guardian/frontend/assets/1731150/851a8c7a-ae11-41cb-bad3-edece3f81b78">

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
