### PR TITLE
Split DCR circuit breakers by app

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -66,6 +66,16 @@ trait PerformanceSwitches {
     exposeClientSide = false,
   )
 
+  val DCRCircuitBreakerSwitch = Switch(
+    SwitchGroup.Performance,
+    "dcr-circuit-breaker",
+    "If this switch is switched on then the DCR circuit breaker will be operational",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
+
   val AutoRefreshSwitch = Switch(
     SwitchGroup.Performance,
     "auto-refresh",

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -70,17 +70,21 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     * Returns a tuple of (baseURL, circuitBreaker)
     */
   private[this] def decideService(path: String): (String, CircuitBreaker) = {
+    val articlePattern = "(Article)|(Blocks)".r
+    val faciaPattern = "(Front)|(TagPage)".r
+    val interactivePattern = "(Interactive)".r
+
     path match {
-      case "/Article" | "/AppsArticle" | "/AMPArticle" | "/Blocks" =>
+      case articlePattern(_) =>
         (Configuration.rendering.articleBaseURL, circuitBreakerArticleRendering)
 
-      case "/Front" | "/TagPage" =>
+      case faciaPattern(_) =>
         (Configuration.rendering.faciaBaseURL, circuitBreakerFaciaRendering)
 
-      case "/Interactive" | "/AppsInteractive" | "/AMPInteractive" =>
+      case interactivePattern(_) =>
         (Configuration.rendering.interactiveBaseURL, circuitBreakerInteractiveRendering)
 
-      case "/EmailNewsletters" | _ =>
+      case _ =>
         (Configuration.rendering.baseURL, circuitBreakerRendering)
 
     }


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
