### PR TITLE
Bump commercial to 16.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "16.0.0",
+		"@guardian/commercial": "16.1.0",
 		"@guardian/consent-management-platform": "13.11.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/commercial@16.0.0":
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-16.0.0.tgz#e46cd939ee0f98d84bfc21124f93d4b2d6b041e5"
-  integrity sha512-nR6vBM7Bu5E49m4vWMeeTg1fsM/hsiTKY32r/R3YlMMYbYf2OBk/ExZg+EwMiXA11Z6euUriutSKEiQQ10LdTw==
+"@guardian/commercial@16.1.0":
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-16.1.0.tgz#b70b67b7af9ed52c2dbece062df494de75f5eed4"
+  integrity sha512-K8X4JxugpfMxAVMBESQ3lslfUvfHP41yI9o+NMKzXj3AjMbNCXo9U+Gy18qMkSNSpfW6GBaojvrM9G7YduSQSQ==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"


### PR DESCRIPTION
Bring in the changes from [16.1.0](https://github.com/guardian/commercial/releases/tag/v16.1.0)