### PR TITLE
Bump `actions-riff-raff` from v2 to v4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,10 +30,9 @@ indent_size = 2
 [package.json]
 indent_size = 2
 
-[*.yaml]
+[*.{yaml,yml}]
 indent_size = 2
-[*.yml]
-indent_size = 2
+quote_type = double
 
 [makefile]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -30,7 +30,9 @@ indent_size = 2
 [package.json]
 indent_size = 2
 
-[riff-raff.yaml]
+[*.yaml]
+indent_size = 2
+[*.yml]
 indent_size = 2
 
 [makefile]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: 'Build'
+name: "Build"
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: 'Build'
 
 on:
   push:
@@ -6,17 +6,16 @@ on:
 permissions:
   id-token: write
   contents: read
+  pull-requests: write # Required for riff-raff action
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-        pull-requests: write # Required for riff-raff action
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write # Required for riff-raff action
     steps:
       - uses: actions/checkout@v4
 
@@ -39,11 +41,6 @@ jobs:
         env:
           NODE_ENV: production
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-
       - name: Test, compile
         # Australia/Sydney  -because it is too easy for devs to forget about timezones
         run: |
@@ -56,8 +53,10 @@ jobs:
           -Duser.timezone=Australia/Sydney \
           -jar ./bin/sbt-launch.jar clean compile assets scalafmtCheckAll test Universal/packageBin
 
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           projectName: dotcom:frontend-all
           configPath: riff-raff.yaml
           contentDirectories: |


### PR DESCRIPTION
## What is the value of this and can you measure success?

Upgrades to use the latest version of `guardian/actions-riff-raff`.

Part of https://github.com/guardian/dotcom-rendering/issues/10600

## What does this change?

- Adds write permissions for pull requests and adds `githubToken` to the job step as [required in the major version bump for v3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0)
- Removes step to configure AWS credentials and uses the AWS role ARN directly in the riff-raff action [as required in the major bump for v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4)

## Checklist

- [x] Tested locally, and on CODE if necessary
  - [CODE deployment](https://riffraff.gutools.co.uk/deployment/view/e029e65e-aeeb-4872-9ba7-f13f56f209f2)

