### PR TITLE
Independent DCR Circuit Breaker switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -66,6 +66,16 @@ trait PerformanceSwitches {
     exposeClientSide = false,
   )
 
+  val CircuitBreakerDcrSwitch = Switch(
+    SwitchGroup.Performance,
+    "circuit-breaker-dcr",
+    "If this switch is switched on then the DCR API circuit breaker will be operational",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
+
   val AutoRefreshSwitch = Switch(
     SwitchGroup.Performance,
     "auto-refresh",

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.v1.{Block, Blocks, Content}
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
-import conf.switches.Switches.CircuitBreakerSwitch
+import conf.switches.Switches.CircuitBreakerDcrSwitch
 import crosswords.CrosswordPageWithContent
 import http.{HttpPreconnections, ResultWithPreconnectPreload}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
@@ -133,7 +133,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       }
     }
 
-    if (CircuitBreakerSwitch.isSwitchedOn) {
+    if (CircuitBreakerDcrSwitch.isSwitchedOn) {
       circuitBreaker.withCircuitBreaker(postWithoutHandler(ws, payload, endpoint, timeout)).map(handler)
     } else {
       postWithoutHandler(ws, payload, endpoint, timeout).map(handler)


### PR DESCRIPTION
## What is the value of this and can you measure success?

We want to be able to turn off the circuit breaker for DCR independently of CAPI.

## What does this change?

Create a separate switch for the `DotcomRenderingService` circuit breaker.

Redo of #26914

## Screenshots

N/A

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering 🤞 
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
