### PR TITLE
Improve AB testing documentation

### DIFF
--- a/docs/03-dev-howtos/01-ab-testing.md
+++ b/docs/03-dev-howtos/01-ab-testing.md
@@ -21,7 +21,7 @@ There are six steps in the test lifecycle:
 
 - Decide if you need to create a [server-side AB test](#write-a-server-side-test) or a [client-side](#client-side-ab-tests) one. 
   - You should consider testing server-side if you:
-    - Are making **rendering** changes (e.g. in DCR) and might be concerned about layout shift during rendering
+    - Are testing server-side **rendering** changes (e.g. in DCR)
     - Only require knowledge of the request header in order to vary the response (ie. anonymised page data is sufficient / you do not need to understand current state of a page)
   - Server-side tests support simple A/B tests (control / variant) but not multivariant ones (control / variant1 / variant2), whereas you can do either with client-side tests
 

--- a/docs/03-dev-howtos/01-ab-testing.md
+++ b/docs/03-dev-howtos/01-ab-testing.md
@@ -10,7 +10,7 @@ Read this if you want to [write a server-side AB Test](#write-a-server-side-test
 
 There are six steps in the test lifecycle:
 
- - [Adding a switch to turn the test on & off)](#adding-a-switch). For server-side tests, this is included in the test definition.
+ - Adding a switch to turn the test on & off. [This is required explicitly for client-side AB tests](#adding-a-switch), though for server-side tests the switch is created automatically.
  - Writing a test e.g. [client-side](#writing-a-test) or [server-side](#write-a-server-side-test)
  - [Running the test](#running-the-test) or [configuring your server-side test](#configure-the-test)
  - [Analysis of the test data](#analysis-of-the-test-data)
@@ -305,11 +305,9 @@ It adds a rather large overhead to the cookie (mine is 2.5kb).
 
 # Write a Server-Side Test
 
-If you want to set up your AB test to run away from the client ie. with scala, or in server-side rendered javascript, almost all the steps are different.
-
 *Advantages:*
-- Allows you to run tests that just won't work in javascript ie if you want to render a whole different page
-- Avoid javascript rendering problems (eg a jump if a DOM element is rendered and then hidden)
+- Allows you to run tests that won't work in the client i.e. if you want to render a whole different page
+- Avoids client-side rendering problems (eg a jump if a DOM element is rendered and then hidden)
 
 *Disadvantages:*
 - Can only do AB tests, not multivariant ABC test

--- a/docs/03-dev-howtos/14-override-default-configuration.md
+++ b/docs/03-dev-howtos/14-override-default-configuration.md
@@ -19,7 +19,15 @@ Tired of pointing your `facia.stage` at `CODE`?  Have you ever longed to change 
           facia.stage=CODE
         }
 
-3. If overriding switches, control what you want turned on in file switches-yournamehere.properties. Upload your file to the S3 frontend store bucket (aws-frontend-store/DEV/config).
+3. If overriding switches, control what you want turned on in file `switches-yournamehere.properties` then upload your file to the S3 frontend store bucket (`<bucket>/DEV/config`).
+  - An easy way to do this using the AWS CLI is to download the CODE switches JSON:
+  
+    ```aws s3 cp s3://<bucket>/CODE/config/switches.properties switches-yournamehere.properties --profile frontend```
+    
+    then amend the values you need, and upload back to the DEV section in S3:
+    
+    ```aws s3 cp switches-yournamehere.properties s3://<bucket>/DEV/config/switches-yournamehere.properties --profile frontend```
+
 
 4. Restart the app you're working on
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Updates the documentation for AB testing for future travellers & web developers on frontend and DCR.

## What does this change?

- Adds more info to the top of the AB testing documentation about considering server-side testing
- Mentions client vs server side as opposed to referring to languages like scala vs javascript when talking about what type of test to run
- Strikes out Ophan AB testing dashboard as the link is broken and needs replacing (removing this entirely reduces the likelihood that this will be revived)
- Give tips on overriding local dev configuration, and highlights this importance for local development of AB tests.
