### PR TITLE
Bump Play Google Auth

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,9 +59,9 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.5.7" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.7"
-  val playGoogleAuth = "com.gu.play-googleauth" %% "play-v28" % "2.2.7"
-  val playSecretRotation = "com.gu.play-secret-rotation" %% "play-v28" % "0.18"
-  val playSecretRotationAwsSdk = "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.18"
+  val playGoogleAuth = "com.gu.play-googleauth" %% "play-v28" % "4.0.0"
+  val playSecretRotation = "com.gu.play-secret-rotation" %% "play-v28" % "7.1.0"
+  val playSecretRotationAwsSdk = "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "7.1.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"
   val rome = "rome" % "rome" % romeVersion


### PR DESCRIPTION
## What does this change?

Bumping Google Auth library to avoid authentication issue some users are experiencing due to missing Locale field

Currently there are only two users who have reported this issue, but we are concerned that Google might be rolling out a change, and that other users may be affected in future.

Tested in CODE, and an affected user has verified that they can now log in.