### PR TITLE
Fix `CuratedContent` type mismatch

### DIFF
--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -134,8 +134,12 @@ case class PressedPage(
       item <- pressedCollection.curatedPlusBackfillDeduplicated
       id <- {
         item match {
-          case curatedContent: CuratedContent =>
-            curatedContent.content.sectionId ++ curatedContent.content.tags.map(_.id)
+          case curatedContent: pressed.CuratedContent => {
+            curatedContent.properties.maybeContent match {
+              case Some(content) => content.metadata.sectionId.map(_.value) ++ content.tags.tags.map(_.id)
+              case None => List.empty
+            }
+          }
           case _ => Nil
         }
       }

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -137,7 +137,7 @@ case class PressedPage(
           case curatedContent: pressed.CuratedContent => {
             curatedContent.properties.maybeContent match {
               case Some(content) => content.metadata.sectionId.map(_.value) ++ content.tags.tags.map(_.id)
-              case None => List.empty
+              case None          => Nil
             }
           }
           case _ => Nil

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -134,12 +134,10 @@ case class PressedPage(
       item <- pressedCollection.curatedPlusBackfillDeduplicated
       id <- {
         item match {
-          case curatedContent: pressed.CuratedContent => {
-            curatedContent.properties.maybeContent match {
-              case Some(content) => content.metadata.sectionId.map(_.value) ++ content.tags.tags.map(_.id)
-              case None          => Nil
-            }
-          }
+          case curatedContent: pressed.CuratedContent =>
+            curatedContent.properties.maybeContent
+              .map(content => content.metadata.sectionId.map(_.value) ++ content.tags.tags.map(_.id))
+              .getOrElse(Nil)
           case _ => Nil
         }
       }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Able to run the `main` branch

## What does this change?

Use the `pressed.CuratedContent` explicitely, to ensure there is an overlap with the  `PressedPage` type

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
