### PR TITLE
Tag link: update test details

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -52,6 +52,6 @@ object TagLinkDesign
       name = "tag-link-design",
       description = "Render an updated sticky design for tag links",
       owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 7, 31),
-      participationGroup = Perc0E,
+      sellByDate = LocalDate.of(2024, 7, 25),
+      participationGroup = Perc20A,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?
Moves tag link to 20% audience bucket and brings switch expiry date closer. 
