### PR TITLE
Update Email Signup to send verification email.

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -78,23 +78,14 @@ class EmailFormService(wsClient: WSClient, emailEmbedAgent: NewsletterSignupAgen
         .obj(
           "email" -> form.email,
           "set-lists" -> form.listNames,
+          "refViewId" -> form.refViewId,
+          "ref" -> form.ref,
         )
         .fields,
     )
 
-    val queryStringParameters = form.ref.map("ref" -> _).toList ++
-      form.refViewId.map("refViewId" -> _).toList ++
-      form.listNames.map("listName" -> _).toList
-
-    //FIXME: this should go via the identity api client / app
-    // NOTE - always using the '/consent-signup' (no confirmation email)
-    // should we be splitting the list into newsletters that require confirmation
-    // and those that don't, then sending two separate requests?
-    // Currently, no editorial newsletters require confirmation emails, but the
-    // feature is still supported.
     wsClient
-      .url(s"${Configuration.id.apiRoot}/consent-signup")
-      .withQueryStringParameters(queryStringParameters: _*)
+      .url(s"${Configuration.id.apiRoot}/consent-email")
       .addHttpHeaders(getHeaders(request): _*)
       .post(consentMailerPayload)
   }


### PR DESCRIPTION
## What is the value of this and can you measure success?

This changes the newsletter page to send email confirmation before email signup.

## What does this change?
Sends a post request to `/consent-email` instead of `consent-signup`
## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
