### PR TITLE
Extend adaptive site experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,7 +13,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     Set(
       AdaptiveSite,
       CommercialMegaTest,
-      CrosswordMobileBanner,
       DCRTagPages,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
@@ -35,15 +34,6 @@ object AdaptiveSite
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 5, 2),
       participationGroup = Perc1A,
-    )
-
-object CrosswordMobileBanner
-    extends Experiment(
-      name = "crossword-mobile-banner",
-      description = "Test banner advert in mobile crossword page",
-      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 4, 2),
-      participationGroup = Perc2A,
     )
 
 object DCRTagPages

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -33,7 +33,7 @@ object AdaptiveSite
       name = "adaptive-site",
       description = "Enables serving an adaptive version of the site that responds to page performance",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 4, 2),
+      sellByDate = LocalDate.of(2024, 5, 2),
       participationGroup = Perc1A,
     )
 


### PR DESCRIPTION

## What is the value of this and can you measure success?

Extend the `adaptive-site` experiment by a month.
We still do not have analysed the impact of this experiment on user behaviour

See exchange with @sndrs [in previous PR](https://github.com/guardian/frontend/pull/27005#discussion_r1548272171).

> **Max :**
>
> @sndrs should we continue with this?
>
> ---
> **Alex :**
> 
> maybe until we know if it's useful?
> 
> alternatively, we could remove it and the code entirely, and add it back if it turns it was? we should have enough data at this point.
> 
> it seems like it should be useful, so i'm not massively pro removing it yet, but it's taking a up slot, so ¯_(ツ)_/¯
> 
> what do you think?
> 
> ---
> **Max :**
> 
> There does not seem to be a great contention for buckets — let's keep it until we get some data analysis.



## What does this change?