### PR TITLE
Euro 2024 atom header

### DIFF
--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -1,6 +1,7 @@
 package conf.switches
 
 import conf.switches.Expiry.never
+import java.time.LocalDate
 
 trait JournalismSwitches {
 
@@ -71,6 +72,16 @@ trait JournalismSwitches {
     owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
     safeState = Off,
     sellByDate = never,
+    exposeClientSide = true,
+  )
+
+  val Euro2024Header = Switch(
+    SwitchGroup.Journalism,
+    name = "euro-2024-header",
+    description = "Show the Euro 2024 interactive atom header on football pages",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = LocalDate.of(2024, 7, 15),
     exposeClientSide = true,
   )
 }

--- a/common/app/views/fragments/atoms/interactive.scala.html
+++ b/common/app/views/fragments/atoms/interactive.scala.html
@@ -36,7 +36,7 @@
 @if(shouldFence) {
     <iframe class="interactive-atom-fence" srcdoc="@iframeBody.toString"></iframe>
 } else {
-    <figure class="interactive interactive-atom">
+    <figure class="interactive interactive-atom" style="margin: 0;">
         <style>
             @HtmlFormat.raw(interactive.css)
         </style>

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -97,6 +97,7 @@ class FixturesController(
                 contentApiClient
                   .getResponse(contentApiClient.item(id, edition))
                   .map(_.interactive.map(InteractiveAtom.make(_)))
+                  .recover{ case _ => None}
                   .map(renderMatchList(page, fixtures, filters, _))
               case _ =>
                 Future.successful(renderMatchList(page, fixtures, filters, None))

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -42,12 +42,12 @@ class FixturesController(
 
   private def renderAllFixtures(date: LocalDate): Action[AnyContent] =
     Action { implicit request =>
-      renderMatchList(page, fixtures(date), filters, None)
+      renderMatchList(page, fixtures(date), filters)
     }
 
   private def renderMoreFixtures(fixtures: Fixtures): Action[AnyContent] =
     Action { implicit request =>
-      renderMoreMatches(page, fixtures, filters, None)
+      renderMoreMatches(page, fixtures, filters)
     }
 
   def moreTagFixturesForJson(year: String, month: String, day: String, tag: String): Action[AnyContent] =

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -35,12 +35,12 @@ class FixturesController(
 
   private def renderAllFixtures(date: LocalDate): Action[AnyContent] =
     Action { implicit request =>
-      renderMatchList(page, fixtures(date), filters)
+      renderMatchList(page, fixtures(date), filters, None)
     }
 
   private def renderMoreFixtures(fixtures: Fixtures): Action[AnyContent] =
     Action { implicit request =>
-      renderMoreMatches(page, fixtures, filters)
+      renderMoreMatches(page, fixtures, filters, None)
     }
 
   def moreTagFixturesForJson(year: String, month: String, day: String, tag: String): Action[AnyContent] =
@@ -86,6 +86,7 @@ class FixturesController(
             result._1,
             result._2,
             filters,
+            None,
           )
         },
       )

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -11,6 +11,7 @@ import java.time.LocalDate
 import pa.FootballTeam
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import scala.concurrent.Future
+import conf.switches.Switches
 
 class FixturesController(
     val competitionsService: CompetitionsService,
@@ -86,35 +87,21 @@ class FixturesController(
 
   private def renderTagFixtures(date: LocalDate, tag: String): Action[AnyContent] =
     getTagFixtures(date, tag)
-      .map(result =>
-        Action.async { implicit request =>
-          tag match {
-            case "euro-2024" =>
-              val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
-              val edition = Edition(request)
-              contentApiClient
-                .getResponse(contentApiClient.item(id, edition))
-                .map(_.interactive.map(InteractiveAtom.make(_)))
-                .map(
-                  renderMatchList(
-                    result._1,
-                    result._2,
-                    filters,
-                    _,
-                  ),
-                )
-            case _ =>
-              Future(
-                renderMatchList(
-                  result._1,
-                  result._2,
-                  filters,
-                  None,
-                ),
-              )
+      .map {
+        case (page, fixtures) =>
+          Action.async { implicit request =>
+            tag match {
+              case "euro-2024" if Switches.Euro2024Header.isSwitchedOn =>
+                val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
+                val edition = Edition(request)
+                contentApiClient
+                  .getResponse(contentApiClient.item(id, edition))
+                  .map(_.interactive.map(InteractiveAtom.make(_)))
+                  .map(renderMatchList(page, fixtures, filters, _))
+              case _ =>
+                Future.successful(renderMatchList(page, fixtures, filters, None))
+            }
           }
-
-        },
-      )
+      }
       .getOrElse(Action(NotFound))
 }

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -97,7 +97,7 @@ class FixturesController(
                 contentApiClient
                   .getResponse(contentApiClient.item(id, edition))
                   .map(_.interactive.map(InteractiveAtom.make(_)))
-                  .recover{ case _ => None}
+                  .recover { case _ => None }
                   .map(renderMatchList(page, fixtures, filters, _))
               case _ =>
                 Future.successful(renderMatchList(page, fixtures, filters, None))

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -15,7 +15,7 @@ case class TablesPage(
     urlBase: String,
     filters: Map[String, Seq[CompetitionFilter]] = Map.empty,
     comp: Option[Competition],
-    atom: Option[InteractiveAtom],
+    atom: Option[InteractiveAtom] = None,
 ) {
   lazy val singleCompetition = tables.size == 1
 }
@@ -111,12 +111,11 @@ class LeagueTableController(
       val comps = competitionsService.competitions.filter(_.showInTeamsList).filter(_.hasTeams)
 
       val htmlResponse =
-        () =>
-          football.views.html.teamlist(TablesPage(page, groups, "/football", filters(tableOrder), None, None), comps)
+        () => football.views.html.teamlist(TablesPage(page, groups, "/football", filters(tableOrder), None), comps)
       val jsonResponse =
         () =>
           football.views.html.fragments
-            .teamlistBody(TablesPage(page, groups, "/football", filters(tableOrder), None, None), comps)
+            .teamlistBody(TablesPage(page, groups, "/football", filters(tableOrder), None), comps)
       renderFormat(htmlResponse, jsonResponse, page, Switches.all)
 
     }
@@ -211,7 +210,6 @@ class LeagueTableController(
                 table.competition.url,
                 filters(tableOrder),
                 Some(table.competition),
-                None,
               ),
             )
         val jsonResponse = () =>

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -86,11 +86,11 @@ class LeagueTableController(
       val htmlResponse =
         () =>
           football.views.html.tablesList
-            .tablesPage(TablesPage(page, groups, "/football", filters(tableOrder), None, None))
+            .tablesPage(TablesPage(page, groups, "/football", filters(tableOrder), None))
       val jsonResponse =
         () =>
           football.views.html.tablesList
-            .tablesPage(TablesPage(page, groups, "/football", filters(tableOrder), None, None))
+            .tablesPage(TablesPage(page, groups, "/football", filters(tableOrder), None))
       renderFormat(htmlResponse, jsonResponse, page, Switches.all)
 
     }

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -5,6 +5,9 @@ import conf.switches.Switches
 import feed.CompetitionsService
 import model._
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import model.content.InteractiveAtom
+import contentapi.ContentApiClient
+import scala.concurrent.Future
 
 case class TablesPage(
     page: Page,
@@ -12,6 +15,7 @@ case class TablesPage(
     urlBase: String,
     filters: Map[String, Seq[CompetitionFilter]] = Map.empty,
     comp: Option[Competition],
+    atom: Option[InteractiveAtom],
 ) {
   lazy val singleCompetition = tables.size == 1
 }
@@ -19,6 +23,7 @@ case class TablesPage(
 class LeagueTableController(
     val competitionsService: CompetitionsService,
     val controllerComponents: ControllerComponents,
+    val contentApiClient: ContentApiClient,
 )(implicit context: ApplicationContext)
     extends BaseController
     with GuLogging
@@ -80,10 +85,12 @@ class LeagueTableController(
 
       val htmlResponse =
         () =>
-          football.views.html.tablesList.tablesPage(TablesPage(page, groups, "/football", filters(tableOrder), None))
+          football.views.html.tablesList
+            .tablesPage(TablesPage(page, groups, "/football", filters(tableOrder), None, None))
       val jsonResponse =
         () =>
-          football.views.html.tablesList.tablesPage(TablesPage(page, groups, "/football", filters(tableOrder), None))
+          football.views.html.tablesList
+            .tablesPage(TablesPage(page, groups, "/football", filters(tableOrder), None, None))
       renderFormat(htmlResponse, jsonResponse, page, Switches.all)
 
     }
@@ -104,18 +111,19 @@ class LeagueTableController(
       val comps = competitionsService.competitions.filter(_.showInTeamsList).filter(_.hasTeams)
 
       val htmlResponse =
-        () => football.views.html.teamlist(TablesPage(page, groups, "/football", filters(tableOrder), None), comps)
+        () =>
+          football.views.html.teamlist(TablesPage(page, groups, "/football", filters(tableOrder), None, None), comps)
       val jsonResponse =
         () =>
           football.views.html.fragments
-            .teamlistBody(TablesPage(page, groups, "/football", filters(tableOrder), None), comps)
+            .teamlistBody(TablesPage(page, groups, "/football", filters(tableOrder), None, None), comps)
       renderFormat(htmlResponse, jsonResponse, page, Switches.all)
 
     }
 
   def renderCompetitionJson(competition: String): Action[AnyContent] = renderCompetition(competition)
   def renderCompetition(competition: String): Action[AnyContent] =
-    Action { implicit request =>
+    Action.async { implicit request =>
       val table = loadTables
         .find(_.competition.url.endsWith(s"/$competition"))
         .orElse(loadTables.find(_.competition.id == competition))
@@ -127,13 +135,30 @@ class LeagueTableController(
             s"${table.competition.fullName} table",
           )
 
+          val futureAtom = if (Switches.Euro2024Header.isSwitchedOn && competition == "euro-2024") {
+            val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
+            val edition = Edition(request)
+            contentApiClient
+              .getResponse(contentApiClient.item(id, edition))
+              .map(_.interactive.map(InteractiveAtom.make(_)))
+              .recover { case _ => None }
+          } else Future.successful(None)
+
           val smallTableGroup =
             table.copy(groups = table.groups.map { group => group.copy(entries = group.entries.take(10)) }).groups(0)
-          val htmlResponse = () =>
-            football.views.html.tablesList
-              .tablesPage(
-                TablesPage(page, Seq(table), table.competition.url, filters(tableOrder), Some(table.competition)),
-              )
+          val htmlResponse = (atom: Option[InteractiveAtom]) =>
+            () =>
+              football.views.html.tablesList
+                .tablesPage(
+                  TablesPage(
+                    page,
+                    Seq(table),
+                    table.competition.url,
+                    filters(tableOrder),
+                    Some(table.competition),
+                    atom,
+                  ),
+                )
           val jsonResponse = () =>
             football.views.html.tablesList.tablesComponent(
               table.competition,
@@ -142,14 +167,13 @@ class LeagueTableController(
               multiGroup = table.multiGroup,
             )
 
-          renderFormat(htmlResponse, jsonResponse, page)
-
+          futureAtom.map(maybeAtom => renderFormat(htmlResponse(maybeAtom), jsonResponse, page))
         }
         .getOrElse(
           if (request.isJson) {
-            Cached(60)(JsonNotFound())
+            Future.successful(Cached(60)(JsonNotFound()))
           } else {
-            Redirect("/football/tables")
+            Future.successful(Redirect("/football/tables"))
           },
         )
     }
@@ -181,7 +205,14 @@ class LeagueTableController(
         val htmlResponse = () =>
           football.views.html.tablesList
             .tablesPage(
-              TablesPage(page, Seq(groupTable), table.competition.url, filters(tableOrder), Some(table.competition)),
+              TablesPage(
+                page,
+                Seq(groupTable),
+                table.competition.url,
+                filters(tableOrder),
+                Some(table.competition),
+                None,
+              ),
             )
         val jsonResponse = () =>
           football.views.html.tablesList.tablesComponent(

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -35,7 +35,7 @@ class MatchDayController(
       val matches = MatchDayList(competitionsService.competitions, date)
       val webTitle = if (date == LocalDate.now(Edition.defaultEdition.timezoneId)) "Live matches" else "Matches"
       val page = new FootballPage("football/live", "football", webTitle)
-      renderMatchList(page, matches, filters, None)
+      renderMatchList(page, matches, filters)
     }
 
   def competitionMatchesJson(competitionTag: String): Action[AnyContent] = competitionMatches(competitionTag)
@@ -64,7 +64,7 @@ class MatchDayController(
               .map(_.interactive.map(InteractiveAtom.make(_)))
               .recover { case _ => None }
               .map(renderMatchList(page, matches, filters, _))
-          } else Future.successful(renderMatchList(page, matches, filters, None))
+          } else Future.successful(renderMatchList(page, matches, filters))
         }
         .getOrElse {
           Future.successful(NotFound)

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -34,7 +34,7 @@ class MatchDayController(
       val matches = MatchDayList(competitionsService.competitions, date)
       val webTitle = if (date == LocalDate.now(Edition.defaultEdition.timezoneId)) "Live matches" else "Matches"
       val page = new FootballPage("football/live", "football", webTitle)
-      renderMatchList(page, matches, filters)
+      renderMatchList(page, matches, filters, None)
     }
 
   def competitionMatchesJson(competitionTag: String): Action[AnyContent] = competitionMatches(competitionTag)
@@ -59,7 +59,7 @@ class MatchDayController(
           val maybeInteractiveAtom = contentApiClient.getResponse(contentApiClient.item("/atom/interactive/interactives/2023/01/euros-2024/match-centre-euros-2024-header", edition)).map(_.interactive.map(atom => InteractiveAtom.make(atom)))
           maybeInteractiveAtom.map(maybeAtom => {
             println(maybeAtom)
-            renderMatchList(page, matches, filters)
+            renderMatchList(page, matches, filters, maybeAtom)
           })
         }
         .getOrElse {

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -62,6 +62,7 @@ class MatchDayController(
             contentApiClient
               .getResponse(contentApiClient.item(id, edition))
               .map(_.interactive.map(InteractiveAtom.make(_)))
+              .recover{ case _ => None}
               .map(renderMatchList(page, matches, filters, _))
           } else Future.successful(renderMatchList(page, matches, filters, None))
         }

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -56,11 +56,10 @@ class MatchDayController(
           val page = new FootballPage(s"football/$competitionTag/live", "football", webTitle)
           val matches = CompetitionMatchDayList(competitionsService.competitions, competition.id, date)
           val edition = Edition(request)
-          val maybeInteractiveAtom = contentApiClient.getResponse(contentApiClient.item("/atom/interactive/interactives/2023/01/euros-2024/match-centre-euros-2024-header", edition)).map(_.interactive.map(atom => InteractiveAtom.make(atom)))
-          maybeInteractiveAtom.map(maybeAtom => {
-            println(maybeAtom)
-            renderMatchList(page, matches, filters, maybeAtom)
-          })
+          val id = "/atom/interactive/interactives/2023/01/euros-2024/match-centre-euros-2024-header"
+          contentApiClient.getResponse(contentApiClient.item(id, edition))
+            .map(_.interactive.map(InteractiveAtom.make(_)))
+            .map(renderMatchList(page, matches, filters, _))
         }
         .getOrElse {
           Future.successful(NotFound)

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -62,7 +62,7 @@ class MatchDayController(
             contentApiClient
               .getResponse(contentApiClient.item(id, edition))
               .map(_.interactive.map(InteractiveAtom.make(_)))
-              .recover{ case _ => None}
+              .recover { case _ => None }
               .map(renderMatchList(page, matches, filters, _))
           } else Future.successful(renderMatchList(page, matches, filters, None))
         }

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -57,7 +57,8 @@ class MatchDayController(
           val matches = CompetitionMatchDayList(competitionsService.competitions, competition.id, date)
           val edition = Edition(request)
           val id = "/atom/interactive/interactives/2023/01/euros-2024/match-centre-euros-2024-header"
-          contentApiClient.getResponse(contentApiClient.item(id, edition))
+          contentApiClient
+            .getResponse(contentApiClient.item(id, edition))
             .map(_.interactive.map(InteractiveAtom.make(_)))
             .map(renderMatchList(page, matches, filters, _))
         }

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -26,7 +26,7 @@ trait MatchListController extends BaseController with Requests {
       page: FootballPage,
       matchesList: MatchesList,
       filters: Map[String, Seq[CompetitionFilter]],
-      atom: Option[InteractiveAtom],
+      atom: Option[InteractiveAtom] = None,
   )(implicit request: RequestHeader, context: ApplicationContext) = {
     Cached(10) {
       if (request.isJson)
@@ -45,7 +45,7 @@ trait MatchListController extends BaseController with Requests {
       page: FootballPage,
       matchesList: MatchesList,
       filters: Map[String, Seq[CompetitionFilter]],
-      atom: Option[InteractiveAtom],
+      atom: Option[InteractiveAtom] = None,
   )(implicit request: RequestHeader, context: ApplicationContext) = {
     Cached(10) {
       if (request.isJson)

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -13,6 +13,7 @@ import play.api.mvc.{BaseController, RequestHeader}
 import play.twirl.api.Html
 
 import java.time.format.DateTimeFormatter
+import model.content.InteractiveAtom
 
 trait MatchListController extends BaseController with Requests {
   def competitionsService: Competitions
@@ -25,6 +26,7 @@ trait MatchListController extends BaseController with Requests {
       page: FootballPage,
       matchesList: MatchesList,
       filters: Map[String, Seq[CompetitionFilter]],
+      atom: Option[InteractiveAtom],
   )(implicit request: RequestHeader, context: ApplicationContext) = {
     Cached(10) {
       if (request.isJson)
@@ -32,9 +34,10 @@ trait MatchListController extends BaseController with Requests {
           "html" -> football.views.html.matchList.matchesComponent(matchesList),
           "next" -> Html(matchesList.nextPage.getOrElse("")),
           "previous" -> Html(matchesList.previousPage.getOrElse("")),
+          "atom" -> atom,
         )
       else
-        RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters))
+        RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters, atom))
     }
   }
 
@@ -42,6 +45,7 @@ trait MatchListController extends BaseController with Requests {
       page: FootballPage,
       matchesList: MatchesList,
       filters: Map[String, Seq[CompetitionFilter]],
+      atom: Option[InteractiveAtom],
   )(implicit request: RequestHeader, context: ApplicationContext) = {
     Cached(10) {
       if (request.isJson)
@@ -51,7 +55,7 @@ trait MatchListController extends BaseController with Requests {
           "previous" -> Html(matchesList.previousPage.getOrElse("")),
         )
       else
-        RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters))
+        RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters, atom))
     }
   }
 

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -34,7 +34,7 @@ trait MatchListController extends BaseController with Requests {
           "html" -> football.views.html.matchList.matchesComponent(matchesList),
           "next" -> Html(matchesList.nextPage.getOrElse("")),
           "previous" -> Html(matchesList.previousPage.getOrElse("")),
-          "atom" -> atom,
+          "atom" -> atom.isDefined,
         )
       else
         RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters, atom))

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -8,6 +8,7 @@ import model._
 import football.model._
 import pa.FootballTeam
 import model.Competition
+import model.content.InteractiveAtom
 
 class ResultsController(
     val competitionsService: CompetitionsService,
@@ -54,13 +55,13 @@ class ResultsController(
   }
 
   private def renderWith(
-      renderFunction: (FootballPage, Results, Map[String, Seq[CompetitionFilter]]) => Result,
+      renderFunction: (FootballPage, Results, Map[String, Seq[CompetitionFilter]], Option[InteractiveAtom]) => Result,
   )(date: LocalDate, tag: Option[String] = None): Result = {
     val result = for {
       p <- page(tag)
       r <- results(date, tag)
     } yield {
-      renderFunction(p, r, filters)
+      renderFunction(p, r, filters, None)
     }
     result.getOrElse(NotFound("No results"))
   }

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -4,7 +4,8 @@
 @import model.ApplicationContext
 @import views.html.fragments.commercial.pageLogo
 @import java.time.format.DateTimeFormatter
-@(page: FootballPage, matchesList: MatchesList, filters: Map[String, Seq[CompetitionFilter]])(
+@import model.content.InteractiveAtom
+@(page: FootballPage, matchesList: MatchesList, filters: Map[String, Seq[CompetitionFilter]], maybeAtom: Option[InteractiveAtom])(
     implicit request: RequestHeader, context: ApplicationContext
 )
 
@@ -14,6 +15,9 @@
     <article id="article" class="content content--footballfixtures" itemprop="mainContentOfPage" itemtype="http://schema.org/Article" role="main">
         <div class="content__main">
             <div class="gs-container">
+                <div class="interactive-atom-euro-2024" style="width: 100%;">
+                    @maybeAtom.map(atom => views.html.fragments.atoms.interactive(atom, shouldFence = false))
+                </div>
                 <div class="content__main-column">
                     <h2 class="hide-on-mobile-if-localnav content__inline-section page-type--football">
                     @matchesList.getPageTitle(Edition(request))

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -15,9 +15,7 @@
     <article id="article" class="content content--footballfixtures" itemprop="mainContentOfPage" itemtype="http://schema.org/Article" role="main">
         <div class="content__main">
             <div class="gs-container">
-                <div class="interactive-atom-euro-2024" style="width: 100%;">
-                    @maybeAtom.map(atom => views.html.fragments.atoms.interactive(atom, shouldFence = false))
-                </div>
+                @maybeAtom.map(atom => views.html.fragments.atoms.interactive(atom, shouldFence = false))
                 <div class="content__main-column">
                     <h2 class="hide-on-mobile-if-localnav content__inline-section page-type--football">
                     @matchesList.getPageTitle(Edition(request))

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -14,8 +14,12 @@
 <div class="l-side-margins">
     <article id="article" class="content content--footballfixtures" itemprop="mainContentOfPage" itemtype="http://schema.org/Article" role="main">
         <div class="content__main">
+            @maybeAtom.map{ atom =>
+                <div class="gs-container">
+                    @views.html.fragments.atoms.interactive(atom, shouldFence = false)
+                </div>
+            }
             <div class="gs-container">
-                @maybeAtom.map(atom => views.html.fragments.atoms.interactive(atom, shouldFence = false))
                 <div class="content__main-column">
                     <h2 class="hide-on-mobile-if-localnav content__inline-section page-type--football">
                     @matchesList.getPageTitle(Edition(request))

--- a/sport/app/football/views/tablesList/tablesPage.scala.html
+++ b/sport/app/football/views/tablesList/tablesPage.scala.html
@@ -8,6 +8,11 @@
 <div class="l-side-margins">
     <article id="article" class="content content--article tonal tonal--tone-news" itemprop="mainContentOfPage" itemtype="http://schema.org/Article" role="main">
         <div class="content__main tonal__main">
+            @page.atom.map{ atom =>
+                <div class="gs-container">
+                    @views.html.fragments.atoms.interactive(atom, shouldFence = false)
+                </div>
+            }
             <div class="gs-container">
                 <div class="content__main-column">
                     <@if(!page.singleCompetition){h1}else{h2} class="hide-on-mobile-if-localnav content__inline-section page-heading--football">

--- a/sport/app/football/views/wallchart/embed.scala.html
+++ b/sport/app/football/views/wallchart/embed.scala.html
@@ -8,7 +8,7 @@
     </head>
     <body id="top" itemscope itemtype="http://schema.org/WebPage">
         <div id="js-context" class="football-wallchart-embed">
-            @wallchart(competition, competitionStages, next)
+            @wallchart(competition, competitionStages, next, None)
             @fragments.analytics.base()(page, request, context)
         </div>
     </body>

--- a/sport/app/football/views/wallchart/page.scala.html
+++ b/sport/app/football/views/wallchart/page.scala.html
@@ -1,9 +1,10 @@
 @import _root_.football.model.CompetitionStageLike
 @import model.{Competition, Page}
+@import model.content.InteractiveAtom
 
-@(page: Page, competition: Competition, competitionStages: List[CompetitionStageLike], next: Option[pa.FootballMatch])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: Page, competition: Competition, competitionStages: List[CompetitionStageLike], next: Option[pa.FootballMatch], maybeAtom: Option[InteractiveAtom])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @mainLegacy(page, Some("football")){
 }{
-    @wallchart(competition, competitionStages, next)
+    @wallchart(competition, competitionStages, next, maybeAtom)
 }

--- a/sport/app/football/views/wallchart/wallchart.scala.html
+++ b/sport/app/football/views/wallchart/wallchart.scala.html
@@ -2,10 +2,16 @@
 @import model.Competition
 @import conf.switches.Switches
 @import conf.Configuration
+@import model.ApplicationContext
+@import model.content.InteractiveAtom
 
-@(competition: Competition, competitionStages: List[CompetitionStageLike], next: Option[pa.FootballMatch])(implicit request: RequestHeader)
-<div class="l-side-margins wc-overview">
-
+@(competition: Competition, competitionStages: List[CompetitionStageLike], next: Option[pa.FootballMatch], maybeAtom: Option[InteractiveAtom])(implicit request: RequestHeader, context: ApplicationContext)
+<div class="l-side-margins wc-overview content">
+    @maybeAtom.map{ atom =>
+        <div class="gs-container">
+            @views.html.fragments.atoms.interactive(atom, shouldFence = false)
+        </div>
+    }
     @competitionStages.map {
         case knockoutStage: _root_.football.model.KnockoutSpider => {
             <div class="facia-container facia-container--layout-content">

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -23,8 +23,8 @@ GET        /football/:tag/fixtures/more/:year/:month/:day.json                  
 GET        /football/:tag/fixtures/more/:year/:month/:day                                      football.controllers.FixturesController.moreTagFixturesFor(year, month, day, tag)
 GET        /football/:tag/fixtures/:year/:month/:day.json                                      football.controllers.FixturesController.tagFixturesForJson(year, month, day, tag)
 GET        /football/:tag/fixtures/:year/:month/:day                                           football.controllers.FixturesController.tagFixturesFor(year, month, day, tag)
-GET        /football/:tag/fixtures                                                             football.controllers.FixturesController.tagFixturesJson(tag)
-GET        /football/:tag/fixtures.json                                                        football.controllers.FixturesController.tagFixtures(tag)
+GET        /football/:tag/fixtures                                                             football.controllers.FixturesController.tagFixtures(tag)
+GET        /football/:tag/fixtures.json                                                        football.controllers.FixturesController.tagFixturesJson(tag)
 
 GET        /football/results/:year/:month/:day.json                                            football.controllers.ResultsController.allResultsForJson(year, month, day)
 GET        /football/results/:year/:month/:day                                                 football.controllers.ResultsController.allResultsFor(year, month, day)

--- a/sport/test/LeagueTablesFeatureTest.scala
+++ b/sport/test/LeagueTablesFeatureTest.scala
@@ -18,7 +18,8 @@ import org.scalatest.matchers.should.Matchers
     with BeforeAndAfterAll
     with WithMaterializer
     with WithTestApplicationContext
-    with WithTestWsClient {
+    with WithTestWsClient
+    with WithTestContentApiClient {
 
   Feature("League Tables") {
 
@@ -67,7 +68,7 @@ import org.scalatest.matchers.should.Matchers
 
     Scenario("Should redirect when no competition table data found") {
       val leagueTableController =
-        new LeagueTableController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents())
+        new LeagueTableController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents(), testContentApiClient)
       val result = leagueTableController.renderCompetition("sfgsfgsfg")(FakeRequest())
       status(result) should be(303)
     }

--- a/sport/test/LeagueTablesFeatureTest.scala
+++ b/sport/test/LeagueTablesFeatureTest.scala
@@ -68,7 +68,11 @@ import org.scalatest.matchers.should.Matchers
 
     Scenario("Should redirect when no competition table data found") {
       val leagueTableController =
-        new LeagueTableController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents(), testContentApiClient)
+        new LeagueTableController(
+          testCompetitionsService,
+          play.api.test.Helpers.stubControllerComponents(),
+          testContentApiClient,
+        )
       val result = leagueTableController.renderCompetition("sfgsfgsfg")(FakeRequest())
       status(result) should be(303)
     }

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -17,14 +17,19 @@ import org.scalatest.matchers.should.Matchers
     with WithMaterializer
     with BeforeAndAfterAll
     with WithTestApplicationContext
-    with WithTestWsClient {
+    with WithTestWsClient
+    with WithTestContentApiClient {
 
   val fixturesUrl = "/football/fixtures"
   val fixtureForUrl = "/football/fixtures/2012/oct/20"
   val tag = "premierleague"
 
   lazy val fixturesController =
-    new FixturesController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents())
+    new FixturesController(
+      testCompetitionsService,
+      play.api.test.Helpers.stubControllerComponents(),
+      testContentApiClient,
+    )
 
   "can load the all fixtures page" in {
     val result = fixturesController.allFixtures()(TestRequest())

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -21,7 +21,11 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
     with WithTestContentApiClient {
 
   lazy val leagueTableController =
-    new LeagueTableController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents(), testContentApiClient)
+    new LeagueTableController(
+      testCompetitionsService,
+      play.api.test.Helpers.stubControllerComponents(),
+      testContentApiClient,
+    )
 
   "League Table Controller" should "200 when content type is table" in {
     val result = leagueTableController.renderLeagueTables()(TestRequest())

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -17,10 +17,11 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
     with BeforeAndAfterAll
     with WithTestApplicationContext
     with WithTestExecutionContext
-    with WithTestWsClient {
+    with WithTestWsClient
+    with WithTestContentApiClient {
 
   lazy val leagueTableController =
-    new LeagueTableController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents())
+    new LeagueTableController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents(), testContentApiClient)
 
   "League Table Controller" should "200 when content type is table" in {
     val result = leagueTableController.renderLeagueTables()(TestRequest())


### PR DESCRIPTION
## What is the value of this and can you measure success?

Make the Euro 2024 **stand out** and be consistent across all relevant pages.

Part of https://github.com/guardian/dotcom-rendering/issues/11553

## What does this change?

Insert the euro 2024 header interactive atom on selected sport pages.

## Screenshots

<img width="1029" alt="image" src="https://github.com/guardian/frontend/assets/76776/d10f06d0-ccbf-487f-b428-15272cbc39b9">

<img width="1424" alt="image" src="https://github.com/guardian/frontend/assets/76776/2da578cd-fa84-4ac4-8ce7-aab6ad9dd9c9">

<img width="779" alt="image" src="https://github.com/guardian/frontend/assets/76776/9346999a-2d61-4e29-8d0d-3bae94f5d664">


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
