### PR TITLE
Fix `make validate` 

### DIFF
--- a/tools/task-runner/run-task-verbose-formater.js
+++ b/tools/task-runner/run-task-verbose-formater.js
@@ -12,36 +12,33 @@ const log = (title, parents, message = '') => {
 const render = (tasks, parents = []) => {
     // eslint-disable-next-line no-restricted-syntax
     for (const task of tasks) {
-        task.subscribe(event => {
-            if (event.type === 'SUBTASKS') {
-                render(task.subtasks, parents.concat([task.title]));
-                return;
+        task.on('SUBTASKS', event => {
+            render(task.subtasks, parents.concat([task.title]));
+        });
+        task.on('STATE', event => {
+            if (task.isPending()) {
+                log(task.title, parents, chalk.dim('...'));
             }
-            if (event.type === 'STATE') {
-                if (task.isPending()) {
-                    log(task.title, parents, chalk.dim('...'));
-                }
-                if (task.hasFailed()) {
-                    log(task.title, parents, chalk.red(figures.cross));
-                }
-                if (task.isSkipped()) {
-                    log(
-                        task.title,
-                        parents,
-                        `${chalk.dim(figures.arrowDown)} (${task.output})`
-                    );
-                }
-                if (
-                    task.isCompleted() &&
-                    !task.hasFailed() &&
-                    !task.isSkipped()
-                ) {
-                    log(task.title, parents, chalk.dim.green(figures.tick));
-                }
+            if (task.hasFailed()) {
+                log(task.title, parents, chalk.red(figures.cross));
             }
-            if (event.type === 'DATA') {
-                console.log(event.data);
+            if (task.isSkipped()) {
+                log(
+                    task.title,
+                    parents,
+                    `${chalk.dim(figures.arrowDown)} (${task.output})`
+                );
             }
+            if (
+                task.isCompleted() &&
+                !task.hasFailed() &&
+                !task.isSkipped()
+            ) {
+                log(task.title, parents, chalk.dim.green(figures.tick));
+            }
+        });
+        task.on('DATA', event => {
+            console.log(event.data);
         });
     }
 };


### PR DESCRIPTION
## What is the value of this and can you measure success?

Fix `make validate`!

## What does this change?

Listr2 custom renderer no longer has a `subscribe` method, but rather [event emitters since v6](https://listr2.kilic.dev/migration/v6.html).

## Screenshots

<img width="589" alt="image" src="https://github.com/guardian/frontend/assets/76776/b9d44409-1149-4879-8c75-ac33dfae279d">

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
