### PR TITLE
Improve Deeply Read resiliency to failures

### DIFF
--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -67,7 +67,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
               Future
                 .sequence(constructedTrail)
                 .map { maybeTrails =>
-                  (edition, maybeTrails.flatten)
+                  (edition, maybeTrails.flatten.take(10))
                 }
 
           }
@@ -80,8 +80,12 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
         val map = trailsList.toMap
         for {
           (edition, list) <- map
-        } yield log.info(s"Deeply Read in ${edition.displayName}: ${list.map(_.url).toString()}")
-        deeplyReadItems.alter(map)
+        } yield log.info(s"Deeply Read in ${edition.displayName}, ${list.size} items: ${list.map(_.url).toString()}")
+
+        val mapWithTenItems = map.filter { case (_, list) => list.size == 10 }
+        log.info(s"Updating the followings keys: ${mapWithTenItems.keys.toString()}")
+
+        deeplyReadItems.alter(deeplyReadItems.get() ++ mapWithTenItems)
       })
   }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

A more robust DeeplyRead `Box`, where we keep data that is partial or failed to load.

## What does this change?

only update deeply read Map if there are exactly **10 items** and add logging to identify when this is not the case

## Screenshots

N/A

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
