### PR TITLE
Add 0% test for homepage redesign project

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -17,6 +17,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       DCRTagPages,
       UpdatedHeaderDesign,
       MastheadWithHighlights,
+      HomepageRedesign,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -74,4 +75,15 @@ object MastheadWithHighlights
       owners = Seq(Owner.withGithub("cemms1")),
       sellByDate = LocalDate.of(2024, 9, 30),
       participationGroup = Perc0C,
+    )
+
+// This will remain in zero percent since it is acting as a way for internal users to preview the new designs in a live environment
+object HomepageRedesign
+    extends Experiment(
+      name = "homepage-redesign",
+      description =
+        "Allows opting in to see latest designs for the homepage redesign project, ahead of the release date in September 2024",
+      owners = Seq(Owner.withGithub("cemms1")),
+      sellByDate = LocalDate.of(2024, 9, 30),
+      participationGroup = Perc0D,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?

Adds a zero percent test for the homepage redesign project as a whole.
This allows internal users to preview new designs in a live environment, throughout the course of this project.

This is never intended to be used as a "real" AB test and is acting as a way for internal users to easily opt in and out of seeing the new designs.

- Opt in link (prod): https://www.theguardian.com/opt/in/homepage-redesign
- Opt out link (prod): https://www.theguardian.com/opt/out/homepage-redesign 
