### PR TITLE
Update the US nav link for environment from `/environment` to `/us/environment`

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -83,7 +83,7 @@ object NavLinks {
   )
 
   val usEnvironment =
-    NavLink("Environment", "/environment", children = List(climateCrisis, wildlife, energy, pollution, greenLight))
+    NavLink("Environment", "/us/environment", children = List(climateCrisis, wildlife, energy, pollution, greenLight))
 
   val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
   val ukBusiness = NavLink(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1084,7 +1084,7 @@
 				},
 				{
 					"title": "Environment",
-					"url": "/environment",
+					"url": "/us/environment",
 					"children": [
 						{
 							"title": "Climate crisis",


### PR DESCRIPTION
## What does this change?

Update the US nav link for environment from `/environment` to `/us/environment`

We missed this in #27062 

