### PR TITLE
Remove duplicated timezone in Euro 2024 groups

### DIFF
--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -95,7 +95,6 @@
         }
         <span class="football-matches__date">
             @date.format(DateTimeFormatter.ofPattern("E d MMMM "))
-            <span class="football-matches__timezone">(@DateTimeFormatter.ofPattern("z").format(ZonedDateTime.of(date, LocalTime.of(0, 0), Edition(request).timezoneId)))</span>
         </span>
 
     </caption>


### PR DESCRIPTION
## What does this change?

Removes duplicated timezone in Euro 2024 groups

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/9574885/eabf829d-56c0-4412-aba9-97b3a379003c
[after]: https://github.com/guardian/frontend/assets/9574885/ef71242a-38da-484a-8855-4b35eb828dc7

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
