### PR TITLE
Remove custom "decade" logo for australia edition

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -30,8 +30,6 @@
                             fragments.inlineSvg("the-guardian-roundel", "logo")
                         } else if(editionId == "uk") {
                             fragments.inlineSvg("guardian-news-provider-logo", "logo")
-                        } else if(editionId == "au") {
-                            fragments.inlineSvg("guardian-australia-decade-logo", "logo")
                         } else {
                             fragments.inlineSvg("the-guardian-logo", "logo")
                         }

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -154,8 +154,6 @@
             @{
             if(editionId == "uk") {
             fragments.inlineSvg("guardian-news-provider-logo", "logo")
-            } else if(editionId == "au") {
-            fragments.inlineSvg("guardian-australia-decade-logo", "logo")
             } else {
             fragments.inlineSvg("the-guardian-logo", "logo")
             }

--- a/static/src/stylesheets/layout/nav/_header-top-nav.scss
+++ b/static/src/stylesheets/layout/nav/_header-top-nav.scss
@@ -251,7 +251,7 @@ from scrolling */
 }
 
 .inline-guardian-best-website-logo, .inline-guardian-news-provider-logo,
-.inline-guardian-best-newspaper-logo, .inline-guardian-australia-decade-logo {
+.inline-guardian-best-newspaper-logo {
     display: block;
     height: auto;
     width: 146px;

--- a/static/src/stylesheets/layout/nav/_new-header.scss
+++ b/static/src/stylesheets/layout/nav/_new-header.scss
@@ -184,7 +184,7 @@ from scrolling */
     }
 }
 
-.inline-guardian-best-website-logo, .inline-guardian-australia-decade-logo {
+.inline-guardian-best-website-logo {
     display: block;
     height: auto;
     width: 146px;


### PR DESCRIPTION
## What does this change?
 The 'a decade of making a difference' has been removed from the Australian edition, because we are now past a decade. Instead, it will show the standard logo like the Int, US and Europe editions. 

## Why?
This was requested by Editorial.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/20416599/99cf90ad-8a1f-4e9f-bc6d-9e67855df7de
[after]: https://github.com/guardian/frontend/assets/20416599/5d458418-56bf-40ce-8ffd-8afb2695cd64




## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
