### PR TITLE
Extend Tag Pages experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -43,7 +43,7 @@ object DCRTagPages
       name = "dcr-tag-pages",
       description = "Render tag pages with DCR",
       owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 4, 15),
+      sellByDate = LocalDate.of(2024, 6, 18),
       participationGroup = Perc10A,
     )
 


### PR DESCRIPTION
## Why?

To keep the build green.

