### PR TITLE
Fix `make watch` by making it ESM

### DIFF
--- a/dev/bs-config.mjs
+++ b/dev/bs-config.mjs
@@ -1,4 +1,5 @@
-const path = require('path');
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // To run browser-sync with this config:
 //
@@ -56,7 +57,11 @@ const config = {
 	scrollThrottle: 0,
 	reloadDelay: 0,
 	reloadDebounce: 100,
-	plugins: [path.dirname(require.resolve('bs-fullscreen-message'))],
+	plugins: [
+		path.dirname(
+			fileURLToPath(import.meta.resolve('bs-fullscreen-message')),
+		),
+	],
 	injectChanges: true,
 	startPath: null,
 	minify: false,
@@ -92,4 +97,4 @@ const config = {
 	},
 };
 
-module.exports = config;
+export default config;

--- a/dev/webpack-loaders/svg-loader/index.js
+++ b/dev/webpack-loaders/svg-loader/index.js
@@ -1,4 +1,4 @@
-import path from 'node:path';
+const path = require('node:path');
 
 function svgLoader(content) {
 	const match = content.match(/<svg([^>]+)+>([\s\S]+)<\/svg>/i);
@@ -15,4 +15,4 @@ function svgLoader(content) {
 	return `module.exports = ${JSON.stringify({ markup })}`;
 }
 
-export default svgLoader;
+module.exports = svgLoader;

--- a/dev/webpack-loaders/svg-loader/index.mjs
+++ b/dev/webpack-loaders/svg-loader/index.mjs
@@ -1,4 +1,4 @@
-const path = require('path');
+import path from 'node:path';
 
 function svgLoader(content) {
 	const match = content.match(/<svg([^>]+)+>([\s\S]+)<\/svg>/i);
@@ -15,4 +15,4 @@ function svgLoader(content) {
 	return `module.exports = ${JSON.stringify({ markup })}`;
 }
 
-module.exports = svgLoader;
+export default svgLoader;

--- a/makefile
+++ b/makefile
@@ -31,7 +31,7 @@ check-node-env: # PRIVATE
 # Watch and automatically compile/reload all JS/SCSS.
 # Uses port 3000 insead of 9000.
 watch: compile-watch
-	@./dev/watch.js
+	@./dev/watch.mjs
 
 sbt: # PRIVATE
 	./sbt

--- a/tools/__tasks__/compile/css/sass.mjs
+++ b/tools/__tasks__/compile/css/sass.mjs
@@ -1,4 +1,4 @@
-import compile from '../../../compile-css.mjs';
+import { compileSass as compile } from '../../../compile-css.mjs';
 
 /** @type {import('listr2').ListrTask} */
 const task = {

--- a/tools/__tasks__/compile/javascript/webpack.mjs
+++ b/tools/__tasks__/compile/javascript/webpack.mjs
@@ -20,7 +20,7 @@ const task = {
 				}
 				const info = stats.toJson();
 				if (stats.hasErrors()) {
-					throw new Error(chalk.red(info.errors));
+					throw new Error(chalk.red(JSON.stringify(info.errors)));
 				}
 				observer.complete();
 			});

--- a/tools/compile-css.mjs
+++ b/tools/compile-css.mjs
@@ -53,9 +53,16 @@ const REMIFICATIONS = {
 	propList: ['*'],
 };
 
+/** @param {string} sassGlob */
 const getFiles = (sassGlob) => glob.sync(path.resolve(sassDir, sassGlob));
 
-export default (sassGlob, { remify = true, browsers = BROWSERS_LIST } = {}) => {
+/**
+ * @param {string} sassGlob
+ * @param {object} [options]
+ * @param {boolean} options.remify
+ * @param {string[]} options.browsers
+ */
+export const compileSass = (sassGlob, { remify = true, browsers = BROWSERS_LIST } = {}) => {
 	if (typeof sassGlob !== 'string') {
 		return Promise.reject(new Error('No glob provided.'));
 	}
@@ -105,3 +112,5 @@ export default (sassGlob, { remify = true, browsers = BROWSERS_LIST } = {}) => {
 		}),
 	);
 };
+
+export default compileSass


### PR DESCRIPTION
## What is the value of this and can you measure success?

Fix `make watch`.

## What does this change?

- Follow-up on #27263 
- Address issue raised by @arelra in #27262 
- turn `watch.js` into `watch.mjs` 


## Screenshot

<img width="475" alt="image" src="https://github.com/guardian/frontend/assets/76776/c8d5b5a5-2d3c-45ae-864c-c9ad0cca9dc2">
