### PR TITLE
Remove `header-top-nav` switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -473,16 +473,6 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
-  val headerTopNav = Switch(
-    SwitchGroup.Feature,
-    "header-top-nav",
-    "When ON, the header has a thin top bar above containing relevant links",
-    owners = group(Feature),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val Callout = Switch(
     SwitchGroup.Feature,
     "callouts",

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -8,7 +8,6 @@ import views.html.stacked
 import views.html.fragments._
 import views.html.fragments.page.body._
 import views.support.Commercial
-import conf.switches.Switches
 
 trait HtmlPage[P <: model.Page] {
   def html(page: P)(implicit request: RequestHeader, applicationContext: ApplicationContext): Html
@@ -31,7 +30,7 @@ object HtmlPageHelpers {
         .isAdFree(request)
     val headerContent: Html = stacked(
       commercial.topBanner() when showTop && showAds,
-      if (Switches.headerTopNav.isSwitchedOn && !page.metadata.hasSlimHeader) headerTopNav() else header() when showTop,
+      if (!page.metadata.hasSlimHeader) headerTopNav() else header() when showTop,
     )
     bannerAndHeaderDiv(headerContent)
   }

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -38,11 +38,11 @@ const showHiringMessage = () => {
         if (!config.get('page.isDev') && config.get('switches.weAreHiring')) {
             window.console.log(
                 '\n' +
-                    '%cHello.\n' +
-                    '\n' +
-                    '%cWe are hiring – ever thought about joining us? \n' +
-                    '%chttps://workforus.theguardian.com/careers/product-engineering%c \n' +
-                    '\n',
+                '%cHello.\n' +
+                '\n' +
+                '%cWe are hiring – ever thought about joining us? \n' +
+                '%chttps://workforus.theguardian.com/careers/product-engineering%c \n' +
+                '\n',
                 'font-family: Georgia, serif; font-size: 32px; color: #052962',
                 'font-family: Georgia, serif; font-size: 16px; color: #767676',
                 'font-family: Helvetica Neue, sans-serif; font-size: 11px; text-decoration: underline; line-height: 1.2rem; color: #767676',
@@ -73,8 +73,8 @@ const addScrollHandler = () => {
         'scroll',
         userPrefs.get('use-idle-callback') && 'requestIdleCallback' in window
             ? () => {
-                  window.requestIdleCallback(onScroll);
-              }
+                window.requestIdleCallback(onScroll);
+            }
             : onScroll,
         { passive: true }
     );
@@ -162,9 +162,7 @@ const bootStandard = () => {
 
     ophan.setEventEmitter(mediator);
 
-    if(window.guardian.config.switches.headerTopNav
-        && document.querySelector('.header-top-nav')
-        ) {
+    if (document.querySelector('.header-top-nav')) {
         headerTopNavInit();
     } else {
         newHeaderInit();


### PR DESCRIPTION
## What is the value of this and can you measure success?

Removes unused switch after removing usage of it in DCR. See https://github.com/guardian/dotcom-rendering/pull/11213

## What does this change?

Removes `header-top-nav` switch, and direct usage of it in this repo.
