### PR TITLE
Do not lookup pressed fronts in S3 if front does not exist

### DIFF
--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -133,6 +133,9 @@ object ConfigAgent extends GuLogging {
   def shouldServeFront(id: String)(implicit context: ApplicationContext): Boolean =
     getPathIds.contains(id) && (context.isPreview || !isFrontHidden(id))
 
+  def frontExistsInConfig(id: String)(implicit context: ApplicationContext): Boolean =
+    getPathIds.contains(id)
+
   def shouldServeEditionalisedFront(edition: Edition, id: String)(implicit context: ApplicationContext): Boolean = {
     shouldServeFront(s"${edition.id.toLowerCase}/$id")
   }


### PR DESCRIPTION
## What does this change?

- checks whether a front id exists in the fronts config before trying to fetch the pressed json from S3

## Why?

- these log messages can be confusing, especially during incident investigation. There is no need to try to access a key from S3 that we know does not exist.