### PR TITLE
Use correct “Match centre” atom url for Euro 2024 header (bis)

### DIFF
--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -92,7 +92,7 @@ class FixturesController(
           Action.async { implicit request =>
             tag match {
               case "euro-2024" if Switches.Euro2024Header.isSwitchedOn =>
-                val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
+                val id = "/atom/interactive/interactives/2023/01/euros-2024/match-centre-euros-2024-header"
                 val edition = Edition(request)
                 contentApiClient
                   .getResponse(contentApiClient.item(id, edition))

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -135,7 +135,7 @@ class LeagueTableController(
           )
 
           val futureAtom = if (Switches.Euro2024Header.isSwitchedOn && competition == "euro-2024") {
-            val id = "/atom/interactive/interactives/2023/01/euros-2024/match-centre-euros-2024-header"
+            val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
             val edition = Edition(request)
             contentApiClient
               .getResponse(contentApiClient.item(id, edition))


### PR DESCRIPTION
## What is the value of this and can you measure success?

Opposite of #27224 – but correctly this time