### PR TITLE
Two quick fixes to make Quick Cryptics nicer

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -42,11 +42,8 @@
             </div>
 
             @crosswordPage.crossword.instructions.map { instructions =>
-                <div class="crossword__instructions">
-                    <strong>Special instructions:</strong> @Html(instructions)
-                </div>
+                <div class="crossword__instructions"><strong>Special instructions:</strong> @Html(instructions)</div>
             }
         </div>
     </div>
 </header>
-

--- a/applications/app/views/fragments/crosswords/printableCrosswordBody.scala.html
+++ b/applications/app/views/fragments/crosswords/printableCrosswordBody.scala.html
@@ -12,9 +12,7 @@
     </h1>
 
     @crosswordPage.crossword.instructions.map { instructions =>
-        <h2 class="printable-crossword__instructions">
-            <strong>Special instructions:</strong> @instructions
-        </h2>
+        <h2 class="printable-crossword__instructions"><strong>Special instructions:</strong> @instructions</h2>
     }
 
     <div class="printable-crossword__grid">@crosswordPage.svg</div>

--- a/common/app/model/CrosswordData.scala
+++ b/common/app/model/CrosswordData.scala
@@ -7,6 +7,7 @@ import org.joda.time.DateTime
 import play.api.libs.json._
 import implicits.Dates.CapiRichDateTime
 import play.api.libs.json
+import views.support.CamelCase
 
 case class CrosswordPosition(x: Int, y: Int)
 
@@ -149,7 +150,7 @@ object CrosswordData {
 
     // Revert back to the original order
     val sortedNewEntries = entries.flatMap(entry => newEntries.find(_.id == entry.id))
-    val crosswordType = crossword.`type`.name.toLowerCase
+    val crosswordType = CamelCase.toHyphenated(crossword.`type`.name)
 
     CrosswordData(
       s"crosswords/$crosswordType/${crossword.number.toString}",

--- a/common/app/views/support/CamelCase.scala
+++ b/common/app/views/support/CamelCase.scala
@@ -7,4 +7,8 @@ object CamelCase {
         first + rest.map(_.capitalize).mkString("")
       case Nil => ""
     }
+
+  private val lowerCaseFollowedByUpperCase = """([a-z])([A-Z])""".r
+  def toHyphenated(s: String): String =
+    lowerCaseFollowedByUpperCase.replaceAllIn(s, m => m.group(1) + "-" + m.group(2)).toLowerCase
 }

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -186,6 +186,7 @@
 
 .crossword__instructions {
     margin: $gs-baseline 0;
+    white-space: pre-line;
 }
 
 .content__dateline-crossword {

--- a/static/src/stylesheets/module/crosswords/_printable.scss
+++ b/static/src/stylesheets/module/crosswords/_printable.scss
@@ -10,6 +10,7 @@
 .printable-crossword__instructions {
     font-weight: normal;
     font-size: 14px;
+    white-space: pre-line;
 }
 
 .printable-crossword__grid {

--- a/static/src/stylesheets/module/crosswords/_vars.scss
+++ b/static/src/stylesheets/module/crosswords/_vars.scss
@@ -12,7 +12,7 @@ $xword-focussed-background-colour: #fff7b2;
 $xword-clue-number-width: 32px;
 
 $xword-grid-sizes: (
-    quickcryptic: 11,
+    quick-cryptic: 11,
     quick: 13,
     cryptic: 15,
     prize: 15,

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -278,4 +278,5 @@ $logoHeight: 110px;
 .crossword__instructions {
     font-size: 13px;
     text-align: left;
+    white-space: pre-line;
 }


### PR DESCRIPTION
## What does this change?

The Quick Cryptic series will include much longer instructions than previously seen, including steps split onto multiple lines. I've applied the `white-space: pre-line` CSS to the instructions element to make it respect the lines and split it visually into paragraphs. (I thought also about actually splitting the text and wrapping each paragraph with a `<p>`, if that sounds preferable I can have another go at that).

Also fixed the conversion from the capi-model crossword type enum. The enum names are pascal-cased, eg. `QuickCryptic`, but frontend routing and CAPI queries expect them to be kebab-cased. The value is used to create the "Print" and "Accessible version" links, so it's important to get them right.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before-url][] | ![after-url][] |

[before]: https://github.com/guardian/frontend/assets/10963046/ddaa231c-d64a-46ca-b9f4-c22a1f6d4f83
[after]: https://github.com/guardian/frontend/assets/10963046/0bbea3cc-db5e-4337-8135-e13b688fe935

[before-url]: https://github.com/guardian/frontend/assets/10963046/0717f747-27fe-4023-bae7-65680f5b12a9
[after-url]: https://github.com/guardian/frontend/assets/10963046/b77d1307-dfc3-48c4-a2ff-cec059812663


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
