### PR TITLE
Remove Super Tuesday from US subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -193,7 +193,6 @@ object NavLinks {
   val usTravel = ukTravel.copy(children = List(travelUs, travelEurope, travelUk))
   val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
   val wellness = NavLink("Wellness", "/wellness")
-  val superTuesday = NavLink("Super Tuesday", "/us-news/super-tuesday")
   val oscars2024 = NavLink("Oscars 2024", "/film/oscars-2024")
 
   val todaysPaper = NavLink(
@@ -310,7 +309,6 @@ object NavLinks {
     List(
       usNews,
       usElections2024,
-      superTuesday,
       world,
       usEnvironment,
       ukraine,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -837,11 +837,6 @@
                 "children" : [ ],
                 "classList" : [ ]
             }, {
-                "title" : "Super Tuesday",
-                "url" : "/us-news/super-tuesday",
-                "children" : [ ],
-                "classList" : [ ]
-            }, {
                 "title" : "World",
                 "url" : "/world",
                 "longTitle" : "World news",


### PR DESCRIPTION
## What is the value of this and can you measure success?

After adding "Super Tuesday" to the subnav in https://github.com/guardian/frontend/pull/26950, it [was requested](https://groups.google.com/a/guardian.co.uk/g/dotcom.platform/c/8EvmNoOUthg/m/GXIRq7XLAAAJ) that this be removed on 7th March

## What does this change?

Removes "Super Tuesday" link from the US subnav

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/43961396/d36299b2-4124-4ada-94e5-c8313a2ed9b0
[after]: https://github.com/guardian/frontend/assets/43961396/8a228428-2108-4403-9f86-ba6184b9c6d8

