### PR TITLE
Update dependabot to pick up Babel updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,16 @@ updates:
     schedule:
       interval: 'daily'
     allow:
-      - dependency-name: "@guardian/*"
+      - dependency-name: '@guardian/*'
+      - dependency-name: '@babel/*'
+    groups:
+      # Most Babel dependencies are released with synchronised versions
+      babel:
+        patterns:
+          - '@babel/*'
     open-pull-requests-limit: 10
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    rebase-strategy: 'disabled'


### PR DESCRIPTION
## What does this change?

Update Dependabot to pick up Babel updates

@babel/traverse@7.22.20 has an [open CVE](https://github.com/guardian/frontend/security/dependabot/117) so lets get Dependabot to upgrade the Babel group.

