### PR TITLE
All task runner `require` calls are static

### DIFF
--- a/tools/__tasks__/compile/conf/index.js
+++ b/tools/__tasks__/compile/conf/index.js
@@ -1,9 +1,12 @@
+const copy = require('./copy.js');
+const inlineSVGs = require('../inline-svgs/index.js');
+
 const task = {
 	description: 'Compile assets for template rendering in Play',
 	task: [
 		// prettier: multi-line
-		require('./copy'),
-		require('../inline-svgs'),
+		copy,
+		inlineSVGs,
 	],
 };
 

--- a/tools/__tasks__/compile/css/index.dev.js
+++ b/tools/__tasks__/compile/css/index.dev.js
@@ -1,11 +1,16 @@
+const clean = require('./clean.js');
+const mkdir = require('./mkdir.js');
+const images = require('../images/index.js');
+const sass = require('./sass.js');
+
 const task = {
 	description: 'Compile CSS',
 	task: [
 		// prettier: multi-line
-		require('./clean'),
-		require('./mkdir'),
-		require('../images'),
-		require('./sass'),
+		clean,
+		mkdir,
+		images,
+		sass,
 	],
 };
 

--- a/tools/__tasks__/compile/css/index.js
+++ b/tools/__tasks__/compile/css/index.js
@@ -1,11 +1,16 @@
+const clean = require('./clean.js');
+const mkdir = require('./mkdir.js');
+const images = require('../images/index.js');
+const sass = require('./sass.js');
+
 const task = {
 	description: 'Compile CSS',
 	task: [
 		// prettier: multi-line
-		require('./clean'),
-		require('./mkdir'),
-		require('../images'),
-		require('./sass'),
+		clean,
+		mkdir,
+		images,
+		sass,
 	],
 };
 

--- a/tools/__tasks__/compile/data/index.dev.js
+++ b/tools/__tasks__/compile/data/index.dev.js
@@ -1,10 +1,14 @@
+const clean = require('./clean.js');
+const download = require('./download.js');
+const amp = require('./amp.js');
+
 const task = {
 	description: 'Clean download and build data assets (dev)',
 	task: [
 		// prettier: multi-line
-		require('./clean'),
-		require('./download'),
-		require('./amp'),
+		clean,
+		download,
+		amp,
 	],
 };
 

--- a/tools/__tasks__/compile/data/index.js
+++ b/tools/__tasks__/compile/data/index.js
@@ -1,10 +1,15 @@
+const clean = require('./clean.js');
+const download = require('./download.js');
+const amp = require('./amp.js');
+
 const task = {
 	description: 'Clean download and build data assets',
 	task: [
 		// prettier: multi-line
-		require('./clean'),
-		require('./download'),
-		require('./amp'),
+		clean,
+		download,
+		amp,
 	],
 };
+
 module.exports = task;

--- a/tools/__tasks__/compile/data/index.watch.js
+++ b/tools/__tasks__/compile/data/index.watch.js
@@ -1,10 +1,14 @@
+const clean = require('./clean.js');
+const download = require('./download.js');
+const amp = require('./amp.js');
+
 const task = {
 	description: 'Clean, download and build data assets (watch)',
 	task: [
 		// prettier: multi-line
-		require('./clean'),
-		require('./download'),
-		require('./amp'),
+		clean,
+		download,
+		amp,
 	],
 };
 

--- a/tools/__tasks__/compile/hash/index.js
+++ b/tools/__tasks__/compile/hash/index.js
@@ -9,12 +9,13 @@ const pify = require('pify');
 
 const writeFile = pify(fs.writeFile);
 
+const clean = require('./clean.js');
 const { paths } = require('../../config');
 
 const task = {
 	description: 'Version assets',
 	task: [
-		require('./clean'),
+		clean,
 		{
 			description: 'Hash assets',
 			task: () => {

--- a/tools/__tasks__/compile/images/icons.js
+++ b/tools/__tasks__/compile/images/icons.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const { paths } = require('../../config');
 
 const fs = require('fs');

--- a/tools/__tasks__/compile/images/index.js
+++ b/tools/__tasks__/compile/images/index.js
@@ -1,11 +1,16 @@
+const clean = require('./clean.js');
+const copy = require('./copy.js');
+const icons = require('./icons.js');
+const svg = require('./svg.js');
+
 const task = {
 	description: 'Compile images',
 	task: [
 		// prettier: multi-line
-		require('./clean'),
-		require('./copy'),
-		require('./icons'),
-		require('./svg'),
+		clean,
+		copy,
+		icons,
+		svg,
 	],
 };
 

--- a/tools/__tasks__/compile/index.dev.js
+++ b/tools/__tasks__/compile/index.dev.js
@@ -1,12 +1,18 @@
+const clean = require('./conf/clean.js');
+const css = require('./css/index.dev.js');
+const data = require('./data/index.dev.js');
+const javascript = require('./javascript/index.dev.js');
+const conf = require('./conf/index.js');
+
 const task = {
 	description: 'Compile assets for development',
 	task: [
 		// prettier: multi-line
-		require('./conf/clean'),
-		require('./css/index.dev'),
-		require('./data/index.dev'),
-		require('./javascript/index.dev'),
-		require('./conf'),
+		clean,
+		css,
+		data,
+		javascript,
+		conf,
 	],
 };
 

--- a/tools/__tasks__/compile/index.js
+++ b/tools/__tasks__/compile/index.js
@@ -1,13 +1,20 @@
+const clean = require('./conf/clean.js');
+const css = require('./css/index.js');
+const data = require('./data/index.js');
+const javascript = require('./javascript/index.js');
+const hash = require('./hash/index.js');
+const conf = require('./conf/index.js');
+
 const task = {
 	description: 'Compile assets for production',
 	task: [
 		// prettier: multi-line
-		require('./conf/clean'),
-		require('./css'),
-		require('./data'),
-		require('./javascript'),
-		require('./hash'),
-		require('./conf'),
+		clean,
+		css,
+		data,
+		javascript,
+		hash,
+		conf,
 	],
 };
 

--- a/tools/__tasks__/compile/index.watch.js
+++ b/tools/__tasks__/compile/index.watch.js
@@ -1,12 +1,18 @@
+const clean = require('./conf/clean.js');
+const css = require('./css/index.dev.js');
+const data = require('./data/index.watch.js');
+const javascript = require('./javascript/index.watch.js');
+const conf = require('./conf/index.js');
+
 const task = {
 	description: 'Compile assets for development',
 	task: [
 		// prettier: multi-line
-		require('./conf/clean'),
-		require('./css/index.dev'),
-		require('./data/index.watch'),
-		require('./javascript/index.watch'),
-		require('./conf'),
+		clean,
+		css,
+		data,
+		javascript,
+		conf,
 	],
 };
 

--- a/tools/__tasks__/compile/javascript/index.atoms.js
+++ b/tools/__tasks__/compile/javascript/index.atoms.js
@@ -1,10 +1,14 @@
+const clean = require('./clean');
+const inlineSVGs = require('../inline-svgs');
+const webpackAtoms = require('./webpack-atoms');
+
 const task = {
 	description: 'Compile JS',
 	task: [
 		// prettier: multi-line
-		require('./clean'),
-		require('../inline-svgs'),
-		require('./webpack-atoms'),
+		clean,
+		inlineSVGs,
+		webpackAtoms,
 	],
 };
 

--- a/tools/__tasks__/compile/javascript/index.dev.js
+++ b/tools/__tasks__/compile/javascript/index.dev.js
@@ -1,14 +1,20 @@
+const inlineSVGs = require('../inline-svgs/index.js');
+const clean = require('./clean.js');
+const copy = require('./copy.js');
+const webpack = require('./webpack.dev');
+const webpackDCR = require('./webpack-dcr.dev');
+const bundlePolyfills = require('./bundle-polyfills');
+
 const task = {
 	description: 'Prepare JS for development',
 	task: [
 		// prettier: multi-line
-		require('../inline-svgs'),
-		require('./clean'),
-		require('./copy'),
-		require('../../commercial/compile'),
-		require('./webpack.dev'),
-		require('./webpack-dcr.dev'),
-		require('./bundle-polyfills'),
+		inlineSVGs,
+		clean,
+		copy,
+		webpack,
+		webpackDCR,
+		bundlePolyfills,
 	],
 };
 

--- a/tools/__tasks__/compile/javascript/index.js
+++ b/tools/__tasks__/compile/javascript/index.js
@@ -1,13 +1,20 @@
+const clean = require('./clean.js');
+const inlineSVGs = require('../inline-svgs/index.js');
+const copy = require('./copy.js');
+const webpack = require('./webpack.js');
+const webpackAtoms = require('./webpack-atoms.js');
+const bundlePolyfills = require('./bundle-polyfills.js');
+
 const task = {
 	description: 'Compile JS',
 	task: [
 		// prettier: multi-line
-		require('./clean'),
-		require('../inline-svgs'),
-		require('./copy'),
-		require('./webpack'),
-		require('./webpack-atoms'),
-		require('./bundle-polyfills'),
+		clean,
+		inlineSVGs,
+		copy,
+		webpack,
+		webpackAtoms,
+		bundlePolyfills,
 	],
 };
 

--- a/tools/__tasks__/compile/javascript/index.watch.js
+++ b/tools/__tasks__/compile/javascript/index.watch.js
@@ -1,11 +1,16 @@
+const inlineSVGs = require('../inline-svgs/index.js');
+const clean = require('./clean.js');
+const copy = require('./copy.js');
+const bundlePolyfills = require('./bundle-polyfills.js');
+
 const task = {
 	description: 'Prepare JS for development',
 	task: [
 		// prettier: multi-line
-		require('../inline-svgs'),
-		require('./clean'),
-		require('./copy'),
-		require('./bundle-polyfills'),
+		inlineSVGs,
+		clean,
+		copy,
+		bundlePolyfills,
 	],
 };
 

--- a/tools/__tasks__/compile/javascript/webpack-atoms.js
+++ b/tools/__tasks__/compile/javascript/webpack-atoms.js
@@ -6,15 +6,13 @@ const webpack = require('webpack');
 const chalk = require('chalk');
 
 const config = require('../../../../webpack.config.atoms.js');
+const reporter = require('../../../webpack-progress-reporter.js');
 
 const task = {
 	description: 'Create Webpack bundles for atoms',
 	task: () =>
 		new Observable((observer) => {
-			config.plugins = [
-				require('../../../webpack-progress-reporter')(observer),
-				...config.plugins,
-			];
+			config.plugins = [reporter(observer), ...config.plugins];
 
 			const bundler = webpack(config);
 

--- a/tools/__tasks__/compile/javascript/webpack.dev.js
+++ b/tools/__tasks__/compile/javascript/webpack.dev.js
@@ -6,15 +6,13 @@ const webpack = require('webpack');
 const chalk = require('chalk');
 
 const config = require('../../../../webpack.config.dev.js');
+const reporter = require('../../../webpack-progress-reporter.js');
 
 const task = {
 	description: 'Create Webpack bundles',
 	task: () =>
 		new Observable((observer) => {
-			config.plugins = [
-				require('../../../webpack-progress-reporter')(observer),
-				...config.plugins,
-			];
+			config.plugins = [reporter(observer), ...config.plugins];
 
 			const bundler = webpack(config);
 

--- a/tools/__tasks__/compile/javascript/webpack.js
+++ b/tools/__tasks__/compile/javascript/webpack.js
@@ -6,15 +6,13 @@ const webpack = require('webpack');
 const chalk = require('chalk');
 
 const config = require('../../../../webpack.config.prod.js');
+const reporter = require('../../../webpack-progress-reporter.js');
 
 const task = {
 	description: 'Create Webpack bundles',
 	task: () =>
 		new Observable((observer) => {
-			config.plugins = [
-				require('../../../webpack-progress-reporter')(observer),
-				...config.plugins,
-			];
+			config.plugins = [reporter(observer), ...config.plugins];
 
 			const bundler = webpack(config);
 

--- a/tools/__tasks__/test/index.js
+++ b/tools/__tasks__/test/index.js
@@ -1,9 +1,12 @@
+const data = require('../compile/data/index.js');
+const javascript = require('./javascript/index.js');
+
 const task = {
 	description: 'Test assets',
 	task: [
 		// prettier: multi-line
-		require('../compile/data'),
-		require('./javascript'),
+		data,
+		javascript,
 	],
 	concurrent: true,
 };

--- a/tools/__tasks__/validate-head/index.js
+++ b/tools/__tasks__/validate-head/index.js
@@ -1,9 +1,12 @@
+const javascript = require('./javascript');
+const sass = require('./sass');
+
 const task = {
 	description: 'Validate commits',
 	task: [
 		// prettier: multi-line
-		require('./javascript'),
-		require('./sass'),
+		javascript,
+		sass,
 	],
 	concurrent: true,
 };

--- a/tools/__tasks__/validate-head/index.js
+++ b/tools/__tasks__/validate-head/index.js
@@ -1,5 +1,5 @@
-const javascript = require('./javascript');
-const sass = require('./sass');
+const javascript = require('./javascript.js');
+const sass = require('./sass.js');
 
 const task = {
 	description: 'Validate commits',

--- a/tools/__tasks__/validate/index.js
+++ b/tools/__tasks__/validate/index.js
@@ -1,11 +1,16 @@
+const javascript = require('./javascript.js');
+const typescript = require('./typescript.js');
+const sass = require('./sass.js');
+const checkForDisallowedStrings = require('./check-for-disallowed-strings.js');
+
 const task = {
 	description: 'Lint assets',
 	task: [
 		// prettier: multi-line
-		require('./javascript'),
-		require('./typescript'),
-		require('./sass'),
-		require('./check-for-disallowed-strings'),
+		javascript,
+		typescript,
+		sass,
+		checkForDisallowedStrings,
 	],
 	concurrent: true,
 };


### PR DESCRIPTION
## What is the value of this and can you measure success?

Paves the way for the upcoming [ESM migration](https://github.com/guardian/frontend/pull/27247).

## What does this change?

Extract dynamic `require` calls to top-level static ones.
