### PR TITLE
Trigger CI workflows on `pull_request` trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: "Build"
 
 on:
-  push:
+  pull_request:
+  push: # Do not rely on `push` for PR CI - see https://github.com/guardian/mobile-apps-api/pull/2760
+    branches:
+      - main # Optimal for GHA workflow caching - see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
 
 permissions:
   id-token: write

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,5 +1,9 @@
 name: typescript
-on: [push]
+on:
+  pull_request:
+  push: # Do not rely on `push` for PR CI - see https://github.com/guardian/mobile-apps-api/pull/2760
+    branches:
+      - main # Optimal for GHA workflow caching - see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,9 @@
 name: Validate
-on: [push]
+on:
+  pull_request:
+  push: # Do not rely on `push` for PR CI - see https://github.com/guardian/mobile-apps-api/pull/2760
+    branches:
+      - main # Optimal for GHA workflow caching - see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
1. This will allow us to accept running our CI workflows on external contributors' PR, e.g. @mkurz, so that we don't have to re-raise his PRs ourselves. See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
2. This shows that workflow triggering makes much more sense when considered using the pull_request trigger. The push trigger should not be used for PR CI: https://github.com/guardian/mobile-apps-api/pull/2760
