### PR TITLE
Bump commercial to 17.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "0.0.0-beta-20240416113921",
+		"@guardian/commercial": "17.11.0",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",
 		"@guardian/identity-auth-frontend": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "17.10.0",
+		"@guardian/commercial": "0.0.0-beta-20240416113921",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",
 		"@guardian/identity-auth-frontend": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,9 +3137,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:17.10.0":
-  version: 17.10.0
-  resolution: "@guardian/commercial@npm:17.10.0"
+"@guardian/commercial@npm:0.0.0-beta-20240416113921":
+  version: 0.0.0-beta-20240416113921
+  resolution: "@guardian/commercial@npm:0.0.0-beta-20240416113921"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -3160,7 +3160,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     "@guardian/support-dotcom-components": ^1.0.7
-  checksum: 10c0/f4e5589376889e540f03cb62c0981dd5c333ea51ae10680c9fa09e37c2b8e8e57e5c04454a8ae83b2763440814852e4e7a6484995a11ca0bb3367051d4642e88
+  checksum: 10c0/3558aee8e34bcc9e764e66322f1e70a4d916df3dfe15a10b47acbf095d25d17f1c60bc120c0cd696917b1cc9539f1910e1a7980c525027a490f1c7f09129f26e
   languageName: node
   linkType: hard
 
@@ -3229,7 +3229,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:^5.0.0"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:17.10.0"
+    "@guardian/commercial": "npm:0.0.0-beta-20240416113921"
     "@guardian/core-web-vitals": "npm:^5.0.0"
     "@guardian/eslint-config-typescript": "npm:^0.7.0"
     "@guardian/identity-auth": "npm:2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,9 +3137,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:0.0.0-beta-20240416113921":
-  version: 0.0.0-beta-20240416113921
-  resolution: "@guardian/commercial@npm:0.0.0-beta-20240416113921"
+"@guardian/commercial@npm:17.11.0":
+  version: 17.11.0
+  resolution: "@guardian/commercial@npm:17.11.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -3160,7 +3160,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     "@guardian/support-dotcom-components": ^1.0.7
-  checksum: 10c0/3558aee8e34bcc9e764e66322f1e70a4d916df3dfe15a10b47acbf095d25d17f1c60bc120c0cd696917b1cc9539f1910e1a7980c525027a490f1c7f09129f26e
+  checksum: 10c0/390a6dadf9241f171424ef968de4d09de7652dc6eb809916489529dd3fe3840ed6b8de9cb1b5de73003a267f3adc7860c18ff314d6d74bf7b9873856759e172e
   languageName: node
   linkType: hard
 
@@ -3229,7 +3229,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:^5.0.0"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:0.0.0-beta-20240416113921"
+    "@guardian/commercial": "npm:17.11.0"
     "@guardian/core-web-vitals": "npm:^5.0.0"
     "@guardian/eslint-config-typescript": "npm:^0.7.0"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
[Changes in this release
](https://github.com/guardian/commercial/pull/1341)
### Minor Changes

-   7819916: Insert ads in certain nested block elements
