### PR TITLE
Update Euro 2020 to Euro 2024

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -212,10 +212,10 @@ object CompetitionsProvider {
       tableDividers = List(2, 6, 21),
     ),
     Competition(
-      "750",
-      "/football/euro-2020",
-      "Euro 2020",
-      "Euro 2020",
+      "750", // This ID was also used for the 2020 Euros
+      "/football/euro-2024",
+      "Euro 2024",
+      "Euro 2024",
       "Internationals",
       showInTeamsList = true,
       tableDividers = List(2),


### PR DESCRIPTION
## What does this change?

Updates Euro 2020 copy to Euro 2024. The PA ID is correct (The ID looks to be the same as for the previous Euros) and therefore the fixtures are correct, so we only needed to update the year.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/9574885/7052b909-1747-471e-9af5-b4b8fab07a05
[after]: https://github.com/guardian/frontend/assets/9574885/15c9178e-9985-425c-9eb6-efa1f833431d

## Checklist

- [x] Tested locally
- [x] Tested on CODE
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
