### PR TITLE
fix: remove DisableAmpTest

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -299,16 +299,6 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val DisableAmpTest = Switch(
-    SwitchGroup.Feature,
-    "disable-amp-test",
-    "If this switch is on, we will disable the amphtml link on articles for a cohort of readers",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val R2PagePressServiceSwitch = Switch(
     SwitchGroup.Feature,
     "r2-page-press-service",


### PR DESCRIPTION
Part of https://github.com/guardian/dotcom-rendering/issues/7486

Removes the switch as it's not used, and there is no plan to use it immediately.
