### PR TITLE
Update `post-merge` message when Node version changes

### DIFF
--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -11,11 +11,11 @@ execa
         const changedFiles = result.stdout.split('\n');
 
         if (changedFiles.includes('.nvmrc')) {
-            const nvmrcVersion = fs.readFileSync('.nvmrc');
+            const nvmrcVersion = fs.readFileSync('.nvmrc').toString().trim();
 
             console.log(
                 `${chalk.red(
-                    `Frontend now requires Node ${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`
+                    `Frontend now requires Node ${nvmrcVersion}\nSwitch to the latest version using \`nvm use\`, \`fnm use\` or \`asdf install\` (or whatever is appropriate) or download from nodejs.org. Then run \`make reinstall\`.`,
                 )}`
             );
         } else if (changedFiles.includes('yarn.lock')) {


### PR DESCRIPTION
## What does this change?

Update the `post-merge` git hook message when `.nvmrc` changes to include examples of how to change node version with more modern node version managers.

Aligns with the `post-merge` hook message in [DCR](https://github.com/guardian/dotcom-rendering/blob/17159b2461fac4bd434f1ef1c2cb97e3f47c7982/.husky/post-merge#L22)

Before:

```
Frontend now requires Node 20.12.2
. Switch to the latest version using `nvm install` or download from nodejs.org. Then run `make reinstall`.
```

After:

```
Frontend now requires Node 20.12.2
Switch to the latest version using `nvm use`, `fnm use` or `asdf install` (or whatever is appropriate) or download from nodejs.org. Then run `make reinstall`.
```
