### PR TITLE
Add more GU team abbreviations

### DIFF
--- a/sport/app/football/model/GuTeamCode.scala
+++ b/sport/app/football/model/GuTeamCode.scala
@@ -17,16 +17,18 @@ object GuTeamCodes {
     team.name match {
       case "China PR"        => "CHN"
       case "Costa Rica"      => "CRC"
+      case "Germany"         => "GER"
       case "Japan"           => "JPN"
       case "Morocco"         => "MAR"
       case "Nigeria"         => "NGA"
       case "Netherlands"     => "NED"
       case "North Macedonia" => "MKD"
       case "New Zealand"     => "NZL"
+      case "Portugal"        => "POR"
       case "Rep of Ireland"  => "IRL"
       case "South Africa"    => "RSA"
       case "South Korea"     => "KOR"
-      case "Spain"           => "ESP"
+      case "Spain"           => "SPA"
       case "Switzerland"     => "SUI"
       case _                 => TeamCodes.codeFor(team)
     }


### PR DESCRIPTION
## What is the value of this and can you measure success?

As requested by the sports desk.

## What does this change?

Fixes #27209 

## Screenshots

<img width="958" alt="image" src="https://github.com/guardian/frontend/assets/76776/11533f82-5c05-4931-b166-c500b9066642">

## Checklist

- [x] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
