### PR TITLE
Bump commercial to 17.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "17.11.0",
+		"@guardian/commercial": "^17.12.0",
 		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/identity-auth": "2.1.0",
 		"@guardian/identity-auth-frontend": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,9 +3137,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:17.11.0":
-  version: 17.11.0
-  resolution: "@guardian/commercial@npm:17.11.0"
+"@guardian/commercial@npm:^17.12.0":
+  version: 17.12.0
+  resolution: "@guardian/commercial@npm:17.12.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -3160,7 +3160,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     "@guardian/support-dotcom-components": ^1.0.7
-  checksum: 10c0/390a6dadf9241f171424ef968de4d09de7652dc6eb809916489529dd3fe3840ed6b8de9cb1b5de73003a267f3adc7860c18ff314d6d74bf7b9873856759e172e
+  checksum: 10c0/636e9d416212356870c45a611219a3fba06260d46e0a9418348b68c4db8c87aa1a03934ab38fd76a18848d83e37b76d03940b0917984ba853a7328fd040acd64
   languageName: node
   linkType: hard
 
@@ -3229,7 +3229,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:^5.0.0"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:17.11.0"
+    "@guardian/commercial": "npm:^17.12.0"
     "@guardian/core-web-vitals": "npm:^5.0.0"
     "@guardian/eslint-config-typescript": "npm:^0.7.0"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
Bring in the changes from [17.12.0](https://github.com/guardian/commercial/releases/tag/v17.12.0)