### PR TITLE
Re-implement Crosswords app download ask 

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -28,6 +28,14 @@
                     @crosswordMeta(crosswordPage)
                 </div>
             }
+            
+            <div class="hide-from-leftcol crossword__clues-header">
+                <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-mobile-link">Download the Guardian app</a> for a better puzzles experience.
+            </div>
+
+            <div class="hide-until-leftcol crossword__clues-header">
+                <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-desktop-link">Download the Guardian app</a> for a better puzzles experience.
+            </div>
 
             <div class="meta__extras meta__extras--crossword">
                 <div class="meta__social" data-component="share">

--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -30,11 +30,11 @@
             }
             
             <div class="hide-from-leftcol crossword__clues-header">
-                <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-mobile-link">Download the Guardian app</a> for a better puzzles experience.
+                <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-mobile-link">Download the Guardian app</a> for a better puzzles experience
             </div>
 
             <div class="hide-until-leftcol crossword__clues-header">
-                <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-desktop-link">Download the Guardian app</a> for a better puzzles experience.
+                <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-desktop-link">Download the Guardian app</a> for a better puzzles experience
             </div>
 
             <div class="meta__extras meta__extras--crossword">


### PR DESCRIPTION
## What is the value of this and can you measure success?

Resolves https://github.com/guardian/frontend/issues/26987 by re-implementing the crosswords meta header text but with the text referring to the Guardian _news_ app rather than the old Puzzles app

The new text is:
> "[Download the Guardian app](https://app.adjust.com/16xt6hai) for a better puzzles experience"

| Before | After |
| ------ | ----- |
| <img width="837" alt="Screenshot 2024-03-20 at 16 26 30" src="https://github.com/guardian/frontend/assets/43961396/f3017a9b-ca12-450e-b9b0-7f5328ea6058"> | <img width="873" alt="image" src="https://github.com/guardian/frontend/assets/43961396/83545f0e-b4d3-4461-a72e-e5107a821c32"> |
