### PR TITLE
[Fairground 🎡] Support Highlights container in DCR

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -42,6 +42,7 @@ object FrontChecks {
       "nav/list",
       "nav/media-list",
       "news/most-popular",
+      "fixed/highlights",
     )
 
   def hasOnlySupportedCollections(faciaPage: PressedPage) =

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -248,6 +248,7 @@ import layout.slices.EmailLayouts
         PressedCollectionBuilder.mkPressedCollection("nav/list"),
         PressedCollectionBuilder.mkPressedCollection("nav/media-list"),
         PressedCollectionBuilder.mkPressedCollection("news/most-popular"),
+        PressedCollectionBuilder.mkPressedCollection("fixed/highlights"),
       ),
     )
 


### PR DESCRIPTION
> [!NOTE]
> This is a companion PR for https://github.com/guardian/dotcom-rendering/pull/11810

## What is the value of this and can you measure success?

Allows DCR to support displaying the Highlights container.

## What does this change?

Adds `fixed/highlights` to list of supported containers in `FaciaPicker` for DCR