### PR TITLE
Add europe and international in the high frequency paths

### DIFF
--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -13,7 +13,7 @@ object LowFrequency extends FrontType
 object StandardFrequency extends FrontType
 object HighFrequency extends FrontType {
   def highFrequencyPaths: List[String] =
-    List("uk", "us", "au", "uk/sport", "us/sport", "au/sport")
+    List("uk", "us", "au", "europe", "international", "uk/sport", "us/sport", "au/sport")
 }
 
 case class CronUpdate(path: String, frontType: FrontType)

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -10,7 +10,7 @@ import services.ConfigAgent
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorker: ToolPressQueueWorker)(implicit
+class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress)(implicit
     executionContext: ExecutionContext,
 ) extends JsonQueueWorker[SNSNotification] {
   override val deleteOnFailure: Boolean = true


### PR DESCRIPTION
Closes: https://github.com/guardian/dotcom-rendering/issues/11311

## What does this change?
Adds europe and international in the high frequency updated paths. They will be pressed every 2 minutes on CODE and every 1 minute in PROD.

## Why?
These regular presses are triggered by a cron job running in the admin app and can have high, standard or low frequency. Editions and sports fronts have a high update frequency. In this PR I'm adding europe and international - they're missing possibly due to an oversight. This will allow the europe front to get the latest updates in the EU Election Tracker that will be launched this June. This content will be coming from CAPI and will change without any update from the Fronts tool.

See more about the fronts architecutre here: https://github.com/guardian/frontend/blob/main/docs/02-architecture/02-fronts-architecture.md

## Screenshots

After deploying to CODE:

* [europe](https://logs.gutools.co.uk/s/dotcom/goto/13d15b00-185c-11ef-912a-7b72effa9fa7) and [international](https://logs.gutools.co.uk/s/dotcom/goto/fd4d3200-185b-11ef-912a-7b72effa9fa7) fronts are pressed every 2 minutes as expected

![image](https://github.com/guardian/frontend/assets/19683595/aeddc115-6c06-43fc-8d28-ad1db72d3ee7)


![image](https://github.com/guardian/frontend/assets/19683595/9c91abe1-1fcb-4905-bb76-ac70052c60c6)

See also timestamps in the fronts bucket.

| europe | international |
|--------|--------|
| <img width="259" alt="image" src="https://github.com/guardian/frontend/assets/19683595/469c0ec0-def9-4d3b-9ad7-c74d17c887a8"> | <img width="265" alt="image" src="https://github.com/guardian/frontend/assets/19683595/96d89564-4076-4b10-b133-08e604f1324f"> | 

## Checklist

- [X] Tested locally, and on CODE if necessary
