### PR TITLE
Add Super Tuesday and Oscars 2024 to the sub nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -447,8 +447,8 @@ object NavLinks {
     longTitle = Some("Culture home"),
     iconName = Some("home"),
     List(
-      film,
       oscars2024,
+      film,
       music,
       tvAndRadio,
       books,
@@ -460,8 +460,8 @@ object NavLinks {
   )
   val auCulturePillar = ukCulturePillar.copy(
     children = List(
-      film,
       oscars2024,
+      film,
       music,
       books,
       tvAndRadio,
@@ -473,8 +473,8 @@ object NavLinks {
   )
   val usCulturePillar = ukCulturePillar.copy(
     children = List(
-      film,
       oscars2024,
+      film,
       books,
       music,
       artAndDesign,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -193,6 +193,8 @@ object NavLinks {
   val usTravel = ukTravel.copy(children = List(travelUs, travelEurope, travelUk))
   val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
   val wellness = NavLink("Wellness", "/wellness")
+  val superTuesday = NavLink("Super Tuesday", "/us-news/super-tuesday")
+  val oscars2024 = NavLink("Oscars 2024", "/film/oscars-2024")
 
   val todaysPaper = NavLink(
     "Today's paper",
@@ -308,6 +310,7 @@ object NavLinks {
     List(
       usNews,
       usElections2024,
+      superTuesday,
       world,
       usEnvironment,
       ukraine,
@@ -317,6 +320,7 @@ object NavLinks {
       science,
       newsletters,
       wellness,
+      oscars2024,
     ),
   )
   val intNewsPillar = ukNewsPillar.copy(
@@ -444,6 +448,7 @@ object NavLinks {
     iconName = Some("home"),
     List(
       film,
+      oscars2024,
       music,
       tvAndRadio,
       books,
@@ -456,6 +461,7 @@ object NavLinks {
   val auCulturePillar = ukCulturePillar.copy(
     children = List(
       film,
+      oscars2024,
       music,
       books,
       tvAndRadio,
@@ -468,6 +474,7 @@ object NavLinks {
   val usCulturePillar = ukCulturePillar.copy(
     children = List(
       film,
+      oscars2024,
       books,
       music,
       artAndDesign,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -471,6 +471,11 @@
                 "children" : [ ],
                 "classList" : [ ]
             }, {
+                "title" : "Oscars 2024",
+                "url" : "/film/oscars-2024",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
                 "title" : "Music",
                 "url" : "/music",
                 "children" : [ ],
@@ -832,6 +837,11 @@
                 "children" : [ ],
                 "classList" : [ ]
             }, {
+                "title" : "Super Tuesday",
+                "url" : "/us-news/super-tuesday",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
                 "title" : "World",
                 "url" : "/world",
                 "longTitle" : "World news",
@@ -1005,6 +1015,11 @@
                 "url" : "/wellness",
                 "children" : [ ],
                 "classList" : [ ]
+            }, {
+                "title" : "Oscars 2024",
+                "url" : "/film/oscars-2024",
+                "children" : [ ],
+                "classList" : [ ]
             } ],
             "classList" : [ ]
         },
@@ -1138,6 +1153,11 @@
             "children" : [ {
                 "title" : "Film",
                 "url" : "/film",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Oscars 2024",
+                "url" : "/film/oscars-2024",
                 "children" : [ ],
                 "classList" : [ ]
             }, {
@@ -1728,6 +1748,11 @@
             "children" : [ {
                 "title" : "Film",
                 "url" : "/film",
+                "children" : [ ],
+                "classList" : [ ]
+            }, {
+                "title" : "Oscars 2024",
+                "url" : "/film/oscars-2024",
                 "children" : [ ],
                 "classList" : [ ]
             }, {

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -466,13 +466,13 @@
             "longTitle" : "Culture home",
             "iconName" : "home",
             "children" : [ {
-                "title" : "Film",
-                "url" : "/film",
+                "title" : "Oscars 2024",
+                "url" : "/film/oscars-2024",
                 "children" : [ ],
                 "classList" : [ ]
             }, {
-                "title" : "Oscars 2024",
-                "url" : "/film/oscars-2024",
+                "title" : "Film",
+                "url" : "/film",
                 "children" : [ ],
                 "classList" : [ ]
             }, {
@@ -1151,13 +1151,13 @@
             "longTitle" : "Culture home",
             "iconName" : "home",
             "children" : [ {
-                "title" : "Film",
-                "url" : "/film",
+                "title" : "Oscars 2024",
+                "url" : "/film/oscars-2024",
                 "children" : [ ],
                 "classList" : [ ]
             }, {
-                "title" : "Oscars 2024",
-                "url" : "/film/oscars-2024",
+                "title" : "Film",
+                "url" : "/film",
                 "children" : [ ],
                 "classList" : [ ]
             }, {
@@ -1746,13 +1746,13 @@
             "longTitle" : "Culture home",
             "iconName" : "home",
             "children" : [ {
-                "title" : "Film",
-                "url" : "/film",
-                "children" : [ ],
-                "classList" : [ ]
-            }, {
                 "title" : "Oscars 2024",
                 "url" : "/film/oscars-2024",
+                "children" : [ ],
+                "classList" : [ ]
+            },{
+                "title" : "Film",
+                "url" : "/film",
                 "children" : [ ],
                 "classList" : [ ]
             }, {


### PR DESCRIPTION
## What is the value of this and can you measure success?

Resolves #26949 

## What does this change?

- Adds "Super Tuesday" to the US network front subnav under the News pillar, after "US Elections 2024".
- Adds "Oscars 2024" to the US network front subnav under the News pillar, after "Wellness".
- Adds "Oscars 2024" to the US, UK and AUS network front subnavs under the Culture pillar, ~after~ in front of "Film".

## Screenshots

> [!NOTE]
> Screenshots are slightly out of date as the request was to put Oscars 2024 in front of Film on the Culture subnavs rather than after it


|             | Before      | After      |
|-------------|-------------|------------|
| US News     | ![before-us-news][] | ![after-us-news][] |
| US Culture  | ![before-us][] | ![after-us][] |
| UK Culture  | ![before-uk][] | ![after-uk][] |
| AU Culture  | ![before-au][] | ![after-au][] |


[before-us-news]:https://github.com/guardian/frontend/assets/43961396/635d9267-3bae-49ed-b7b6-929f3bd15972
[before-us]: https://github.com/guardian/frontend/assets/43961396/6eab7b38-c9bf-4be7-83e4-6f1eb24f5e44
[before-uk]:https://github.com/guardian/frontend/assets/43961396/29c96773-0e3a-4abf-bf9a-cad85c66b0dc
[before-au]: https://github.com/guardian/frontend/assets/43961396/442c3ebc-6f6b-4af5-8d74-0c6792d432af

[after-us-news]: https://github.com/guardian/frontend/assets/43961396/a8654d4d-dc5e-4a2d-ab4b-1d19a27276f9
[after-us]: https://github.com/guardian/frontend/assets/43961396/0ce4eab2-946c-4e6d-bf45-e1cedc459f8c
[after-uk]: https://github.com/guardian/frontend/assets/43961396/79bb5475-4a10-43ad-8c8a-54f764826c64
[after-au]: https://github.com/guardian/frontend/assets/43961396/9dda04a0-e489-44d0-a358-ceda208bbe41

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering

