### PR TITLE
Add quick-cryptic crossword

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -17,11 +17,11 @@ GET        /survey/:formName/show                                               
 GET        /survey/thankyou                                                     controllers.SurveyPageController.thankYou()
 
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.svg       controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.json      controllers.CrosswordPageController.renderJson(crosswordType: String, id: Int)
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id           controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|special|genius|speedy|weekend>/:id/print          controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
-GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id     controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.svg       controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.json      controllers.CrosswordPageController.renderJson(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id           controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|special|genius|speedy|weekend>/:id/print          controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
+GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id     controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search
 GET        /crosswords/search                                                                                                controllers.CrosswordSearchController.search()

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1,6 +1,6 @@
 package model.dotcomrendering.pageElements
 
-import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
+import com.gu.contentapi.client.model.v1.ElementType.{List => _, Map => _, _}
 import com.gu.contentapi.client.model.v1.EmbedTracksType.DoesNotTrack
 import com.gu.contentapi.client.model.v1.{
   ElementType,

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -180,7 +180,7 @@ object BlockElement {
       case Callout                   => Some(UnsupportedBlockElement(None))
       case Cartoon                   => Some(UnsupportedBlockElement(None))
       case Recipe                    => Some(UnsupportedBlockElement(None))
-
+      case List                      => Some(UnsupportedBlockElement(None))
     }
   }
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -19,11 +19,11 @@ GET            /assets/*path                                                    
 
 # Crosswords
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
-GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.svg               controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
-GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.json              controllers.CrosswordPageController.renderJson(crosswordType: String, id: Int)
-GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id                   controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
-GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|special|genius|speedy|weekend>/:id/print                  controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
-GET            /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id        controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.svg               controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.json              controllers.CrosswordPageController.renderJson(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id                   controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|special|genius|speedy|weekend>/:id/print                  controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
+GET            /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id        controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search
 GET            /crosswords/search                                                                                                controllers.CrosswordSearchController.search()

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -18,7 +18,7 @@ GET           /oauth2callback                                                   
 GET           /logout                                                                          controllers.OAuthLoginPreviewController.logout
 
 # Crossword
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id    controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|prize|everyman|azed|special|genius|speedy|weekend>/:id    controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
 
 
 # Commercial

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.17"
   val awsVersion = "1.12.638"
-  val capiVersion = "21.0.0"
-  val faciaVersion = "5.0.0"
+  val capiVersion = "23.0.0"
+  val faciaVersion = "5.0.3"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/static/src/stylesheets/module/crosswords/_vars.scss
+++ b/static/src/stylesheets/module/crosswords/_vars.scss
@@ -12,7 +12,7 @@ $xword-focussed-background-colour: #fff7b2;
 $xword-clue-number-width: 32px;
 
 $xword-grid-sizes: (
-    quick-cryptic: 11,
+    quickcryptic: 11,
     quick: 13,
     cryptic: 15,
     prize: 15,

--- a/static/src/stylesheets/module/crosswords/_vars.scss
+++ b/static/src/stylesheets/module/crosswords/_vars.scss
@@ -12,6 +12,7 @@ $xword-focussed-background-colour: #fff7b2;
 $xword-clue-number-width: 32px;
 
 $xword-grid-sizes: (
+    quick-cryptic: 11,
     quick: 13,
     cryptic: 15,
     prize: 15,


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

Add quick-cryptic crossword to known types in routes files to see if we can render. 
Updates capi libs to get the new crossword type id

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->

Fixes https://github.com/guardian/dotcom-rendering/issues/10810
