### PR TITLE
Euro 2024: Three groups to a row instead of four

### DIFF
--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -228,11 +228,8 @@
         }
 
         @include mq(desktop) {
-            width: 24.5%;
-        }
-
-        @include mq(leftCol) {
-            &:nth-of-type(-n+4) {
+            width: 33.3%;
+            &:nth-of-type(-n + 3) {
                 .table--league-table {
                     border: 0;
                     .table__caption--top {


### PR DESCRIPTION
## What does this change?

Reduces the number of items in a row from 4 to 3 on the Euro 2024 groups

## Why?

Readability

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/9574885/efef4cb4-efc8-478a-96a4-082c5f70fd91
[after]: https://github.com/guardian/frontend/assets/9574885/d59866ef-5bfc-4f44-9a49-676e288547d3

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
