### PR TITLE
Ensure live updates are linked to football sportsblog

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -203,9 +203,7 @@ object MatchMetadata extends Football {
     }
 
     val minByMin = related.find { c =>
-      val webPublicationDate =
-        DateHelpers.asZonedDateTime(c.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")))
-      DateHelpers.sameDay(webPublicationDate, matchDate) && c.minByMin && !c.preview
+      c.minByMin && !c.preview
     }
     val preview = related.find { c =>
       val webPublicationDate =


### PR DESCRIPTION
## What is the value of this and can you measure success?
Ensures match report and live updates tabs are displayed with links
Resolves https://github.com/guardian/dotcom-rendering/issues/11762
## What does this change?
Removes failing date checking which I think is unnecessary
## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/frontend/assets/110032454/9f93f137-c3a0-45ed-a47e-0498a5e551d3
[after]: https://github.com/guardian/frontend/assets/110032454/9726e10b-23a2-4475-9f9e-285b6ed92c8a



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
