### PR TITLE
Add serverside AB test for DCR video pages

### DIFF
--- a/applications/app/services/dotcomrendering/MediaPicker.scala
+++ b/applications/app/services/dotcomrendering/MediaPicker.scala
@@ -2,9 +2,12 @@ package services.dotcomrendering
 
 import common.GuLogging
 import model.Cors.RichRequestHeader
-import model.MediaPage
+import model.{MediaPage, Video, Audio}
 import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
+import experiments.DCRVideoPages
+import navigation.NavLinks.media
+import experiments.ActiveExperiments
 
 object MediaPicker extends GuLogging {
 
@@ -17,7 +20,11 @@ object MediaPicker extends GuLogging {
     *
     * */
   private def dcrCouldRender(mediaPage: MediaPage): Boolean = {
-    false
+    mediaPage.media match {
+      case Video(content, source, mediaAtom) => true
+      case Audio(content)                    => false
+      case _                                 => false
+    }
   }
 
   def getTier(
@@ -27,7 +34,7 @@ object MediaPicker extends GuLogging {
   ): RenderType = {
 
     // defaulting to false until we are ready to release and create a 0% test
-    val participatingInTest = false // ActiveExperiments.isParticipating(DCRMedia)
+    val participatingInTest = ActiveExperiments.isParticipating(DCRVideoPages)
     val dcrCanRender = dcrCouldRender(mediaPage)
 
     val tier = {

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     Set(
       CommercialMegaTest,
       DCRTagPages,
+      DCRVideoPages,
       UpdatedHeaderDesign,
       MastheadWithHighlights,
     )
@@ -35,6 +36,18 @@ object DCRTagPages
       owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 4, 30),
       participationGroup = Perc20A,
+    )
+
+object DCRVideoPages
+    extends Experiment(
+      name = "dcr-video-pages",
+      description = "Render video pages with DCR",
+      owners = Seq(
+        Owner.withGithub("commercial.dev@theguardian.com"),
+        Owner.withGithub("dotcom.platform@theguardian.com"),
+      ),
+      sellByDate = LocalDate.of(2024, 5, 30),
+      participationGroup = Perc0A,
     )
 
 object UpdatedHeaderDesign


### PR DESCRIPTION
## What does this change?
Add a server-side AB test to test DCR rendered videos

[This DCR PR](https://github.com/guardian/dotcom-rendering/pull/11285) will bring the DCR design in line with the frontend rendered one so once merged we are ready to start testing it.

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
