### PR TITLE
Create advert density by section AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,4 +44,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2024, 3, 29)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-section-ad-density",
+    "Increase inline advert density on article pages in high value sections.",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 7, 26)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,6 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
+import { sectionAdDensity } from './tests/section-ad-density';
 import { signInGateAlternativeWording } from './tests/sign-in-gate-alternative-wording';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -13,4 +14,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateAlternativeWording,
 	remoteRRHeaderLinksTest,
 	mpuWhenNoEpic,
+	sectionAdDensity,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/section-ad-density.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/section-ad-density.ts
@@ -1,0 +1,31 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const sectionAdDensity: ABTest = {
+	id: 'SectionAdDensity',
+	author: '@commercial-dev',
+	start: '2024-03-07',
+	expiry: '2024-07-26',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria:
+		'Article pages in the following sections: business, environment, music, money, artanddesign, science, stage, travel, wellness, games',
+	successMeasure:
+		'Overall revenue increases without harming attention time and page views per session metrics.',
+	description:
+		'Increase inline advert density on article pages in high value sections.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

Adds an AB test and a switch

## Why?

The AB test will be used for assessing the impact of varying inline ad density on article pages belonging to high value sections of the Guardian, e.g. business, money.
