### PR TITLE
Remove commercial mega test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      CommercialMegaTest,
       DarkModeWeb,
       DCRTagPages,
       DCRVideoPages,
@@ -20,15 +19,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
-
-object CommercialMegaTest
-    extends Experiment(
-      name = "commercial-mega-test",
-      description = "Test the revenue effect of changes made during Q4",
-      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 8, 8),
-      participationGroup = Perc5A,
-    )
 
 object DCRTagPages
     extends Experiment(

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "18.1.0",
+		"@guardian/commercial": "18.3.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,9 +3028,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:18.1.0":
-  version: 18.1.0
-  resolution: "@guardian/commercial@npm:18.1.0"
+"@guardian/commercial@npm:18.3.0":
+  version: 18.3.0
+  resolution: "@guardian/commercial@npm:18.3.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -3051,7 +3051,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     typescript: ~5.3.3
-  checksum: 10c0/7c8dc716e14f4814fe75787be2840b6d458ee2a936ba5a34296ba0cf53ab7a0f1f7e9098aef97c3bb0c4730c9b42002f623e4abd78c804263f4e1496228e94b8
+  checksum: 10c0/483c8aa709e808ff1c0be8d285d8d48bdbc38cc8f3afb5c3fe6f4e609186b15f9ab2df1f7d9cf62094e33ac72665bbea0a8f5427d84ca21333bc9ade22a13d3a
   languageName: node
   linkType: hard
 
@@ -3125,7 +3125,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:18.1.0"
+    "@guardian/commercial": "npm:18.3.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
## What does this change?
Removes the commercial Q4 mega test that was added [here](https://github.com/guardian/frontend/pull/26992) and [here](https://github.com/guardian/frontend/pull/27013). We've bumped the version of commercial to remove references to the test in the commercial code. See release notes [here](https://github.com/guardian/commercial/releases/tag/v18.3.0)

## Checklist

- [X] Tested locally, and on CODE if necessary
