### PR TITLE
Bump node sass to 9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 		"madge": "^5.0.1",
 		"mkdirp": "^1.0.4",
 		"mockdate": "^3.0.5",
-		"node-sass": "^8.0.0",
+		"node-sass": "^9.0.0",
 		"object-fit-videos": "^1.0.3",
 		"ophan-tracker-js": "1.4.0",
 		"ora": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,7 +2870,7 @@ __metadata:
     madge: "npm:^5.0.1"
     mkdirp: "npm:^1.0.4"
     mockdate: "npm:^3.0.5"
-    node-sass: "npm:^8.0.0"
+    node-sass: "npm:^9.0.0"
     object-fit-videos: "npm:^1.0.3"
     ophan-tracker-js: "npm:1.4.0"
     ora: "npm:^1.3.0"
@@ -13307,9 +13307,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-sass@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "node-sass@npm:8.0.0"
+"node-sass@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "node-sass@npm:9.0.0"
   dependencies:
     async-foreach: "npm:^0.1.3"
     chalk: "npm:^4.1.2"
@@ -13327,7 +13327,7 @@ __metadata:
     true-case-path: "npm:^2.2.1"
   bin:
     node-sass: bin/node-sass
-  checksum: 10c0/46fba66fdd53ccea3893428b4617056ba0803bf148527c627f409d876c2efcdb37a921e5a41d3f98f4cb57fc265bd29dd7662ed0b9e9364b3941f52164770a60
+  checksum: 10c0/4154f0bd34b9fec67c2c62d76ee93092e8b2cc4967b0250ed3d33257093b018cbff25fa9109208c383156d7a345e4199ab1bae573e49fe260d3458fc5f1c27ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
Keep things up to date
## What does this change?
Bumps node-sass from 8.0 to 9.0
## Screenshots
N/A
<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
