### PR TITLE
Even better Deeply Read logging

### DIFF
--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -83,7 +83,9 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
         } yield log.info(s"Deeply Read in ${edition.displayName}, ${list.size} items: ${list.map(_.url).toString()}")
 
         val mapWithTenItems = map.filter { case (_, list) => list.size == 10 }
-        log.info(s"Updating the followings keys: ${mapWithTenItems.keys.toString()}")
+        log.info(
+          s"Updating the following ${mapWithTenItems.size} editions: ${mapWithTenItems.keys.map(_.id).toList.sorted.toString()}",
+        )
 
         deeplyReadItems.alter(deeplyReadItems.get() ++ mapWithTenItems)
       })


### PR DESCRIPTION
## What is the value of this and can you measure success?

The current formatting of keys is hard to parse, and it is helpful to know the size of the new map.

## What does this change?

Better logging for the Deeply Read agent.

## Screenshots

N/A – best to look at the Logs

## Checklist

- [X] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
