### PR TITLE
Add Validation Action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,19 @@
+name: Validate
+on: [push]
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+
+        - run: corepack enable
+        - uses: actions/setup-node@v4
+          with:
+            node-version-file: '.nvmrc'
+            cache: yarn
+
+        - run: make validate


### PR DESCRIPTION
## What is the value of this and can you measure success?

Any deviation from our standards is automatically caught.

## What does this change?

Ensure that we run `make validate` in our continuous integration by adding an action for it.

## Screenshots

<img width="731" alt="image" src="https://github.com/guardian/frontend/assets/76776/ddda4d31-ceb1-4b18-a578-fe40aacaf624">