### PR TITLE
Bump pekko to 1.0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,8 @@ val common = library("common")
       pekkoActor,
       pekkoStream,
       pekkoSlf4j,
+      pekkoSerializationJackson,
+      pekkoActorTyped,
     ),
     TestAssets / mappings ~= filterAssets,
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,10 +78,12 @@ object Dependencies {
   val jerseyClient = "com.sun.jersey" % "jersey-client" % jerseyVersion
   val w3cSac = "org.w3c.css" % "sac" % "1.3"
   val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "8.10.23"
-  val pekkoVersion = "1.0.2"
+  val pekkoVersion = "1.0.3"
   val pekkoActor = "org.apache.pekko" %% "pekko-actor" % pekkoVersion
   val pekkoStream = "org.apache.pekko" %% "pekko-stream" % pekkoVersion
   val pekkoSlf4j = "org.apache.pekko" %% "pekko-slf4j" % pekkoVersion
+  val pekkoSerializationJackson = "org.apache.pekko" %% "pekko-serialization-jackson" % pekkoVersion
+  val pekkoActorTyped = "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion
 
   val logback2 = "net.logstash.logback" % "logstash-logback-encoder" % "4.11"
   // logback2  to prevent "error: reference to logback is ambiguous;"


### PR DESCRIPTION
Pulled from: 
* https://github.com/guardian/frontend/pull/27297

This commit also adds explicit dependencies on version 1.0.3 of `pekko-actor-typed` and `pekko-serialization-jackson` to avoid this error when running the tests:

```[Guice/ErrorInCustomProvider]: IllegalStateException: You are using version 1.0.3 of Apache Pekko, but it appears you (perhaps indirectly) also depend on older versions of related artifacts. You can solve this by adding an explicit dependency on version 1.0.3 of the [pekko-serialization-jackson, pekko-actor-typed] artifacts to your project. Here's a complete collection of detected artifacts: (1.0.2, [pekko-actor-typed, pekko-serialization-jackson]), (1.0.3, [pekko-actor, pekko-protobuf-v3, pekko-slf4j, pekko-stream]). See also: https://pekko.apache.org/docs/pekko/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed``` 


Tested on CODE

