### PR TITLE
render html formatted instructions on printable pages

### DIFF
--- a/applications/app/views/fragments/crosswords/printableCrosswordBody.scala.html
+++ b/applications/app/views/fragments/crosswords/printableCrosswordBody.scala.html
@@ -12,7 +12,7 @@
     </h1>
 
     @crosswordPage.crossword.instructions.map { instructions =>
-        <h2 class="printable-crossword__instructions"><strong>Special instructions:</strong> @instructions</h2>
+        <h2 class="printable-crossword__instructions"><strong>Special instructions:</strong> @Html(instructions)</h2>
     }
 
     <div class="printable-crossword__grid">@crosswordPage.svg</div>


### PR DESCRIPTION

## What is the value of this and can you measure success?

Setters have more control over display of instructions in output, consistency between interactive and print-friendly crossword pages

## What does this change?

the main/interactive crossword pages already do the same, this just brings the printable pages to the same behaviour

This just uses Twirl's `@Html` renderer to output the HTML without any escaping - which is a potential XSS vector! If a crossword were uploaded with a malicious script or iframe tag (or anything else) it would be rendered and run in reader's browsers.

However: crosswordv2 does already run sanitization of the tags provided to CAPI and downstream services, rejecting any crossword that contains a tag that is not one of span,i,b,sup,sup for clues, and this will be extended for instructions when supported there.

`@Html` is also already used several times in the crosswords templates; for providing formatted clues
(<https://github.com/guardian/frontend/blob/b799f043d2343d2caf444114fc78285a4ef9cb0b/applications/app/views/fragments/crosswords/crosswordEntries.scala.html#L8>), and formatted instructions for the main/interactive crossword pages (<https://github.com/guardian/frontend/blob/b799f043d2343d2caf444114fc78285a4ef9cb0b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html#L53>), so doing the same on the printable page isn't really making anything worse, though we could consider doing some more strict validation on the rendering layer too in the future, either here or in dcr.

## Screenshots


| Before      | After      |
|-------------|------------|
| <img width="697" alt="image" src="https://github.com/guardian/frontend/assets/10963046/7bb1e978-42f9-4809-ad72-3fdf100a0fde"> | <img width="676" alt="image" src="https://github.com/guardian/frontend/assets/10963046/a403e6de-f43c-4925-bfea-216207c24461"> |


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
