### PR TITLE
Bump commercial 17.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "17.3.1",
+		"@guardian/commercial": "17.4.0",
 		"@guardian/consent-management-platform": "13.12.0",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",

--- a/static/src/javascripts/projects/common/modules/experiments/tests/section-ad-density.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/section-ad-density.ts
@@ -5,7 +5,7 @@ export const sectionAdDensity: ABTest = {
 	author: '@commercial-dev',
 	start: '2024-03-07',
 	expiry: '2024-07-26',
-	audience: 0 / 100,
+	audience: 5 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria:
 		'Article pages in the following sections: business, environment, music, money, artanddesign, science, stage, travel, wellness, games',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/commercial@17.3.1":
-  version "17.3.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.3.1.tgz#3f61745b92d124f282068a13bac1228ee8d81e37"
-  integrity sha512-PnZ28NrXHCsHsGIsLEMZSrHQ2E6NxIdv09tjWXXZH99WegeQ+4sxv6fVgImEDjOWNK508Z0wmONVt0ohp+eMEg==
+"@guardian/commercial@17.4.0":
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.4.0.tgz#c7c33cfc90a7b7414513e53a70bd2af49344ea40"
+  integrity sha512-UQqjLoGfJCvUlXyLbFNhLZNftxjVjm0j0nru/VoLrM7voykSF7rwk0tOQPrBZvLMVS+W8MXKg5DA2F3BCEvYJA==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"


### PR DESCRIPTION
Attempt 2

### Minor Changes

-   6d621db: Fix a bug with spacefinder avoiding other ads on mobile
-   6d621db: Add "high value sections" ab test, increasing ad density on articles in high value sections

### Patch Changes

-   6d621db: Fix bug with spacefinder avoiding sfdebug elements
-   be423b1: adds the 2x2 slot to allow the mobile-sticky to be empty

[Full Changelog](https://github.com/guardian/commercial/blob/main/CHANGELOG.md)