### PR TITLE
Add template for `ElectionResultsAgent`

### DIFF
--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -6,13 +6,13 @@ import conf.switches.SwitchboardLifecycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import controllers.{Application, HealthCheck}
 import frontpress.{DraftFapiFrontPress, FrontPressCron, LiveFapiFrontPress, ToolPressQueueWorker}
-import lifecycle.FaciaPressLifecycle
+import lifecycle.{ElectionResultsAgentLifecycle, FaciaPressLifecycle}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.routing.Router
 import play.api._
 import play.api.mvc.EssentialFilter
-import services.ConfigAgentLifecycle
+import services.{ConfigAgentLifecycle, ElectionResultsAgent}
 import router.Routes
 import _root_.commercial.targeting.TargetingLifecycle
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
@@ -32,6 +32,8 @@ trait AppComponents extends FrontendComponents {
   lazy val toolPressQueueWorker = wire[ToolPressQueueWorker]
   lazy val frontPressCron = wire[FrontPressCron]
 
+  lazy val electionResultsAgent = wire[ElectionResultsAgent]
+
   lazy val healthCheck = wire[HealthCheck]
   lazy val applicationController: Application = wire[Application]
   lazy val logbackOperationsPool = wire[LogbackOperationsPool]
@@ -43,6 +45,7 @@ trait AppComponents extends FrontendComponents {
     wire[CloudWatchMetricsLifecycle],
     wire[FaciaPressLifecycle],
     wire[TargetingLifecycle],
+    wire[ElectionResultsAgentLifecycle],
   )
 
   lazy val router: Router = wire[Routes]

--- a/facia-press/app/lifecycle/ElectionResultsAgentLifecycle.scala
+++ b/facia-press/app/lifecycle/ElectionResultsAgentLifecycle.scala
@@ -1,0 +1,45 @@
+package lifecycle
+
+import app.LifecycleComponent
+import common.{GuLogging, JobScheduler, PekkoAsync}
+import play.api.inject.ApplicationLifecycle
+import services.ElectionResultsAgent
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
+
+class ElectionResultsAgentLifecycle(
+    applicationLifecycle: ApplicationLifecycle,
+    jobs: JobScheduler,
+    pekkoAsync: PekkoAsync,
+    electionResultsAgent: ElectionResultsAgent,
+)(implicit ec: ExecutionContext)
+    extends LifecycleComponent
+    with GuLogging {
+
+  applicationLifecycle.addStopHook { () =>
+    Future {
+      descheduleJobs()
+    }
+  }
+
+  override def start(): Unit = {
+    descheduleJobs()
+    scheduleJobs()
+
+    pekkoAsync.after1s {
+      electionResultsAgent.refresh()
+    }
+  }
+
+  private def scheduleJobs(): Unit = {
+    // This job runs every 2 minutes
+    jobs.scheduleEvery("ElectionResultsJob", 2.minutes) {
+      electionResultsAgent.refresh()
+    }
+  }
+
+  private def descheduleJobs(): Unit = {
+    jobs.deschedule("ElectionResultsJob")
+  }
+}

--- a/facia-press/app/services/ElectionResultsAgent.scala
+++ b/facia-press/app/services/ElectionResultsAgent.scala
@@ -1,0 +1,17 @@
+package services
+
+import common.{Box, GuLogging}
+
+import scala.concurrent.Future
+
+class ElectionResultsAgent extends GuLogging {
+
+  private lazy val electionResults = Box[Map[String, String]](Map.empty)
+
+  def refresh(): Future[Unit] = {
+    log.info("Fetching election data")
+    Future.successful(())
+  }
+
+  def getResults: Map[String, String] = electionResults.get()
+}

--- a/facia-press/test/services/ElectionResultsAgentTest.scala
+++ b/facia-press/test/services/ElectionResultsAgentTest.scala
@@ -1,0 +1,13 @@
+package services
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ElectionResultsAgentTest extends AnyFlatSpec with Matchers {
+
+  it should "initialise with results being an empty Seq" in {
+    val electionResultsAgent = new ElectionResultsAgent()
+    electionResultsAgent.getResults shouldBe Map.empty
+  }
+
+}


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
