### PR TITLE
Render tag pages with tag page rendering service

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -152,6 +152,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
     lazy val articleBaseURL = configuration.getMandatoryStringProperty("article-rendering.baseURL")
     lazy val faciaBaseURL = configuration.getMandatoryStringProperty("facia-rendering.baseURL")
+    lazy val tagPageBaseURL = configuration.getMandatoryStringProperty("tag-page-rendering.baseURL")
     lazy val interactiveBaseURL = configuration.getMandatoryStringProperty("interactive-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -292,7 +292,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     )
 
     val json = DotcomTagPagesRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.faciaBaseURL + "/TagPage", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.tagPageBaseURL + "/TagPage", CacheTime.Facia)
   }
 
   def getInteractive(

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -117,6 +117,7 @@ rendering.endpoint=http://localhost:3030
 rendering.baseURL=http://localhost:3030
 article-rendering.baseURL=http://localhost:3030
 facia-rendering.baseURL=http://localhost:3030
+tag-page-rendering.baseURL=http://localhost:3030
 interactive-rendering.baseURL=http://localhost:3030
 misc-rendering.baseURL=http://localhost:3030
 


### PR DESCRIPTION
This change directs requests for rendering tag pages to the new tag page rendering stack, created in https://github.com/guardian/dotcom-rendering/pull/11421.