### PR TITLE
Remove puzzles app from nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -256,7 +256,6 @@ object NavLinks {
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val guardianLive =
     NavLink("Live events", "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown")
-  val guardianPuzzlesApp = NavLink("Guardian Puzzles app", s"https://puzzles.theguardian.com/download")
   val guardianLicensing = NavLink("Guardian Licensing", s"https://licensing.theguardian.com/")
   val jobsRecruiter = NavLink(
     "Hire with Guardian Jobs",
@@ -615,13 +614,11 @@ object NavLinks {
     digitalNewspaperArchive,
     printShop,
     ukPatrons,
-    guardianPuzzlesApp,
     guardianLicensing,
   )
   val auBrandExtensions = List(
     auEvents,
     digitalNewspaperArchive,
-    guardianPuzzlesApp,
     auWeekend,
     guardianLicensing,
     aboutUs,
@@ -629,7 +626,6 @@ object NavLinks {
   val usBrandExtensions = List(
     jobs,
     digitalNewspaperArchive,
-    guardianPuzzlesApp,
     guardianLicensing,
     aboutUs,
   )
@@ -637,7 +633,6 @@ object NavLinks {
     jobs,
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
-    guardianPuzzlesApp,
     guardianLicensing,
     aboutUs,
   )

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -808,11 +808,6 @@
             "children" : [ ],
             "classList" : [ ]
         }, {
-            "title" : "Guardian Puzzles app",
-            "url" : "https://puzzles.theguardian.com/download",
-            "children" : [ ],
-            "classList" : [ ]
-        }, {
             "title" : "Guardian Licensing",
             "url" : "https://licensing.theguardian.com/",
             "children" : [ ],
@@ -1388,11 +1383,6 @@
             "children" : [ ],
             "classList" : [ ]
         }, {
-            "title" : "Guardian Puzzles app",
-            "url" : "https://puzzles.theguardian.com/download",
-            "children" : [ ],
-            "classList" : [ ]
-        }, {
             "title" : "Guardian Licensing",
             "url" : "https://licensing.theguardian.com/",
             "children" : [ ],
@@ -1960,11 +1950,6 @@
         }, {
             "title" : "Digital Archive",
             "url" : "https://theguardian.newspapers.com",
-            "children" : [ ],
-            "classList" : [ ]
-        }, {
-            "title" : "Guardian Puzzles app",
-            "url" : "https://puzzles.theguardian.com/download",
             "children" : [ ],
             "classList" : [ ]
         }, {
@@ -2708,11 +2693,6 @@
             "children" : [ ],
             "classList" : [ ]
         }, {
-            "title" : "Guardian Puzzles app",
-            "url" : "https://puzzles.theguardian.com/download",
-            "children" : [ ],
-            "classList" : [ ]
-        }, {
             "title" : "Guardian Licensing",
             "url" : "https://licensing.theguardian.com/",
             "children" : [ ],
@@ -3446,11 +3426,6 @@
         }, {
             "title" : "Digital Archive",
             "url" : "https://theguardian.newspapers.com",
-            "children" : [ ],
-            "classList" : [ ]
-        }, {
-            "title" : "Guardian Puzzles app",
-            "url" : "https://puzzles.theguardian.com/download",
             "children" : [ ],
             "classList" : [ ]
         }, {


### PR DESCRIPTION
## What is the value of this and can you measure success?
Resolves https://github.com/guardian/frontend/issues/26935
## What does this change?
Removes puzzles app from nav
## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/110032454/7d38dd8c-c3b4-447e-bda8-94ed2b536ff3
[after]: https://github.com/guardian/frontend/assets/110032454/46dca182-a8f2-4835-a71b-318fb42f90af



## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
