### PR TITLE
Get most viewed and deeply read data by location in new route

### DIFF
--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -214,12 +214,12 @@ class MostPopularController(
         case "CA" => editions.Us
         case "AU" => editions.Au
         case "NZ" => editions.Au
-        case _    => editions.International
+        case _    => Edition.defaultEdition
       }
 
       // Synchronous edition popular, from the mostPopularAgent (stateful)
       val editionPopular: Option[MostPopularCollectionResponse] = {
-        val editionPopularContent = mostPopularAgent.mostPopular(edition)
+        val editionPopularContent = geoMostPopularAgent.mostPopular(countryCode)
         if (editionPopularContent.isEmpty) None
         Some(
           MostPopularCollectionResponse(

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -214,7 +214,7 @@ class MostPopularController(
         case "CA" => editions.Us
         case "AU" => editions.Au
         case "NZ" => editions.Au
-        case _    => Edition.defaultEdition
+        case _    => editions.International
       }
 
       // Synchronous edition popular, from the mostPopularAgent (stateful)

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -206,7 +206,16 @@ class MostPopularController(
 
   def renderWithDeeplyRead(): Action[AnyContent] =
     Action.async { implicit request =>
-      val edition = Edition(request)
+      val headers = request.headers.toSimpleMap
+      val countryCode = headers.getOrElse("X-GU-GeoLocation", "country:row").replace("country:", "")
+      val edition = countryCode match {
+        case "GB" => editions.Uk
+        case "US" => editions.Us
+        case "CA" => editions.Us
+        case "AU" => editions.Au
+        case "NZ" => editions.Au
+        case _    => Edition.defaultEdition
+      }
 
       // Synchronous edition popular, from the mostPopularAgent (stateful)
       val editionPopular: Option[MostPopularCollectionResponse] = {

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -208,14 +208,6 @@ class MostPopularController(
     Action.async { implicit request =>
       val headers = request.headers.toSimpleMap
       val countryCode = headers.getOrElse("X-GU-GeoLocation", "country:row").replace("country:", "")
-      val edition = countryCode match {
-        case "GB" => editions.Uk
-        case "US" => editions.Us
-        case "CA" => editions.Us
-        case "AU" => editions.Au
-        case "NZ" => editions.Au
-        case _    => Edition.defaultEdition
-      }
 
       // Synchronous edition popular, from the mostPopularAgent (stateful)
       val editionPopular: Option[MostPopularCollectionResponse] = {
@@ -232,6 +224,14 @@ class MostPopularController(
         )
       }
 
+      val edition = countryCode match {
+        case "GB" => editions.Uk
+        case "US" => editions.Us
+        case "CA" => editions.Us
+        case "AU" => editions.Au
+        case "NZ" => editions.Au
+        case _    => Edition.defaultEdition
+      }
       val deeplyReadItems = deeplyReadAgent.getTrails(edition)
 
       // Async global deeply read


### PR DESCRIPTION
This PR pertains to fetching data for the Most Viewed component (section in right-column on articles). We have a [new endpoint](https://api.nextgen.guardianapps.co.uk/most-read-with-deeply-read.json) that fetches Deeply Read data in addition to Most Viewed data.

## What has changed?

In the new endpoint, fetch Most Viewed and Deeply Read content by country code, rather than edition. This brings the functionality in line with the previous method of fetching Most Viewed content.

## Why?

We want to maintain the current behaviour of fetching Most Viewed data by geolocation rather than edition
