### PR TITLE
Bump commercial v19.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "0.0.0-beta-20240604172725",
+		"@guardian/commercial": "19.1.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "19.0.0",
+		"@guardian/commercial": "0.0.0-beta-20240604172725",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,9 +2696,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:19.0.0":
-  version: 19.0.0
-  resolution: "@guardian/commercial@npm:19.0.0"
+"@guardian/commercial@npm:0.0.0-beta-20240604172725":
+  version: 0.0.0-beta-20240604172725
+  resolution: "@guardian/commercial@npm:0.0.0-beta-20240604172725"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -2719,7 +2719,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     typescript: ~5.3.3
-  checksum: 10c0/b498eb5bd3448e528fe9ae1affc6c2ce0fc942050c353f4b58971c088423b6bb093c2e801f67639dc46633e3b56705485c4808a04c20171672b7dc532ef292c7
+  checksum: 10c0/87b67556524da41d7528032dc9f51399ec741053f8eea67d52a341cadaaa59b24dce86c3c3ea9e295a664726f54cefa31208273278820bffdd39834c22c1af5a
   languageName: node
   linkType: hard
 
@@ -2793,7 +2793,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:19.0.0"
+    "@guardian/commercial": "npm:0.0.0-beta-20240604172725"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,9 +2696,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:0.0.0-beta-20240604172725":
-  version: 0.0.0-beta-20240604172725
-  resolution: "@guardian/commercial@npm:0.0.0-beta-20240604172725"
+"@guardian/commercial@npm:19.1.0":
+  version: 19.1.0
+  resolution: "@guardian/commercial@npm:19.1.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -2719,7 +2719,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     typescript: ~5.3.3
-  checksum: 10c0/87b67556524da41d7528032dc9f51399ec741053f8eea67d52a341cadaaa59b24dce86c3c3ea9e295a664726f54cefa31208273278820bffdd39834c22c1af5a
+  checksum: 10c0/030bfa21688aa6e0c86ff818277b1438dc57755d077999e38ddc3d5549f565b910f139e7d835b3d361214604e3e4a3e2b90b7023cb91350329908d60ef3191db
   languageName: node
   linkType: hard
 
@@ -2793,7 +2793,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:0.0.0-beta-20240604172725"
+    "@guardian/commercial": "npm:19.1.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
## What does this change?

This PR bumps Commercial from v19.0.0 to v19.1.0

### Minor Changes

-   [`a027366`](https://github.com/guardian/commercial/commit/a0273661ce465ecd2af161ed7498f6b55080120c): Only play interscroller video ad when ad is in the viewport
-   [`15fdb02`](https://github.com/guardian/commercial/commit/15fdb02fd27b2857995ca2791c6a864f04aaeeef): Split consented & consentless code
-   [`244b7aa`](https://github.com/guardian/commercial/commit/244b7aac712d69b8b30e0f6e7a0df3f1a5023e1c): Adds 300x50 ad size to mobile-sticky

### Patch Changes

-   [`f2b2788`](https://github.com/guardian/commercial/commit/f2b2788633cdc26b3eceaea3f766970bbb168ed3): Bypass metrics sampling for video interscroller

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
