### PR TITLE
Remove `darkModeInApps` and `discussionInApps` switches

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -493,28 +493,6 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val DarkModeInApps = Switch(
-    SwitchGroup.Feature,
-    "dark-mode-in-apps",
-    "If this switch is on, we will allow dark mode in apps articles",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    // This is a random date in the future but this switch should be removed far before then
-    sellByDate = Some(LocalDate.of(2024, 6, 5)),
-    exposeClientSide = true,
-  )
-
-  val DiscussionInApps = Switch(
-    SwitchGroup.Feature,
-    "discussion-in-apps",
-    "If this switch is on, we will render discussion in apps articles",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    // This is a random date in the future but this switch should be removed far before then
-    sellByDate = Some(LocalDate.of(2024, 6, 5)),
-    exposeClientSide = true,
-  )
-
   val DCRVideoPages = Switch(
     SwitchGroup.Feature,
     "dcr-video-pages",


### PR DESCRIPTION
## What does this change?
Removes `darkModeInApps` and `discussionInApps` switches. No further change is needed in this repo as they are not used anywhere.

See related PR in DCR for the `darkModeInApps` switch: https://github.com/guardian/dotcom-rendering/pull/11528. The current PR will be merged after the DCR one.

## Why?
We no longer need them. We support these features in production.
