### PR TITLE
Add AB tests for new Sticky Liveblog Ask component

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -54,4 +54,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2024, 7, 31)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-sticky-liveblog-ask-test",
+    "A sticky reader revenue ask on the left column of a liveblog",
+    owners = Seq(Owner.withEmail("growth@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 7, 31)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
+import { stickyLiveBlogAskTest } from './tests/sticky-liveblog-ask';
 
 // keep in sync with ab-tests in dotcom-rendering
 // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -13,4 +14,5 @@ export const concurrentTests: readonly ABTest[] = [
 	remoteRRHeaderLinksTest,
 	mpuWhenNoEpic,
 	deeplyReadRightColumn,
+	stickyLiveBlogAskTest,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sticky-liveblog-ask.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sticky-liveblog-ask.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const stickyLiveBlogAskTest: ABTest = {
+	id: 'StickyLiveBlogAskTest',
+	author: '@growth',
+	start: '2024-07-01',
+	expiry: '2024-07-31',
+	audience: 1,
+	audienceOffset: 0,
+	audienceCriteria: 'everyone',
+	successMeasure: 'There is more revenue generated when this is on the page',
+	description:
+		'Test that revenue is generated from this ask than when there is only an epic on a pageview.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sticky-liveblog-ask.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sticky-liveblog-ask.ts
@@ -3,7 +3,7 @@ import type { ABTest } from '@guardian/ab-core';
 export const stickyLiveBlogAskTest: ABTest = {
 	id: 'StickyLiveBlogAskTest',
 	author: '@growth',
-	start: '2024-07-01',
+	start: '2024-06-25',
 	expiry: '2024-07-31',
 	audience: 1,
 	audienceOffset: 0,


### PR DESCRIPTION
## What is the value of this and can you measure success? 

This PR adds an AB test for the new component Sticky Liveblog Ask which is a new experimental Reader Revenue support ask ([PR11723](https://github.com/guardian/dotcom-rendering/pull/11723)).

This PR must be merged before that in dotcom-rendering.

This AB test has the variant - showing the sticky liveblog ask,  and a control of no sticky liveblog ask.  This is intended to discover if the sticky ask removes the revenue from the existing epic on the page or, because it is more visible, adds to it.

## What does this change?

Adds an AB test.

## Screenshots

Please see [PR11723](https://github.com/guardian/dotcom-rendering/pull/11723)

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
