### PR TITLE
Extend expiry date for ab-mpu-when-no-epic test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -41,7 +41,7 @@ trait ABTestSwitches {
     "Test MPU when there is no epic at the end of Article on the page.",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 3, 29)),
+    sellByDate = Some(LocalDate.of(2024, 4, 30)),
     exposeClientSide = true,
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mpu-when-no-epic.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mpu-when-no-epic.ts
@@ -4,7 +4,7 @@ export const mpuWhenNoEpic: ABTest = {
 	id: 'MpuWhenNoEpic',
 	author: '@commercial-dev',
 	start: '2023-11-22',
-	expiry: '2024-02-29',
+	expiry: '2024-04-30',
 	audience: 10 / 100,
 	audienceOffset: 5 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
## What does this change?

This PR extends the expiry date for `ab-mpu-when-no-epic` AB Test.


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
