### PR TITLE
Update footer links

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -21,7 +21,12 @@ object FooterLinks {
   val termsAndConditions = FooterLink("Terms & conditions", "/help/terms-of-service", "terms")
 
   def help(edition: String): FooterLink =
-    FooterLink("Help", "https://manage.theguardian.com/help-centre", s"${edition} : footer : tech feedback", "js-tech-feedback-report")
+    FooterLink(
+      "Help",
+      "https://manage.theguardian.com/help-centre",
+      s"${edition} : footer : tech feedback",
+      "js-tech-feedback-report",
+    )
   def workForUs(edition: String): FooterLink =
     FooterLink("Work for us", "https://workforus.theguardian.com", s"${edition} : footer : work for us")
 

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -88,8 +88,8 @@ object FooterLinks {
     FooterLink("LinkedIn", "https://www.linkedin.com/company/theguardian", s"${edition} : footer : linkedin")
   def instagram(edition: String): FooterLink =
     FooterLink("Instagram", "https://www.instagram.com/guardian", s"${edition} : footer : instagram")
-  def twitter(edition: String): FooterLink =
-    FooterLink("Twitter", "https://twitter.com/guardian", s"${edition}: footer : twitter")
+  def x(edition: String): FooterLink =
+    FooterLink("X", "https://x.com/guardian", s"${edition}: footer : x")
   def newsletters(edition: String): FooterLink =
     FooterLink(
       text = "Newsletters",
@@ -110,7 +110,7 @@ object FooterLinks {
     youtube("uk"),
     instagram("uk"),
     linkedin("uk"),
-    twitter("uk"),
+    x("uk"),
     newsletters("uk"),
   )
 
@@ -122,7 +122,7 @@ object FooterLinks {
     youtube("us"),
     instagram("us"),
     linkedin("us"),
-    twitter("us"),
+    x("us"),
     newsletters("us"),
   )
 
@@ -135,7 +135,7 @@ object FooterLinks {
     youtube("au"),
     instagram("au"),
     linkedin("au"),
-    twitter("au"),
+    x("au"),
     newsletters("au"),
   )
 
@@ -147,7 +147,7 @@ object FooterLinks {
     youtube("international"),
     instagram("international"),
     linkedin("international"),
-    twitter("international"),
+    x("international"),
     newsletters("international"),
   )
 

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -89,7 +89,7 @@ object FooterLinks {
   def instagram(edition: String): FooterLink =
     FooterLink("Instagram", "https://www.instagram.com/guardian", s"${edition} : footer : instagram")
   def x(edition: String): FooterLink =
-    FooterLink("X", "https://x.com/guardian", s"${edition}: footer : x")
+    FooterLink("X", "https://x.com/guardian", s"${edition}: footer : twitter")
   def newsletters(edition: String): FooterLink =
     FooterLink(
       text = "Newsletters",

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -21,7 +21,7 @@ object FooterLinks {
   val termsAndConditions = FooterLink("Terms & conditions", "/help/terms-of-service", "terms")
 
   def help(edition: String): FooterLink =
-    FooterLink("Help", "/help", s"${edition} : footer : tech feedback", "js-tech-feedback-report")
+    FooterLink("Help", "https://manage.theguardian.com/help-centre", s"${edition} : footer : tech feedback", "js-tech-feedback-report")
   def workForUs(edition: String): FooterLink =
     FooterLink("Work for us", "https://workforus.theguardian.com", s"${edition} : footer : work for us")
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
Requested by CP https://groups.google.com/a/guardian.co.uk/g/dotcom.platform/c/Llg3aqkPCfY/m/-TNbFyXbAAAJ

## What does this change?
This updates the twitter link from https://twitter.com/guardian to https://x.com/guardian and https://www.theguardian.com/help to https://manage.theguardian.com/help-centre
## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/110032454/cb2ce0ce-ca26-446a-a64f-12e92e4b99f7
[after]: https://github.com/guardian/frontend/assets/110032454/d0a48392-5ef2-4ed6-b6b4-9bf6d9003e34

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
