### PR TITLE
Reinstate affiliate links for all eligible DCR articles behind a 0% test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,6 +16,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       DCRVideoPages,
       UpdatedHeaderDesign,
       MastheadWithHighlights,
+      AffiliateLinksDCR,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -46,6 +47,15 @@ object DarkModeWeb
       owners = Seq(Owner.withGithub("jakeii"), Owner.withGithub("mxdvl")),
       sellByDate = LocalDate.of(2024, 7, 30),
       participationGroup = Perc0D,
+    )
+
+object AffiliateLinksDCR
+    extends Experiment(
+      name = "affiliate-links-dcr",
+      description = "Display affiliate links on all eligible DCR articles",
+      owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
+      sellByDate = LocalDate.of(2024, 7, 30),
+      participationGroup = Perc0E,
     )
 
 object DCRVideoPages

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -5,6 +5,7 @@ import com.gu.contentapi.client.model.v1.{Block => APIBlock}
 import common.Edition
 import common.commercial.EditionAdTargeting.adTargetParamValueWrites
 import conf.Configuration
+import experiments.{ActiveExperiments, AffiliateLinksDCR}
 import model.dotcomrendering.pageElements.PageElement
 import model.{ContentFormat, ContentPage}
 import play.api.libs.json._
@@ -69,7 +70,8 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
+    val isInAffiliateLinksTest = ActiveExperiments.isParticipating(AffiliateLinksDCR)(request)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 
     val edition = Edition(request)

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -5,7 +5,6 @@ import com.gu.contentapi.client.model.v1.{Block => APIBlock}
 import common.Edition
 import common.commercial.EditionAdTargeting.adTargetParamValueWrites
 import conf.Configuration
-import experiments.{ActiveExperiments, AffiliateLinksDCR}
 import model.dotcomrendering.pageElements.PageElement
 import model.{ContentFormat, ContentPage}
 import play.api.libs.json._
@@ -70,7 +69,6 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val isInAffiliateLinksTest = ActiveExperiments.isParticipating(AffiliateLinksDCR)(request)
     val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -487,7 +487,7 @@ object DotcomRenderingDataModel {
       blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
     }
 
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
     val shouldAddDisclaimer = hasAffiliateLinks(bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -22,6 +22,7 @@ import model.{
   Pillar,
 }
 import org.joda.time.format.DateTimeFormat
+import org.jsoup.Jsoup
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.AffiliateLinksCleaner
@@ -242,18 +243,26 @@ object DotcomRenderingUtils {
   }
 
   def shouldAddAffiliateLinks(content: ContentType): Boolean = {
-    AffiliateLinksCleaner.shouldAddAffiliateLinks(
-      switchedOn = Switches.AffiliateLinks.isSwitchedOn,
-      section = content.metadata.sectionId,
-      showAffiliateLinks = content.content.fields.showAffiliateLinks,
-      supportedSections = Configuration.affiliateLinks.affiliateLinkSections,
-      defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
-      alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
-      tagPaths = content.content.tags.tags.map(_.id),
-      firstPublishedDate = content.content.fields.firstPublicationDate,
-      pageUrl = content.metadata.id,
-      contentType = "article",
-    )
+    val contentHtml = Jsoup.parse(content.fields.body)
+    val bodyElements = contentHtml.select("body").first().children()
+    if (bodyElements.size >= 2) {
+      val firstEl = bodyElements.get(0)
+      val secondEl = bodyElements.get(1)
+      if (firstEl.tagName == "p" && secondEl.tagName == "p") {
+        AffiliateLinksCleaner.shouldAddAffiliateLinks(
+          switchedOn = Switches.AffiliateLinks.isSwitchedOn,
+          section = content.metadata.sectionId,
+          showAffiliateLinks = content.content.fields.showAffiliateLinks,
+          supportedSections = Configuration.affiliateLinks.affiliateLinkSections,
+          defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
+          alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
+          tagPaths = content.content.tags.tags.map(_.id),
+          firstPublishedDate = content.content.fields.firstPublicationDate,
+          pageUrl = content.metadata.id,
+          contentType = "article",
+        )
+      } else false
+    } else false
   }
 
   def contentDateTimes(content: ContentType): ArticleDateTimes = {

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -242,7 +242,7 @@ object DotcomRenderingUtils {
     }
   }
 
-  def shouldAddAffiliateLinks(content: ContentType): Boolean = {
+  def shouldAddAffiliateLinks(content: ContentType)(implicit request: RequestHeader): Boolean = {
     val contentHtml = Jsoup.parse(content.fields.body)
     val bodyElements = contentHtml.select("body").first().children()
     if (bodyElements.size >= 2) {

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -248,7 +248,7 @@ object DotcomRenderingUtils {
     if (bodyElements.size >= 2) {
       val firstEl = bodyElements.get(0)
       val secondEl = bodyElements.get(1)
-      if (firstEl.tagName == "p" && secondEl.tagName == "p") {
+      if (firstEl.tagName == "p" && secondEl.tagName == "p" && secondEl.text().length >= 250) {
         AffiliateLinksCleaner.shouldAddAffiliateLinks(
           switchedOn = Switches.AffiliateLinks.isSwitchedOn,
           section = content.metadata.sectionId,

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -1,8 +1,10 @@
 package views.support.cleaner
 import conf.Configuration
+import conf.switches.Switches.ServerSideExperiments
 import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.test.FakeRequest
 import views.support.AffiliateLinksCleaner._
 
 class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
@@ -16,6 +18,8 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
   }
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
+    val fakeTestVariantRequest = FakeRequest().withHeaders("X-GU-Experiment-0perc-E" -> "variant")
+    val fakeTestControlRequest = FakeRequest().withHeaders("X-GU-Experiment-0perc-E" -> "control")
     val supportedSections = Set("film", "books", "fashion")
     val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
     val newPublishedDate = Some(new DateTime(2020, 8, 15, 0, 0))
@@ -32,7 +36,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -44,7 +48,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(true)
+    )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -56,7 +60,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -68,7 +72,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(true)
+    )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -80,7 +84,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -92,7 +96,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -104,7 +108,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(true)
+    )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -116,7 +120,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -128,7 +132,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       oldPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(true)
+    )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -140,7 +144,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       newPublishedDate,
       deniedPageUrl,
       "article",
-    ) should be(false)
+    )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -152,6 +156,18 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       newPublishedDate,
       deniedPageUrl,
       "gallery",
-    ) should be(true)
+    )(fakeTestControlRequest) should be(true)
+    shouldAddAffiliateLinks(
+      switchedOn = true,
+      "film",
+      None,
+      supportedSections,
+      Set.empty,
+      Set.empty,
+      List.empty,
+      newPublishedDate,
+      deniedPageUrl,
+      "article",
+    )(fakeTestVariantRequest) should be(true)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -18,7 +18,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
   }
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
-    val fakeTestVariantRequest = FakeRequest().withHeaders("X-GU-Experiment-0perc-E" -> "variant")
     val fakeTestControlRequest = FakeRequest().withHeaders("X-GU-Experiment-0perc-E" -> "control")
     val supportedSections = Set("film", "books", "fashion")
     val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
@@ -157,17 +156,5 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       deniedPageUrl,
       "gallery",
     )(fakeTestControlRequest) should be(true)
-    shouldAddAffiliateLinks(
-      switchedOn = true,
-      "film",
-      None,
-      supportedSections,
-      Set.empty,
-      Set.empty,
-      List.empty,
-      newPublishedDate,
-      deniedPageUrl,
-      "article",
-    )(fakeTestVariantRequest) should be(true)
   }
 }


### PR DESCRIPTION
## What does this change?
Reinstates affiliate links for all eligible DCR articles behind a 0% test. We've added a 0% server side test, and we check if a user is in the variant before considering a DCR article published after the cutoff date that isn't on the allowlist. For anyone not in the variant, the allowlist and cutoff date still apply for DCR rendered articles.

We now check that the first two elements in the body content of a DCR article are both paragraph elements. This ensures that the disclaimer doesn't clash with thumbnail images or rich links. We also check that the second paragraph element is over 250 characters. This is to make sure that there is enough text to wrap around the disclaimer if an image was to follow next, so that we don't get unwanted whitespace on the page. These checks should ensure that the DCR version of the disclaimer doesn't negatively impact the UI. These checks apply to articles in the allowlist and before the cutoff date, as they will improve the page experience for everyone.

## Screenshots

### Disclaimer on mobile:
<img width="330" alt="Screenshot 2024-05-15 at 15 07 12" src="https://github.com/guardian/frontend/assets/108270776/70f93b33-9d61-4cb8-8da0-719d6ee6d74f">

### Affiliate links not inserted to avoid disclaimer clashing with thumbnail image on mobile:
<img width="338" alt="Screenshot 2024-05-15 at 15 15 32" src="https://github.com/guardian/frontend/assets/108270776/ebbe23ff-4ddd-4832-8604-1f762473ed2e">

If we **didn't** have the check, the disclaimer would look like this:

<img width="331" alt="Screenshot 2024-04-04 at 17 13 54" src="https://github.com/guardian/frontend/assets/108270776/b5c84d7b-09a0-49ff-8b5f-67a44ee84959">


### Affiliate links not inserted to avoid disclaimer clashing with thumbnail image on desktop:
<img width="1476" alt="Screenshot 2024-05-15 at 15 19 04" src="https://github.com/guardian/frontend/assets/108270776/d183df91-b7b9-479a-a8ec-889eea3b8b9d">

If we **didn't** have this check, the disclaimer would look like this:

<img width="200" alt="Screenshot 2024-04-11 at 15 57 12" src="https://github.com/guardian/frontend/assets/108270776/5387a6dc-6d9f-43da-a45a-4e1d51b46fda">

