### PR TITLE
Guardian is best website of the year

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -29,7 +29,7 @@
                         if(page.metadata.hasSlimHeader) {
                             fragments.inlineSvg("the-guardian-roundel", "logo")
                         } else if(editionId == "uk") {
-                            fragments.inlineSvg("guardian-best-newspaper-logo", "logo")
+                            fragments.inlineSvg("guardian-best-website-logo", "logo")
                         } else if(editionId == "au") {
                             fragments.inlineSvg("guardian-australia-decade-logo", "logo")
                         } else {

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -153,7 +153,7 @@
 
             @{
             if(editionId == "uk") {
-            fragments.inlineSvg("guardian-best-newspaper-logo", "logo")
+            fragments.inlineSvg("guardian-best-website-logo", "logo")
             } else if(editionId == "au") {
             fragments.inlineSvg("guardian-australia-decade-logo", "logo")
             } else {


### PR DESCRIPTION
## What does this change?
Switches to Guardian Best Website of the Year logo

Change in DCR:
* https://github.com/guardian/dotcom-rendering/pull/11203

## Screenshots

### Wide
![image](https://github.com/guardian/frontend/assets/19683595/b41bcb0a-613e-40f1-9ba3-45e7afa9ee83)

### Tablet
![image](https://github.com/guardian/frontend/assets/19683595/ead40558-1131-46a2-9cc9-0fba9c14f29e)

### Mobile
![image](https://github.com/guardian/frontend/assets/19683595/ab4000a6-0171-4629-943d-c2512795b799)

## Checklist

- [X] Tested locally, and on CODE if necessary
