### PR TITLE
Render old liveblogs via DCR

### DIFF
--- a/article/app/services/dotcomrendering/ArticlePicker.scala
+++ b/article/app/services/dotcomrendering/ArticlePicker.scala
@@ -18,8 +18,6 @@ object ArticlePageChecks {
 
   def isNotAGallery(page: PageWithStoryPackage): Boolean = !page.item.tags.isGallery
 
-  def isNotLiveBlog(page: PageWithStoryPackage): Boolean = !page.item.tags.isLiveBlog
-
   def isNotPaidContent(page: PageWithStoryPackage): Boolean = !page.item.tags.isPaidContent
 }
 

--- a/article/app/services/dotcomrendering/ArticlePicker.scala
+++ b/article/app/services/dotcomrendering/ArticlePicker.scala
@@ -29,7 +29,6 @@ object ArticlePicker {
     Map(
       ("isSupportedType", ArticlePageChecks.isSupportedType(page)),
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
-      ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
     )
   }
 
@@ -39,7 +38,6 @@ object ArticlePicker {
       Set(
         "isSupportedType",
         "isNotAGallery",
-        "isNotLiveBlog",
       ),
     )
 

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -44,10 +44,13 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
   }
 
   it should "count in body links" in {
-    val result = articleController.renderArticle(liveBlogUrl)(TestRequest(liveBlogUrl))
-    val body = contentAsString(result)
-    body should include(""""inBodyInternalLinkCount":38""")
-    body should include(""""inBodyExternalLinkCount":42""")
+    val fakeRequest = FakeRequest("GET", s"$liveBlogUrl.json?dcr")
+      .withHeaders("Origin" -> "http://www.theorigin.com")
+
+    val result = articleController.renderArticle(liveBlogUrl)(fakeRequest)
+    val content = contentAsString(result)
+    content should include(""""inBodyInternalLinkCount":38""")
+    content should include(""""inBodyExternalLinkCount":42""")
   }
 
   it should "not cache 404s" in {


### PR DESCRIPTION
Closes [#25309](https://github.com/guardian/frontend/issues/25309)

## What does this change?
Removes the check that was preventing old liveblogs from being rendered via DCR.

## Why?
It [looks like](https://logs.gutools.co.uk/s/dotcom/goto/0ede38e0-f5be-11ee-a704-6f5e483e1cb5) it's one of the last types of content still rendered by frontend.

![image](https://github.com/guardian/frontend/assets/19683595/dfc8181d-73c0-4740-bc47-2d5d38eeb1af)

![Screenshot 2024-04-08 at 16 39 41](https://github.com/guardian/frontend/assets/19683595/5f80732d-4a9e-41ce-ad4a-c67c17ecabb2)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/19683595/b953bd58-074d-4709-b818-5713573a111b) | ![image](https://github.com/guardian/frontend/assets/19683595/cd42f785-03b0-4fe1-999b-24da085b0b68) |
| ![image](https://github.com/guardian/frontend/assets/19683595/f8d3e0c8-ca93-474d-b04d-82182923cb71) | ![image](https://github.com/guardian/frontend/assets/19683595/bd434f40-3e46-4826-9380-0a491a019072) |
| ![image](https://github.com/guardian/frontend/assets/19683595/71bd96dc-160b-4051-a426-ef222aff5786) | ![image](https://github.com/guardian/frontend/assets/19683595/bd94e2ca-d3b3-463f-8966-3d37023ad2a8) |
| ![image](https://github.com/guardian/frontend/assets/19683595/9b7e9977-b801-4de9-9d50-0b985928df75) | ![image](https://github.com/guardian/frontend/assets/19683595/7200006e-7261-413c-8884-6c4b0f00f3b2) |
| ![image](https://github.com/guardian/frontend/assets/19683595/b50bb092-35a9-47ed-887a-bec76a7ea98d) | ![image](https://github.com/guardian/frontend/assets/19683595/a698309d-a863-4e39-9db0-0d16c6de8564) |


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
