### PR TITLE
Replace `us-politics` In `NavLinks` List

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -649,7 +649,7 @@ object NavLinks {
   // the navigation. The workaround for this is to add the section to this list,as has been done with CiF and education
   val tagPages = List(
     "us/soccer",
-    "us-news/us-politics",
+    "us-news/us-elections-2024",
     "australia-news/australian-politics",
     "australia-news/australian-immigration-and-asylum",
     "australia-news/indigenous-australians",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -3300,7 +3300,7 @@
 	},
 	"tagPages": [
 		"us/soccer",
-		"us-news/us-politics",
+		"us-news/us-elections-2024",
 		"australia-news/australian-politics",
 		"australia-news/australian-immigration-and-asylum",
 		"australia-news/indigenous-australians",


### PR DESCRIPTION
US politics was removed from the subnav, and replaced with "US elections 2024", for the duration of the elections in #26840. This means that the subnav disappears for any pieces that are categorised as falling under this subnav item.

Replacing this categorisation with `us-elections-2024` means that these pieces will be categorised as falling under "US elections 2024" where applicable, and be categorised another way otherwise, bringing back their subnavs.
