### PR TITLE
move add slot in crossword ad for option 2

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -802,12 +802,13 @@ class Crossword extends Component {
                         {anagramHelper}
                     </div>
                 </div>
+                <div class="crossword__container__below-controls"></div>
                 <Controls
                     hasSolutions={this.hasSolutions()}
                     clueInFocus={focused}
                     crossword={this}
                 />
-                <div class="crossword__container__below-controls"></div>
+
                 <Clues
                     clues={this.cluesData()}
                     focussed={focused}

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -166,6 +166,11 @@ $garnett-large-button-icon: 20px;
 $garnett-x-large-button-icon: 24px;
 
 
+// Mobile Sticky
+// =============================================================================
+$mobile-sticky-width: 320px;
+$mobile-sticky-height: 74px;
+
 // MPU
 // =============================================================================
 $mpu-original-width: 300px;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -104,13 +104,14 @@
 }
 
 #dfp-ad--crossword-banner-mobile {
-    width: 320px;
-    height: 74px;
+    padding: 10px 0 14px;
+    width: $mobile-sticky-width;
+    height: $mobile-sticky-height;
     background-color: #ffffff;
 }
 
 .ad-slot-container--centre-slot.crossword-mobile-banner-ad {
-    padding-bottom: 14px;
+
     display: flex;
     @include mq($from: phablet) {
         display: none;


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
This PR continues the work of adding a crossword banner ad on mobile devices. 
In order to do this effectively were rand this as a server side AB test. 

Previously [here](https://github.com/guardian/frontend/pull/26845) we set a positioning for the ad slot as option 1, for which results from testing were analysed.

We would now like to test ad position in option 2.

The server side test has been set up previously in this [PR](https://github.com/guardian/frontend/pull/26867/files), for Option 1, so we will employ the existing "Experiments", and therefore is in `main`

## Screenshots

| Test |
|------|
|<img width="300" alt="Screenshot 2024-03-08 at 10 57 49" src="https://github.com/guardian/frontend/assets/49187886/8eb94c17-ca4d-4f9d-b90b-76e334adfe4e">|

## Testing
To test you may have to add `opt/in/crossword-mobile-banner` to the URL to add put you in the test group.

| Variant Group - console|
|------|
|<img width="414" alt="Screenshot 2024-03-08 at 13 08 45" src="https://github.com/guardian/frontend/assets/49187886/12c2168a-c5ca-425e-b746-c758f672eebc">|

| X-GU-Experiment Grp Cookie |
|------|
|<img width="700" alt="Screenshot 2024-03-08 at 16 45 30" src="https://github.com/guardian/frontend/assets/49187886/1271b599-82bc-4320-922b-a74d3c6f4226">|


## Checklist


- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
