### PR TITLE
Add euro 2024 to first place of sports nav across all editions

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -393,6 +393,7 @@ object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
+      euro2024,
       football,
       cricket,
       rugbyUnion,
@@ -408,6 +409,7 @@ object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
+      euro2024,
       football,
       AFL,
       NRL,
@@ -421,6 +423,7 @@ object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
+      euro2024,
       usSoccer,
       NFL,
       tennis,
@@ -434,6 +437,7 @@ object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
+      euro2024,
       football,
       cricket,
       rugbyUnion,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -452,6 +452,13 @@
 			"iconName": "home",
 			"children": [
 				{
+					"title": "Euro 2024",
+					"url": "/football/euro-2024",
+					"longTitle": "football/euro-2024",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -1299,6 +1306,13 @@
 			"iconName": "home",
 			"children": [
 				{
+					"title": "Euro 2024",
+					"url": "/football/euro-2024",
+					"longTitle": "football/euro-2024",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Soccer",
 					"url": "/us/soccer",
 					"children": [
@@ -2023,6 +2037,13 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
+				{
+					"title": "Euro 2024",
+					"url": "/football/euro-2024",
+					"longTitle": "football/euro-2024",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Football",
 					"url": "/football",
@@ -2840,6 +2861,13 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
+				{
+					"title": "Euro 2024",
+					"url": "/football/euro-2024",
+					"longTitle": "football/euro-2024",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Football",
 					"url": "/football",
@@ -3846,6 +3874,13 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
+				{
+					"title": "Euro 2024",
+					"url": "/football/euro-2024",
+					"longTitle": "football/euro-2024",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Football",
 					"url": "/football",


### PR DESCRIPTION
## What is the value of this and can you measure success?
Fixes https://github.com/guardian/dotcom-rendering/issues/11587
## What does this change?
Adds euro 2024 to first place of sports nav across all editions
## Screenshots

<img width="972" alt="image" src="https://github.com/guardian/frontend/assets/110032454/9d671cae-a4a9-4525-b6b7-e20a874106d7">


-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
