### PR TITLE
actually enforce new permissions for `admin` and `preview`

### DIFF
--- a/common/app/http/GuardianAuthWithExemptions.scala
+++ b/common/app/http/GuardianAuthWithExemptions.scala
@@ -10,7 +10,6 @@ import common.Environment.stage
 import conf.Configuration.aws.mandatoryCredentials
 import model.ApplicationContext
 import org.apache.pekko.stream.Materializer
-import org.slf4j.LoggerFactory
 import play.api.Mode
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -34,8 +33,6 @@ class GuardianAuthWithExemptions(
     with BaseController {
 
   private val outer = this
-
-  val logger = LoggerFactory.getLogger(this.getClass)
 
   private val permissions: PermissionsProvider = PermissionsProvider(
     PermissionsConfig(
@@ -105,14 +102,12 @@ class GuardianAuthWithExemptions(
           if (permissions.hasPermission(requiredPermission, user.email)) {
             nextFilter(request)
           } else {
-//            Future.successful(
-//              Results.Forbidden(
-//                s"You do not have permission to access $system. " +
-//                  s"You should contact Central Production to request '$requiredEditorialPermissionName' permission.",
-//              ),
-//            )
-            logger.warn(s"${user.email} used $system, but didn't have '$requiredEditorialPermissionName' permission.")
-            nextFilter(request)
+            Future.successful(
+              Results.Forbidden(
+                s"You do not have permission to access $system. " +
+                  s"You should contact Central Production to request '$requiredEditorialPermissionName' permission.",
+              ),
+            )
           }
         }
       }


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/frontend/pull/27078 introduced logging when users interact with `admin` and `preview` but didn't have the necessary [permission](https://github.com/guardian/permissions/pull/184)... this PR actually enforces those permissions by serving `403`s if the user doesn't have the permission needed.

## Screenshots
When the user doesn't have permission in the permissions tool (see https://github.com/guardian/permissions/pull/184):
<img width="1065" alt="image" src="https://github.com/guardian/frontend/assets/19289579/75f387a1-0424-49d4-bb21-7d094c00cb29">
<img width="1005" alt="image" src="https://github.com/guardian/frontend/assets/19289579/54531dea-39ec-420e-b872-76257d27e9d1">

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
