### PR TITLE
Add switch for ad block ask AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -54,4 +54,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2024, 5, 31)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-ad-block-ask",
+    "Show new ad block ask component in ad slots when we detect ad blocker usage",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 5, 31)),
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

We'll be able to progresively roll out the new ad block ask component.

## What does this change?

Add a switch for a client side AB test, where we'll show a new component in place of advertising when we detect usage of an ad blocker.
