### PR TITLE
Order Euro 2024 spider chart like our print one

### DIFF
--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -134,8 +134,12 @@ case class PressedPage(
       item <- pressedCollection.curatedPlusBackfillDeduplicated
       id <- {
         item match {
-          case curatedContent: CuratedContent =>
-            curatedContent.content.sectionId ++ curatedContent.content.tags.map(_.id)
+          case curatedContent: pressed.CuratedContent => {
+            curatedContent.properties.maybeContent match {
+              case Some(content) => content.metadata.sectionId.map(_.value) ++ content.tags.tags.map(_.id)
+              case None => List.empty
+            }
+          }
           case _ => Nil
         }
       }

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -137,7 +137,7 @@ case class PressedPage(
           case curatedContent: pressed.CuratedContent => {
             curatedContent.properties.maybeContent match {
               case Some(content) => content.metadata.sectionId.map(_.value) ++ content.tags.tags.map(_.id)
-              case None => List.empty
+              case None          => Nil
             }
           }
           case _ => Nil

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -214,12 +214,12 @@ object KnockoutSpider {
       //   3 ━┓   ┃   ┃   ┏━ 7
       //      ┣━━━┛   ┗━━━┫
       //   4 ━┛           ┗━ 8
-      ZonedDateTime.of(2024, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 38
-      ZonedDateTime.of(2024, 6, 30, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 40
-      ZonedDateTime.of(2024, 7, 1, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 41
-      ZonedDateTime.of(2024, 7, 1, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 42
       ZonedDateTime.of(2024, 6, 30, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 39
       ZonedDateTime.of(2024, 6, 29, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 37
+      ZonedDateTime.of(2024, 7, 1, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 42
+      ZonedDateTime.of(2024, 7, 1, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 41
+      ZonedDateTime.of(2024, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 38
+      ZonedDateTime.of(2024, 6, 30, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 40
       ZonedDateTime.of(2024, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 43
       ZonedDateTime.of(2024, 7, 2, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 44
 
@@ -232,9 +232,9 @@ object KnockoutSpider {
       //   ━┓     ┃   ┃     ┏━
       //    ┣━ 2 ━┛   ┗━ 4 ━┫
       //   ━┛               ┗━
-      ZonedDateTime.of(2024, 7, 6, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 48
-      ZonedDateTime.of(2024, 7, 5, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 46
       ZonedDateTime.of(2024, 7, 5, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 45
+      ZonedDateTime.of(2024, 7, 5, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 46
+      ZonedDateTime.of(2024, 7, 6, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Match 48
       ZonedDateTime.of(2024, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 47
 
       //   Semi-Final
@@ -246,8 +246,8 @@ object KnockoutSpider {
       //   ━┓  ┃          ┃  ┏━
       //    ┣━━┛          ┗━━┫
       //   ━┛                ┗━
-      ZonedDateTime.of(2024, 7, 10, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 50
       ZonedDateTime.of(2024, 7, 9, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 49
+      ZonedDateTime.of(2024, 7, 10, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 50
 
       //   Final
       //


### PR DESCRIPTION
## What is the value of this and can you measure success?

Less confusion for our football fans.

## What does this change?

Reorder the matches so it matches our print wall chart, [and the UEFA one](https://www.uefa.com/euro2024/fixtures-results/bracket/).

- #27216 

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
