### PR TITLE
Use 375px width for mobile viewport in responsive viewer rather than 320px

### DIFF
--- a/preview/app/views/responsive_viewer.scala.html
+++ b/preview/app/views/responsive_viewer.scala.html
@@ -4,7 +4,7 @@
     <head>
         <script>
             var breakpoints = [
-                { width: 320, height: 480, name: "Mobile" },
+                { width: 375, height: 480, name: "Mobile" },
                 { width: 1295, height: 1024, name: "Desktop" },
                 { width: 768, height: 1024, name: "Tablet portrait" },
                 { width: 1024, height: 768, name: "Tablet landscape" }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Uses 375px width for the mobile viewport in the responsive viewer since this better represents the size of mobile devices nowadays. There are very few devices in use in 2024 with a 320px screen width. This should help editorial staff preview content in a way that best represents how the majority of users will see it.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/43961396/d98a6550-0295-4b07-bc83-34ab056eb443
[after]: https://github.com/guardian/frontend/assets/43961396/fce3dd9c-38ae-44cd-bec8-0f83b8b23e70




## Checklist

- [x] Tested ~locally~, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
