### PR TITLE
Bump commercial to 18.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "^17.14.0",
+		"@guardian/commercial": "18.0.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/identity-auth": "2.1.0",
 		"@guardian/identity-auth-frontend": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3396,9 +3396,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:^17.14.0":
-  version: 17.14.0
-  resolution: "@guardian/commercial@npm:17.14.0"
+"@guardian/commercial@npm:18.0.0":
+  version: 18.0.0
+  resolution: "@guardian/commercial@npm:18.0.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -3418,7 +3418,8 @@ __metadata:
     "@guardian/identity-auth-frontend": ^4.0.0
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
-  checksum: 10c0/41092276fb0588f41a108e90007b529d832876c4206af2c27b1d1c5061c98a93430d13e9a8aa981c1acbc5006e93327c5588d5b3867bd57f7b3d7cfa2d4c48bf
+    typescript: ~5.3.3
+  checksum: 10c0/723c22e70f3c1beded5118b7f68c4e953fd9ca8a1f6fea9591a1b365ef6d1efe334bf46a1cdec9d31d844941f8a0a29df228a25f33778899a2a33c2cdbec6221
   languageName: node
   linkType: hard
 
@@ -3492,7 +3493,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:^17.14.0"
+    "@guardian/commercial": "npm:18.0.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
## What does this change?
Bump commercial to [18.0.0](https://github.com/guardian/commercial/releases/tag/v18.0.0)

### Major Changes

-   Pin typescript@5.3.3 and remove resolution

### Minor Changes

-   Add 'interactive' slot to size mappings, instead of falling back to data attributes , merge them with size mappings
