### PR TITLE
Bump @guardian/commercial to v19.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "18.6.2",
+		"@guardian/commercial": "19.0.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,9 +2696,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:18.6.2":
-  version: 18.6.2
-  resolution: "@guardian/commercial@npm:18.6.2"
+"@guardian/commercial@npm:19.0.0":
+  version: 19.0.0
+  resolution: "@guardian/commercial@npm:19.0.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -2719,7 +2719,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     typescript: ~5.3.3
-  checksum: 10c0/8f8684d1a3f1b6d86b65e29d0621f79d28e1ac2f92920ac74371fec9f55717bf7a41a8447ee716259eae9a1856e0f191ac4d50901a127b277d4f39f5288881ab
+  checksum: 10c0/b498eb5bd3448e528fe9ae1affc6c2ce0fc942050c353f4b58971c088423b6bb093c2e801f67639dc46633e3b56705485c4808a04c20171672b7dc532ef292c7
   languageName: node
   linkType: hard
 
@@ -2793,7 +2793,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:18.6.2"
+    "@guardian/commercial": "npm:19.0.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
## What does this change?
Bring in the changes from [v19.0.0](https://github.com/guardian/commercial/releases/tag/v19.0.0)