### PR TITLE
Remove `us-politics` From `NavLinks` List

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -649,7 +649,6 @@ object NavLinks {
   // the navigation. The workaround for this is to add the section to this list,as has been done with CiF and education
   val tagPages = List(
     "us/soccer",
-    "us-news/us-politics",
     "australia-news/australian-politics",
     "australia-news/australian-immigration-and-asylum",
     "australia-news/indigenous-australians",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -3300,7 +3300,6 @@
 	},
 	"tagPages": [
 		"us/soccer",
-		"us-news/us-politics",
 		"australia-news/australian-politics",
 		"australia-news/australian-immigration-and-asylum",
 		"australia-news/indigenous-australians",


### PR DESCRIPTION
US politics was removed from the subnav for the duration of the 2024 US elections in #26840. The means that the subnav disappears for any pieces that are categorised as falling under this subnav item.

Removing this categorisation means that these pieces will instead be categorised another way, bringing back their subnavs.
