### PR TITLE
Order Euro 2024 spider chart (almost) correctly

### DIFF
--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -218,7 +218,6 @@ object KnockoutSpider {
       ZonedDateTime.of(2024, 6, 30, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 40
       ZonedDateTime.of(2024, 7, 1, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 41
       ZonedDateTime.of(2024, 7, 1, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 42
-
       ZonedDateTime.of(2024, 6, 30, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 39
       ZonedDateTime.of(2024, 6, 29, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 37
       ZonedDateTime.of(2024, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 43
@@ -233,10 +232,10 @@ object KnockoutSpider {
       //   ━┓     ┃   ┃     ┏━
       //    ┣━ 2 ━┛   ┗━ 4 ━┫
       //   ━┛               ┗━
-      ZonedDateTime.of(2024, 7, 6, 17, 0, 0, 0, ZoneId.of("Europe/London")),  // Match 48
-      ZonedDateTime.of(2024, 7, 5, 20, 0, 0, 0, ZoneId.of("Europe/London")),  // Match 46
-      ZonedDateTime.of(2024, 7, 5, 17, 0, 0, 0, ZoneId.of("Europe/London")),  // Match 45
-      ZonedDateTime.of(2024, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")),  // Match 47
+      ZonedDateTime.of(2024, 7, 6, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 48
+      ZonedDateTime.of(2024, 7, 5, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 46
+      ZonedDateTime.of(2024, 7, 5, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 45
+      ZonedDateTime.of(2024, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 47
 
       //   Semi-Final
       //

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -205,21 +205,61 @@ object KnockoutSpider {
     // Euro 2024
     // https://www.uefa.com/euro2024/news/0275-151eb1c333ea-d30deec67b13-1000--uefa-euro-2024-fixtures-when-and-where-are-the-matches/
     "750" -> List(
-      ZonedDateTime.of(2024, 6, 30, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 40
-      ZonedDateTime.of(2024, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 38
-      ZonedDateTime.of(2024, 7, 1, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 42
-      ZonedDateTime.of(2024, 7, 1, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 41
-      ZonedDateTime.of(2024, 7, 2, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 44
-      ZonedDateTime.of(2024, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 43
-      ZonedDateTime.of(2024, 6, 30, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 39
-      ZonedDateTime.of(2024, 6, 29, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 37
-      ZonedDateTime.of(2024, 7, 5, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 46
-      ZonedDateTime.of(2024, 7, 5, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 45
-      ZonedDateTime.of(2024, 7, 6, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 48
-      ZonedDateTime.of(2024, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 47
-      ZonedDateTime.of(2024, 7, 9, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 49
-      ZonedDateTime.of(2024, 7, 10, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 50
-      ZonedDateTime.of(2024, 7, 14, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final         // Match 51
+      //   Round of 16
+      //
+      //   1 ━┓           ┏━ 5
+      //      ┣━━━┓   ┏━━━┫
+      //   2 ━┛   ┃   ┃   ┗━ 6
+      //          ┣━━━┫
+      //   3 ━┓   ┃   ┃   ┏━ 7
+      //      ┣━━━┛   ┗━━━┫
+      //   4 ━┛           ┗━ 8
+      ZonedDateTime.of(2024, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 38
+      ZonedDateTime.of(2024, 6, 30, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 40
+      ZonedDateTime.of(2024, 7, 1, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 41
+      ZonedDateTime.of(2024, 7, 1, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 42
+
+      ZonedDateTime.of(2024, 6, 30, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 39
+      ZonedDateTime.of(2024, 6, 29, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 37
+      ZonedDateTime.of(2024, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 43
+      ZonedDateTime.of(2024, 7, 2, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 44
+
+      //   Quarter Final
+      //
+      //   ━┓               ┏━
+      //    ┣━ 1 ━┓   ┏━ 3 ━┫
+      //   ━┛     ┃   ┃     ┗━
+      //          ┣━━━┫
+      //   ━┓     ┃   ┃     ┏━
+      //    ┣━ 2 ━┛   ┗━ 4 ━┫
+      //   ━┛               ┗━
+      ZonedDateTime.of(2024, 7, 6, 17, 0, 0, 0, ZoneId.of("Europe/London")),  // Match 48
+      ZonedDateTime.of(2024, 7, 5, 20, 0, 0, 0, ZoneId.of("Europe/London")),  // Match 46
+      ZonedDateTime.of(2024, 7, 5, 17, 0, 0, 0, ZoneId.of("Europe/London")),  // Match 45
+      ZonedDateTime.of(2024, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")),  // Match 47
+
+      //   Semi-Final
+      //
+      //   ━┓                ┏━
+      //    ┣━━┓          ┏━━┫
+      //   ━┛  ┃          ┃  ┗━
+      //       ┣━ 1 ━━ 2 ━┫
+      //   ━┓  ┃          ┃  ┏━
+      //    ┣━━┛          ┗━━┫
+      //   ━┛                ┗━
+      ZonedDateTime.of(2024, 7, 10, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 50
+      ZonedDateTime.of(2024, 7, 9, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 49
+
+      //   Final
+      //
+      //   ━┓             ┏━
+      //    ┣━━┓       ┏━━┫
+      //   ━┛  ┃       ┃  ┗━
+      //       ┣━━ 1 ━━┫
+      //   ━┓  ┃       ┃  ┏━
+      //    ┣━━┛       ┗━━┫
+      //   ━┛             ┗━
+      ZonedDateTime.of(2024, 7, 14, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 51
     ),
     // Womens Euro 2022
     "423" -> List(

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -181,6 +181,7 @@ object CompetitionDisplayHelpers {
     teamName
       .replace("Czech Republic", "Czech Rep.")
       .replace("Holland", "Netherlands")
+      .replace("Winner of Match", "Winner match")
   }
 
   // We do not currently support scores above 10 so we default to a max


### PR DESCRIPTION
## What is the value of this and can you measure success?

The Euro 2024 web spider chart is correctly ordered.

## What does this change?

- Add visual documentation so future travellers can understand how the ordering maps to the actual wall chart.
- Reorder the matches accordingly
- Clean up names so we get more info

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/76776/e2497623-4529-4358-a7a5-afaa8a876f66
[after]: https://github.com/guardian/frontend/assets/76776/380ae971-0ae4-409a-972d-879261f0ffa1

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
