### PR TITLE
Create switch and test for onward journeys 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -59,7 +59,7 @@ trait ABTestSwitches {
     ABTests,
     "ab-onward-journeys",
     "Test click through rate when there is only one onward journey container shown.",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
     safeState = Off,
     sellByDate = Some(LocalDate.of(2024, 6, 7)),
     exposeClientSide = true,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -54,4 +54,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2024, 5, 31)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-onward-journeys",
+    "Test click through rate when there is only one onward journey container shown.",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 6, 7)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
+import { onwardJourneys } from "./tests/onward-journeys";
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateAlternativeWording } from './tests/sign-in-gate-alternative-wording';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -13,4 +14,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateAlternativeWording,
 	remoteRRHeaderLinksTest,
 	mpuWhenNoEpic,
+	onwardJourneys,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-journeys.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-journeys.ts
@@ -1,0 +1,37 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const onwardJourneys: ABTest = {
+	id: 'OnwardJourneys',
+	start: '2025-03-01', //  update once test is ready to go live
+	expiry: '2025-12-01', //  update once test is ready to go live
+	author: '@web-experience',
+	description:
+		'Show the user one onward journey containers at a time to see which is the most effective',
+	audience: 25 / 100,
+	audienceOffset: 0,
+	audienceCriteria: 'all users',
+	dataLinkNames: 'OnwardJourneys',
+	idealOutcome:
+		'Determine which combination of onward journey containers is the most effective',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-1',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-2',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-3',
+			test: (): void => {},
+		},
+	],
+	successMeasure: '',
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-journeys.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-journeys.ts
@@ -18,19 +18,27 @@ export const onwardJourneys: ABTest = {
 	variants: [
 		{
 			id: 'control',
-			test: (): void => {},
+			test: (): void => {
+				/* no-op */
+			},
 		},
 		{
 			id: 'variant-1',
-			test: (): void => {},
+			test: (): void => {
+				/* no-op */
+			},
 		},
 		{
 			id: 'variant-2',
-			test: (): void => {},
+			test: (): void => {
+				/* no-op */
+			},
 		},
 		{
 			id: 'variant-3',
-			test: (): void => {},
+			test: (): void => {
+				/* no-op */
+			},
 		},
 	],
 	successMeasure: '',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-journeys.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-journeys.ts
@@ -2,8 +2,8 @@ import type { ABTest } from '@guardian/ab-core';
 
 export const onwardJourneys: ABTest = {
 	id: 'OnwardJourneys',
-	start: '2025-03-01', //  update once test is ready to go live
-	expiry: '2025-12-01', //  update once test is ready to go live
+	start: '2024-05-09',
+	expiry: '2024-05-16',
 	author: '@web-experience',
 	description:
 		'Show the user one onward journey containers at a time to see which is the most effective',


### PR DESCRIPTION
## What does this change?
Adds a switch and an A/B test so that we can measure the CTR on each onward journey container. By onwards content, we are referring to the 3 modules "top row", "bottom row", and "most viewed". Further information about what these 3 modules can contain [can be found here](https://docs.google.com/document/d/1CJax6m0gY07nG89BAIuDeE7OIntJqtuYzHt8-iY19Co/edit#bookmark=id.of7gnocwnb9e)

The test will have one control - the article as it currently exists with all 3 modules - and 3 variants, each with only one module visible. We are not currently concerned about the potential content variants within each row.

The test will run for 1 week.

It will run on all DCR articles with a sample size of 25% for each variant.
