### PR TITLE
Bump commercial to 19.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
-		"@guardian/commercial": "19.9.1",
+		"@guardian/commercial": "19.10.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,9 +2681,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:19.9.1":
-  version: 19.9.1
-  resolution: "@guardian/commercial@npm:19.9.1"
+"@guardian/commercial@npm:19.10.0":
+  version: 19.10.0
+  resolution: "@guardian/commercial@npm:19.10.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.1.1"
@@ -2704,7 +2704,7 @@ __metadata:
     "@guardian/libs": ^17.0.0
     "@guardian/source-foundations": ^14.1.2
     typescript: ~5.3.3
-  checksum: 10c0/bacc021d3bfca4fbdab26fcaba037ea936a9a5a98df6f0c577f60ef8d748a85c8e8bbd2a5a83084f774bc4674d23af7e06daa9c7e9fdff68185c9806e0522130
+  checksum: 10c0/be76cc2811b74e0a71e9360e823c9b62475c07f364215c19794f48f5f1c8a610bb1cbe62d14badd535bdad6fac97d3eb1a64510cbc54ab80dcb1a85cd09a61a4
   languageName: node
   linkType: hard
 
@@ -2777,7 +2777,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
-    "@guardian/commercial": "npm:19.9.1"
+    "@guardian/commercial": "npm:19.10.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
## What does this change?
Bring in the changes in [19.10.0](https://github.com/guardian/commercial/releases/tag/v19.10.0) 