### PR TITLE
Use correct “Match centre” atom url for Euro 2024 header

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -135,7 +135,7 @@ class LeagueTableController(
           )
 
           val futureAtom = if (Switches.Euro2024Header.isSwitchedOn && competition == "euro-2024") {
-            val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
+            val id = "/atom/interactive/interactives/2023/01/euros-2024/match-centre-euros-2024-header"
             val edition = Edition(request)
             contentApiClient
               .getResponse(contentApiClient.item(id, edition))


### PR DESCRIPTION
## What is the value of this and can you measure success?

Not a jarring user experience.

Part of https://github.com/guardian/dotcom-rendering/issues/11553

## What does this change?

What it says on the tin

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/76776/877ea6b1-7fbb-4346-90a1-c124a812516e
[after]: https://github.com/guardian/frontend/assets/76776/84d1e9a8-914f-4801-9432-f92b19e87b8a

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
