### PR TITLE
404 if city is not found for weather

### DIFF
--- a/onward/app/weather/controllers/WeatherController.scala
+++ b/onward/app/weather/controllers/WeatherController.scala
@@ -2,7 +2,7 @@ package weather.controllers
 
 import common.JsonComponent.resultFor
 import common.Seqs.RichSeq
-import common.{ GuLogging, ImplicitControllerExecutionContext, JsonComponent, JsonNotFound}
+import common.{GuLogging, ImplicitControllerExecutionContext, JsonComponent, JsonNotFound}
 import model.{CacheTime, Cached}
 import play.api.libs.json.Json.{stringify, toJson}
 import play.api.mvc._

--- a/onward/app/weather/controllers/WeatherController.scala
+++ b/onward/app/weather/controllers/WeatherController.scala
@@ -2,8 +2,8 @@ package weather.controllers
 
 import common.JsonComponent.resultFor
 import common.Seqs.RichSeq
-import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent}
-import model.Cached
+import common.{ GuLogging, ImplicitControllerExecutionContext, JsonComponent, JsonNotFound}
+import model.{CacheTime, Cached}
 import play.api.libs.json.Json.{stringify, toJson}
 import play.api.mvc._
 import weather.WeatherApi
@@ -16,13 +16,12 @@ class WeatherController(weatherApi: WeatherApi, val controllerComponents: Contro
     extends BaseController
     with ImplicitControllerExecutionContext
     with GuLogging {
-  val MaximumForecastDays = 10
 
   def theWeather(): Action[AnyContent] =
     Action.async { implicit request =>
       val (country, city, region) = readLocationHeaders
 
-      for {
+      val weatherFuture: Future[Result] = for {
         location <- whatIsMyCity(country, city, region)
         currentWeather <- weatherApi.getWeatherForCityId(CityId(location.id))
         forecasts <- weatherApi.getForecastForCityId(CityId(location.id))
@@ -35,6 +34,14 @@ class WeatherController(weatherApi: WeatherApi, val controllerComponents: Contro
         val weatherJson = stringify(toJson(weather))
         Cached(10.minutes)(resultFor(request, weatherJson))
       }
+
+      weatherFuture.recover({
+        case _: CityNotFoundException =>
+          Cached(CacheTime.NotFound)(JsonNotFound())
+
+        case error: Throwable =>
+          InternalServerError(s"An error occurred: ${error.getMessage}")
+      })
     }
 
   def forCity(cityId: String): Action[AnyContent] =
@@ -92,26 +99,12 @@ class WeatherController(weatherApi: WeatherApi, val controllerComponents: Contro
                   s"city [$maybeCity] and region [$maybeRegion]" +
                   s"to a valid location.",
               )
-              getWeatherFromEdition(request)
+              Future.failed(CityNotFoundException())
           }
         }
-      case (_, _) =>
-        getWeatherFromEdition(request)
-    }
-  }
-
-  private def getWeatherFromEdition(request: Request[AnyContent]) = {
-    val edition = Edition(request)
-    CityResponse.fromEdition(edition) match {
-      case Some(defaultLocation) => Future.successful(defaultLocation)
-      case None =>
-        Future.failed(
-          CityNotfoundException(
-            s"Could not work out a default location for edition [$edition].",
-          ),
-        )
+      case (_, _) => Future.failed(CityNotFoundException())
     }
   }
 }
 
-case class CityNotfoundException(message: String) extends Exception(message)
+case class CityNotFoundException() extends Exception("City not found")


### PR DESCRIPTION
## What does this change?
The onwards app has been logging around ~500k errors a day relating to the weather widget. This is due to the fact that if a city is not found, and a fallback for that edition has not been provided - which is the case for International and Europe edition - then the future will fail and the API returns a 500. 

Editiorial decided that instead of adding fallbacks for these editions, they would like to remove all fallbacks and instead hide the widget if the users location cannot be found in the accuweather dataset. 

To accomodate this, the API has been updated to return a 404 if the location cannot be found, rather than a 500. 

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
