### PR TITLE
Show total images for “next” request in DCR

### DIFF
--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -105,7 +105,19 @@ class ImageContentController(
             case _                     => None
           },
         )
-        Cached(CacheTime.Default)(JsonComponent.fromWritable(JsArray(lightboxJson)))
+
+        if (request.forceDCR)
+          Cached(CacheTime.Default)(
+            JsonComponent.fromWritable(
+              Json.obj(
+                "total" -> response.total,
+                "images" -> JsArray(lightboxJson),
+              ),
+            ),
+          )
+        else
+          Cached(CacheTime.Default)(JsonComponent.fromWritable(JsArray(lightboxJson)))
+
       }
     }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

We can show a proper counter in DCR Lightbox.

## What does this change?

Add an `total` field which contains the total number of images for an endpoint.

## Screenshots

<img width="506" alt="image" src="https://github.com/guardian/frontend/assets/76776/89e8781f-7252-4816-b813-217a616aa27c">

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
