### PR TITLE
Add Donald Trump trials subnav in US section

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -20,6 +20,7 @@ object NavLinks {
   val usNews = NavLink("US", "/us-news", longTitle = Some("US news"))
   val usPolitics = NavLink("US Politics", "/us-news/us-politics", longTitle = Some("US politics"))
   val usElections2024 = NavLink("US elections 2024", "/us-news/us-elections-2024")
+  val trumpTrials = NavLink("Donald Trump trials", "/us-news/donald-trump-trials")
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")
@@ -309,6 +310,7 @@ object NavLinks {
     List(
       usNews,
       usElections2024,
+      trumpTrials,
       world,
       usEnvironment,
       ukraine,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1013,6 +1013,12 @@
 					"classList": []
 				},
 				{
+					"title": "Donald Trump trials",
+					"url": "/us-news/donald-trump-trials",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "World",
 					"url": "/world",
 					"longTitle": "World news",


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/11146

## What does this change?
Adds Donald Trump trials subnav in US section

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/guardian/frontend/assets/19683595/e5055bd4-0bfc-46c7-adb1-d47094c5cc31) | ![image](https://github.com/guardian/frontend/assets/19683595/78a24966-661e-4197-9f54-6ebfed18fe57) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
