### PR TITLE
Add more logging to Deeply Read & reduce bugs

### DIFF
--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -35,8 +35,8 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       .sequence(Edition.allEditions.map { edition =>
         ophanApi.getDeeplyRead(edition).flatMap {
           ophanDeeplyReadItems =>
-            log.info(s"ophanItems updated with: ${ophanDeeplyReadItems.size} new items")
-            val constructedTrail: Seq[Future[Trail]] = ophanDeeplyReadItems.map {
+            log.info(s"Fetched ${ophanDeeplyReadItems.size} Deeply Read items for ${edition.displayName}")
+            val constructedTrail: Seq[Future[Option[Trail]]] = ophanDeeplyReadItems.map {
               ophanItem =>
                 log.info(s"CAPI lookup for Ophan deeply read item: ${ophanItem.toString}")
                 val path = removeStartingSlash(ophanItem.path)
@@ -47,7 +47,8 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
                   .showFields("all")
                   .showReferences("none")
                   .showAtoms("none")
-                val trailFromCapiResponse = contentApiClient
+
+                contentApiClient
                   .getResponse(capiRequest)
                   .map { res =>
                     res.content.flatMap { capiData =>
@@ -60,13 +61,23 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
                       log.error(s"Error retrieving CAPI data for Deeply Read item: ${path}. ${e.getMessage}")
                       None
                   }
-                trailFromCapiResponse.map(_.get)
             }
             Future.sequence(constructedTrail)
+              .map { maybeTrails =>
+                (edition, maybeTrails.flatten)
+              }
+
+        }
+        .recover { e =>
+          log.error(s"Failed to fetch Deeply Read items for ${edition.displayName}. ${e.getMessage()}")
+          (edition, Seq.empty)
         }
       })
       .map(trailsList => {
-        val map = Edition.allEditions.zip(trailsList).toMap
+        val map = trailsList.toMap
+        for {
+          (edition, list) <- map
+        } yield log.info(s"Deeply Read in ${edition.displayName}: ${list.map(_.url).toString()}")
         deeplyReadItems.alter(map)
       })
   }


### PR DESCRIPTION
## What is the value of this and can you measure success?

We recently stopped receiving data for Deeply Read, but our current logging was insufficient to correctly identify the source of the error, so we add more logging to help future developers investigate where things may have gone awry.

We also [may have fixed a bug](https://github.com/guardian/dotcom-rendering/issues/11066) by flattening, rather than getting, where `Seq[Option[Trail]]` was turned into `Seq[Trail]`. It is possible that previously any issue in querying CAPI for any of the trail would result in the entire Future to fail.

## What does this change?

Add logging for:
- a `DeeplyReadAgent.refresh()` failure
- a `ophanApi.getDeeplyRead(edition) ` failure
- the edition for which items are fetched
- the final number of items update in the map

Change the `trailFromCapiResponse.map(_.get)` into `trailFromCapiResponse.map(_.flatten)` to prevent errors being thrown!

## Screenshots

N/A

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
