### PR TITLE
Allow dependabot to open PRs for any dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    allow:
-      - dependency-name: '@guardian/*'
-      - dependency-name: '@babel/*'
     groups:
       # Most Babel dependencies are released with synchronised versions
       babel:


### PR DESCRIPTION
We should allow dependabot to upgrade as many of our dependencies as possible.