### PR TITLE
Add elements ids to nested List elements

### DIFF
--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -9,7 +9,19 @@ object ElementsEnhancer {
   //     Also look for "03feb394-a17d-4430-8384-edd1891e0d01"
 
   def enhanceElement(element: JsValue): JsValue = {
-    element.as[JsObject] ++ Json.obj("elementId" -> java.util.UUID.randomUUID.toString)
+    val elementWithId = element.as[JsObject] ++ Json.obj("elementId" -> java.util.UUID.randomUUID.toString)
+    val elementType = elementWithId.value("_type").as[String]
+    val elementIsList = elementType == "model.dotcomrendering.pageElements.ListBlockElement"
+
+    if (elementIsList) {
+      val listItems = elementWithId.value("items").as[JsArray]
+      val listItemsWithIds = listItems.value.map { item =>
+        enhanceElements(item.as[JsObject].value("elements"))
+      }
+      elementWithId ++ Json.obj("items" -> listItemsWithIds)
+    } else {
+      elementWithId
+    }
   }
 
   def enhanceElements(elements: JsValue): IndexedSeq[JsValue] = {

--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -16,7 +16,8 @@ object ElementsEnhancer {
     if (elementIsList) {
       val listItems = elementWithId.value("items").as[JsArray]
       val listItemsWithIds = listItems.value.map { item =>
-        enhanceElements(item.as[JsObject].value("elements"))
+        val obj = item.as[JsObject]
+        obj ++ Json.obj("elements" -> enhanceElements(obj.value("elements")))
       }
       elementWithId ++ Json.obj("items" -> listItemsWithIds)
     } else {


### PR DESCRIPTION
Co-authored-with: @JamieB-gu 

## What does this change?

Add elements ids to nested List elements because we need to recursively rendered these in DCR and the schema currently requires elementIds for all elements

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/1229808/2c82593c-87ad-4b7a-98d8-c312a2a7d9e0
[after]: https://github.com/guardian/frontend/assets/1229808/3d9d4a83-632f-43ee-9048-e40f11248002


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
