### PR TITLE
Euro 2024 matches use BST in all editions

### DIFF
--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -2,6 +2,7 @@
 @import common.Edition
 @import java.time.LocalTime
 @import java.time.ZonedDateTime
+@import java.time.ZoneId
 @(fm: pa.FootballMatch, round: pa.Round, competition: model.Competition)(implicit request: RequestHeader)
 
 @import implicits.Football._
@@ -25,8 +26,8 @@
             }
             @if(fm.isFixture){
                 <div class="football-match__date">
-                    <span class="football-match__kickoff">@fm.date.format(DateTimeFormatter.ofPattern("HH:mm  z").withZone(Edition(request).timezoneId))</span>
-                    @fm.date.withZoneSameInstant(Edition(request).timezoneId).toLocalDate.format(DateTimeFormatter.ofPattern("E dd MMMM "))
+                    <span class="football-match__kickoff">@fm.date.format(DateTimeFormatter.ofPattern("HH:mm  z").withZone(ZoneId.of("Europe/London")))</span>
+                    @fm.date.withZoneSameInstant(ZoneId.of("Europe/London")).toLocalDate.format(DateTimeFormatter.ofPattern("E dd MMMM "))
                 </div>
             }
 

--- a/sport/app/football/views/wallchart/knockoutSpider.scala.html
+++ b/sport/app/football/views/wallchart/knockoutSpider.scala.html
@@ -1,5 +1,6 @@
 @import java.time.format.DateTimeFormatter
 @import java.time.ZonedDateTime
+@import java.time.ZoneId
 @import common.Edition
 @import java.time.LocalTime
 @(competition: model.Competition, knockoutStage: _root_.football.model.KnockoutSpider)(implicit request: RequestHeader)
@@ -67,5 +68,5 @@
         }
     </div>
 
-    <div class="football-knockout-chart__timezone">All matches are in <span class="football-matches__timezone">@DateTimeFormatter.ofPattern("z").format(ZonedDateTime.of(knockoutStage.matches.head.date.toLocalDate, LocalTime.of(0, 0), Edition(request).timezoneId))</span> time</div>
+    <div class="football-knockout-chart__timezone">All matches are in <span class="football-matches__timezone">@DateTimeFormatter.ofPattern("z").format(ZonedDateTime.of(knockoutStage.matches.head.date.toLocalDate, LocalTime.of(0, 0), ZoneId.of("Europe/London")))</span> time</div>
 </div>


### PR DESCRIPTION
## What is the value of this and can you measure success?

Ensure we follow our house style

## What does this change?

Disregard the edition and force `Europe/London` for all match starts

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
