### PR TITLE
remove crosswords-mobile-banner 2 perc test group for option 1

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,7 +12,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       AdaptiveSite,
-      CrosswordMobileBanner,
       DCRTagPages,
       OscarsNewsletterEmbed1,
       OscarsNewsletterEmbed2,
@@ -27,15 +26,6 @@ object AdaptiveSite
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 4, 2),
       participationGroup = Perc1A,
-    )
-
-object CrosswordMobileBanner
-    extends Experiment(
-      name = "crossword-mobile-banner",
-      description = "Test banner advert in mobile crossword page",
-      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 4, 2),
-      participationGroup = Perc2A,
     )
 
 object DCRTagPages


### PR DESCRIPTION
## What is the value of this and can you measure success?
We have tested adding an advert into the crossword page for mobile users with Option 1.

The results showed no significant reduction in UX metrics and a positive impact on revenue. Therefore we want to roll this out to all users

## What does this change?
This PR removes the server side AB test 2% bucket group.

This will result in the crossword-mobile-banner going live to all users, resulting in it being the `control` group when we test Option 2.

** To be absolutely sure, additionally tested using `opt/out/crossword-mobile-banner` and refershing Locally or in CODE will result in the ad showing up. As well as being removed from the `Dev Switchboard`, under `server-side Experiments`.

## Screenshots
<img width="250" alt="Screenshot 2024-03-11 at 10 41 42" src="https://github.com/guardian/frontend/assets/49187886/9b715335-66c4-4157-a66f-0e084996e798">



| Before      | After      |
|-------------|------------|
| <img width="350" alt="Screenshot 2024-03-11 at 10 57 35" src="https://github.com/guardian/frontend/assets/49187886/c8862e21-562e-4d2f-b7df-b406e5c4925c"> | <img width="350" alt="Screenshot 2024-03-11 at 10 58 27" src="https://github.com/guardian/frontend/assets/49187886/d2147bdd-60e6-4118-b4bb-baa02f41a5c5"> |



<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
