### PR TITLE
Remove Java 11 assertion from project settings

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -33,13 +33,6 @@ object ProjectSettings {
     Compile / doc / sources := Seq.empty,
     Compile / doc := target.map(_ / "none").value,
     scalaVersion := "2.13.13",
-    initialize := {
-      val _ = initialize.value
-      assert(
-        sys.props("java.specification.version") == "11",
-        "Java 11 is required for this project.",
-      )
-    },
     cleanAll := Def.taskDyn {
       val allProjects = ScopeFilter(inAnyProject)
       clean.all(allProjects)


### PR DESCRIPTION
## What does this change?
Remove Java 11 assertion from project settings

## Why?
This is not necessary. We pass `-release:11` in Scala options so the Scala compiler is already going to enforce that Java 11 is the minimum supported version. Because of this PR: https://github.com/guardian/scala-steward-public-repos/pull/67 running Scala steward for frontend was failing due to this assertion because Scala Steward is running with Java 21.

