### PR TITLE
Extend expiring switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -41,7 +41,7 @@ trait ABTestSwitches {
     "Test MPU when there is no epic at the end of Article on the page.",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 5, 31)),
+    sellByDate = Some(LocalDate.of(2024, 7, 31)),
     exposeClientSide = true,
   )
 
@@ -51,7 +51,7 @@ trait ABTestSwitches {
     "Show new ad block ask component in ad slots when we detect ad blocker usage",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 5, 31)),
+    sellByDate = Some(LocalDate.of(2024, 7, 31)),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
They have expired and a test is failing. This will make the build green again.