### PR TITLE
Deeply read right ab test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -64,4 +64,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2024, 6, 7)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-deeply-read-right-column",
+    "Add deeply read component to the right hand column",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 7, 31)),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,19 +16,9 @@ object ActiveExperiments extends ExperimentsDefinition {
       DCRVideoPages,
       UpdatedHeaderDesign,
       MastheadWithHighlights,
-      DeeplyReadRightColumn,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
-
-object DeeplyReadRightColumn
-    extends Experiment(
-      name = "deeply-read-right-column",
-      description = "Test the impact of adding deeply read component to the right column",
-      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2024, 7, 31),
-      participationGroup = Perc0A,
-    )
 
 object UpdatedHeaderDesign
     extends Experiment(

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,29 +16,18 @@ object ActiveExperiments extends ExperimentsDefinition {
       DCRVideoPages,
       UpdatedHeaderDesign,
       MastheadWithHighlights,
+      DeeplyReadRightColumn,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
 
-object DCRTagPages
+object DeeplyReadRightColumn
     extends Experiment(
-      name = "dcr-tag-pages",
-      description = "Render tag pages with DCR",
-      owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 5, 31),
-      participationGroup = Perc20A,
-    )
-
-object DCRVideoPages
-    extends Experiment(
-      name = "dcr-video-pages",
-      description = "Render video pages with DCR",
-      owners = Seq(
-        Owner.withGithub("commercial.dev@theguardian.com"),
-        Owner.withGithub("dotcom.platform@theguardian.com"),
-      ),
-      sellByDate = LocalDate.of(2024, 5, 30),
-      participationGroup = Perc10A,
+      name = "deeply-read-right-column",
+      description = "Test the impact of adding deeply read component to the right column",
+      owners = Seq(Owner.withGithub("@guardian/dotcom-platform")),
+      sellByDate = LocalDate.of(2024, 7, 31),
+      participationGroup = Perc0A,
     )
 
 object UpdatedHeaderDesign
@@ -67,4 +56,25 @@ object DarkModeWeb
       owners = Seq(Owner.withGithub("jakeii"), Owner.withGithub("mxdvl")),
       sellByDate = LocalDate.of(2024, 7, 30),
       participationGroup = Perc0D,
+    )
+
+object DCRVideoPages
+    extends Experiment(
+      name = "dcr-video-pages",
+      description = "Render video pages with DCR",
+      owners = Seq(
+        Owner.withGithub("commercial.dev@theguardian.com"),
+        Owner.withGithub("dotcom.platform@theguardian.com"),
+      ),
+      sellByDate = LocalDate.of(2024, 5, 30),
+      participationGroup = Perc10A,
+    )
+
+object DCRTagPages
+    extends Experiment(
+      name = "dcr-tag-pages",
+      description = "Render tag pages with DCR",
+      owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2024, 5, 31),
+      participationGroup = Perc20A,
     )

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,7 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
-import { deeplyReadRightColumn} from "common/modules/experiments/tests/deeply-read-right-column";
+import { deeplyReadRightColumn } from './tests/deeply-read-right-column';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
-import { onwardJourneys } from "./tests/onward-journeys";
+import { onwardJourneys } from './tests/onward-journeys';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateAlternativeWording } from './tests/sign-in-gate-alternative-wording';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { deeplyReadRightColumn} from "common/modules/experiments/tests/deeply-read-right-column";
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 import { onwardJourneys } from "./tests/onward-journeys";
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
@@ -15,4 +16,5 @@ export const concurrentTests: readonly ABTest[] = [
 	remoteRRHeaderLinksTest,
 	mpuWhenNoEpic,
 	onwardJourneys,
+	deeplyReadRightColumn,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/deeply-read-right-column.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/deeply-read-right-column.ts
@@ -8,18 +8,18 @@ export const deeplyReadRightColumn: ABTest = {
 	audience: 0 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
-	successMeasure: 'Improved CTR',
+	successMeasure: 'Improved click though rate',
 	description:
 		'Test the impact of adding deeply read component to the right column.',
 	variants: [
 		{
-			id: 'control',
+			id: 'most-viewed-only',
 			test: (): void => {
 				/* no-op */
 			},
 		},
 		{
-			id: 'deeply-read-and-most-read',
+			id: 'deeply-read-and-most-viewed',
 			test: (): void => {
 				/* no-op */
 			},

--- a/static/src/javascripts/projects/common/modules/experiments/tests/deeply-read-right-column.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/deeply-read-right-column.ts
@@ -5,8 +5,8 @@ export const deeplyReadRightColumn: ABTest = {
 	author: '@dotcom-platform',
 	start: '2024-05-01',
 	expiry: '2024-07-31',
-	audience: 0,
-	audienceOffset: 0,
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: 'Improved CTR',
 	description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/deeply-read-right-column.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/deeply-read-right-column.ts
@@ -1,0 +1,35 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const deeplyReadRightColumn: ABTest = {
+	id: 'DeeplyReadRightColumn',
+	author: '@dotcom-platform',
+	start: '2024-05-01',
+	expiry: '2024-07-31',
+	audience: 0,
+	audienceOffset: 0,
+	audienceCriteria: '',
+	successMeasure: 'Improved CTR',
+	description:
+		'Test the impact of adding deeply read component to the right column.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'deeply-read-and-most-read',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'deeply-read-only',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What is the value of this and can you measure success?
We want to test click through rate of adding 5 deeply read articles to the right hand column:
- Most read and deeply read together
- Deeply read only
## What does this change?
Creates an AB testing the above
DCR pr here: https://github.com/guardian/dotcom-rendering/pull/11299
Part of https://github.com/guardian/dotcom-rendering/issues/10746
## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
