### PR TITLE
Add Euro 2024 to the nav bar

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -110,6 +110,7 @@ object NavLinks {
 
   /* SPORT */
 
+  private val euro2024 = NavLink("Euro 2024", "/football/euro-2024", Some("football/euro-2024"))
   private val footballScores = NavLink("Live scores", "/football/live", Some("football/live"))
   private val footballTables = NavLink("Tables", "/football/tables", Some("football/tables"))
   private val footballFixtures = NavLink("Fixtures", "/football/fixtures", Some("football/fixtures"))
@@ -123,6 +124,7 @@ object NavLinks {
     "Football",
     "/football",
     children = List(
+      euro2024,
       footballScores,
       footballTables,
       footballFixtures,
@@ -135,6 +137,7 @@ object NavLinks {
     "Soccer",
     "/us/soccer",
     children = List(
+      euro2024,
       footballScores,
       footballTables,
       soccerSchedules,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -168,6 +168,13 @@
 					"url": "/football",
 					"children": [
 						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Live scores",
 							"url": "/football/live",
 							"longTitle": "football/live",
@@ -448,6 +455,13 @@
 					"title": "Football",
 					"url": "/football",
 					"children": [
+						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
 						{
 							"title": "Live scores",
 							"url": "/football/live",
@@ -1130,6 +1144,13 @@
 					"url": "/us/soccer",
 					"children": [
 						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Live scores",
 							"url": "/football/live",
 							"longTitle": "football/live",
@@ -1281,6 +1302,13 @@
 					"title": "Soccer",
 					"url": "/us/soccer",
 					"children": [
+						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
 						{
 							"title": "Live scores",
 							"url": "/football/live",
@@ -2000,6 +2028,13 @@
 					"url": "/football",
 					"children": [
 						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Live scores",
 							"url": "/football/live",
 							"longTitle": "football/live",
@@ -2614,6 +2649,13 @@
 					"url": "/football",
 					"children": [
 						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Live scores",
 							"url": "/football/live",
 							"longTitle": "football/live",
@@ -2802,6 +2844,13 @@
 					"title": "Football",
 					"url": "/football",
 					"children": [
+						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
 						{
 							"title": "Live scores",
 							"url": "/football/live",
@@ -3606,6 +3655,13 @@
 					"url": "/football",
 					"children": [
 						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Live scores",
 							"url": "/football/live",
 							"longTitle": "football/live",
@@ -3794,6 +3850,13 @@
 					"title": "Football",
 					"url": "/football",
 					"children": [
+						{
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
+							"longTitle": "football/euro-2024",
+							"children": [],
+							"classList": []
+						},
 						{
 							"title": "Live scores",
 							"url": "/football/live",


### PR DESCRIPTION
## What does this change?

Brings back this change fixed:
* https://github.com/guardian/frontend/pull/27204
