### PR TITLE
Remove solar eclipse from US SubNav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -194,9 +194,6 @@ object NavLinks {
   val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
   val wellness = NavLink("Wellness", "/wellness")
 
-  /** temporary for April 2024 Total Solar Eclipse over America */
-  val eclipse = NavLink("Solar eclipse", "/science/solar-eclipse ")
-
   val todaysPaper = NavLink(
     "Today's paper",
     "/theguardian",
@@ -321,7 +318,6 @@ object NavLinks {
       science,
       newsletters,
       wellness,
-      eclipse,
     ),
   )
   val intNewsPillar = ukNewsPillar.copy(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1222,12 +1222,6 @@
 					"url": "/wellness",
 					"children": [],
 					"classList": []
-				},
-				{
-					"title": "Solar eclipse",
-					"url": "/science/solar-eclipse ",
-					"children": [],
-					"classList": []
 				}
 			],
 			"classList": []


### PR DESCRIPTION
## What is the value of this and can you measure success?

The eclipse has passed… and we no longer need to bring attention to it.

Follow-up on #27016

Part of https://github.com/guardian/dotcom-rendering/issues/10490

## What does this change?

Remove the solar eclipse from the US SubNav

## Screenshots

TBC

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
