### PR TITLE
Add opt in 0% test for tag link experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -73,6 +73,5 @@ object TagLinkDesign
       description = "Render an updated sticky design for tag links",
       owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 7, 31),
-      participationGroup =
-        Perc0E,
+      participationGroup = Perc0E,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,6 +16,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       UpdatedHeaderDesign,
       UpdateLogoAdPartner,
       MastheadWithHighlights,
+      TagLinkDesign,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -64,4 +65,14 @@ object DCRTagPages
       owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 5, 31),
       participationGroup = Perc20A,
+    )
+
+object TagLinkDesign
+    extends Experiment(
+      name = "tag-link-design",
+      description = "Render an updated sticky design for tag links",
+      owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2024, 7, 31),
+      participationGroup =
+        Perc0E,
     )


### PR DESCRIPTION
## What does this change?
Adds the tag link experiment - part of the big events project - to a 0% participation group. This allows design to opt-in and test the new designs.
 