### PR TITLE
Proper next images count

### DIFF
--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -100,27 +100,25 @@ class ImageContentController(
     Action.async { implicit request =>
       val direction = Direction.forPathSegment(rawDirection)
 
-      /**
-        * unfortunately we have to infer the date from the path,
-        * because getting the real publication date would require
+      /** unfortunately we have to infer the date from the path, because getting the real publication date would require
         * another call to the content API…
         */
       val maybeDate = path match {
         case dateExtractor(rawYear, rawMonth, rawDate) => {
           (Try(rawYear.toInt).toOption, rawMonth, Try(rawDate.toInt).toOption) match {
-            case (Some(year), "jan", Some(date)) => Some(LocalDate.of(year, 1, date))
-            case (Some(year), "feb", Some(date)) => Some(LocalDate.of(year, 2, date))
-            case (Some(year), "mar", Some(date)) => Some(LocalDate.of(year, 3, date))
-            case (Some(year), "apr", Some(date)) => Some(LocalDate.of(year, 4, date))
-            case (Some(year), "may", Some(date)) => Some(LocalDate.of(year, 5, date))
-            case (Some(year), "jun", Some(date)) => Some(LocalDate.of(year, 6, date))
-            case (Some(year), "jul", Some(date)) => Some(LocalDate.of(year, 7, date))
-            case (Some(year), "aug", Some(date)) => Some(LocalDate.of(year, 8, date))
-            case (Some(year), "sep", Some(date)) => Some(LocalDate.of(year, 9, date))
-            case (Some(year), "oct", Some(date)) => Some(LocalDate.of(year, 10, date))
-            case (Some(year), "nov", Some(date)) => Some(LocalDate.of(year, 11, date))
-            case (Some(year), "dec", Some(date)) => Some(LocalDate.of(year, 12, date))
-            case _                               => None
+            case (Some(year), "jan", Some(day)) => Some(LocalDate.of(year, 1, day))
+            case (Some(year), "feb", Some(day)) => Some(LocalDate.of(year, 2, day))
+            case (Some(year), "mar", Some(day)) => Some(LocalDate.of(year, 3, day))
+            case (Some(year), "apr", Some(day)) => Some(LocalDate.of(year, 4, day))
+            case (Some(year), "may", Some(day)) => Some(LocalDate.of(year, 5, day))
+            case (Some(year), "jun", Some(day)) => Some(LocalDate.of(year, 6, day))
+            case (Some(year), "jul", Some(day)) => Some(LocalDate.of(year, 7, day))
+            case (Some(year), "aug", Some(day)) => Some(LocalDate.of(year, 8, day))
+            case (Some(year), "sep", Some(day)) => Some(LocalDate.of(year, 9, day))
+            case (Some(year), "oct", Some(day)) => Some(LocalDate.of(year, 10, day))
+            case (Some(year), "nov", Some(day)) => Some(LocalDate.of(year, 11, day))
+            case (Some(year), "dec", Some(day)) => Some(LocalDate.of(year, 12, day))
+            case _                              => None
           }
         }
         case _ => None

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -107,10 +107,10 @@ class ImageContentController(
       val direction = Direction.forPathSegment(rawDirection)
 
       /**
-       * unfortunately we have to infer the date from the path,
-       * because getting the real publication date would require
-       * another call to the content API…
-       */
+        * unfortunately we have to infer the date from the path,
+        * because getting the real publication date would require
+        * another call to the content API…
+        */
       val maybeDate = path match {
         case dateExtractor(rawYear, rawMonth, rawDate) => {
           (Try(rawYear.toInt).toOption, rawMonth, Try(rawDate.toInt).toOption) match {
@@ -164,6 +164,7 @@ class ImageContentController(
               Json.obj(
                 "total" -> response.total,
                 "direction" -> timeDirection,
+                "date" -> maybeDate,
                 "images" -> JsArray(lightboxJson),
               ),
             ),

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -18,16 +18,11 @@ import services.ImageQuery
 import services.dotcomrendering.{ImageContentPicker, RemoteRender}
 import views.support.RenderOtherStatus
 
-import scala.concurrent.Future
 import com.gu.contentapi.client.model.Direction.Next
 import com.gu.contentapi.client.model.Direction.Previous
-import java.time.LocalDate
-import java.time.Instant
-import java.time.LocalTime
-import org.joda.time.DateTime
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
+import scala.concurrent.Future
 import scala.util.Try
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 
 class ImageContentController(
     val contentApiClient: ContentApiClient,
@@ -99,7 +94,6 @@ class ImageContentController(
   private def isSupported(c: ApiContent) = c.isImageContent
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
 
-  private val ONE_HUNDRED_YEARS = 3600 * 24 * 365 * 100
   private lazy val dateExtractor = """.+/(\d{4})/(\w{3})/(\d{2})/.+""".r
 
   def getNextLightboxJson(path: String, tag: String, rawDirection: String): Action[AnyContent] =


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allow a nice counter in the Lightbox for series

## What does this change?

Infer the start date from the item, as the content API incorrectly returns the total for all items in the series, without regard for the direction (see https://github.com/guardian/content-api/issues/2902).

## Screenshots

<img width="939" alt="Screenshot of JSON response" src="https://github.com/guardian/frontend/assets/76776/b53d4ed8-eb56-427f-98d7-90fd76f663b4">


## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
