### PR TITLE
fix casing of quick cryptic

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -227,7 +227,7 @@ object NavLinks {
       NavLink("Blog", "/crosswords/crossword-blog"),
       NavLink("Quick", "/crosswords/series/quick"),
       NavLink("Speedy", "/crosswords/series/speedy"),
-      NavLink("Quick Cryptic", "/crosswords/series/quick-cryptic"),
+      NavLink("Quick cryptic", "/crosswords/series/quick-cryptic"),
       NavLink("Everyman", "/crosswords/series/everyman"),
       NavLink("Quiptic", "/crosswords/series/quiptic"),
       NavLink("Cryptic", "/crosswords/series/cryptic"),

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -872,7 +872,7 @@
 						"classList": []
 					},
 					{
-						"title": "Quick Cryptic",
+						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
 						"classList": []
@@ -1613,7 +1613,7 @@
 						"classList": []
 					},
 					{
-						"title": "Quick Cryptic",
+						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
 						"classList": []
@@ -2306,7 +2306,7 @@
 						"classList": []
 					},
 					{
-						"title": "Quick Cryptic",
+						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
 						"classList": []
@@ -3202,7 +3202,7 @@
 						"classList": []
 					},
 					{
-						"title": "Quick Cryptic",
+						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
 						"classList": []
@@ -4193,7 +4193,7 @@
 						"classList": []
 					},
 					{
-						"title": "Quick Cryptic",
+						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
 						"classList": []


### PR DESCRIPTION
to match house style, as requested

follow up to #27022 

## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
