### PR TITLE
Remove `trackNavBetweenImages` function call from hosted content gallery

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -531,7 +531,6 @@ HostedGallery.prototype.states = {
 				if (this.index < this.$images.length) {
 					// last img
 					this.index += 1;
-					this.trackNavBetweenImages(e);
 				}
 				this.reloadState = true;
 			},
@@ -539,12 +538,10 @@ HostedGallery.prototype.states = {
 				if (this.index > 1) {
 					// first img
 					this.index -= 1;
-					this.trackNavBetweenImages(e);
 				}
 				this.reloadState = true;
 			},
 			reload(e) {
-				this.trackNavBetweenImages(e);
 				this.reloadState = true;
 			},
 			'toggle-info': function () {


### PR DESCRIPTION
## What is the value of this and can you measure success?

We had a bug report that hosted content galleries pagination feature was not updating the page number or the URL hash.

Hosted content is full-page advertiser content. This content is created by advertisers and hosted by the Guardian. Hosted content paths begin with `/advertiser-content`.

An example of a hosted content gallery:

https://www.theguardian.com/advertiser-content/microsoft-ai-for-earth/meet-the-changemakers

## What does this change?

This changes removes calls to the function `trackNavBetweenImages` that no longer exists which caused an exception to be thrown. This appears to be a regression introduced in https://github.com/guardian/frontend/pull/27188

