### PR TITLE
Fix Euro 2024 subnav item

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -109,8 +109,7 @@ object NavLinks {
   val letters = NavLink("Letters", "/tone/letters")
 
   /* SPORT */
-
-  private val euro2024 = NavLink("Euro 2024", "/football/euro-2024", Some("football/euro-2024"))
+  private val euro2024 = NavLink("Euro 2024", "/football/euro-2024")
   private val footballScores = NavLink("Live scores", "/football/live", Some("football/live"))
   private val footballTables = NavLink("Tables", "/football/tables", Some("football/tables"))
   private val footballFixtures = NavLink("Fixtures", "/football/fixtures", Some("football/fixtures"))

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -170,7 +170,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -454,7 +453,6 @@
 				{
 					"title": "Euro 2024",
 					"url": "/football/euro-2024",
-					"longTitle": "football/euro-2024",
 					"children": [],
 					"classList": []
 				},
@@ -465,7 +463,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -1153,7 +1150,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -1308,7 +1304,6 @@
 				{
 					"title": "Euro 2024",
 					"url": "/football/euro-2024",
-					"longTitle": "football/euro-2024",
 					"children": [],
 					"classList": []
 				},
@@ -1319,7 +1314,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2040,7 +2034,6 @@
 				{
 					"title": "Euro 2024",
 					"url": "/football/euro-2024",
-					"longTitle": "football/euro-2024",
 					"children": [],
 					"classList": []
 				},
@@ -2051,7 +2044,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2672,7 +2664,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2864,7 +2855,6 @@
 				{
 					"title": "Euro 2024",
 					"url": "/football/euro-2024",
-					"longTitle": "football/euro-2024",
 					"children": [],
 					"classList": []
 				},
@@ -2875,7 +2865,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -3685,7 +3674,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -3877,7 +3865,6 @@
 				{
 					"title": "Euro 2024",
 					"url": "/football/euro-2024",
-					"longTitle": "football/euro-2024",
 					"children": [],
 					"classList": []
 				},
@@ -3888,7 +3875,6 @@
 						{
 							"title": "Euro 2024",
 							"url": "/football/euro-2024",
-							"longTitle": "football/euro-2024",
 							"children": [],
 							"classList": []
 						},


### PR DESCRIPTION
## What does this change?

Fixes the display name for the Euro 2024 link in the subnav

## Screenshots

| Before          | After           |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/9574885/492ea79b-6eb5-44c0-875d-38fd2ff5ee78
[after]: https://github.com/guardian/frontend/assets/9574885/7bb49a91-f1bf-4160-8d9d-1e22248adba1

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
