### PR TITLE
add a permission check for `preview` and `admin` (LOG ONLY)

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -5,7 +5,6 @@ import dfp._
 import common.dfp._
 import common._
 import conf.switches.SwitchboardLifecycle
-import conf.CachedHealthCheckLifeCycle
 import controllers.{AdminControllers, HealthCheck}
 import _root_.dfp.DfpDataCacheLifecycle
 import com.amazonaws.regions.Regions
@@ -106,6 +105,7 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
       // in [admin].
       "/interactive-librarian/",
     ),
+    requiredEditorialPermissionName = "admin_tool_access",
   )
 
   lazy val healthCheck = wire[HealthCheck]

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ val common = library("common")
       jSoup,
       json4s,
       panDomainAuth,
+      editorialPermissions,
       quartzScheduler,
       redisClient,
       rome,

--- a/common/app/http/GuardianAuthWithExemptions.scala
+++ b/common/app/http/GuardianAuthWithExemptions.scala
@@ -10,6 +10,7 @@ import common.Environment.stage
 import conf.Configuration.aws.mandatoryCredentials
 import model.ApplicationContext
 import org.apache.pekko.stream.Materializer
+import org.slf4j.LoggerFactory
 import play.api.Mode
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -33,6 +34,8 @@ class GuardianAuthWithExemptions(
     with BaseController {
 
   private val outer = this
+
+  val logger = LoggerFactory.getLogger(this.getClass)
 
   private val permissions: PermissionsProvider = PermissionsProvider(
     PermissionsConfig(
@@ -102,12 +105,14 @@ class GuardianAuthWithExemptions(
           if (permissions.hasPermission(requiredPermission, user.email)) {
             nextFilter(request)
           } else {
-            Future.successful(
-              Results.Forbidden(
-                s"You do not have permission to access $system. " +
-                  s"You should contact Central Production to request '$requiredEditorialPermissionName' permission.",
-              ),
-            )
+//            Future.successful(
+//              Results.Forbidden(
+//                s"You do not have permission to access $system. " +
+//                  s"You should contact Central Production to request '$requiredEditorialPermissionName' permission.",
+//              ),
+//            )
+            logger.warn(s"${user.email} used $system, but didn't have '$requiredEditorialPermissionName' permission.")
+            nextFilter(request)
           }
         }
       }

--- a/common/app/http/GuardianAuthWithExemptions.scala
+++ b/common/app/http/GuardianAuthWithExemptions.scala
@@ -1,15 +1,18 @@
 package http
 
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
+import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 import common.Environment.stage
+import conf.Configuration.aws.mandatoryCredentials
 import model.ApplicationContext
 import org.apache.pekko.stream.Materializer
 import play.api.Mode
 import play.api.libs.ws.WSClient
-import play.api.mvc.{BaseController, _}
+import play.api.mvc._
 
 import java.net.URL
 import scala.concurrent.Future
@@ -22,6 +25,7 @@ class GuardianAuthWithExemptions(
     s3Client: AmazonS3,
     system: String,
     extraDoNotAuthenticatePathPrefixes: Seq[String],
+    requiredEditorialPermissionName: String,
 )(implicit
     val mat: Materializer,
     context: ApplicationContext,
@@ -29,6 +33,19 @@ class GuardianAuthWithExemptions(
     with BaseController {
 
   private val outer = this
+
+  private val permissions: PermissionsProvider = PermissionsProvider(
+    PermissionsConfig(
+      stage = if (stage == "PROD") "PROD" else "CODE",
+      region = Regions.EU_WEST_1.getName,
+      awsCredentials = mandatoryCredentials,
+    ),
+  )
+
+  private val requiredPermission = PermissionDefinition(
+    name = requiredEditorialPermissionName,
+    app = "frontend",
+  )
 
   private def toolsDomainSuffix =
     stage match {
@@ -81,9 +98,17 @@ class GuardianAuthWithExemptions(
       if (doNotAuthenticate(request)) {
         nextFilter(request)
       } else {
-        // TODO: in future PR add a permission check here based on user, likely via a function passed in to GuardianAuthWithExemptions
         AuthAction.authenticateRequest(request) { user =>
-          nextFilter(request)
+          if (permissions.hasPermission(requiredPermission, user.email)) {
+            nextFilter(request)
+          } else {
+            Future.successful(
+              Results.Forbidden(
+                s"You do not have permission to access $system. " +
+                  s"You should contact Central Production to request '$requiredEditorialPermissionName' permission.",
+              ),
+            )
+          }
         }
       }
     }

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -116,6 +116,7 @@ trait AppComponents
     s3Client,
     system = "preview",
     extraDoNotAuthenticatePathPrefixes = healthCheck.healthChecks.map(_.path),
+    requiredEditorialPermissionName = "preview_access",
   )
 
   override lazy val capiHttpClient: HttpClient = new CapiHttpClient(wsClient) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,6 +59,7 @@ object Dependencies {
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.7"
   val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "3.1.0"
+  val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "2.15"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"
   val rome = "rome" % "rome" % romeVersion


### PR DESCRIPTION
### Prerequisites
- [x] https://github.com/guardian/permissions/pull/184 adds the permission definitions to permissions tool
- [x] https://github.com/guardian/platform/pull/1590 makes the infra changes to allow reading the permissions-cache

## What does this change?
It makes sense (given [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege))  that we restrict access to `preview` (as one can view unpublished content) and `admin` (since one can set-up redirects, flick feature switches etc.)

This adds a permission check for `preview` and `admin` using the new `preview_access` and `admin_tool_access` permissions respectively (added in https://github.com/guardian/permissions/pull/184).

This PR makes use of the placeholder made in https://github.com/guardian/frontend/pull/27012.

The risk is legitimate users are locked out of the tools, SO in this PR we're ONLY logging users who access `admin` and/or `preview` without the permission so we can get people's permissions in good shape, before actually enforcing the new permissions in https://github.com/guardian/frontend/pull/27092.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
