### PR TITLE
Remove mobile-discussion-ads switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -442,14 +442,4 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
-
-  val mobileDiscussionAds: Switch = Switch(
-    group = Commercial,
-    name = "mobile-discussion-ads",
-    description = "Enables adverts to be added to the comments section on articles rendered by DCR on mobile devices",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/atom-renderer": "^2.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "17.6.0",
+		"@guardian/commercial": "17.7.0",
 		"@guardian/consent-management-platform": "13.12.1",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,10 +2423,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/commercial@17.6.0":
-  version "17.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.6.0.tgz#b1668ede2f1ae6a2452b904dc9325fcd9a4baba7"
-  integrity sha512-DX8PSKGlrYRZhyMtPTMinD8qkKead8+XpZN31L8C0EmIUZ/OGl4XPOqsSBdhjUqTszT4oxcFufWOIPM1n0gfHg==
+"@guardian/commercial@17.7.0":
+  version "17.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial/-/commercial-17.7.0.tgz#4adfe90dfabb23e37aa2ec5b491423f42c782c3b"
+  integrity sha512-/5CS301ReNNS9+k5N3t9zX2FscuRT+NmQVKAMLcQ+/bDB1B0P9wN6T8vPj0QueX9Rmi18894ycCjYXy2xcG+0Q==
   dependencies:
     "@changesets/cli" "^2.26.2"
     "@guardian/ophan-tracker-js" "2.0.4"


### PR DESCRIPTION
## What does this change?

- Remove DCR discussion ads feature switch
- Updates commercial

## Why?

- This feature has been live for a while and the switch is no longer needed