### PR TITLE
Add “Solar eclipse” to US Subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -194,6 +194,9 @@ object NavLinks {
   val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
   val wellness = NavLink("Wellness", "/wellness")
 
+  /** temporary for April 2024 Total Solar Eclipse over America */
+  val eclipse = NavLink("Solar eclipse", "/science/solar-eclipse ")
+
   val todaysPaper = NavLink(
     "Today's paper",
     "/theguardian",
@@ -317,6 +320,7 @@ object NavLinks {
       science,
       newsletters,
       wellness,
+      eclipse,
     ),
   )
   val intNewsPillar = ukNewsPillar.copy(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1216,6 +1216,12 @@
 					"url": "/wellness",
 					"children": [],
 					"classList": []
+				},
+				{
+					"title": "Solar eclipse",
+					"url": "/science/solar-eclipse ",
+					"children": [],
+					"classList": []
 				}
 			],
 			"classList": []


### PR DESCRIPTION
## What is the value of this and can you measure success?

Bring attention to a unique celestial event!

Part of https://github.com/guardian/dotcom-rendering/issues/10490

## What does this change?

Add a new `eclipse` NavLink and add it as the last item in the US Subnav

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/76776/fb6e19d8-40f4-4dd4-a116-beded14ea37b
[after]: https://github.com/guardian/frontend/assets/76776/103c8d9e-ad26-45c8-8e4b-42ef9ced9b4e


## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
