### PR TITLE
Set live updated logo styling for Advertising partner

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -167,7 +167,7 @@ trait CommercialSwitches {
       "Enable the updated logo styling for advertising partner and exclusive advertising partner US labels.",
     owners = group(Commercial),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = LocalDate.of(2024, 7, 31),
     exposeClientSide = true,
   )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -159,6 +159,17 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val updateLogoAdPartner: Switch = Switch(
+    group = Commercial,
+    name = "update-logo-ad-partner",
+    description =
+      "Enable the updated logo styling for advertising partner and exclusive advertising partner US labels.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }
 
 trait PrebidSwitches {

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,7 +14,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       DarkModeWeb,
       DCRTagPages,
       UpdatedHeaderDesign,
-      UpdateLogoAdPartner,
       MastheadWithHighlights,
       TagLinkDesign,
     )
@@ -47,15 +46,6 @@ object DarkModeWeb
       owners = Seq(Owner.withGithub("jakeii"), Owner.withGithub("mxdvl")),
       sellByDate = LocalDate.of(2024, 7, 30),
       participationGroup = Perc0D,
-    )
-
-object UpdateLogoAdPartner
-    extends Experiment(
-      name = "update-logo-ad-partner",
-      description = "Update logo for advertising partner and exclusive advertising partner US",
-      owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 7, 30),
-      participationGroup = Perc0A,
     )
 
 object DCRTagPages


### PR DESCRIPTION
## What does this change?
This PR replaces the 0% AB test with a switch to set live the updated logo styling for `Advertising partner` and `Exclusive advertising partner` labels. 

I contacted CP to make the labels live until I test in CODE and all works as expected. Check https://github.com/guardian/dotcom-rendering/pull/11485 

## Checklist

- [x] Tested locally, and on CODE if necessary

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
