### PR TITLE
Skip riff-raff-artifact so fork PRs do not crash on roleArn missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           cache: yarn
           node-version-file: .nvmrc
-
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
@@ -36,11 +35,8 @@ jobs:
           java-version: 11
 
       - run: make reinstall
-
       - run: make validate
-
       - run: make test
-
       - run: make compile
 
       - name: Test, compile
@@ -56,6 +52,9 @@ jobs:
           -jar ./bin/sbt-launch.jar clean compile assets scalafmtCheckAll test Universal/packageBin
 
       - uses: guardian/actions-riff-raff@v4
+        env:
+          GU_RIFF_RAFF_ROLE_ARN: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+        if: ${{ env.GU_RIFF_RAFF_ROLE_ARN }}
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}


### PR DESCRIPTION
As mentioned in https://github.com/github/docs/issues/6861:

> It is common for projects to include a secret for deploying things and an action that uses that secret.
> 
> When one forks that repository, the secret won't be present and the workflow will break.
> 
> This experience is incredibly painful.

For guardian/frontend, we're using [actions-riff-raff](https://github.com/guardian/actions-riff-raff), which needs a `roleArn` which is provided as a repository secret. For PRs like https://github.com/guardian/frontend/pull/27233, from an external contributor, the CI appears to fail, even though all tests have passed.

### CI never runs on forks unless we authorise the contributor

The [GitHub docs](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks#approving-workflow-runs-on-a-pull-request-from-a-public-fork) say:

> By default, all first-time contributors require approval to run workflows.

...so it could be argued that ideally, the build should still produce the riff-raff artifact for fork PRs.