### PR TITLE
Remove final cup SVG

### DIFF
--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -21,10 +21,7 @@
         </div>
         <div class="football-match__details">
             @if(round.name.contains("Final")) {
-                <div class="bigfatfinal">
-                    @fragments.inlineSvg(competition.finalMatchSVG.getOrElse("euro_2020_badge"), "badges", List("world__cup-svg", "world__cup-badge", "bigfatfinal__image"))
-                    <div class="football-match__name"><b>Final</b></div>
-                </div>
+                <div class="football-match__name"><b>Final</b></div>
             }
             @if(fm.isFixture){
                 <div class="football-match__date">

--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -442,10 +442,6 @@
         margin-left: 1px;
     }
 
-    .bigfatfinal__image__svg {
-        height: 80px;
-    }
-
     @include mq(desktop) {
         display: block;
     }


### PR DESCRIPTION
## What is the value of this and can you measure success?

No outdated imagery.

## What does this change?

Remove cup SVG from spider diagram.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://github.com/guardian/frontend/assets/76776/6e1d98cf-220c-4204-b891-ab2eb7581b91
[after]: https://github.com/guardian/frontend/assets/76776/3ba0750c-20c4-44d0-ba73-d36e997ce269

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
