### PR TITLE
Fix auto generated tag links

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -213,7 +213,8 @@ object DotcomRenderingUtils {
     val withTagLinks =
       if (article.content.isPaidContent) elems
       else TextCleaner.tagLinks(elems, article.content.tags, article.content.showInRelated, edition)
-    elems
+
+    withTagLinks
   }
 
   def isSpecialReport(page: ContentPage): Boolean =


### PR DESCRIPTION
## What does this change?

Auto generated tag links were not being applied by Frontend.

This [regression](https://github.com/guardian/frontend/pull/26969/files#diff-809507325827d319791e3c05b0f9975f1ef429f1f6513f74b8de8af01854ed38R216) was picked up by regenerating fixtures in DCR which is not great - we should have a better test.

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/7014230/29aab81e-8c03-49d6-bde0-a37aa4fcedf7
[after]: https://github.com/guardian/frontend/assets/7014230/e45b6d87-336d-4b5c-bac3-890d834a43bd



