### PR TITLE
use lazy val for single PanDomainAuthSettingsRefresher

### DIFF
--- a/common/app/http/GuardianAuthWithExemptions.scala
+++ b/common/app/http/GuardianAuthWithExemptions.scala
@@ -57,7 +57,7 @@ class GuardianAuthWithExemptions(
       case _      => s"local.dev-gutools.co.uk" // covers DEV, LOCAL, tests etc.
     }
 
-  override val panDomainSettings =
+  override lazy val panDomainSettings =
     new PanDomainAuthSettingsRefresher(
       domain = toolsDomainSuffix,
       system,


### PR DESCRIPTION
## What is the value of this and can you measure success?

#27108 fails at runtime because it cannot be constructed immediately - the val must be `lazy` to allow items to be constructed in the correct order


## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
