### PR TITLE
Enhance timeline elements with ids

### DIFF
--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -2,50 +2,55 @@ package model.dotcomrendering
 
 import play.api.libs.json.{Json, _}
 
+/**
+  * The `ElementsEnhancer` object provides functions to enhance JSON representations of elements used in Dotcom Rendering.
+  * It adds unique identifiers to elements, as expected by the DCR schemas. More information on the decision for this can be found in PageElement-Identifiers.md or by searching for "03feb394-a17d-4430-8384-edd1891e0d01"
+  *
+ */
+
 object ElementsEnhancer {
 
-  // Note:
-  //     In the file PageElement-Identifiers.md you will find a discussion of identifiers used by PageElements
-  //     Also look for "03feb394-a17d-4430-8384-edd1891e0d01"
-
   def enhanceElement(element: JsValue): JsValue = {
+    // Add an elementId to the element
     val elementWithId = element.as[JsObject] ++ Json.obj("elementId" -> java.util.UUID.randomUUID.toString)
+    // Extract element type
     val elementType = elementWithId.value("_type").as[String]
-    val elementIsList = elementType == "model.dotcomrendering.pageElements.ListBlockElement"
 
-    val elementIsTimeline = elementType == "model.dotcomrendering.pageElements.TimelineBlockElement"
-
-    if (elementIsList) {
-      val listItems = elementWithId.value("items").as[JsArray]
-      val listItemsWithIds = listItems.value.map { item =>
-        val obj = item.as[JsObject]
-        obj ++ Json.obj("elements" -> enhanceElements(obj.value("elements")))
-      }
-      elementWithId ++ Json.obj("items" -> listItemsWithIds)
-    } else if (elementIsTimeline) {
-      val sectionsList = elementWithId.value("sections").as[List[JsObject]]
-      val sectionListWithIds = sectionsList.map { section =>
-        val eventList = section.value("events").as[List[JsObject]]
-        val eventListWithIds = eventList.map { event =>
-          val bodyList = event.value("body").as[JsArray]
-          val bodyListWithIds = bodyList.value.map(currentBlock => {
-            enhanceElement(currentBlock)
-          })
-          event ++ Json.obj("body" -> bodyListWithIds)
-        }
-        section ++ Json.obj("events" -> eventListWithIds)
-      }
-      elementWithId ++ Json.obj("sections" -> sectionListWithIds)
-    } else {
-      elementWithId
+    // If element has further nesting, continue to enhance. otherwise, return the enhanced element
+    elementType match {
+      case "model.dotcomrendering.pageElements.ListBlockElement"     => enhanceListBlockElement(elementWithId)
+      case "model.dotcomrendering.pageElements.TimelineBlockElement" => enhanceTimelineBlockElement(elementWithId)
+      case _                                                         => elementWithId;
     }
+
+  }
+  def enhanceListBlockElement(elementWithId: JsObject): JsObject = {
+    val listItems = elementWithId.value("items").as[JsArray]
+    val listItemsWithIds = listItems.value.map { item =>
+      val obj = item.as[JsObject]
+      obj ++ Json.obj("elements" -> enhanceElements(obj.value("elements")))
+    }
+    elementWithId ++ Json.obj("items" -> listItemsWithIds)
+  }
+
+  def enhanceTimelineBlockElement(element: JsObject): JsObject = {
+    val sectionsList = element.value("sections").as[List[JsObject]]
+    val sectionsListWithIds = sectionsList.map { section =>
+      val eventsList = section.value("events").as[List[JsObject]]
+      val eventsListWithIds = eventsList.map { event =>
+        val bodyElementsWithIds = enhanceElements(event.value("body").as[JsArray])
+        event.as[JsObject] ++ Json.obj("body" -> bodyElementsWithIds)
+      }
+      section.as[JsObject] ++ Json.obj("events" -> eventsListWithIds)
+    }
+    element ++ Json.obj("sections" -> sectionsListWithIds)
   }
 
   def enhanceElements(elements: JsValue): IndexedSeq[JsValue] = {
     elements.as[JsArray].value.map(element => enhanceElement(element))
   }.toIndexedSeq
 
-  def enhanceObjectWithElementsAtDepth1(obj: JsValue): JsValue = {
+  def enhanceObjectWithElements(obj: JsValue): JsValue = {
     obj.asOpt[JsObject] match {
       case Some(o) =>
         val elements = o.value("elements")
@@ -54,21 +59,21 @@ object ElementsEnhancer {
     }
   }
 
-  def enhanceObjectsWithElementsAtDepth1(objs: JsValue): IndexedSeq[JsValue] = {
-    objs.as[JsArray].value.map(obj => enhanceObjectWithElementsAtDepth1(obj))
+  def enhanceObjectsWithElements(objs: JsValue): IndexedSeq[JsValue] = {
+    objs.as[JsArray].value.map(obj => enhanceObjectWithElements(obj))
   }.toIndexedSeq
 
   def enhanceBlocks(obj: JsObject): JsObject = {
     obj ++
-      Json.obj("blocks" -> enhanceObjectsWithElementsAtDepth1(obj.value("blocks")))
+      Json.obj("blocks" -> enhanceObjectsWithElements(obj.value("blocks")))
   }
 
   def enhanceDcrObject(obj: JsObject): JsObject = {
     obj ++
-      Json.obj("blocks" -> enhanceObjectsWithElementsAtDepth1(obj.value("blocks"))) ++
+      Json.obj("blocks" -> enhanceObjectsWithElements(obj.value("blocks"))) ++
       Json.obj("mainMediaElements" -> enhanceElements(obj.value("mainMediaElements"))) ++
-      Json.obj("keyEvents" -> enhanceObjectsWithElementsAtDepth1(obj.value("keyEvents"))) ++
-      Json.obj("pinnedPost" -> enhanceObjectWithElementsAtDepth1(obj.value("pinnedPost"))) ++
+      Json.obj("keyEvents" -> enhanceObjectsWithElements(obj.value("keyEvents"))) ++
+      Json.obj("pinnedPost" -> enhanceObjectWithElements(obj.value("pinnedPost"))) ++
       Json.obj("promotedNewsletter" -> obj.value("promotedNewsletter"))
   }
 }

--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -9,7 +9,6 @@ object ElementsEnhancer {
   //     Also look for "03feb394-a17d-4430-8384-edd1891e0d01"
 
   def enhanceElement(element: JsValue): JsValue = {
-    println(">>> enhanceElement")
     val elementWithId = element.as[JsObject] ++ Json.obj("elementId" -> java.util.UUID.randomUUID.toString)
     val elementType = elementWithId.value("_type").as[String]
     val elementIsList = elementType == "model.dotcomrendering.pageElements.ListBlockElement"
@@ -24,8 +23,6 @@ object ElementsEnhancer {
       }
       elementWithId ++ Json.obj("items" -> listItemsWithIds)
     } else if (elementIsTimeline) {
-      println(">>> enhanceElement : elementIsTimeline")
-
       val sectionsList = elementWithId.value("sections").as[List[JsObject]]
       val sectionListWithIds = sectionsList.map { section =>
         val eventList = section.value("events").as[List[JsObject]]
@@ -34,9 +31,7 @@ object ElementsEnhancer {
           val bodyListWithIds = bodyList.value.map(currentBlock => {
             enhanceElement(currentBlock)
           })
-
           event ++ Json.obj("body" -> bodyListWithIds)
-
         }
         section ++ Json.obj("events" -> eventListWithIds)
       }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -877,6 +877,8 @@ object PageElement {
       case _: WitnessBlockElement         => true
       case _: VineBlockElement            => true
       case _: ListBlockElement            => true
+      case _: TimelineBlockElement        => true
+
       // TODO we should quick fail here for these rather than pointlessly go to DCR
       case table: TableBlockElement if table.isMandatory.exists(identity) => true
 
@@ -1479,6 +1481,7 @@ object PageElement {
         }.toList
 
       case Timeline =>
+        println("inside timeline")
         element.timelineTypeData.map { timelineTypeData =>
           TimelineBlockElement(
             sections = makeTimelineSection(

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1481,7 +1481,6 @@ object PageElement {
         }.toList
 
       case Timeline =>
-        println("inside timeline")
         element.timelineTypeData.map { timelineTypeData =>
           TimelineBlockElement(
             sections = makeTimelineSection(


### PR DESCRIPTION
## What does this change?
Enhances the timeline element so that each child element has an element id. This is required for the DCR to correctly match the elements with its schema.

It also refactors the ElementsEnhancer using pattern matching and adds comments to help improve readability. 

It also renames enhanceObjectWithElementsAtDepth1 => enhanceObjectsWithElements as we are no longer limiting the function to only going to a depth of 1.

## Screenshots

# Data Structure

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/20416599/2916b382-44b5-447d-a5ff-d2d36fe2dd07
[after]: https://github.com/guardian/frontend/assets/20416599/789f83ba-ee00-4a16-a8fb-aa078aae7bbe

# Article

| Before      | After      |
|-------------|------------|
| ![before-1][] | ![after-1][] |

[before-1]: https://github.com/guardian/frontend/assets/20416599/76a86f28-18bc-465b-b164-bb9a08165e8d
[after-1]: https://github.com/guardian/frontend/assets/20416599/d3809eae-7ddf-4733-a759-e308a5b367ef


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
