### PR TITLE
Improve server side experiments section of ab test admin page

### DIFF
--- a/admin/app/views/fragments/serverBasedExperiments.scala.html
+++ b/admin/app/views/fragments/serverBasedExperiments.scala.html
@@ -1,6 +1,7 @@
 @import conf.switches.Switch
 @import experiments.Experiment
 @import experiments.ActiveExperiments.allExperiments
+@import conf.Configuration
 
 @()
 
@@ -8,15 +9,25 @@
     <h3 class="abtest-item__titlebar">Server-based tests</h3>
 
     <div class="row">
-        <div class="col-md-7">
-            <table class="table table-bordered ">
+            <table class="table table-bordered table-r table-bordered table-hover">
                 <thead>
                     <th colspan="4">Name</th>
+                    <th colspan="3">State</th>
+                    <th colspan="5">Links</th>
+                    <th colspan="3">Bucket</th>
+                    <th colspan="3">Expires</th>
+                    <th colspan="3">Audience</th>
                 </thead>
                 <tbody>
                     @allExperiments.map { experiment =>
                         <tr>
-                            <td colspan="4">@experiment.name @status(experiment)</td>
+                            <td colspan="4">@experiment.name</td>
+                            <td colspan="3">@status(experiment)</td>
+                            <td colspan="5">@variants(experiment)</td>
+                            <td colspan="3"><pre>@experiment.participationGroup</pre></td>
+                            <td colspan="3">@Switch.expiry(experiment.switch).daysToExpiry days</td>
+                            <td colspan="3">@experiment.participationGroup.percentage%</td>
+
                         </tr>
                     }
                     @if(allExperiments.isEmpty) {
@@ -24,7 +35,6 @@
                     }
                 </tbody>
             </table>
-        </div>
     </div>
 </div>
 
@@ -44,4 +54,15 @@
             <span class="abtest-server-label label label-danger">off</span>
         }
     }
+}
+
+@variants(experiment: Experiment) = {
+    <div class="abtest-item__participation">
+        <div class="component participation">
+            <span class="participation__links">
+                <a class="participation__opt-out" href="@Configuration.site.host/opt/out/@experiment.name">opt out</a>
+                <a class="component participation-item" href="@Configuration.site.host/opt/in/@experiment.name">opt in</a>
+            </span>
+        </div>
+    </div>
 }

--- a/admin/app/views/fragments/serverBasedExperiments.scala.html
+++ b/admin/app/views/fragments/serverBasedExperiments.scala.html
@@ -23,7 +23,7 @@
                         <tr>
                             <td colspan="4">@experiment.name</td>
                             <td colspan="3">@status(experiment)</td>
-                            <td colspan="5">@variants(experiment)</td>
+                            <td colspan="5">@links(experiment)</td>
                             <td colspan="3"><pre>@experiment.participationGroup</pre></td>
                             <td colspan="3">@Switch.expiry(experiment.switch).daysToExpiry days</td>
                             <td colspan="3">@experiment.participationGroup.percentage%</td>
@@ -56,12 +56,19 @@
     }
 }
 
-@variants(experiment: Experiment) = {
+@links(experiment: Experiment) = {
     <div class="abtest-item__participation">
         <div class="component participation">
             <span class="participation__links">
-                <a class="participation__opt-out" href="@Configuration.site.host/opt/out/@experiment.name">opt out</a>
-                <a class="component participation-item" href="@Configuration.site.host/opt/in/@experiment.name">opt in</a>
+
+                    <a class="participation__opt-out" href="@Configuration.site.host/opt/out/@experiment.name">opt out</a>
+                    <a class="participation__opt-in" href="@Configuration.site.host/opt/in/@experiment.name">opt in</a>
+                 @if(Configuration.environment.isDev) {
+                    <p class="participation__help">
+                        These links won't work locally.<br>See
+                        <a href="https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#forcing-yourself-into-the-test">How to force yourself into the test locally</a>
+                    </p>
+                }
             </span>
         </div>
     </div>

--- a/admin/app/views/fragments/serverBasedExperiments.scala.html
+++ b/admin/app/views/fragments/serverBasedExperiments.scala.html
@@ -60,14 +60,17 @@
     <div class="abtest-item__participation">
         <div class="component participation">
             <span class="participation__links">
-
+                @if(experiment.switch.isSwitchedOn) {
                     <a class="participation__opt-out" href="@Configuration.site.host/opt/out/@experiment.name">opt out</a>
                     <a class="participation__opt-in" href="@Configuration.site.host/opt/in/@experiment.name">opt in</a>
-                 @if(Configuration.environment.isDev) {
-                    <p class="participation__help">
-                        These links won't work locally.<br>See
-                        <a href="https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#forcing-yourself-into-the-test">How to force yourself into the test locally</a>
-                    </p>
+                    @if(Configuration.environment.isDev) {
+                        <p class="participation__help">
+                            These links won't work locally.<br>See
+                            <a href="https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#forcing-yourself-into-the-test">How to force yourself into the test locally</a>
+                        </p>
+                    }
+                } else {
+                    <a  href="/dev/switchboard#Server-side%20Experiments">Switch on the test to be able to opt in</a>
                 }
             </span>
         </div>

--- a/admin/public/css/abtests.css
+++ b/admin/public/css/abtests.css
@@ -1,42 +1,47 @@
-.participation__test, .participation__variant {
-    display: inline;
+.participation__test,
+.participation__variant {
+	display: inline;
+}
+
+.participation__help {
+	font-size: 11px;
 }
 
 .well--table .table {
-    background-color: blanchedalmond;
+	background-color: blanchedalmond;
 }
 
 .ab-panel {
-    margin: 20px;
+	margin: 20px;
 }
 
 .ab-panel__label {
-    margin-right: 20px;
+	margin-right: 20px;
 }
 
 .abtests-active {
-    margin-top: 20px;
+	margin-top: 20px;
 }
 
 .abtest-item__titlebar {
-    margin-top: 10px;
-    margin-bottom: 10px;
-    padding-bottom: 4px;
+	margin-top: 10px;
+	margin-bottom: 10px;
+	padding-bottom: 4px;
 }
 
 .abtest-item--expired .abtest-item__expiry {
-    color: #a55;
+	color: #a55;
 }
 
 .abtests-expired-title a {
-    font-size: 20px;
+	font-size: 20px;
 }
 
 .abtest-item__active-label,
 .abtest-item__expired-label,
 .abtest-item__switched-on-label,
 .abtest-item__switched-off-label {
-    display: none;
+	display: none;
 }
 
 .abtest-item--active .abtest-item__active-label,
@@ -44,127 +49,127 @@
 .abtest-item--switched-on .abtest-item__switched-on-label,
 .abtest-item--switched-off .abtest-item__switched-off-label,
 .abtest-server-label {
-    display: inline-block;
-    position: relative;
-    top: -2px;
+	display: inline-block;
+	position: relative;
+	top: -2px;
 }
 
 .abtest-item__participation {
-    margin-bottom: 12px;
+	margin-bottom: 12px;
 }
 
 .abtest-item__chart-container {
-    position: relative;
-    height: 200px;
-    width: 100%;
+	position: relative;
+	height: 200px;
+	width: 100%;
 }
 
 .abtest-item__chart {
-    width: 100%;
-    background-color: #fff;
-    position: absolute;
+	width: 100%;
+	background-color: #fff;
+	position: absolute;
 }
 
 .abtest-item__chart-placeholder {
-    width: 97%;
-    margin-left: 2%;
-    text-align: center;
-    font-size: 32px;
-    margin-top: 0;
-    border-bottom: 1px solid;
-    line-height: 150px;
-    position: absolute;
-    color: #444;
+	width: 97%;
+	margin-left: 2%;
+	text-align: center;
+	font-size: 32px;
+	margin-top: 0;
+	border-bottom: 1px solid;
+	line-height: 150px;
+	position: absolute;
+	color: #444;
 }
 
 .abtest-item__chart-placeholder:after {
-    content: " ";
-    clear: both;
-    display: block;
+	content: ' ';
+	clear: both;
+	display: block;
 }
 
 .participation__links a {
-    display: inline-block;
-    margin-right: 20px;
+	display: inline-block;
+	margin-right: 20px;
 }
 
 .participation__label {
-    font-weight: bold;
-    display: inline-block;
-    margin-right: 20px;
+	font-weight: bold;
+	display: inline-block;
+	margin-right: 20px;
 }
 
 .participation__opt-out,
 .participation__opt-out:hover {
-    color: #a55;
+	color: #a55;
 }
 
 .abtest-item__description-label,
 .abtest-item__hypothesis-label {
-    font-weight: bold;
+	font-weight: bold;
 }
 
 .audience-breakdown__ruler-division {
-    width: 25%;
+	width: 25%;
 }
 
 .audience-breakdown__tests {
-    margin-bottom: 32px;
+	margin-bottom: 32px;
 }
 
 .audience-item__container {
-    position: relative;
+	position: relative;
 }
 
 .audience-item__test {
-    position: absolute;
-    top: 3px;
+	position: absolute;
+	top: 3px;
 }
 
 .audience-item__test-label {
-    display: block;
-    text-align: center;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    padding: 8px 3px;
+	display: block;
+	text-align: center;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	padding: 8px 3px;
 }
 
 .audience-item__caption {
-    background: #F8F8F8;
-    border: 2px solid #DFDFDF;
-    color: #717171;
-    font-size: 13px;
-    position: relative;
-    text-align: center;
-    top: -98px;
-    left:-100px;
-    display: none;
-    padding: 6px 6px 0;
-    width: 200px;
-    height: 50px;
+	background: #f8f8f8;
+	border: 2px solid #dfdfdf;
+	color: #717171;
+	font-size: 13px;
+	position: relative;
+	text-align: center;
+	top: -98px;
+	left: -100px;
+	display: none;
+	padding: 6px 6px 0;
+	width: 200px;
+	height: 50px;
 }
 
 .audience-item__caption:after {
-    content:'';
-    position: absolute;
-    bottom: -7px;
-    width: 10px;
-    height:10px;
-    border-bottom: 2px solid #dfdfdf;
-    border-right: 2px solid #dfdfdf;
-    background: #f8f8f8;
-    left: 50%;
-    margin-left: -10px;
-    -moz-transform: rotate(45deg);
-    -webkit-transform: rotate(45deg);
-    transform: rotate(45deg);
+	content: '';
+	position: absolute;
+	bottom: -7px;
+	width: 10px;
+	height: 10px;
+	border-bottom: 2px solid #dfdfdf;
+	border-right: 2px solid #dfdfdf;
+	background: #f8f8f8;
+	left: 50%;
+	margin-left: -10px;
+	-moz-transform: rotate(45deg);
+	-webkit-transform: rotate(45deg);
+	transform: rotate(45deg);
 }
 
 .audience-item__test:hover .audience-item__caption {
-    display: block;
+	display: block;
 }
 
 .audience-item__caption-test,
 .audience-item__caption-range {
-    text-align: center;
+	text-align: center;
 }


### PR DESCRIPTION
## What does this change?
Improve server side experiments section of ab test admin page

It would be useful to be able to see information about size and expiration for server side tests

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/1731150/6a5601b0-74e9-40fa-a5ed-acf70329338f
[after]: https://github.com/guardian/frontend/assets/1731150/94c94357-b65f-4402-b410-a3d60e9a014e


## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
