### PR TITLE
Delete redplanet

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -129,16 +129,6 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val redplanetForAUSSwitch: Switch = Switch(
-    group = CommercialPrebid,
-    name = "redplanet-for-aus",
-    description = "Turn on Redplanet in AUS",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val commercialMetrics: Switch = Switch(
     group = Commercial,
     name = "commercial-metrics",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
 		"@guardian/automat-modules": "^0.3.8",
-		"@guardian/commercial": "19.4.0",
+		"@guardian/commercial": "19.5.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,9 +2696,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:19.4.0":
-  version: 19.4.0
-  resolution: "@guardian/commercial@npm:19.4.0"
+"@guardian/commercial@npm:19.5.0":
+  version: 19.5.0
+  resolution: "@guardian/commercial@npm:19.5.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.0.4"
@@ -2719,7 +2719,7 @@ __metadata:
     "@guardian/libs": ^16.1.0
     "@guardian/source-foundations": ^14.1.2
     typescript: ~5.3.3
-  checksum: 10c0/7a63bdb55db274af4d1ffa0f52361cb9fcd9cab6fac0821ae278a13e2a9ba16268b205bcfdb626cb67201319a481c072ce09511a626879e8fccaa0fc620767c2
+  checksum: 10c0/cf99907006da707b0a26807b8702a784f0086fc5fc30748f656f79c99e687716e62db955a7f53527c5bcf2e9a1a56f25667a0d1cd1d8d5c5fb881fe7ad438632
   languageName: node
   linkType: hard
 
@@ -2793,7 +2793,7 @@ __metadata:
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
     "@guardian/automat-modules": "npm:^0.3.8"
-    "@guardian/commercial": "npm:19.4.0"
+    "@guardian/commercial": "npm:19.5.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
## What does this change?
Delete the redplanet switch, and bump the commercial code to a version without redplanet. We have permission to remove redplanet from the site, reducing the amount of javascript we'll be shipping to users. As a result, we won't need the switch any more.