### PR TITLE
Show affiliate links on all eligible galleries

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -34,6 +34,7 @@
                 tagPaths = page.gallery.content.tags.tags.map(_.id),
                 firstPublishedDate = page.gallery.content.fields.firstPublicationDate,
                 pageUrl = request.uri,
+                contentType = "gallery",
             )
         )
 

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -47,6 +47,7 @@ object GalleryCaptionCleaners {
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
         page.gallery.content.fields.firstPublicationDate,
+        contentType = "gallery",
       ),
     )
 

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -84,6 +84,7 @@ object BodyProcessor {
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         tags = article.content.tags.tags.map(_.id),
         publishedDate = article.content.fields.firstPublicationDate,
+        contentType = "article",
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -252,6 +252,7 @@ object DotcomRenderingUtils {
       tagPaths = content.content.tags.tags.map(_.id),
       firstPublishedDate = content.content.fields.firstPublicationDate,
       pageUrl = content.metadata.id,
+      contentType = "article",
     )
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -872,6 +872,7 @@ case class AffiliateLinksCleaner(
     appendDisclaimer: Option[Boolean] = None,
     tags: List[String],
     publishedDate: Option[DateTime],
+    contentType: String,
 ) extends HtmlCleaner
     with GuLogging {
 
@@ -887,6 +888,7 @@ case class AffiliateLinksCleaner(
         tags,
         publishedDate,
         pageUrl,
+        contentType,
       )
     ) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, skimlinksId)
@@ -943,6 +945,7 @@ object AffiliateLinksCleaner {
       tagPaths: List[String],
       firstPublishedDate: Option[DateTime],
       pageUrl: String,
+      contentType: String,
   ): Boolean = {
     val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
 
@@ -964,15 +967,6 @@ object AffiliateLinksCleaner {
       "fashion/2024/mar/17/beauty-spot-10-best-root-cover-ups",
       "fashion/2024/apr/05/peptides-help-with-good-looking-skin-but-dont-expect-botox-in-a-bottle",
       "fashion/2024/apr/13/sali-hughes-top-50-beauty-products-for-under-20-pounds",
-      "fashion/gallery/2024/mar/09/spring-in-your-step-10-menswear-trends-to-update-your-wardrobe-in-pictures",
-      "fashion/gallery/2024/mar/08/street-smart-what-to-wear-to-run-errands",
-      "fashion/gallery/2024/mar/09/the-edit-mens-sweatshirts-in-pictures",
-      "lifeandstyle/gallery/2024/jan/22/colourful-glass-furniture-from-vases-to-lampshades-in-pictures",
-      "lifeandstyle/gallery/2023/nov/27/cosy-bedding-in-pictures",
-      "fashion/gallery/2024/mar/24/we-love-fashion-fixes-for-the-week-ahead-in-pictures",
-      "fashion/gallery/2024/apr/06/we-love-fashion-fixes-for-the-week-ahead-in-pictures",
-      "fashion/gallery/2024/apr/05/instant-spark-what-to-wear-for-a-first-date",
-      "fashion/gallery/2024/mar/31/crossbody-carrier-18-of-the-best-handbags-in-pictures",
     )
 
     val urlIsInAllowList = affiliateLinksAllowList.contains(cleanedPageUrl)
@@ -983,7 +977,7 @@ object AffiliateLinksCleaner {
     if (
       !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && (firstPublishedDate.exists(
         _.isBefore(publishedCutOffDate),
-      ) || urlIsInAllowList)
+      ) || urlIsInAllowList || contentType == "gallery")
     ) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -31,6 +31,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -42,6 +43,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -53,6 +55,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -64,6 +67,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -75,6 +79,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("bereavement"),
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -86,6 +91,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("tech"),
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -97,6 +103,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("tech"),
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -108,6 +115,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("bereavement"),
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -119,6 +127,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("tech"),
       oldPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -130,6 +139,19 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       newPublishedDate,
       deniedPageUrl,
+      "article",
     ) should be(false)
+    shouldAddAffiliateLinks(
+      switchedOn = true,
+      "film",
+      None,
+      supportedSections,
+      Set.empty,
+      Set.empty,
+      List.empty,
+      newPublishedDate,
+      deniedPageUrl,
+      "gallery",
+    ) should be(true)
   }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?
Adding affiliate links to more galleries will increase the number of affiliate links on the site, so will have a revenue benefit associated.

## What does this change?
We now want to launch skimlinks on all eligible galleries, and no longer use an allowlist for gallery content. We now pass in a `contentType` parameter to the shouldAddAffiliateLinks check, and if the `contentType` is gallery, we don't perform the allowlist or cut off date check. Note that we still need these checks for DCR rendered articles with affiliate links, as we're still in the process of finding the best way to insert the DCR disclaimer so that it doesn't clash with other page elements, so we're only making affiliate links available on a limited number of DCR pages. The gallery disclaimer design is simpler as it's contained about the main page content, so we don't have the same issues.

## Screenshots
Disclaimer now being added to a gallery which isn't on the allowlist and is published after the cut-off date.

<img width="403" alt="Screenshot 2024-04-23 at 18 33 22" src="https://github.com/guardian/frontend/assets/108270776/ed197ae7-c9dc-46f3-98f6-db1b1a1532fc">
