### PR TITLE
Rename ab test with extra dash to match convention

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -57,7 +57,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sticky-liveblog-ask-test",
+    "ab-sticky-live-blog-ask-test",
     "A sticky reader revenue ask on the left column of a liveblog",
     owners = Seq(Owner.withEmail("growth@theguardian.com")),
     safeState = Off,


### PR DESCRIPTION
## What is the value of this and can you measure success?

A tiny change to fix the ab test which is not working from the [PR27261](https://github.com/guardian/frontend/pull/27261)

## What does this change?

It adds a dash to the test name in ABTestSwitches.scala to match the slightly different ab test name elsewhere in the frontend code where the blog part is title case accidentally (like StickyLiveBlogAskTest). 

## Screenshots

No visible change other than the sticky liveblog showing for the variant - see DCR [PR11723](https://github.com/guardian/dotcom-rendering/pull/11723) which contains screenshots.

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
