### PR TITLE
Block supporter revenue messaging in the Sport section

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -71,7 +71,7 @@ trait ABTestSwitches {
     "Block supporter revenue messaging in the Sport section",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 6, 1)),
+    sellByDate = Some(LocalDate.of(2024, 5, 31)),
     exposeClientSide = true,
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -64,4 +64,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2024, 4, 2)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-block-supporter-revenue-messaging-sport",
+    "Block supporter revenue messaging in the Sport section",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 6, 1)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { blockSupporterRevenueMessagingSport } from './tests/block-supporter-revenue-messaging-sport';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 import { oscarsNewsletterEmbed } from './tests/oscars-newsletter-embed';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
@@ -17,4 +18,5 @@ export const concurrentTests: readonly ABTest[] = [
 	mpuWhenNoEpic,
 	sectionAdDensity,
 	oscarsNewsletterEmbed,
+	blockSupporterRevenueMessagingSport,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/block-supporter-revenue-messaging-sport.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/block-supporter-revenue-messaging-sport.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const blockSupporterRevenueMessagingSport: ABTest = {
+	id: 'BlockSupporterRevenueMessagingSport',
+	author: '@commercial-dev',
+	start: '2024-03-14',
+	expiry: '2024-06-01',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Fronts and articles in the Sport section',
+	successMeasure:
+		'Ad revenue and ad ration increases without significantly impacting supporter revenue',
+	description: 'Block supporter revenue messaging in the Sport section',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/block-supporter-revenue-messaging-sport.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/block-supporter-revenue-messaging-sport.ts
@@ -9,7 +9,7 @@ export const blockSupporterRevenueMessagingSport: ABTest = {
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Fronts and articles in the Sport section',
 	successMeasure:
-		'Ad revenue and ad ration increases without significantly impacting supporter revenue',
+		'Ad revenue and ad ratio increases without significantly impacting supporter revenue',
 	description: 'Block supporter revenue messaging in the Sport section',
 	variants: [
 		{

--- a/static/src/javascripts/projects/common/modules/experiments/tests/block-supporter-revenue-messaging-sport.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/block-supporter-revenue-messaging-sport.ts
@@ -25,5 +25,7 @@ export const blockSupporterRevenueMessagingSport: ABTest = {
 			},
 		},
 	],
-	canRun: () => true,
+	canRun: () =>
+		window.guardian.config.page.section === 'sport' ||
+		window.guardian.config.page.section === 'football',
 };

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -34,6 +34,8 @@ import userPrefs from 'common/modules/user-prefs';
 import fastdom from 'lib/fastdom-promise';
 import { getCountryCode } from 'lib/geolocation';
 import { reportError } from 'lib/report-error';
+import { isInVariantSynchronous } from '../experiments/ab';
+import { blockSupporterRevenueMessagingSport } from '../experiments/tests/block-supporter-revenue-messaging-sport';
 
 export const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp'; // timestamp of when we were last told not to show a RR banner
 const twentyMins = 20 * 60_000;
@@ -165,11 +167,19 @@ export const fetchBannerData = async (): Promise<ModuleDataResponse | null> => {
 	const purchaseInfo = getPurchaseInfo();
 	const isSignedIn = await isUserLoggedIn();
 	const payload = await buildBannerPayload(purchaseInfo, isSignedIn);
+	const shouldHideBannerForTest =
+		isInVariantSynchronous(
+			blockSupporterRevenueMessagingSport,
+			'variant',
+		) &&
+		(payload.targeting.sectionId === 'sport' ||
+			payload.targeting.sectionId === 'football');
 
 	if (
 		payload.targeting.shouldHideReaderRevenue ||
 		payload.targeting.isPaidContent ||
-		isHosted
+		isHosted ||
+		shouldHideBannerForTest
 	) {
 		return Promise.resolve(null);
 	}


### PR DESCRIPTION
## What is the value of this and can you measure success?
We'd like to test the impact of blocking supporter revenue messaging on ad ratio and revenue. In a similar previous experiment on business liveblogs (see https://github.com/guardian/frontend/pull/26172) we measured an improvement to ad revenue, but this was almost exactly offset by the loss in supporter revenue. We'd like to test the revenue impact for a similar experiment in the Sports section. We will be blocking the sticky reader revenue banner at the bottom of the page, the liveblog reader revenue epics, and the epics that appear at the end of an article body.

## What does this change?

- Adds an AB test (0% until sample sizes are calculated) to block supporter revenue messaging for Sport articles and fronts
- Blocks the reader revenue banner on fronts rendered by frontend for users in the test 

Tested on CODE
