### PR TITLE
Supported DCR tag pages for all

### DIFF
--- a/applications/test/AllIndexControllerTest.scala
+++ b/applications/test/AllIndexControllerTest.scala
@@ -108,7 +108,9 @@ import play.api.test.Helpers._
 
   it should "correctly serve all pages for `default editionalised sections` in the International edition" in {
     val result =
-      allIndexController.all("commentisfree")(TestRequest("/commentisfree/all").withHeaders("X-Gu-Edition" -> "INT"))
+      allIndexController.all("commentisfree")(
+        TestRequest("/commentisfree/all?dcr=false").withHeaders("X-Gu-Edition" -> "INT"),
+      )
     status(result) should be(OK)
   }
 

--- a/applications/test/IndexControllerTest.scala
+++ b/applications/test/IndexControllerTest.scala
@@ -36,7 +36,7 @@ import play.api.libs.ws.WSClient
   )
 
   "Index Controller" should "200 when content type is front" in {
-    val result = indexController.render(section)(TestRequest(s"/$section"))
+    val result = indexController.render(section)(TestRequest(s"/$section?dcr=false"))
     status(result) should be(200)
   }
 
@@ -112,14 +112,14 @@ import play.api.libs.ws.WSClient
   }
 
   it should "not accidentally truncate tags that contain valid strings that are also editions" in {
-    val request = FakeRequest(GET, "/uk/london?page=2")
+    val request = FakeRequest(GET, "/uk/london?page=2&dcr=false")
     val result = indexController.render("uk/london")(request)
 
     status(result) should be(200)
   }
 
   it should "not add editions to section tags" in {
-    val request = FakeRequest(GET, "/sport?page=2")
+    val request = FakeRequest(GET, "/sport?page=2&dcr=false")
     val result = indexController.render("sport")(request)
 
     status(result) should be(200)

--- a/applications/test/IndexMetaDataTest.scala
+++ b/applications/test/IndexMetaDataTest.scala
@@ -35,32 +35,32 @@ import play.api.test.Helpers._
   )
 
   it should "Include organisation metadata" in {
-    val result = indexController.render(articleUrl)(TestRequest(articleUrl))
+    val result = indexController.render(articleUrl)(TestRequest(s"$articleUrl?dcr=false"))
     MetaDataMatcher.ensureOrganisation(result)
   }
 
   it should "Include webpage metadata" in {
-    val result = indexController.render(articleUrl)(TestRequest(articleUrl))
+    val result = indexController.render(articleUrl)(TestRequest(s"$articleUrl?dcr=false"))
     MetaDataMatcher.ensureWebPage(result, articleUrl)
   }
 
   it should "Include app deep link" in {
-    val result = indexController.render(articleUrl)(TestRequest(articleUrl))
+    val result = indexController.render(articleUrl)(TestRequest(s"$articleUrl?dcr=false"))
     MetaDataMatcher.ensureDeepLink(result)
   }
 
   it should "Not include app deep link on the crosswords index" in {
-    val result = indexController.render(crosswordsUrl)(TestRequest(crosswordsUrl))
+    val result = indexController.render(crosswordsUrl)(TestRequest(s"$crosswordsUrl?dcr=false"))
     MetaDataMatcher.ensureNoDeepLink(result)
   }
 
   it should "not include webpage metadata on the crossword index" in {
-    val result = indexController.render(crosswordsUrl)(TestRequest(crosswordsUrl))
+    val result = indexController.render(crosswordsUrl)(TestRequest(s"$crosswordsUrl?dcr=false"))
     MetaDataMatcher.ensureNoIosUrl(result)
   }
 
   it should "Include item list metadata" in {
-    val result = indexController.render(articleUrl)(TestRequest(articleUrl))
+    val result = indexController.render(articleUrl)(TestRequest(s"$articleUrl?dcr=false"))
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
 

--- a/applications/test/SectionTemplateTest.scala
+++ b/applications/test/SectionTemplateTest.scala
@@ -11,22 +11,23 @@ import scala.jdk.CollectionConverters._
 
 @DoNotDiscover class SectionTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
-  it should "render front title" in goTo("/uk-news") { browser =>
+  it should "render front title" in goTo("/uk-news?dcr=false") { browser =>
     browser.el("[data-test-id=header-title]").text should be("UK news")
   }
 
-  it should "add alternate pages to editionalised sections for /uk/culture" in goTo("/uk/culture") { browser =>
-    val alternateLinks = getAlternateLinks(browser)
-    alternateLinks.size should be(3)
-    alternateLinks.exists(link =>
-      toPath(link.attribute("href")) == "/us/culture" && link.attribute("hreflang") == "en-US",
-    ) should be(true)
-    alternateLinks.exists(link =>
-      toPath(link.attribute("href")) == "/au/culture" && link.attribute("hreflang") == "en-AU",
-    ) should be(true)
-    alternateLinks.exists(link =>
-      toPath(link.attribute("href")) == "/uk/culture" && link.attribute("hreflang") == "en-GB",
-    ) should be(true)
+  it should "add alternate pages to editionalised sections for /uk/culture" in goTo("/uk/culture?dcr=false") {
+    browser =>
+      val alternateLinks = getAlternateLinks(browser)
+      alternateLinks.size should be(3)
+      alternateLinks.exists(link =>
+        toPath(link.attribute("href")) == "/us/culture" && link.attribute("hreflang") == "en-US",
+      ) should be(true)
+      alternateLinks.exists(link =>
+        toPath(link.attribute("href")) == "/au/culture" && link.attribute("hreflang") == "en-AU",
+      ) should be(true)
+      alternateLinks.exists(link =>
+        toPath(link.attribute("href")) == "/uk/culture" && link.attribute("hreflang") == "en-GB",
+      ) should be(true)
 
   }
 
@@ -40,7 +41,7 @@ import scala.jdk.CollectionConverters._
       })
   }
 
-  it should "not add alternate pages to non editionalised sections" in goTo("/books") { browser =>
+  it should "not add alternate pages to non editionalised sections" in goTo("/books?dcr=false") { browser =>
     val alternateLinks = getAlternateLinks(browser)
     alternateLinks should be(empty)
   }

--- a/applications/test/TagFeatureTest.scala
+++ b/applications/test/TagFeatureTest.scala
@@ -17,7 +17,7 @@ import org.scalatest.matchers.should.Matchers
 
       Given("I visit a tag page")
 
-      goTo("/technology/askjack") { browser =>
+      goTo("/technology/askjack?dcr=false") { browser =>
         val trails = browser.$(".fc-item__container")
         trails.asScala.length should be(IndexPagePagination.pageSize)
       }
@@ -31,7 +31,7 @@ import org.scalatest.matchers.should.Matchers
       Given("I visit the 'Jemima Kiss' contributor page")
       Switches.ImageServerSwitch.switchOn()
 
-      goTo("/profile/jemimakiss") { browser =>
+      goTo("/profile/jemimakiss?dcr=false") { browser =>
         Then("I should see her profile image")
         val profileImage = browser.el("[data-test-id=header-image]")
         profileImage.attribute("src") should include(s"42593747/Jemima-Kiss.jpg")
@@ -41,7 +41,7 @@ import org.scalatest.matchers.should.Matchers
     Scenario("Should not not display profiles where they don't exist") {
 
       Given("I visit the 'Sam Jones' contributor page")
-      goTo("/profile/samjones") { browser =>
+      goTo("/profile/samjones?dcr=false") { browser =>
         Then("I should not see her profile image")
         val profileImages = browser.find(".profile__img img")
         profileImages.asScala.length should be(0)
@@ -65,7 +65,7 @@ import org.scalatest.matchers.should.Matchers
 
       Given("I visit the 'Cycling' tag page")
 
-      goTo("/sport/cycling") { browser =>
+      goTo("/sport/cycling?dcr=false") { browser =>
         import browser._
 
         val cardsOnFirstPage = browser.find("[data-test-id=facia-card]")
@@ -96,7 +96,7 @@ import org.scalatest.matchers.should.Matchers
 
       Given("I visit page 2 of the 'Cycling' tag page")
 
-      goTo("/sport/cycling?page=2") { browser =>
+      goTo("/sport/cycling?page=2&dcr=false") { browser =>
         import browser._
 
         val cardsOnNextPage = browser.find("[data-test-id=facia-card]")

--- a/applications/test/TagTemplateTest.scala
+++ b/applications/test/TagTemplateTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 
 @DoNotDiscover class TagTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
-  it should "render tag headline" in goTo("/world/turkey") { browser =>
+  it should "render tag headline" in goTo("/world/turkey?dcr=false") { browser =>
     browser.el("[data-test-id=header-title]").text should be("Turkey")
   }
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -524,4 +524,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
+
+  val DCRTagPages = Switch(
+    group = SwitchGroup.Feature,
+    name = "dcr-tag-pages",
+    description = "Render tag pages with DCR",
+    owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,7 +12,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       DarkModeWeb,
-      DCRTagPages,
       UpdatedHeaderDesign,
       UpdateLogoAdPartner,
       MastheadWithHighlights,
@@ -56,15 +55,6 @@ object UpdateLogoAdPartner
       owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2024, 7, 30),
       participationGroup = Perc0A,
-    )
-
-object DCRTagPages
-    extends Experiment(
-      name = "dcr-tag-pages",
-      description = "Render tag pages with DCR",
-      owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 5, 31),
-      participationGroup = Perc20A,
     )
 
 object TagLinkDesign

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -60,12 +60,12 @@ import scala.concurrent.duration._
   }
 
   it should "Include webpage metadata" in {
-    val result = faciaController.renderFront(frontPath)(TestRequest(frontPath))
+    val result = faciaController.renderFront(frontPath)(TestRequest(s"$frontPath?dcr=false"))
     MetaDataMatcher.ensureWebPage(result, frontPath)
   }
 
   it should "Include item list metadata" in {
-    val result = faciaController.renderFront(frontPath)(TestRequest(frontPath))
+    val result = faciaController.renderFront(frontPath)(TestRequest(s"$frontPath?dcr=false"))
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

DCR tag pages for all

## What does this change?

Turn the experiment into a feature switch.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/76776/690ec475-55f5-4dd6-9813-a50f411d9ac4
[after]: https://github.com/guardian/frontend/assets/76776/3b6d3cf6-1082-47dc-9642-9d148547a3bb

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
