### PR TITLE
Support the Euro 2024 wall chart

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -43,7 +43,7 @@ class LeagueTableController(
     "Champions League",
     "Women's Champions League",
     "Europa League",
-    "Euro 2024 qualifying",
+    "Euro 2024",
     "Nations League",
     "Women's Nations League",
     "Africa Cup of Nations",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -219,7 +219,7 @@ object CompetitionsProvider {
       "Internationals",
       showInTeamsList = true,
       tableDividers = List(2),
-      startDate = Some(LocalDate.of(2019, 11, 30)),
+      startDate = Some(LocalDate.of(2023, 12, 1)),
     ),
     Competition(
       "751",

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -203,6 +203,7 @@ object KnockoutSpider {
       ZonedDateTime.of(2023, 8, 20, 11, 0, 0, 0, ZoneId.of("Europe/London")), // Finals
     ),
     // Euro 2024
+    // https://www.uefa.com/euro2024/news/0275-151eb1c333ea-d30deec67b13-1000--uefa-euro-2024-fixtures-when-and-where-are-the-matches/
     "750" -> List(
       ZonedDateTime.of(2024, 6, 30, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 40
       ZonedDateTime.of(2024, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 38

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -202,23 +202,23 @@ object KnockoutSpider {
       // Winner of Semi-final 1 vs Winner of Semi-final 2 (11am)
       ZonedDateTime.of(2023, 8, 20, 11, 0, 0, 0, ZoneId.of("Europe/London")), // Finals
     ),
-    // Euro 2020
+    // Euro 2024
     "750" -> List(
-      ZonedDateTime.of(2021, 6, 27, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 40
-      ZonedDateTime.of(2021, 6, 26, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 38
-      ZonedDateTime.of(2021, 6, 28, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 42
-      ZonedDateTime.of(2021, 6, 28, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 41
-      ZonedDateTime.of(2021, 6, 29, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 44
-      ZonedDateTime.of(2021, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 43
-      ZonedDateTime.of(2021, 6, 27, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 39
-      ZonedDateTime.of(2021, 6, 26, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 37
-      ZonedDateTime.of(2021, 7, 2, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 46
-      ZonedDateTime.of(2021, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 45
-      ZonedDateTime.of(2021, 7, 3, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 48
-      ZonedDateTime.of(2021, 7, 3, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 47
-      ZonedDateTime.of(2021, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 49
-      ZonedDateTime.of(2021, 7, 7, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 50
-      ZonedDateTime.of(2021, 7, 11, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final         // Match 51
+      ZonedDateTime.of(2024, 6, 30, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 40
+      ZonedDateTime.of(2024, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 38
+      ZonedDateTime.of(2024, 7, 1, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 42
+      ZonedDateTime.of(2024, 7, 1, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 41
+      ZonedDateTime.of(2024, 7, 2, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 44
+      ZonedDateTime.of(2024, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 43
+      ZonedDateTime.of(2024, 6, 30, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 39
+      ZonedDateTime.of(2024, 6, 29, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 37
+      ZonedDateTime.of(2024, 7, 5, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 46
+      ZonedDateTime.of(2024, 7, 5, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 45
+      ZonedDateTime.of(2024, 7, 6, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 48
+      ZonedDateTime.of(2024, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 47
+      ZonedDateTime.of(2024, 7, 9, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 49
+      ZonedDateTime.of(2024, 7, 10, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 50
+      ZonedDateTime.of(2024, 7, 14, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final         // Match 51
     ),
     // Womens Euro 2022
     "423" -> List(


### PR DESCRIPTION
## What is the value of this and can you measure success?

Make the Euro 2024 wall chart and spider diagram in `/football/euro-2024/overview` work, so it’s ready when the group stages kicks off in June, followed by the knockout stages.

Part of https://github.com/guardian/dotcom-rendering/issues/7437

## What does this change?

Update the times for each of the knockout matches [according to the official schedule](https://www.uefa.com/euro2024/news/0275-151eb1c333ea-d30deec67b13-1000--uefa-euro-2024-fixtures-when-and-where-are-the-matches/).

## Screenshots

![Screenshot 2024-05-01 at 13-27-34 Euro 2024 wallchart Football The Guardian](https://github.com/guardian/frontend/assets/76776/29b7e576-7794-4f70-aa77-e28ab78f0aab)

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
