### PR TITLE
Bump commercial to 18.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "18.3.0",
+		"@guardian/commercial": "18.4.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,9 +3028,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:18.3.0":
-  version: 18.3.0
-  resolution: "@guardian/commercial@npm:18.3.0"
+"@guardian/commercial@npm:18.4.0":
+  version: 18.4.0
+  resolution: "@guardian/commercial@npm:18.4.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -3051,7 +3051,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     typescript: ~5.3.3
-  checksum: 10c0/483c8aa709e808ff1c0be8d285d8d48bdbc38cc8f3afb5c3fe6f4e609186b15f9ab2df1f7d9cf62094e33ac72665bbea0a8f5427d84ca21333bc9ade22a13d3a
+  checksum: 10c0/040a1d7f157b7b561932c1a44d596ef3c6e9bd02ccbb62e854147a607799f8cd81e366b426a349edbc451552899eab13efce55372878ffe2521af0d26671a247
   languageName: node
   linkType: hard
 
@@ -3125,7 +3125,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:18.3.0"
+    "@guardian/commercial": "npm:18.4.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
## What does this change?
Includes [this change](https://github.com/guardian/commercial/pull/1377) with a fix to spacefinder


