### PR TITLE
Enable increasing load from switchboard

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -206,4 +206,24 @@ trait PerformanceSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val ShorterSurrogateCacheForRecentArticles = Switch(
+    SwitchGroup.Performance,
+    "shorter-surrogate-cache-for-recent-articles",
+    "Shorten the surrogate cache time for recent articles for load testing",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = LocalDate.of(2024, 7, 1),
+    exposeClientSide = false,
+  )
+
+  val ShorterSurrogateCacheForOlderArticles = Switch(
+    SwitchGroup.Performance,
+    "shorter-surrogate-cache-for-older-articles",
+    "Shorten the surrogate cache time for older articles for load testing",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = LocalDate.of(2024, 7, 1),
+    exposeClientSide = false,
+  )
 }

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -1,6 +1,8 @@
 package model
 
 import conf.switches.Switches.LongCacheSwitch
+import conf.switches.Switches.ShorterSurrogateCacheForOlderArticles
+import conf.switches.Switches.ShorterSurrogateCacheForRecentArticles
 import org.joda.time.DateTime
 import play.api.http.Writeable
 import play.api.mvc._
@@ -17,7 +19,7 @@ object CacheTime {
 
   object Default extends CacheTime(60)
   object LiveBlogActive extends CacheTime(5, Some(60))
-  object RecentlyUpdated extends CacheTime(60)
+  def RecentlyUpdated = CacheTime(60, if (ShorterSurrogateCacheForRecentArticles.isSwitchedOn) Some(30) else None)
   // There is lambda which invalidates the cache on press events, so the facia cache time can be high.
   object Facia extends CacheTime(60, Some(900))
   object ArchiveRedirect extends CacheTime(60, Some(300))
@@ -25,9 +27,9 @@ object CacheTime {
   object NotFound extends CacheTime(10) // This will be overwritten by fastly
   object DiscussionDefault extends CacheTime(60)
   object DiscussionClosed extends CacheTime(60, Some(longCacheTime))
-
-  def LastDayUpdated: CacheTime = CacheTime(60, Some(longCacheTime))
-  def NotRecentlyUpdated: CacheTime = CacheTime(60, Some(longCacheTime))
+  private def oldArticleCacheTime = if (ShorterSurrogateCacheForOlderArticles.isSwitchedOn) 60 else longCacheTime
+  def LastDayUpdated = CacheTime(60, Some(oldArticleCacheTime))
+  def NotRecentlyUpdated = CacheTime(60, Some(oldArticleCacheTime))
 }
 
 object Cached extends implicits.Dates {
@@ -111,8 +113,10 @@ object Cached extends implicits.Dates {
   private def cacheHeaders(cacheTime: CacheTime, result: Result, maybeEtag: Option[String]): Result = {
     val now = DateTime.now
 
-    val surrogateMaxAge =
-      cacheTime.surrogateSeconds.filter(_ => LongCacheSwitch.isSwitchedOn).getOrElse(cacheTime.cacheSeconds)
+    val surrogateMaxAge = cacheTime.surrogateSeconds match {
+      case Some(age) if LongCacheSwitch.isSwitchedOn => age
+      case _                                         => cacheTime.cacheSeconds
+    }
 
     val etagHeaderString: String = maybeEtag.getOrElse(
       s""""guRandomEtag${scala.util.Random.nextInt()}${scala.util.Random


### PR DESCRIPTION
## What is the value of this and can you measure success?

Enable load testing of our system without a deploy.
Part of https://github.com/guardian/dotcom-rendering/issues/11670

## What does this change?

Conditinally set the `Surrogate-Control` based on a switch

## Checklist

- [x] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering (but it could topple it over)
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
