### PR TITLE
Use updated `etag-caching` lib with small API change for missing values

### DIFF
--- a/common/app/services/fronts/FrontJsonFapi.scala
+++ b/common/app/services/fronts/FrontJsonFapi.scala
@@ -50,7 +50,7 @@ trait FrontJsonFapi extends GuLogging {
   def get(path: String, pageType: PressedPageType): Future[Option[PressedPage]] =
     errorLoggingF(s"FrontJsonFapi.get $path") {
       val objectId = s3ObjectIdFor(path, pageType.suffix)
-      pressedPageCache.get(objectId).map(Some(_)).recover { case s3Exception: S3Exception =>
+      pressedPageCache.get(objectId).recover { case s3Exception: S3Exception =>
         logS3ExceptionWithDevHint(objectId, s3Exception)
         None
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val awsEc2 = "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion
   val awsKinesis = "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion
   val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
-  val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "3.0.12"
+  val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "4.0.0"
   val awsSes = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion
   val awsSns = "com.amazonaws" % "aws-java-sdk-sns" % awsVersion
   val awsSts = "com.amazonaws" % "aws-java-sdk-sts" % awsVersion


### PR DESCRIPTION
The `etag-caching` library has made a small change to its API with https://github.com/guardian/etag-caching/pull/56 (it now returns `Option[T]` where before it just returned `T`), so we need to make a small code change to adapt to it.

#### Context - background to ETag Caching in Frontend

* See https://github.com/guardian/frontend/pull/26338 for the PR that first introduced ETag Caching to Frontend

