### PR TITLE
construct a single PanDomainAuthSettingsRefresher per app instance

### DIFF
--- a/common/app/http/GuardianAuthWithExemptions.scala
+++ b/common/app/http/GuardianAuthWithExemptions.scala
@@ -57,7 +57,7 @@ class GuardianAuthWithExemptions(
       case _      => s"local.dev-gutools.co.uk" // covers DEV, LOCAL, tests etc.
     }
 
-  override def panDomainSettings =
+  override val panDomainSettings =
     new PanDomainAuthSettingsRefresher(
       domain = toolsDomainSuffix,
       system,


### PR DESCRIPTION
## What is the value of this and can you measure success?

Fewer (hopefully no) unhealthy preview instance replacements.

## What does this change?

We're seeing frequent healthcheck failures and unhealthy instances from preview since #27012 
There haven't been conclusive error logs, but since that was merged there has been a substantial increase of "request timeout" and "connection refused" logs, which indicate some sort of resource exhaustion. Going through that PR I noticed that the construction of a `PanDomainAuthSettingsRefresher` is declared as a `def` (ie. function) rather than a `val` - which means every time the settings is referenced a new instance is constructed. Each instance on construction schedules updates to itself on a new thread pool, which means this quickly mounts up and we'll have lots of schedulers attempting to update their own instance of the refresher, clogging up memory, threads and sockets.

Instead declare as `val` to ensure the refresher is only constructed once per EC2 instance.

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
