### PR TITLE
Update @guardian/commercial to version 17.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "17.2.0",
+		"@guardian/commercial": "17.3.0",
 		"@guardian/consent-management-platform": "13.12.0",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "17.3.0",
+		"@guardian/commercial": "17.3.1",
 		"@guardian/consent-management-platform": "13.12.0",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/commercial@17.3.0":
-  version "17.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.3.0.tgz#7d86675299f58607ec88e36df3630e848f0f3ba1"
-  integrity sha512-/uGmRwyli9FYv/61OiwZkIug7SYuwjcsfcfawtH1mfKGiLtaayWvijh6GjCnzobW+ZfK8mjjgpUzFjDmV1vRmA==
+"@guardian/commercial@17.3.1":
+  version "17.3.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.3.1.tgz#3f61745b92d124f282068a13bac1228ee8d81e37"
+  integrity sha512-PnZ28NrXHCsHsGIsLEMZSrHQ2E6NxIdv09tjWXXZH99WegeQ+4sxv6fVgImEDjOWNK508Z0wmONVt0ohp+eMEg==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/commercial@17.2.0":
-  version "17.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.2.0.tgz#653b355462eaf7606e4abef1993075c0a2e3e365"
-  integrity sha512-ag0MSfRLOaN5IajHmmfPA7/5HvO6RraUri1pgaPdENaBeLysq56sfT0u1eJhpO68iJ0LXzh3dh2WSY1Wrhp06w==
+"@guardian/commercial@17.3.0":
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.3.0.tgz#7d86675299f58607ec88e36df3630e848f0f3ba1"
+  integrity sha512-/uGmRwyli9FYv/61OiwZkIug7SYuwjcsfcfawtH1mfKGiLtaayWvijh6GjCnzobW+ZfK8mjjgpUzFjDmV1vRmA==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"


### PR DESCRIPTION
## What does this change?
Commercial [Changelog](https://github.com/guardian/commercial/blob/main/CHANGELOG.md) since 17.1.1

## 17.3.1

### Patch Changes

- 08e8a48: Remove HR as candidate for mobile spacefinder

## 17.3.0

### Minor Changes

- bece12b: Improve spacefinder's handling of ranked and list articles on mobile

## 17.2.0

### Minor Changes

- 9baa4cb: Refresh the page when the user changes their consent