### PR TITLE
Bump commercial to v17.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "17.3.1",
+		"@guardian/commercial": "0.0.0-beta-20240319131735",
 		"@guardian/consent-management-platform": "13.12.0",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "0.0.0-beta-20240319131735",
+		"@guardian/commercial": "17.5.0",
 		"@guardian/consent-management-platform": "13.12.0",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/commercial@17.3.1":
-  version "17.3.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.3.1.tgz#3f61745b92d124f282068a13bac1228ee8d81e37"
-  integrity sha512-PnZ28NrXHCsHsGIsLEMZSrHQ2E6NxIdv09tjWXXZH99WegeQ+4sxv6fVgImEDjOWNK508Z0wmONVt0ohp+eMEg==
+"@guardian/commercial@0.0.0-beta-20240319131735":
+  version "0.0.0-beta-20240319131735"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-0.0.0-beta-20240319131735.tgz#2b047cc1fe6d20ceb179f7df547c8c88e4b49b60"
+  integrity sha512-i3W08dNiX1zh8LTHGCehUBeVfV1Do+CW1x4JrLG6GLPh+7XocL+M0YESdT6PZGUcdo+5IOWML9vyqm6sp74mHg==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/commercial@0.0.0-beta-20240319131735":
-  version "0.0.0-beta-20240319131735"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-0.0.0-beta-20240319131735.tgz#2b047cc1fe6d20ceb179f7df547c8c88e4b49b60"
-  integrity sha512-i3W08dNiX1zh8LTHGCehUBeVfV1Do+CW1x4JrLG6GLPh+7XocL+M0YESdT6PZGUcdo+5IOWML9vyqm6sp74mHg==
+"@guardian/commercial@17.5.0":
+  version "17.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.5.0.tgz#3f077eafbd30c449dbc7899527e91f9b50fc8004"
+  integrity sha512-AYb/prXkcIzjpFgg6hLyHjn13KMALp16exUV5DZE4CyKeogQ0r+mE9hOdLvWNc7ZRZqBnSJAiwT6BwlqNEeY3A==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,7 +2423,6 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-
 "@guardian/commercial@17.5.0":
   version "17.5.0"
   resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.5.0.tgz#3f077eafbd30c449dbc7899527e91f9b50fc8004"


### PR DESCRIPTION
Bring in the changes from [v17.5.0](https://github.com/guardian/commercial/releases/tag/v17.5.0)
