### PR TITLE
Only show the crossword-banner ad if there's a comments section

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -43,12 +43,14 @@
                     </div>
                 </div>
                 @if(adsEnabled) {
-                <div class="content__secondary-column hide-until-wide" aria-hidden="true">
-                    @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map())
-                </div>
-                <div class="crossword-banner hide-until-tablet hide-from-wide" aria-hidden="true">
-                    @fragments.commercial.standardAd("crossword-banner", Seq("crossword-banner"), Map())
-                </div>
+                    <div class="content__secondary-column hide-until-wide" aria-hidden="true">
+                        @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map())
+                    </div>
+                    @if(crosswordPage.item.trail.isCommentable) {
+                        <div class="crossword-banner hide-until-tablet hide-from-wide" aria-hidden="true">
+                            @fragments.commercial.standardAd("crossword-banner", Seq("crossword-banner"), Map())
+                        </div>
+                    }
                 }
             </div>
         </div>


### PR DESCRIPTION
## What does this change?
At the moment we're showing a crossword-banner ad and a merch high ad between the 740px and 1300px breakpoints on crosswords. This is fine for crosswords with comments, as the comments section acts as a buffer between the two ads. However, not all crosswords are commentable, so for those we shouldn't show any crossword-banner ad as it doesn't look great.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="633" alt="Screenshot 2024-06-20 at 17 13 01" src="https://github.com/guardian/frontend/assets/108270776/1d798b04-72df-465c-812b-120dd70b4793"> | <img width="634" alt="Screenshot 2024-06-20 at 17 13 09" src="https://github.com/guardian/frontend/assets/108270776/3d3e5bc2-665a-41e9-b9c5-1ba65ee74767"> |





