### PR TITLE
Commercial Q4 mega test to 5%

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -47,16 +47,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-section-ad-density",
-    "Increase inline advert density on article pages in high value sections.",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 7, 26)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-block-supporter-revenue-messaging-sport",
     "Block supporter revenue messaging in the Sport section",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -24,7 +24,7 @@ object CommercialMegaTest
       description = "Test the revenue effect of changes made during Q4",
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2024, 8, 8),
-      participationGroup = Perc0A,
+      participationGroup = Perc5A,
     )
 
 object AdaptiveSite


### PR DESCRIPTION
## What does this change?
Launch Commercial Q4 mega test by increasing it to 5%

[Initial 0% test
](https://github.com/guardian/frontend/pull/27013)

[Commercial PR introducing changes ](https://github.com/guardian/commercial/pull/1318)

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
