### PR TITLE
Replace redirected pillar links with hard links for each edition

### DIFF
--- a/applications/app/services/dotcomrendering/MediaPicker.scala
+++ b/applications/app/services/dotcomrendering/MediaPicker.scala
@@ -5,8 +5,6 @@ import model.Cors.RichRequestHeader
 import model.{MediaPage, Video, Audio}
 import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
-import navigation.NavLinks.media
-import experiments.ActiveExperiments
 import conf.switches.Switches.DCRVideoPages
 
 object MediaPicker extends GuLogging {

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -11,8 +11,10 @@ object NavLinks {
   val tech = NavLink("Tech", "/technology")
   val ukTech = NavLink("Tech", "/uk/technology")
   val usTech = NavLink("Tech", "/us/technology")
+  val auTech = NavLink("Tech", "/au/technology")
   val politics = NavLink("UK politics", "/politics")
   val media = NavLink("Media", "/media")
+  val auMedia = NavLink("Media", "/au/media")
   val globalDevelopment = NavLink("Global development", "/global-development")
   val australiaNews = NavLink("Australia", "/australia-news", longTitle = Some("Australia news"))
   val auPolitics = NavLink("AU politics", "/australia-news/australian-politics", longTitle = Some("Politics"))
@@ -80,8 +82,10 @@ object NavLinks {
 
   val ukEnvironment =
     NavLink("Environment", "/uk/environment", children = List(climateCrisis, wildlife, energy, pollution))
-  val auEnvironment = ukEnvironment.copy(children =
-    List(climateCrisis, energy, wildlife, biodiversity, oceans, pollution, greatBarrierReef),
+  val auEnvironment = NavLink(
+    "Environment",
+    "/au/environment",
+    children = List(climateCrisis, energy, wildlife, biodiversity, oceans, pollution, greatBarrierReef),
   )
   val usEnvironment =
     NavLink("Environment", "/us/environment", children = List(climateCrisis, wildlife, energy, pollution, greenLight))
@@ -100,7 +104,7 @@ object NavLinks {
     "/us/business",
     children = List(economics, diversityEquality, smallBusiness, retail),
   )
-  val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate, retail))
+  val auBusiness = NavLink("Business", "au/business", children = List(markets, money, projectSyndicate, retail))
 
   /* OPINION */
   val columnists = NavLink("Columnists", "/index/contributors")
@@ -168,9 +172,11 @@ object NavLinks {
   val film = NavLink("Film", "/film")
   val ukFilm = NavLink("Film", "/uk/film")
   val usFilm = NavLink("Film", "/us/film")
+  val auFilm = NavLink("Film", "/au/film")
   val tvAndRadio = NavLink("TV & radio", "/tv-and-radio")
   val ukTvAndRadio = NavLink("TV & radio", "/uk/tv-and-radio")
   val usTvAndRadio = NavLink("TV & radio", "/us/tv-and-radio")
+  val auTvAndRadio = NavLink("TV & radio", "/au/tv-and-radio")
   val music = NavLink("Music", "/music")
   val games = NavLink("Games", "/games")
   val books = NavLink("Books", "/books")
@@ -201,7 +207,8 @@ object NavLinks {
   val travelAsia = NavLink("Asia", "/travel/asia")
   val ukTravel = NavLink("Travel", "/uk/travel", children = List(travelUk, travelEurope, travelUs))
   val usTravel = NavLink("Travel", "/us/travel", children = List(travelUs, travelEurope, travelUk))
-  val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
+  val auTravel =
+    NavLink("Travel", "/au/travel", children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
   val usWellness = NavLink("Wellness", "/us/wellness")
 
   val todaysPaper = NavLink(
@@ -307,10 +314,10 @@ object NavLinks {
       climateCrisis,
       indigenousAustralia,
       auImmigration,
-      media,
+      auMedia,
       auBusiness,
       science,
-      tech,
+      auTech,
       podcastsAU,
       newsletters,
     ),
@@ -467,10 +474,10 @@ object NavLinks {
   )
   val auCulturePillar = ukCulturePillar.copy(
     children = List(
-      film,
+      auFilm,
       music,
       books,
-      tvAndRadio,
+      auTvAndRadio,
       artAndDesign,
       stage,
       games,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -8,12 +8,11 @@ object NavLinks {
 
   /* NEWS */
   val science = NavLink("Science", "/science")
-  val tech = NavLink("Tech", "/technology")
   val ukTech = NavLink("Tech", "/uk/technology")
   val usTech = NavLink("Tech", "/us/technology")
   val auTech = NavLink("Tech", "/au/technology")
   val politics = NavLink("UK politics", "/politics")
-  val media = NavLink("Media", "/media")
+  val ukMedia = NavLink("Media", "/uk/media")
   val auMedia = NavLink("Media", "/au/media")
   val globalDevelopment = NavLink("Global development", "/global-development")
   val australiaNews = NavLink("Australia", "/australia-news", longTitle = Some("Australia news"))
@@ -71,7 +70,7 @@ object NavLinks {
     "UK",
     "/uk-news",
     longTitle = Some("UK news"),
-    children = List(politics, education, media, society, law, scotland, wales, northernIreland),
+    children = List(politics, education, ukMedia, society, law, scotland, wales, northernIreland),
   )
   val world = NavLink(
     "World",
@@ -90,21 +89,21 @@ object NavLinks {
   val usEnvironment =
     NavLink("Environment", "/us/environment", children = List(climateCrisis, wildlife, energy, pollution, greenLight))
 
-  val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
   val ukMoney = NavLink("Money", "/uk/money", children = List(property, pensions, savings, borrowing, careers))
   val usMoney = NavLink("Money", "/us/money", children = List(property, pensions, savings, borrowing, careers))
+  val auMoney = NavLink("Money", "/au/money", children = List(property, pensions, savings, borrowing, careers))
 
   val ukBusiness = NavLink(
     "Business",
     "/uk/business",
-    children = List(economics, banking, money, markets, projectSyndicate, businessToBusiness, retail),
+    children = List(economics, banking, ukMoney, markets, projectSyndicate, businessToBusiness, retail),
   )
   val usBusiness = NavLink(
     "Business",
     "/us/business",
     children = List(economics, diversityEquality, smallBusiness, retail),
   )
-  val auBusiness = NavLink("Business", "au/business", children = List(markets, money, projectSyndicate, retail))
+  val auBusiness = NavLink("Business", "au/business", children = List(markets, auMoney, projectSyndicate, retail))
 
   /* OPINION */
   val columnists = NavLink("Columnists", "/index/contributors")
@@ -169,11 +168,9 @@ object NavLinks {
   val NHL = NavLink("NHL", "/sport/nhl")
 
   /* CULTURE */
-  val film = NavLink("Film", "/film")
   val ukFilm = NavLink("Film", "/uk/film")
   val usFilm = NavLink("Film", "/us/film")
   val auFilm = NavLink("Film", "/au/film")
-  val tvAndRadio = NavLink("TV & radio", "/tv-and-radio")
   val ukTvAndRadio = NavLink("TV & radio", "/uk/tv-and-radio")
   val usTvAndRadio = NavLink("TV & radio", "/us/tv-and-radio")
   val auTvAndRadio = NavLink("TV & radio", "/au/tv-and-radio")
@@ -348,7 +345,7 @@ object NavLinks {
       science,
       globalDevelopment,
       football,
-      tech,
+      ukTech,
       ukBusiness,
       obituaries,
     ),
@@ -500,9 +497,9 @@ object NavLinks {
     children = List(
       books,
       music,
-      tvAndRadio,
+      ukTvAndRadio,
       artAndDesign,
-      film,
+      ukFilm,
       games,
       classical,
       stage,
@@ -568,7 +565,7 @@ object NavLinks {
       men,
       family,
       ukTravel,
-      money,
+      ukMoney,
     ),
   )
 

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -9,6 +9,7 @@ object NavLinks {
   /* NEWS */
   val science = NavLink("Science", "/science")
   val tech = NavLink("Tech", "/technology")
+  val ukTech = NavLink("Tech", "/uk/technology")
   val usTech = NavLink("Tech", "/us/technology")
   val politics = NavLink("UK politics", "/politics")
   val media = NavLink("Media", "/media")
@@ -76,29 +77,29 @@ object NavLinks {
     longTitle = Some("World news"),
     children = List(europe, usNews, americas, asia, australiaNews, middleEast, africa, inequality, globalDevelopment),
   )
+
   val ukEnvironment =
-    NavLink("Environment", "/environment", children = List(climateCrisis, wildlife, energy, pollution))
+    NavLink("Environment", "/uk/environment", children = List(climateCrisis, wildlife, energy, pollution))
   val auEnvironment = ukEnvironment.copy(children =
     List(climateCrisis, energy, wildlife, biodiversity, oceans, pollution, greatBarrierReef),
   )
-
   val usEnvironment =
     NavLink("Environment", "/us/environment", children = List(climateCrisis, wildlife, energy, pollution, greenLight))
 
   val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
+  val ukMoney = NavLink("Money", "/uk/money", children = List(property, pensions, savings, borrowing, careers))
   val usMoney = NavLink("Money", "/us/money", children = List(property, pensions, savings, borrowing, careers))
+
   val ukBusiness = NavLink(
     "Business",
-    "/business",
+    "/uk/business",
     children = List(economics, banking, money, markets, projectSyndicate, businessToBusiness, retail),
   )
-
   val usBusiness = NavLink(
     "Business",
     "/us/business",
     children = List(economics, diversityEquality, smallBusiness, retail),
   )
-
   val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate, retail))
 
   /* OPINION */
@@ -165,8 +166,10 @@ object NavLinks {
 
   /* CULTURE */
   val film = NavLink("Film", "/film")
+  val ukFilm = NavLink("Film", "/uk/film")
   val usFilm = NavLink("Film", "/us/film")
   val tvAndRadio = NavLink("TV & radio", "/tv-and-radio")
+  val ukTvAndRadio = NavLink("TV & radio", "/uk/tv-and-radio")
   val usTvAndRadio = NavLink("TV & radio", "/us/tv-and-radio")
   val music = NavLink("Music", "/music")
   val games = NavLink("Games", "/games")
@@ -196,7 +199,7 @@ object NavLinks {
   val travelUs = NavLink("US", "/travel/usa")
   val travelAustralasia = NavLink("Australasia", "/travel/australasia")
   val travelAsia = NavLink("Asia", "/travel/asia")
-  val ukTravel = NavLink("Travel", "/travel", children = List(travelUk, travelEurope, travelUs))
+  val ukTravel = NavLink("Travel", "/uk/travel", children = List(travelUk, travelEurope, travelUs))
   val usTravel = NavLink("Travel", "/us/travel", children = List(travelUs, travelEurope, travelUk))
   val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
   val usWellness = NavLink("Wellness", "/us/wellness")
@@ -290,7 +293,7 @@ object NavLinks {
       education,
       society,
       science,
-      tech,
+      ukTech,
       globalDevelopment,
       obituaries,
     ),
@@ -452,9 +455,9 @@ object NavLinks {
     longTitle = Some("Culture home"),
     iconName = Some("home"),
     List(
-      film,
+      ukFilm,
       music,
-      tvAndRadio,
+      ukTvAndRadio,
       books,
       artAndDesign,
       stage,
@@ -516,7 +519,7 @@ object NavLinks {
       loveAndSex,
       beauty,
       home,
-      money,
+      ukMoney,
       cars,
     ),
   )

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -86,6 +86,7 @@ object NavLinks {
     NavLink("Environment", "/us/environment", children = List(climateCrisis, wildlife, energy, pollution, greenLight))
 
   val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
+  val usMoney = NavLink("Money", "/us/money", children = List(property, pensions, savings, borrowing, careers))
   val ukBusiness = NavLink(
     "Business",
     "/business",
@@ -164,13 +165,15 @@ object NavLinks {
 
   /* CULTURE */
   val film = NavLink("Film", "/film")
+  val usFilm = NavLink("Film", "/us/film")
   val tvAndRadio = NavLink("TV & radio", "/tv-and-radio")
+  val usTvAndRadio = NavLink("TV & radio", "/us/tv-and-radio")
   val music = NavLink("Music", "/music")
   val games = NavLink("Games", "/games")
   val books = NavLink("Books", "/books")
   val artAndDesign = NavLink("Art & design", "/artanddesign")
   val stage = NavLink("Stage", "/stage")
-  val classical = NavLink("Classical", "/music/classicalmusicandopera")
+  val classical = NavLink("Classical", "/music/classical-music-and-opera")
 
   /* LIFE */
   val fashion = NavLink("Fashion", "/fashion")
@@ -194,7 +197,7 @@ object NavLinks {
   val travelAustralasia = NavLink("Australasia", "/travel/australasia")
   val travelAsia = NavLink("Asia", "/travel/asia")
   val ukTravel = NavLink("Travel", "/travel", children = List(travelUk, travelEurope, travelUs))
-  val usTravel = ukTravel.copy(children = List(travelUs, travelEurope, travelUk))
+  val usTravel = NavLink("Travel", "/us/travel", children = List(travelUs, travelEurope, travelUk))
   val auTravel = ukTravel.copy(children = List(travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
   val usWellness = NavLink("Wellness", "/us/wellness")
 
@@ -473,11 +476,11 @@ object NavLinks {
   )
   val usCulturePillar = ukCulturePillar.copy(
     children = List(
-      film,
+      usFilm,
       books,
       music,
       artAndDesign,
-      tvAndRadio,
+      usTvAndRadio,
       stage,
       classical,
       games,
@@ -540,7 +543,7 @@ object NavLinks {
       health,
       family,
       usTravel,
-      money,
+      usMoney,
     ),
   )
   val intLifestylePillar = ukLifestylePillar.copy(

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -96,8 +96,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     val maybeNavLink = NavMenu.findDescendantByUrl("/money/work-and-careers", edition, root.children, root.otherLinks)
     val parent = maybeNavLink.flatMap(link => NavMenu.findParent(link, edition, root.children, root.otherLinks))
     val pillar = NavMenu.getPillar(parent, edition, root.children, root.otherLinks)
-
-    parent.map(_ should be(money))
+    parent.map(_ should be(ukMoney))
     pillar.map(_ should be(ukLifestylePillar))
   }
 
@@ -120,7 +119,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     val pillar = NavMenu.getPillar(parent, edition, root.children, root.otherLinks)
     val subnav = NavMenu.getSubnav(fakePage().metadata.customSignPosting, maybeNavLink, parent, pillar)
 
-    subnav shouldBe Some(ParentSubnav(money, money.children))
+    subnav shouldBe Some(ParentSubnav(ukMoney, ukMoney.children))
   }
 
   "On `/culture`, the subnav" should "only have children, which are not tertiary" in {

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -220,7 +220,7 @@
 				},
 				{
 					"title": "Business",
-					"url": "/business",
+					"url": "/uk/business",
 					"children": [
 						{
 							"title": "Economics",
@@ -300,7 +300,7 @@
 				},
 				{
 					"title": "Environment",
-					"url": "/environment",
+					"url": "/uk/environment",
 					"children": [
 						{
 							"title": "Climate crisis",
@@ -380,7 +380,7 @@
 				},
 				{
 					"title": "Tech",
-					"url": "/technology",
+					"url": "/uk/technology",
 					"children": [],
 					"classList": []
 				},
@@ -564,7 +564,7 @@
 			"children": [
 				{
 					"title": "Film",
-					"url": "/film",
+					"url": "/uk/film",
 					"children": [],
 					"classList": []
 				},
@@ -576,7 +576,7 @@
 				},
 				{
 					"title": "TV & radio",
-					"url": "/tv-and-radio",
+					"url": "/uk/tv-and-radio",
 					"children": [],
 					"classList": []
 				},
@@ -639,7 +639,7 @@
 				},
 				{
 					"title": "Travel",
-					"url": "/travel",
+					"url": "/uk/travel",
 					"children": [
 						{
 							"title": "UK",
@@ -700,7 +700,7 @@
 				},
 				{
 					"title": "Money",
-					"url": "/money",
+					"url": "/uk/money",
 					"children": [
 						{
 							"title": "Property",
@@ -1790,7 +1790,7 @@
 				},
 				{
 					"title": "Environment",
-					"url": "/environment",
+					"url": "/uk/environment",
 					"children": [
 						{
 							"title": "Climate crisis",
@@ -1863,7 +1863,7 @@
 				},
 				{
 					"title": "Business",
-					"url": "/business",
+					"url": "/uk/business",
 					"children": [
 						{
 							"title": "Markets",
@@ -2160,7 +2160,7 @@
 			"children": [
 				{
 					"title": "Travel",
-					"url": "/travel",
+					"url": "/uk/travel",
 					"children": [
 						{
 							"title": "Australasia",
@@ -2568,7 +2568,7 @@
 				},
 				{
 					"title": "Environment",
-					"url": "/environment",
+					"url": "/uk/environment",
 					"children": [
 						{
 							"title": "Climate crisis",
@@ -2666,7 +2666,7 @@
 				},
 				{
 					"title": "Business",
-					"url": "/business",
+					"url": "/uk/business",
 					"children": [
 						{
 							"title": "Economics",
@@ -3011,7 +3011,7 @@
 				},
 				{
 					"title": "Travel",
-					"url": "/travel",
+					"url": "/uk/travel",
 					"children": [
 						{
 							"title": "UK",
@@ -3560,7 +3560,7 @@
 				},
 				{
 					"title": "Environment",
-					"url": "/environment",
+					"url": "/uk/environment",
 					"children": [
 						{
 							"title": "Climate crisis",
@@ -3658,7 +3658,7 @@
 				},
 				{
 					"title": "Business",
-					"url": "/business",
+					"url": "/uk/business",
 					"children": [
 						{
 							"title": "Economics",
@@ -4003,7 +4003,7 @@
 				},
 				{
 					"title": "Travel",
-					"url": "/travel",
+					"url": "/uk/travel",
 					"children": [
 						{
 							"title": "UK",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -50,7 +50,7 @@
 						},
 						{
 							"title": "Media",
-							"url": "/media",
+							"url": "/uk/media",
 							"children": [],
 							"classList": []
 						},
@@ -236,7 +236,7 @@
 						},
 						{
 							"title": "Money",
-							"url": "/money",
+							"url": "/uk/money",
 							"children": [
 								{
 									"title": "Property",
@@ -1873,7 +1873,7 @@
 						},
 						{
 							"title": "Money",
-							"url": "/money",
+							"url": "/au/money",
 							"children": [
 								{
 									"title": "Property",
@@ -2517,7 +2517,7 @@
 						},
 						{
 							"title": "Media",
-							"url": "/media",
+							"url": "/uk/media",
 							"children": [],
 							"classList": []
 						},
@@ -2660,7 +2660,7 @@
 				},
 				{
 					"title": "Tech",
-					"url": "/technology",
+					"url": "/uk/technology",
 					"children": [],
 					"classList": []
 				},
@@ -2682,7 +2682,7 @@
 						},
 						{
 							"title": "Money",
-							"url": "/money",
+							"url": "/uk/money",
 							"children": [
 								{
 									"title": "Property",
@@ -2912,7 +2912,7 @@
 				},
 				{
 					"title": "TV & radio",
-					"url": "/tv-and-radio",
+					"url": "/uk/tv-and-radio",
 					"children": [],
 					"classList": []
 				},
@@ -2924,7 +2924,7 @@
 				},
 				{
 					"title": "Film",
-					"url": "/film",
+					"url": "/uk/film",
 					"children": [],
 					"classList": []
 				},
@@ -3036,7 +3036,7 @@
 				},
 				{
 					"title": "Money",
-					"url": "/money",
+					"url": "/uk/money",
 					"children": [
 						{
 							"title": "Property",
@@ -3509,7 +3509,7 @@
 						},
 						{
 							"title": "Media",
-							"url": "/media",
+							"url": "/uk/media",
 							"children": [],
 							"classList": []
 						},
@@ -3652,7 +3652,7 @@
 				},
 				{
 					"title": "Tech",
-					"url": "/technology",
+					"url": "/uk/technology",
 					"children": [],
 					"classList": []
 				},
@@ -3674,7 +3674,7 @@
 						},
 						{
 							"title": "Money",
-							"url": "/money",
+							"url": "/uk/money",
 							"children": [
 								{
 									"title": "Property",
@@ -3904,7 +3904,7 @@
 				},
 				{
 					"title": "TV & radio",
-					"url": "/tv-and-radio",
+					"url": "/uk/tv-and-radio",
 					"children": [],
 					"classList": []
 				},
@@ -3916,7 +3916,7 @@
 				},
 				{
 					"title": "Film",
-					"url": "/film",
+					"url": "/uk/film",
 					"children": [],
 					"classList": []
 				},
@@ -4028,7 +4028,7 @@
 				},
 				{
 					"title": "Money",
-					"url": "/money",
+					"url": "/uk/money",
 					"children": [
 						{
 							"title": "Property",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -2121,7 +2121,7 @@
 				},
 				{
 					"title": "TV & radio",
-					"url": "/us/tv-and-radio",
+					"url": "/au/tv-and-radio",
 					"children": [],
 					"classList": []
 				},

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -606,7 +606,7 @@
 				},
 				{
 					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
+					"url": "/music/classical-music-and-opera",
 					"children": [],
 					"classList": []
 				}
@@ -1385,7 +1385,7 @@
 			"children": [
 				{
 					"title": "Film",
-					"url": "/film",
+					"url": "/us/film",
 					"children": [],
 					"classList": []
 				},
@@ -1409,7 +1409,7 @@
 				},
 				{
 					"title": "TV & radio",
-					"url": "/tv-and-radio",
+					"url": "/us/tv-and-radio",
 					"children": [],
 					"classList": []
 				},
@@ -1421,7 +1421,7 @@
 				},
 				{
 					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
+					"url": "/music/classical-music-and-opera",
 					"children": [],
 					"classList": []
 				},
@@ -1490,7 +1490,7 @@
 				},
 				{
 					"title": "Travel",
-					"url": "/travel",
+					"url": "/us/travel",
 					"children": [
 						{
 							"title": "US",
@@ -1515,7 +1515,7 @@
 				},
 				{
 					"title": "Money",
-					"url": "/money",
+					"url": "/us/money",
 					"children": [
 						{
 							"title": "Property",
@@ -2145,7 +2145,7 @@
 				},
 				{
 					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
+					"url": "/music/classical-music-and-opera",
 					"children": [],
 					"classList": []
 				}
@@ -2936,7 +2936,7 @@
 				},
 				{
 					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
+					"url": "/music/classical-music-and-opera",
 					"children": [],
 					"classList": []
 				},
@@ -3928,7 +3928,7 @@
 				},
 				{
 					"title": "Classical",
-					"url": "/music/classicalmusicandopera",
+					"url": "/music/classical-music-and-opera",
 					"children": [],
 					"classList": []
 				},

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1790,7 +1790,7 @@
 				},
 				{
 					"title": "Environment",
-					"url": "/uk/environment",
+					"url": "/au/environment",
 					"children": [
 						{
 							"title": "Climate crisis",
@@ -1857,13 +1857,13 @@
 				},
 				{
 					"title": "Media",
-					"url": "/media",
+					"url": "/au/media",
 					"children": [],
 					"classList": []
 				},
 				{
 					"title": "Business",
-					"url": "/uk/business",
+					"url": "au/business",
 					"children": [
 						{
 							"title": "Markets",
@@ -1931,7 +1931,7 @@
 				},
 				{
 					"title": "Tech",
-					"url": "/technology",
+					"url": "/au/technology",
 					"children": [],
 					"classList": []
 				},
@@ -2103,7 +2103,7 @@
 			"children": [
 				{
 					"title": "Film",
-					"url": "/film",
+					"url": "/au/film",
 					"children": [],
 					"classList": []
 				},
@@ -2121,7 +2121,7 @@
 				},
 				{
 					"title": "TV & radio",
-					"url": "/tv-and-radio",
+					"url": "/us/tv-and-radio",
 					"children": [],
 					"classList": []
 				},
@@ -2160,7 +2160,7 @@
 			"children": [
 				{
 					"title": "Travel",
-					"url": "/uk/travel",
+					"url": "/au/travel",
 					"children": [
 						{
 							"title": "Australasia",


### PR DESCRIPTION
## What does this change?

Replace redirected pillar links with hard links for each edition.

Currently pillar links for [editionalised](https://github.com/guardian/frontend/blob/60c6b55944d52d87039a2a844665cf39dc7fe437/common/app/common/Edition.scala#L20-L35) pages are non-editionalised e.g. `theguardian.com/money` and will redirect the user to `theguardian.com/uk/money`.

This is sub-optimal for SEO so this change updates each pillar link to the canonical hard link for each edition.

## Checklist

- [x] Tested locally, and on CODE if necessary
