### PR TITLE
Enable affiliate links for articles on an allowlist

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -6,6 +6,9 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.{RenderClasses, RowInfo}
 @import views.GalleryCaptionCleaners
+@import views.support.AffiliateLinksCleaner
+@import conf.switches.Switches
+@import conf.Configuration
 
 @import model.DotcomContentType
 @(page: GalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
@@ -19,7 +22,20 @@
         )"
         itemscope itemtype="@page.item.metadata.schemaType" role="main">
 
-        @fragments.galleryHeader(page)
+        @fragments.galleryHeader(
+            page,
+            page.item.lightbox.containsAffiliateableLinks && AffiliateLinksCleaner.shouldAddAffiliateLinks(
+                switchedOn = Switches.AffiliateLinks.isSwitchedOn,
+                section = page.gallery.content.metadata.sectionId,
+                showAffiliateLinks = page.gallery.content.fields.showAffiliateLinks,
+                supportedSections = Configuration.affiliateLinks.affiliateLinkSections,
+                defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
+                alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
+                tagPaths = page.gallery.content.tags.tags.map(_.id),
+                firstPublishedDate = page.gallery.content.fields.firstPublicationDate,
+                pageUrl = request.uri,
+            )
+        )
 
         <div class="@RenderClasses(
                     "l-side-margins", "l-side-margins--media", "l-side-margins--gallery"

--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -15,7 +15,7 @@
 
             @if(gallery.item.fields.standfirst.isDefined) {
                 <div class="tonal__standfirst">
-                        @fragments.standfirst(gallery.item)
+                    @fragments.standfirst(gallery.item)
                 </div>
             }
 

--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -15,7 +15,7 @@
 
             @if(gallery.item.fields.standfirst.isDefined) {
                 <div class="tonal__standfirst">
-                    @fragments.standfirst(gallery.item)
+                        @fragments.standfirst(gallery.item)
                 </div>
             }
 
@@ -46,7 +46,9 @@
                     @fragments.meta.dateline(gallery.item.trail.webPublicationDate, gallery.item.fields.lastModified, gallery.item.content.hasBeenModified, gallery.item.fields.firstPublicationDate, gallery.item.tags.isLiveBlog, gallery.item.fields.isLive)
                 }
 
-                @fragments.affiliateLinksDisclaimer("gallery")
+                @if(shouldAddDisclaimer) {
+                    @fragments.affiliateLinksDisclaimer("gallery")
+                }
             </div>
         </div>
     </div>

--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -47,7 +47,7 @@
                 }
 
                 @if(shouldAddDisclaimer) {
-                    @fragments.affiliateLinksDisclaimer("gallery")
+                    @fragments.affiliateLinksDisclaimer()
                 }
             </div>
         </div>

--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -1,4 +1,5 @@
-@(gallery: model.GalleryPage)(implicit request: RequestHeader)
+@(gallery: model.GalleryPage,
+  shouldAddDisclaimer: Boolean)(implicit request: RequestHeader)
 
 @import views.support.TrailCssClasses.toneClass
 
@@ -44,6 +45,8 @@
                 @if(!gallery.item.trail.shouldHidePublicationDate) {
                     @fragments.meta.dateline(gallery.item.trail.webPublicationDate, gallery.item.fields.lastModified, gallery.item.content.hasBeenModified, gallery.item.fields.firstPublicationDate, gallery.item.tags.isLiveBlog, gallery.item.fields.isLive)
                 }
+
+                @fragments.affiliateLinksDisclaimer("gallery")
             </div>
         </div>
     </div>

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -44,7 +44,6 @@ object GalleryCaptionCleaners {
         request.uri,
         page.gallery.content.metadata.sectionId,
         page.gallery.content.fields.showAffiliateLinks,
-        "gallery",
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
         page.gallery.content.fields.firstPublicationDate,

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -82,7 +82,6 @@ object BodyProcessor {
         pageUrl = request.uri,
         sectionId = article.content.metadata.sectionId,
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
-        contentType = "article",
         tags = article.content.tags.tags.map(_.id),
         publishedDate = article.content.fields.firstPublicationDate,
       ),

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -33,7 +33,6 @@ import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import services.NewsletterData
-import views.html.fragments.affiliateLinksDisclaimer
 import views.support.{CamelCase, ContentLayout, JavaScriptPage}
 // -----------------------------------------------------------------
 // DCR DataModel
@@ -582,16 +581,16 @@ object DotcomRenderingDataModel {
 
     val selectedTopics = topicResult.map(topic => Seq(Topic(topic.`type`, topic.name)))
 
-    def getAffiliateLinksDisclaimer(shouldAddAffiliateLinks: Boolean, shouldAddDisclaimer: Boolean) = {
+    def addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks: Boolean, shouldAddDisclaimer: Boolean) = {
       if (shouldAddAffiliateLinks && shouldAddDisclaimer) {
-        Some(affiliateLinksDisclaimer("article").body)
+        Some("true")
       } else {
         None
       }
     }
 
     DotcomRenderingDataModel(
-      affiliateLinksDisclaimer = getAffiliateLinksDisclaimer(shouldAddAffiliateLinks, shouldAddDisclaimer),
+      affiliateLinksDisclaimer = addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks, shouldAddDisclaimer),
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
       beaconURL = Configuration.debug.beaconUrl,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -276,7 +276,7 @@ object DotcomRenderingUtils {
       alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
       tagPaths = content.content.tags.tags.map(_.id),
       firstPublishedDate = content.content.fields.firstPublicationDate,
-      pageUrl = content.metadata.webUrl,
+      pageUrl = content.metadata.id,
     )
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -9,7 +9,7 @@ import common.Edition
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import model.content.Atom
-import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement, TextCleaner}
+import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.pressed.{PressedContent, SpecialReport}
 import model.{
   ArticleDateTimes,
@@ -24,7 +24,6 @@ import model.{
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.html.fragments.affiliateLinksDisclaimer
 import views.support.AffiliateLinksCleaner
 
 import java.net.URLEncoder
@@ -175,30 +174,6 @@ object DotcomRenderingUtils {
     val ids = liveblog.currentPage.currentPage.blocks.map(_.id).toSet
     relevantBlocks.filter(block => ids(block.id))
   }.toSeq
-
-  private def addDisclaimer(
-      elems: List[PageElement],
-      capiElems: Seq[ClientBlockElement],
-      affiliateLinks: Boolean,
-  ): List[PageElement] = {
-    if (affiliateLinks) {
-      val hasLinks = capiElems.exists(elem =>
-        elem.`type` match {
-          case Text =>
-            val textString = elem.textTypeData.toList.mkString("\n") // just concat all the elems here for this test
-            stringContainsAffiliateableLinks(textString)
-          case _ => false
-        },
-      )
-
-      if (hasLinks) {
-        elems :+ DisclaimerBlockElement(affiliateLinksDisclaimer("article").body)
-      } else {
-        elems
-      }
-    } else elems
-  }
-
   def stringContainsAffiliateableLinks(textString: String): Boolean = {
     AffiliateLinksCleaner.stringContainsAffiliateableLinks(textString)
   }
@@ -238,8 +213,7 @@ object DotcomRenderingUtils {
     val withTagLinks =
       if (article.content.isPaidContent) elems
       else TextCleaner.tagLinks(elems, article.content.tags, article.content.showInRelated, edition)
-
-    addDisclaimer(withTagLinks, capiElems, affiliateLinks)
+    elems
   }
 
   def isSpecialReport(page: ContentPage): Boolean =

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -276,6 +276,7 @@ object DotcomRenderingUtils {
       alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
       tagPaths = content.content.tags.tags.map(_.id),
       firstPublishedDate = content.content.fields.firstPublicationDate,
+      pageUrl = content.metadata.webUrl,
     )
   }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -222,11 +222,6 @@ object ContentAtomBlockElement {
   implicit val ContentAtomBlockElementWrites: Writes[ContentAtomBlockElement] = Json.writes[ContentAtomBlockElement]
 }
 
-case class DisclaimerBlockElement(html: String) extends PageElement
-object DisclaimerBlockElement {
-  implicit val DisclaimerBlockElementWrites: Writes[DisclaimerBlockElement] = Json.writes[DisclaimerBlockElement]
-}
-
 case class DocumentBlockElement(
     embedUrl: Option[String],
     height: Option[Int],
@@ -821,7 +816,6 @@ object PageElement {
       case _: CodeBlockElement            => true
       case _: CommentBlockElement         => true
       case _: ContentAtomBlockElement     => true
-      case _: DisclaimerBlockElement      => true
       case _: DocumentBlockElement        => true
       case _: EmbedBlockElement           => true
       case _: ExplainerAtomBlockElement   => true

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -18,13 +18,15 @@
 
 @galleryDisclaimer() = {
     <br>
+    <p class="gallery__disclaimer">
         The Guardian’s product and service reviews are independent and are in no
         way influenced by any advertiser or commercial initiative. We will earn a
         commission from the retailer if you buy something through an affiliate link.
 	    <a
-		    href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
+            href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
 		    >Learn more</a
 	    >.
+    </p>
 }
 
 @{contentType match {

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -1,36 +1,10 @@
-@(contentType: String)
-
-
-@articleDisclaimer() = {
-    <p><sup>
-        The Guardian’s product and service reviews are independent and are
-        in no way influenced by any advertiser or commercial initiative. We
-        will earn a commission from the retailer if you buy something
-        through an affiliate link.
-        <a
-            href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
-            data-link-name="in body link"
-            class="u-underline"
-            >Learn more</a
-        >.
-    </sup></p>
-}
-
-@galleryDisclaimer() = {
-    <br>
-    <p class="gallery__disclaimer">
-        The Guardian’s product and service reviews are independent and are in no
-        way influenced by any advertiser or commercial initiative. We will earn a
-        commission from the retailer if you buy something through an affiliate link.
-	    <a
-            href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
-		    >Learn more</a
-	    >.
-    </p>
-}
-
-@{contentType match {
-    case "gallery" => galleryDisclaimer()
-    case "article" => articleDisclaimer()
-    case _ => Html("")
-}}
+<br>
+<p class="gallery__disclaimer">
+    The Guardian’s product and service reviews are independent and are in no
+    way influenced by any advertiser or commercial initiative. We will earn a
+    commission from the retailer if you buy something through an affiliate link.
+	<a
+        href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
+		>Learn more</a
+	>.
+</p>

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -969,12 +969,16 @@ object AffiliateLinksCleaner {
   ): Boolean = {
     val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
 
+    val cleanedPageUrl = if (pageUrl.charAt(0) == '/') {
+      pageUrl.substring(1);
+    } else pageUrl
+
     val affiliateLinksAllowList = List(
-      "/lifeandstyle/2023/dec/11/are-diy-face-masks-as-good-as-shop-bought-ones",
-      "/fashion/gallery/2024/mar/08/street-smart-what-to-wear-to-run-errands",
+      "lifeandstyle/2023/dec/11/are-diy-face-masks-as-good-as-shop-bought-ones",
+      "fashion/gallery/2024/mar/08/street-smart-what-to-wear-to-run-errands",
     )
 
-    val urlIsInAllowList = affiliateLinksAllowList.contains(pageUrl)
+    val urlIsInAllowList = affiliateLinksAllowList.contains(cleanedPageUrl)
 
     // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off date.
     // The cut off date is temporary while we are working on improving the compliance of affiliate links.

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -942,7 +942,10 @@ object AffiliateLinksCleaner {
 
   def insertAffiliateDisclaimer(document: Document, contentType: String): Document = {
     if (contentType == "gallery") {
-      document.body().prepend(affiliateLinksDisclaimer(contentType).toString())
+      document
+        .getElementsByClass("gallery__meta-container")
+        .first()
+        .append(affiliateLinksDisclaimer(contentType).toString())
     }
     document
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -974,8 +974,21 @@ object AffiliateLinksCleaner {
     } else pageUrl
 
     val affiliateLinksAllowList = List(
-      "lifeandstyle/2023/dec/11/are-diy-face-masks-as-good-as-shop-bought-ones",
+      "lifeandstyle/2024/jan/03/six-winter-warmers-tried-and-tested-the-heated-poncho-has-changed-me-i-will-never-have-sex-again",
+      "lifeandstyle/2024/mar/11/im-south-asian-and-have-dark-eye-circles-what-can-i-do",
+      "fashion/2024/mar/08/the-four-makeup-staples-i-cant-live-without",
+      "travel/2023/mar/03/readers-favourite-budget-beach-campsites-hotels-in-europe",
+      "travel/2024/feb/25/10-of-the-best-places-in-the-uk-to-see-them-bloom",
+      "lifeandstyle/2023/dec/10/with-christmas-around-the-corner-what-to-give-the-gardener-in-your-life-",
+      "fashion/2024/mar/01/spring-is-around-the-corner-time-to-soothe-and-restore-your-cracked-heels",
+      "fashion/2024/mar/10/compact-and-bijou-why-women-need-a-pocket-mirror",
+      "fashion/2024/mar/03/how-to-reset-your-wardrobe-for-spring",
+      "lifeandstyle/2024/mar/03/beauty-spot-eyebrow-essentials-10-of-the-best",
+      "fashion/gallery/2024/mar/09/spring-in-your-step-10-menswear-trends-to-update-your-wardrobe-in-pictures",
       "fashion/gallery/2024/mar/08/street-smart-what-to-wear-to-run-errands",
+      "fashion/gallery/2024/mar/09/the-edit-mens-sweatshirts-in-pictures",
+      "lifeandstyle/gallery/2024/jan/22/colourful-glass-furniture-from-vases-to-lampshades-in-pictures",
+      "lifeandstyle/gallery/2023/nov/27/cosy-bedding-in-pictures",
     )
 
     val urlIsInAllowList = affiliateLinksAllowList.contains(cleanedPageUrl)

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -19,6 +19,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
     val supportedSections = Set("film", "books", "fashion")
     val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
     val newPublishedDate = Some(new DateTime(2020, 8, 15, 0, 0))
+    val allowedPageUrl = "/fashion/gallery/2024/mar/08/street-smart-what-to-wear-to-run-errands"
+    val deniedPageUrl = "/fashion/2024/feb/16/sunscreen-in-winter-yep-spf-moisturiser-is-essential-all-year-round"
 
     shouldAddAffiliateLinks(
       switchedOn = false,
@@ -29,6 +31,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -39,6 +42,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -49,6 +53,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -59,6 +64,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -69,6 +75,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("bereavement"),
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -79,6 +86,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("tech"),
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -89,6 +97,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("tech"),
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -99,6 +108,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       List("bereavement"),
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -109,6 +119,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       List("tech"),
       oldPublishedDate,
+      deniedPageUrl,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -119,6 +130,18 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       List("tech"),
       newPublishedDate,
+      allowedPageUrl,
+    ) should be(true)
+    shouldAddAffiliateLinks(
+      switchedOn = true,
+      "film",
+      None,
+      supportedSections,
+      Set.empty,
+      Set.empty,
+      List.empty,
+      newPublishedDate,
+      deniedPageUrl,
     ) should be(false)
   }
 }

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -286,3 +286,25 @@
         fill: $brightness-86;
     }
 }
+
+.gallery__disclaimer {
+    color: $brightness-86;
+    margin-bottom: .5rem;
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    font-size: 12px;
+
+    @include mq(desktop) {
+        padding-right: $gs-gutter / 2;
+    }
+
+    a {
+        color: $brightness-86;
+        border-bottom: 1px solid $brightness-46;
+        transition: border-color .15s ease-out;
+
+        &:hover {
+            border-bottom: 1px solid $brightness-97;
+            text-decoration: none;
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?
Makes the following changes to allow us to reimplement skimlinks in accordance with the new approved designs:

- Implements an allowlist for articles to show affiliate links after the cutoff date so that we can test the new styling
- Updates the testing to test articles that are and aren't on the allowlist
- Moves the disclaimer in galleries from the first caption to the standfirst - we no longer append to the html
- Stops sending the disclaimer block element to DCR and instead just tells DCR if a disclaimer should exist or not, as DCR now handles disclaimer insertion itself
- General tidying - we no longer need to enter contentType into the cleaner parameters as we handle disclaimer insertion separately and we can remove the article specific disclaimer as this is handled by DCR

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2024-03-14 at 12 15 11](https://github.com/guardian/frontend/assets/108270776/edb733f9-d2f6-45ca-97c7-60d682276d59) | ![Screenshot 2024-03-14 at 12 14 57](https://github.com/guardian/frontend/assets/108270776/055e91a1-5718-4f0f-babe-7cdbd6306311) |
| ![Screenshot 2024-03-14 at 12 07 48](https://github.com/guardian/frontend/assets/108270776/e39d8e72-4e66-4846-b94d-7b0f927f5162) | ![Screenshot 2024-03-14 at 12 08 05](https://github.com/guardian/frontend/assets/108270776/6bc9ee40-85e2-446a-a00e-ea672e5969ee) |




