### PR TITLE
Update to latest version of capi client to pick up cotton capital tag change

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.22"
   val awsVersion = "1.12.638"
-  val capiVersion = "25.0.0"
+  val capiVersion = "25.0.1"
   val faciaVersion = "5.0.6"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?

Update to capi client v25.0.1
Fixes https://github.com/guardian/dotcom-rendering/issues/10994