### PR TITLE
change newsletterSignupAgent.refresh period from 60 to 15 minutes

### DIFF
--- a/common/app/services/newsletters/NewsletterSignupLifecycle.scala
+++ b/common/app/services/newsletters/NewsletterSignupLifecycle.scala
@@ -28,7 +28,7 @@ class NewsletterSignupLifecycle(
 
     descheduleAll()
     newsletterSignupAgent.refresh()
-    jobs.scheduleEveryNMinutes("NewsletterSignupAgentLowFrequencyRefreshJob", 60) {
+    jobs.scheduleEveryNMinutes("NewsletterSignupAgentLowFrequencyRefreshJob", 15) {
       newsletterSignupAgent.refresh()
     }
   }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Frontend holds a cached copy of the [newsletter api data](https://newsletters.guardianapis.com/api/newsletters) in memory using the `NewsletterSignupAgent`, which the `NewsletterSignupLifecycle` refreshes every 60 minutes.

The newsletter API uses a fastly cache, so when frontend refreshes the data it gets will not be the latest version. In practise, this means that updates made to the newsletter data (which can be made by editorial using the [newsletter tool](https://newsletters-tool.gutools.co.uk) take 1-2 hours to appear on the site.

Increasing the frequency to 15 minutes should be safe since:
 - fetching and parsing the data from the API is not an expensive operation
 - [identity fetches the same data every 5 minutes](https://github.com/guardian/identity/blob/main/identity-api/src/main/scala/com/gu/identity/api/newsletters/NewslettersSourceAgent.scala#L95), so frontend should never be 'ahead' of identity (if that happened, frontend might render sign-up forms for newsletters that identity doesn't have yet, so the sign-up requests to identity would fail)

## What does this change?

Changes the frequency of the newsletterSignupAgent.refresh job in `NewsletterSignupLifecycle` from 60 to 15 minutes.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)
