### PR TITLE
Convert the adapted site experiment to a switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -186,4 +186,14 @@ trait PerformanceSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
+
+  val AdaptiveSite = Switch(
+    SwitchGroup.Performance,
+    "adaptive-site",
+    "If switched on, the site will run a pared-back set of features on poorly-performing page views.",
+    owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      AdaptiveSite,
       CommercialMegaTest,
       DCRTagPages,
       UpdatedHeaderDesign,
@@ -27,15 +26,6 @@ object CommercialMegaTest
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2024, 8, 8),
       participationGroup = Perc5A,
-    )
-
-object AdaptiveSite
-    extends Experiment(
-      name = "adaptive-site",
-      description = "Enables serving an adaptive version of the site that responds to page performance",
-      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 5, 2),
-      participationGroup = Perc1A,
     )
 
 object DCRTagPages


### PR DESCRIPTION
## What is the value of this and can you measure success?

It was successful and so it has become permanent (https://github.com/guardian/dotcom-rendering/pull/11174)

## What does this change?

- removes the adapted site experiment
- adds an adaptive site switch

