### PR TITLE
make more articles eligible for affiliate links

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -255,7 +255,7 @@ object DotcomRenderingUtils {
     if (bodyElements.size >= 2) {
       val firstEl = bodyElements.get(0)
       val secondEl = bodyElements.get(1)
-      if (firstEl.tagName == "p" && secondEl.tagName == "p" && secondEl.text().length >= 250) {
+      if (firstEl.tagName == "p" && secondEl.tagName == "p" && secondEl.text().length >= 150) {
         AffiliateLinksCleaner.shouldAddAffiliateLinks(
           switchedOn = Switches.AffiliateLinks.isSwitchedOn,
           section = content.metadata.sectionId,


### PR DESCRIPTION
## What is the value of this and can you measure success?

To expose more articles and make them eligible for affiliate links (hence more revenue)
This is a result of the Disclaimer message being reduced in length [PR here](https://github.com/guardian/dotcom-rendering/pull/11459), so we can now reduce the minimum char length of the 2nd paragraph.

Success will be measured by reducing the minimum char length and displaying the disclaimer, whilst also ensuring the whitespace around potential paragraphs are not too extreme.

## What does this change?
We have a logic to detect the character length of the 2nd paragraph in an "affiliatable" article, currently set at 250.
Please see [slides](https://docs.google.com/presentation/d/1YX39daWmFoO2HyF4lpMeztQYk1u_WDArP0rQnPMf1ec/edit#slide=id.g2e2973f6548_0_0) for different lengths


## Screenshots
https://m.code.dev-theguardian.com/fashion/2024/apr/13/sali-hughes-top-50-beauty-products-for-under-20-pounds

| Column 1 |
|----------|
| <img width="895" alt="Screenshot 2024-06-05 at 12 13 48" src="https://github.com/guardian/frontend/assets/49187886/10a74a3c-7550-4389-9684-f954ffde52f6">
 |
<!-- Please use the following table template to make image comparison easier to parse:


| Before      | 
|-------------|
| ![before][] | 

[before]: 


-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
