### PR TITLE
Remove `play-json-extensions`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,6 @@ val common = library("common")
       scalaUri,
       commercialShared,
       playJson,
-      playJsonExtensions,
       playJsonJoda,
       jodaForms,
       jacksonDataFormat,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,6 @@ object Dependencies {
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
   val playJsonVersion = "2.9.4"
-  val playJsonExtensionsVersion = "0.42.0"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.11"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion
@@ -95,7 +94,6 @@ object Dependencies {
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.7.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.2"
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
-  val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val atomRenderer = "com.gu" %% "atom-renderer" % "1.2.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"


### PR DESCRIPTION
## What does this change?
Removes `ai.x:play-json-extensions`

## Why?

It was introduced in 

* https://github.com/guardian/frontend/pull/20829 

but its usage got removed in:

* https://github.com/guardian/frontend/pull/21347
* https://github.com/guardian/frontend/pull/21626

## What is the value of this and can you measure success?

Tidy-up and keeping up-to-date

Tested in CODE
