### PR TITLE
Tweak syndication URL for new reuse content form

### DIFF
--- a/common/app/views/fragments/syndication.scala.html
+++ b/common/app/views/fragments/syndication.scala.html
@@ -6,7 +6,7 @@
             <li class="syndication__item">
                 <a class="syndication__action"
                 data-link-name="meta-syndication-@content.content.syndicationType"
-                href="https://syndication.theguardian.com/automation/?url=@URLEncode(content.metadata.webUrl)&type=@content.content.syndicationType&internalpagecode=@content.content.internalPageCode"
+                href="https://syndication.theguardian.com/?url=@URLEncode(content.metadata.webUrl)&type=@content.content.syndicationType&internalpagecode=@content.content.internalPageCode"
                 target="_blank"
                 title="Reuse this content">
                     <span class="syndication__link button button--syndication-reprint button--small">Reuse this content</span>


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are replacing the problematic "reuse this content" form with a more modern and supportable one

## What does this change?

Removes the `/automation` prefix from the "Reuse this content" button target URL. This is not required on the new form.

## Screenshots

n/a, there is no visual change

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
