### PR TITLE
Update some US edition navlinks so that they don't redirect

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -9,6 +9,7 @@ object NavLinks {
   /* NEWS */
   val science = NavLink("Science", "/science")
   val tech = NavLink("Tech", "/technology")
+  val usTech = NavLink("Tech", "/us/technology")
   val politics = NavLink("UK politics", "/politics")
   val media = NavLink("Media", "/media")
   val globalDevelopment = NavLink("Global development", "/global-development")
@@ -80,15 +81,23 @@ object NavLinks {
   val auEnvironment = ukEnvironment.copy(children =
     List(climateCrisis, energy, wildlife, biodiversity, oceans, pollution, greatBarrierReef),
   )
-  val usEnvironment = ukEnvironment.copy(children = List(climateCrisis, wildlife, energy, pollution, greenLight))
+
+  val usEnvironment =
+    NavLink("Environment", "/environment", children = List(climateCrisis, wildlife, energy, pollution, greenLight))
+
   val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
   val ukBusiness = NavLink(
     "Business",
     "/business",
     children = List(economics, banking, money, markets, projectSyndicate, businessToBusiness, retail),
   )
-  val usBusiness =
-    ukBusiness.copy(children = List(economics, diversityEquality, smallBusiness, retail))
+
+  val usBusiness = NavLink(
+    "Business",
+    "/us/business",
+    children = List(economics, diversityEquality, smallBusiness, retail),
+  )
+
   val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate, retail))
 
   /* OPINION */
@@ -124,7 +133,7 @@ object NavLinks {
   )
   val soccer = NavLink(
     title = "Soccer",
-    url = "/soccer",
+    url = "/us/soccer",
     children = List(
       footballScores,
       footballTables,
@@ -187,7 +196,7 @@ object NavLinks {
   val ukTravel = NavLink("Travel", "/travel", children = List(travelUk, travelEurope, travelUs))
   val usTravel = ukTravel.copy(children = List(travelUs, travelEurope, travelUk))
   val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
-  val wellness = NavLink("Wellness", "/wellness")
+  val wellness = NavLink("Wellness", "/us/wellness")
 
   val todaysPaper = NavLink(
     "Today's paper",
@@ -310,7 +319,7 @@ object NavLinks {
       ukraine,
       soccer,
       usBusiness,
-      tech,
+      usTech,
       science,
       newsletters,
       wellness,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -131,7 +131,7 @@ object NavLinks {
       footballClubs,
     ),
   )
-  val soccer = NavLink(
+  val usSoccer = NavLink(
     title = "Soccer",
     url = "/us/soccer",
     children = List(
@@ -196,7 +196,7 @@ object NavLinks {
   val ukTravel = NavLink("Travel", "/travel", children = List(travelUk, travelEurope, travelUs))
   val usTravel = ukTravel.copy(children = List(travelUs, travelEurope, travelUk))
   val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
-  val wellness = NavLink("Wellness", "/us/wellness")
+  val usWellness = NavLink("Wellness", "/us/wellness")
 
   val todaysPaper = NavLink(
     "Today's paper",
@@ -317,12 +317,12 @@ object NavLinks {
       world,
       usEnvironment,
       ukraine,
-      soccer,
+      usSoccer,
       usBusiness,
       usTech,
       science,
       newsletters,
-      wellness,
+      usWellness,
     ),
   )
   val intNewsPillar = ukNewsPillar.copy(
@@ -418,7 +418,7 @@ object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
-      soccer,
+      usSoccer,
       NFL,
       tennis,
       MLB,
@@ -531,7 +531,7 @@ object NavLinks {
   )
   val usLifestylePillar = ukLifestylePillar.copy(
     children = List(
-      wellness,
+      usWellness,
       fashion,
       food,
       recipes,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1127,7 +1127,7 @@
 				},
 				{
 					"title": "Soccer",
-					"url": "/soccer",
+					"url": "/us/soccer",
 					"children": [
 						{
 							"title": "Live scores",
@@ -1176,7 +1176,7 @@
 				},
 				{
 					"title": "Business",
-					"url": "/business",
+					"url": "/us/business",
 					"children": [
 						{
 							"title": "Economics",
@@ -1207,7 +1207,7 @@
 				},
 				{
 					"title": "Tech",
-					"url": "/technology",
+					"url": "/us/technology",
 					"children": [],
 					"classList": []
 				},
@@ -1225,7 +1225,7 @@
 				},
 				{
 					"title": "Wellness",
-					"url": "/wellness",
+					"url": "/us/wellness",
 					"children": [],
 					"classList": []
 				}
@@ -1279,7 +1279,7 @@
 			"children": [
 				{
 					"title": "Soccer",
-					"url": "/soccer",
+					"url": "/us/soccer",
 					"children": [
 						{
 							"title": "Live scores",
@@ -1442,7 +1442,7 @@
 			"children": [
 				{
 					"title": "Wellness",
-					"url": "/wellness",
+					"url": "/us/wellness",
 					"children": [],
 					"classList": []
 				},


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/11192

## What does this change

These URLs in the US subnav --

https://www.theguardian.com/business
https://www.theguardian.com/environment
https://www.theguardian.com/soccer
https://www.theguardian.com/technology
https://www.theguardian.com/wellness

Updated to their /us/ versions --

https://www.theguardian.com/us/business
https://www.theguardian.com/us/environment
https://www.theguardian.com/us/soccer
https://www.theguardian.com/us/technology
https://www.theguardian.com/us/wellness

## Why? 

This is a temporary change requested by the SEO team in the US. It's part of a [larger work](https://github.com/guardian/dotcom-rendering/issues/11148) to improve SEO. In the future we would like to make changes to the navbar so that it doesn't contain links that redirect:
* https://github.com/guardian/dotcom-rendering/issues/11193. 
Until we complete this the team has asked us to update only the links above.

For more details see SEO analysis [here](https://docs.google.com/document/d/1tjVP19-piWCQbtVJ9emyPu3_FYGlRP6qRQsV8DeC7dg/edit)


## Screenshots

Previously we were redirecting:

![image](https://github.com/guardian/frontend/assets/19683595/ad3f2bf1-ee60-4045-b043-315df3110270)

![image](https://github.com/guardian/frontend/assets/19683595/648a1fa9-c863-415c-9077-f53111cc35d2)


After the change we won't: 

![image](https://github.com/guardian/frontend/assets/19683595/057b4d61-2c17-4ad6-8cdd-f3872cc6dd56)



## Checklist

- [x] Tested locally, and on CODE if necessary

