### PR TITLE
Set affiliate links live

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -32,7 +32,6 @@
                 defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
                 alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
                 tagPaths = page.gallery.content.tags.tags.map(_.id),
-                firstPublishedDate = page.gallery.content.fields.firstPublicationDate,
             )
         )
 

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -33,7 +33,6 @@
                 alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
                 tagPaths = page.gallery.content.tags.tags.map(_.id),
                 firstPublishedDate = page.gallery.content.fields.firstPublicationDate,
-                pageUrl = request.uri,
             )
         )
 

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -34,7 +34,6 @@
                 tagPaths = page.gallery.content.tags.tags.map(_.id),
                 firstPublishedDate = page.gallery.content.fields.firstPublicationDate,
                 pageUrl = request.uri,
-                contentType = "gallery",
             )
         )
 

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -46,7 +46,6 @@ object GalleryCaptionCleaners {
         page.gallery.content.fields.showAffiliateLinks,
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
-        page.gallery.content.fields.firstPublicationDate,
       ),
     )
 

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -47,7 +47,6 @@ object GalleryCaptionCleaners {
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
         page.gallery.content.fields.firstPublicationDate,
-        contentType = "gallery",
       ),
     )
 

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -84,7 +84,6 @@ object BodyProcessor {
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         tags = article.content.tags.tags.map(_.id),
         publishedDate = article.content.fields.firstPublicationDate,
-        contentType = "article",
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -83,7 +83,6 @@ object BodyProcessor {
         sectionId = article.content.metadata.sectionId,
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         tags = article.content.tags.tags.map(_.id),
-        publishedDate = article.content.fields.firstPublicationDate,
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,7 +16,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       UpdatedHeaderDesign,
       UpdateLogoAdPartner,
       MastheadWithHighlights,
-      AffiliateLinksDCR,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -56,15 +55,6 @@ object UpdateLogoAdPartner
       owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2024, 7, 30),
       participationGroup = Perc0A,
-    )
-
-object AffiliateLinksDCR
-    extends Experiment(
-      name = "affiliate-links-dcr",
-      description = "Display affiliate links on all eligible DCR articles",
-      owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 7, 30),
-      participationGroup = Perc0E,
     )
 
 object DCRTagPages

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -69,7 +69,7 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 
     val edition = Edition(request)

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -487,7 +487,7 @@ object DotcomRenderingDataModel {
       blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
     }
 
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)(request)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
     val shouldAddDisclaimer = hasAffiliateLinks(bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -258,7 +258,6 @@ object DotcomRenderingUtils {
           alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
           tagPaths = content.content.tags.tags.map(_.id),
           firstPublishedDate = content.content.fields.firstPublicationDate,
-          pageUrl = content.metadata.id,
         )
       } else false
     } else false

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -245,6 +245,12 @@ object DotcomRenderingUtils {
   def shouldAddAffiliateLinks(content: ContentType)(implicit request: RequestHeader): Boolean = {
     val contentHtml = Jsoup.parse(content.fields.body)
     val bodyElements = contentHtml.select("body").first().children()
+    /**
+	     * On smaller devices, the disclaimer is inserted before paragraph 2 of the article body and floats left.
+	     * This logic ensures there are two clear paragraphs of text at the top of the article.
+	     * We don't support inserting the disclaimer next to other element types.
+	     * It also ensures the second paragraph is long enough to accommodate the disclaimer appearing alongside it.
+	     */
     if (bodyElements.size >= 2) {
       val firstEl = bodyElements.get(0)
       val secondEl = bodyElements.get(1)

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -259,7 +259,6 @@ object DotcomRenderingUtils {
           tagPaths = content.content.tags.tags.map(_.id),
           firstPublishedDate = content.content.fields.firstPublicationDate,
           pageUrl = content.metadata.id,
-          contentType = "article",
         )
       } else false
     } else false

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -264,7 +264,6 @@ object DotcomRenderingUtils {
           defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
           alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
           tagPaths = content.content.tags.tags.map(_.id),
-          firstPublishedDate = content.content.fields.firstPublicationDate,
         )
       } else false
     } else false

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -242,15 +242,16 @@ object DotcomRenderingUtils {
     }
   }
 
-  def shouldAddAffiliateLinks(content: ContentType)(implicit request: RequestHeader): Boolean = {
+  def shouldAddAffiliateLinks(content: ContentType): Boolean = {
     val contentHtml = Jsoup.parse(content.fields.body)
     val bodyElements = contentHtml.select("body").first().children()
+
     /**
-	     * On smaller devices, the disclaimer is inserted before paragraph 2 of the article body and floats left.
-	     * This logic ensures there are two clear paragraphs of text at the top of the article.
-	     * We don't support inserting the disclaimer next to other element types.
-	     * It also ensures the second paragraph is long enough to accommodate the disclaimer appearing alongside it.
-	     */
+      * On smaller devices, the disclaimer is inserted before paragraph 2 of the article body and floats left.
+      * This logic ensures there are two clear paragraphs of text at the top of the article.
+      * We don't support inserting the disclaimer next to other element types.
+      * It also ensures the second paragraph is long enough to accommodate the disclaimer appearing alongside it.
+      */
     if (bodyElements.size >= 2) {
       val firstEl = bodyElements.get(0)
       val secondEl = bodyElements.get(1)

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -1,10 +1,9 @@
-<br>
+<br />
 <p class="gallery__disclaimer">
-    The Guardian’s product and service reviews are independent and are in no
-    way influenced by any advertiser or commercial initiative. We will earn a
-    commission from the retailer if you buy something through an affiliate link.
+	The Guardian’s journalism is independent. We will earn a commission if you
+	buy something through an affiliate link.
 	<a
-        href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
+		href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links"
 		>Learn more</a
 	>.
 </p>

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -6,7 +6,6 @@ import common.{Edition, GuLogging, LinkTo}
 import conf.Configuration.affiliateLinks._
 import conf.Configuration.site.host
 import conf.switches.Switches._
-import experiments.{ActiveExperiments, AffiliateLinksDCR}
 import layout.ContentWidths
 import layout.ContentWidths._
 import model._
@@ -873,8 +872,7 @@ case class AffiliateLinksCleaner(
     appendDisclaimer: Option[Boolean] = None,
     tags: List[String],
     publishedDate: Option[DateTime],
-)(implicit request: RequestHeader)
-    extends HtmlCleaner
+) extends HtmlCleaner
     with GuLogging {
 
   override def clean(document: Document): Document = {
@@ -943,15 +941,15 @@ object AffiliateLinksCleaner {
       alwaysOffTags: Set[String],
       tagPaths: List[String],
       firstPublishedDate: Option[DateTime],
-  )(implicit request: RequestHeader): Boolean = {
+  ): Boolean = {
     val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
 
     // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off date.
     // The cut off date is temporary while we are working on improving the compliance of affiliate links.
     if (
-      !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && (firstPublishedDate.exists(
+      !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && firstPublishedDate.exists(
         _.isBefore(publishedCutOffDate),
-      ) || ActiveExperiments.isParticipating(AffiliateLinksDCR))
+      )
     ) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -873,7 +873,6 @@ case class AffiliateLinksCleaner(
     appendDisclaimer: Option[Boolean] = None,
     tags: List[String],
     publishedDate: Option[DateTime],
-    contentType: String,
 )(implicit request: RequestHeader)
     extends HtmlCleaner
     with GuLogging {
@@ -890,7 +889,6 @@ case class AffiliateLinksCleaner(
         tags,
         publishedDate,
         pageUrl,
-        contentType,
       )
     ) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, skimlinksId)
@@ -947,7 +945,6 @@ object AffiliateLinksCleaner {
       tagPaths: List[String],
       firstPublishedDate: Option[DateTime],
       pageUrl: String,
-      contentType: String,
   )(implicit request: RequestHeader): Boolean = {
     val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
 
@@ -979,7 +976,7 @@ object AffiliateLinksCleaner {
     if (
       !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && (firstPublishedDate.exists(
         _.isBefore(publishedCutOffDate),
-      ) || urlIsInAllowList || contentType == "gallery" || ActiveExperiments.isParticipating(AffiliateLinksDCR))
+      ) || urlIsInAllowList || ActiveExperiments.isParticipating(AffiliateLinksDCR))
     ) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -871,7 +871,6 @@ case class AffiliateLinksCleaner(
     showAffiliateLinks: Option[Boolean],
     appendDisclaimer: Option[Boolean] = None,
     tags: List[String],
-    publishedDate: Option[DateTime],
 ) extends HtmlCleaner
     with GuLogging {
 
@@ -885,7 +884,6 @@ case class AffiliateLinksCleaner(
         defaultOffTags,
         alwaysOffTags,
         tags,
-        publishedDate,
       )
     ) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, skimlinksId)
@@ -940,17 +938,10 @@ object AffiliateLinksCleaner {
       defaultOffTags: Set[String],
       alwaysOffTags: Set[String],
       tagPaths: List[String],
-      firstPublishedDate: Option[DateTime],
   ): Boolean = {
-    val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
 
-    // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off date.
-    // The cut off date is temporary while we are working on improving the compliance of affiliate links.
-    if (
-      !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && firstPublishedDate.exists(
-        _.isBefore(publishedCutOffDate),
-      )
-    ) {
+    // Never include affiliate links if it is tagged with an always off tag
+    if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags)) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
       } else {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -941,11 +941,11 @@ object AffiliateLinksCleaner {
   ): Boolean = {
 
     // Never include affiliate links if it is tagged with an always off tag
-    if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags)) {
+    if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && switchedOn) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
       } else {
-        switchedOn && supportedSections.contains(section) && !tagPaths.exists(path => defaultOffTags.contains(path))
+        supportedSections.contains(section) && !tagPaths.exists(path => defaultOffTags.contains(path))
       }
     } else false
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -888,7 +888,6 @@ case class AffiliateLinksCleaner(
         alwaysOffTags,
         tags,
         publishedDate,
-        pageUrl,
       )
     ) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, skimlinksId)
@@ -944,39 +943,15 @@ object AffiliateLinksCleaner {
       alwaysOffTags: Set[String],
       tagPaths: List[String],
       firstPublishedDate: Option[DateTime],
-      pageUrl: String,
   )(implicit request: RequestHeader): Boolean = {
     val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
 
-    val cleanedPageUrl = if (pageUrl.charAt(0) == '/') {
-      pageUrl.substring(1);
-    } else pageUrl
-
-    val affiliateLinksAllowList = List(
-      "lifeandstyle/2024/jan/03/six-winter-warmers-tried-and-tested-the-heated-poncho-has-changed-me-i-will-never-have-sex-again",
-      "lifeandstyle/2024/mar/11/im-south-asian-and-have-dark-eye-circles-what-can-i-do",
-      "fashion/2024/mar/08/the-four-makeup-staples-i-cant-live-without",
-      "travel/2023/mar/03/readers-favourite-budget-beach-campsites-hotels-in-europe",
-      "travel/2024/feb/25/10-of-the-best-places-in-the-uk-to-see-them-bloom",
-      "lifeandstyle/2023/dec/10/with-christmas-around-the-corner-what-to-give-the-gardener-in-your-life-",
-      "fashion/2024/mar/01/spring-is-around-the-corner-time-to-soothe-and-restore-your-cracked-heels",
-      "fashion/2024/mar/10/compact-and-bijou-why-women-need-a-pocket-mirror",
-      "fashion/2024/mar/03/how-to-reset-your-wardrobe-for-spring",
-      "lifeandstyle/2024/mar/03/beauty-spot-eyebrow-essentials-10-of-the-best",
-      "fashion/2024/mar/17/beauty-spot-10-best-root-cover-ups",
-      "fashion/2024/apr/05/peptides-help-with-good-looking-skin-but-dont-expect-botox-in-a-bottle",
-      "fashion/2024/apr/13/sali-hughes-top-50-beauty-products-for-under-20-pounds",
-    )
-
-    val urlIsInAllowList = affiliateLinksAllowList.contains(cleanedPageUrl)
-
     // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off date.
     // The cut off date is temporary while we are working on improving the compliance of affiliate links.
-    // The cut off date does not apply to any URL on the allow list or to galleries
     if (
       !contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && (firstPublishedDate.exists(
         _.isBefore(publishedCutOffDate),
-      ) || urlIsInAllowList || ActiveExperiments.isParticipating(AffiliateLinksDCR))
+      ) || ActiveExperiments.isParticipating(AffiliateLinksDCR))
     ) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -122,16 +122,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       newPublishedDate,
-    )(fakeTestControlRequest) should be(false)
-    shouldAddAffiliateLinks(
-      switchedOn = true,
-      "film",
-      None,
-      supportedSections,
-      Set.empty,
-      Set.empty,
-      List.empty,
-      newPublishedDate,
     )(fakeTestControlRequest) should be(true)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -22,7 +22,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
     val supportedSections = Set("film", "books", "fashion")
     val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
     val newPublishedDate = Some(new DateTime(2020, 8, 15, 0, 0))
-    val deniedPageUrl = "/fashion/2024/feb/16/sunscreen-in-winter-yep-spf-moisturiser-is-essential-all-year-round"
 
     shouldAddAffiliateLinks(
       switchedOn = false,
@@ -33,7 +32,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -44,7 +42,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -55,7 +52,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -66,7 +62,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -77,7 +72,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("bereavement"),
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -88,7 +82,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("tech"),
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -99,7 +92,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("tech"),
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -110,7 +102,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       List("bereavement"),
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -121,7 +112,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       List("tech"),
       oldPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -132,7 +122,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       newPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -143,7 +132,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       newPublishedDate,
-      deniedPageUrl,
     )(fakeTestControlRequest) should be(true)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -1,10 +1,8 @@
 package views.support.cleaner
 import conf.Configuration
-import conf.switches.Switches.ServerSideExperiments
 import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.test.FakeRequest
 import views.support.AffiliateLinksCleaner._
 
 class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
@@ -18,7 +16,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
   }
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
-    val fakeTestControlRequest = FakeRequest().withHeaders("X-GU-Experiment-0perc-E" -> "control")
     val supportedSections = Set("film", "books", "fashion")
     val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
     val newPublishedDate = Some(new DateTime(2020, 8, 15, 0, 0))
@@ -32,7 +29,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(false)
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -42,7 +39,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(true)
+    ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -52,7 +49,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(false)
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -62,7 +59,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(true)
+    ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -72,7 +69,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("bereavement"),
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(false)
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "news",
@@ -82,7 +79,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("tech"),
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(false)
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -92,7 +89,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List("tech"),
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(true)
+    ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -102,7 +99,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       List("bereavement"),
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(false)
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "fashion",
@@ -112,7 +109,7 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       List("tech"),
       oldPublishedDate,
-    )(fakeTestControlRequest) should be(true)
+    ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       "film",
@@ -122,6 +119,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       List.empty,
       newPublishedDate,
-    )(fakeTestControlRequest) should be(true)
+    ) should be(true)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -17,8 +17,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
     val supportedSections = Set("film", "books", "fashion")
-    val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
-    val newPublishedDate = Some(new DateTime(2020, 8, 15, 0, 0))
 
     shouldAddAffiliateLinks(
       switchedOn = false,
@@ -28,7 +26,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -38,7 +35,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      oldPublishedDate,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -48,7 +44,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -58,7 +53,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set.empty,
       List.empty,
-      oldPublishedDate,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -68,7 +62,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("bereavement"),
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -78,7 +71,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -88,7 +80,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set("bereavement"),
       Set.empty,
       List("tech"),
-      oldPublishedDate,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -98,7 +89,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("bereavement"),
-      oldPublishedDate,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -108,17 +98,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       Set.empty,
       Set("bereavement"),
       List("tech"),
-      oldPublishedDate,
-    ) should be(true)
-    shouldAddAffiliateLinks(
-      switchedOn = true,
-      "film",
-      None,
-      supportedSections,
-      Set.empty,
-      Set.empty,
-      List.empty,
-      newPublishedDate,
     ) should be(true)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -34,7 +34,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -46,7 +45,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -58,7 +56,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -70,7 +67,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -82,7 +78,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("bereavement"),
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -94,7 +89,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("tech"),
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -106,7 +100,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("tech"),
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -118,7 +111,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("bereavement"),
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -130,7 +122,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List("tech"),
       oldPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -142,7 +133,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       newPublishedDate,
       deniedPageUrl,
-      "article",
     )(fakeTestControlRequest) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
@@ -154,7 +144,6 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       List.empty,
       newPublishedDate,
       deniedPageUrl,
-      "gallery",
     )(fakeTestControlRequest) should be(true)
   }
 }


### PR DESCRIPTION
## What does this change?
Removes the zero percent test that DCR skimlinks were behind and no longer use contentType, an allowList or a cut-off date to decide skimlinks eligibility.

This means affiliate links will now show for:
- all galleries with affiliatable links
- all DCR articles where:
  - there are affiliatable links
  - the first two page elements are paragraphs
  - the second paragraph is longer than 250 characters

## Screenshots
### Desktop:

<img width="1316" alt="Screenshot 2024-05-21 at 15 46 41" src="https://github.com/guardian/frontend/assets/108270776/a05cfb87-8f6a-456c-a1db-16046f7e4d79">


### Mobile:

<img width="305" alt="Screenshot 2024-05-21 at 15 46 58" src="https://github.com/guardian/frontend/assets/108270776/0a19ea50-f27e-4826-a8ba-952b4594e15e">
