### PR TITLE
Use stage `LOCALTEST` for running tests locally

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -85,7 +85,7 @@ object GuardianConfiguration extends GuLogging {
   private lazy val parameterStore = new ParameterStore(awsRegion)
 
   lazy val configuration: Config = {
-    if (stage == "DEVINFRA")
+    if (stage == "DEVINFRA" || stage == "LOCALTEST")
       ConfigFactory.parseResourcesAnySyntax("env/DEVINFRA.properties")
     else {
       val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -59,7 +59,8 @@ object ProjectSettings {
   )
 
   def getTestStage(isCi: Boolean): Map[String, String] = {
-    if (isCi) Map("STAGE" -> "DEVINFRA") else Map("STAGE" -> "LOCALTEST")
+    val stage = if (isCi) "DEVINFRA" else "LOCALTEST"
+    Map("STAGE" -> stage)
   }
 
   val frontendTestSettings = Seq(

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -58,10 +58,8 @@ object ProjectSettings {
       .withWarnScalaVersionEviction(false),
   )
 
-  def getTestStage(isCi: Boolean): Map[String, String] = {
-    val stage = if (isCi) "DEVINFRA" else "LOCALTEST"
-    Map("STAGE" -> stage)
-  }
+  def isCi = sys.env.get("CI").getOrElse("false") == "true"
+  def testStage = if (isCi) "DEVINFRA" else "LOCALTEST"
 
   val frontendTestSettings = Seq(
     // Use ScalaTest https://groups.google.com/d/topic/play-framework/rZBfNoGtC0M/discussion
@@ -82,7 +80,7 @@ object ProjectSettings {
     Test / javaOptions += "-XX:+UseConcMarkSweepGC",
     Test / javaOptions += "-XX:ReservedCodeCacheSize=128m",
     Test / baseDirectory := file("."),
-    Test / envVars := getTestStage(sys.env.get("CI").getOrElse("false") == "true"),
+    Test / envVars := Map("STAGE" -> testStage),
     // Set testResultLogger back to the default, fixes an issue with `sbt-teamcity-logger`
     //   See: https://github.com/JetBrains/sbt-tc-logger/issues/9
     Test / test / testResultLogger := TestResultLogger.Default,

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -58,6 +58,10 @@ object ProjectSettings {
       .withWarnScalaVersionEviction(false),
   )
 
+  def getTestStage(isCi: Boolean): Map[String, String] = {
+    if (isCi) Map("STAGE" -> "DEVINFRA") else Map("STAGE" -> "LOCALTEST")
+  }
+
   val frontendTestSettings = Seq(
     // Use ScalaTest https://groups.google.com/d/topic/play-framework/rZBfNoGtC0M/discussion
     Test / testOptions := Nil,
@@ -77,7 +81,7 @@ object ProjectSettings {
     Test / javaOptions += "-XX:+UseConcMarkSweepGC",
     Test / javaOptions += "-XX:ReservedCodeCacheSize=128m",
     Test / baseDirectory := file("."),
-    Test / envVars := Map("STAGE" -> "DEVINFRA"),
+    Test / envVars := getTestStage(sys.env.get("CI").getOrElse("false") == "true"),
     // Set testResultLogger back to the default, fixes an issue with `sbt-teamcity-logger`
     //   See: https://github.com/JetBrains/sbt-tc-logger/issues/9
     Test / test / testResultLogger := TestResultLogger.Default,


### PR DESCRIPTION
Frontend has the concept of a `DEVINFRA` stage which *sort of* means "CI environment". Setting this stage has the following behaviour:

- Mocks configuration with a local file, instead of resolving configuration from AWS Parameter Store. This means running tests does not require AWS Credentials
  - Desirable for running tests in CI and locally
- Fails tests where the database of mocked request responses is out of date, instead of generating database updates that can be committed.
  - Desirable in CI, but not locally. We want to generate the files when we run the tests locally so we can commit them as part of the PR

Since #26058 we have been running all tests (in CI and locally) with stage `DEVINFRA` but this results in issues like #26972.

This change:

- introduces a new stage `LOCALTEST` which is used when running tests on a developer machine
  - this stage will use the same mocked configuration as `DEVINFRA`, so AWS credentials are not required
  - this stage will create any necessary database files/updates instead of failing the tests
  - `LOCALTEST` is selected when running tests locally, but not in `CI` where we want to continue using `DEVINFRA`
- `DEVINFRA` continues to behave as before

Closes #26972

