### PR TITLE
Remove unecessary java options from test settings

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -77,7 +77,6 @@ object ProjectSettings {
     // These settings are needed for forking, which in turn is needed for concurrent restrictions.
     Test / javaOptions += "-DAPP_SECRET=this_is_not_a_real_secret_just_for_tests",
     Test / javaOptions += "-Xmx2048M",
-    Test / javaOptions += "-XX:+UseConcMarkSweepGC",
     Test / javaOptions += "-XX:ReservedCodeCacheSize=128m",
     Test / baseDirectory := file("."),
     Test / envVars := Map("STAGE" -> testStage),


### PR DESCRIPTION
## What does this change?
Remove unnecessary java options from test settings

## Why?
This is not needed anymore, the Concurrent Mark and Sweep (CMS) has been deprecated and we should not use it anymore, see https://openjdk.org/jeps/291

Extracted from:
* https://github.com/guardian/frontend/pull/26755
