### PR TITLE
Bump sbt to 1.9.9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9


### PR DESCRIPTION
## What does this change?
Bumps sbt to latest version

## Why?
Keeping up-to-date

Extracted from:
* https://github.com/guardian/frontend/pull/26755 