### PR TITLE
Fix `source` in DCR data model

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -707,7 +707,10 @@ object Video {
     val contentType = DotcomContentType.Video
     val elements = content.elements
     val section = content.metadata.sectionId
-    val source = elements.videos.find(_.properties.isMain).flatMap(_.videos.source).orElse(content.media.headOption.flatMap(_.source))
+    val source = elements.videos
+      .find(_.properties.isMain)
+      .flatMap(_.videos.source)
+      .orElse(content.media.headOption.flatMap(_.source))
 
     val javascriptConfig: Map[String, JsValue] = Map(
       "isPodcast" -> JsBoolean(content.tags.isPodcast),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -707,7 +707,7 @@ object Video {
     val contentType = DotcomContentType.Video
     val elements = content.elements
     val section = content.metadata.sectionId
-    val source: Option[String] = content.media.headOption.flatMap(_.source)
+    val source = elements.videos.find(_.properties.isMain).flatMap(_.videos.source).orElse(content.media.headOption.flatMap(_.source))
 
     val javascriptConfig: Map[String, JsValue] = Map(
       "isPodcast" -> JsBoolean(content.tags.isPodcast),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -707,7 +707,7 @@ object Video {
     val contentType = DotcomContentType.Video
     val elements = content.elements
     val section = content.metadata.sectionId
-    val source: Option[String] = content.media.head.source
+    val source: Option[String] = content.media.headOption.flatMap(_.source)
 
     val javascriptConfig: Map[String, JsValue] = Map(
       "isPodcast" -> JsBoolean(content.tags.isPodcast),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -707,7 +707,7 @@ object Video {
     val contentType = DotcomContentType.Video
     val elements = content.elements
     val section = content.metadata.sectionId
-    val source: Option[String] = elements.videos.find(_.properties.isMain).flatMap(_.videos.source)
+    val source: Option[String] = content.media.head.source
 
     val javascriptConfig: Map[String, JsValue] = Map(
       "isPodcast" -> JsBoolean(content.tags.isPodcast),


### PR DESCRIPTION
## What is the value of this and can you measure success?
At the moment this property is always an empty string for newer video pages using youtube.

This fix will allow showing the source of the media on DCR rendered video pages which use the youtube atom.

This is the source from frontend rendered page that we need to render in DCR
![Screenshot 2024-04-25 at 11 40 08](https://github.com/guardian/frontend/assets/1731150/e3e8262f-fcde-4090-ab85-406a30cdace3)


## What does this change?
`elements.videos` appears to be where the media elements are on old non-youtube video articles like https://www.theguardian.com/film/video/2013/aug/14/chloe-grace-moretz-kick-ass-2-video

For newer aticles like https://www.theguardian.com/global/video/2024/apr/25/160-pilot-whales-stranded-and-26-confirmed-dead-in-western-australia-video it's in `content.media`, using the first item in it seems logical.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/1731150/ffa4268c-7def-4997-8f43-12e88c61c5d4

[after]: https://github.com/guardian/frontend/assets/1731150/8853c855-bfb5-4d1d-abe7-9587ccee7f1e


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
