### PR TITLE
Add keyword targeting to liveblog-top sponsorship

### DIFF
--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -43,6 +43,7 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[Gu
           adTest = lineItem.targeting.adTestValue,
           editions = editionsTargeted(lineItem),
           sections = lineItem.liveBlogTopTargetedSections,
+          keywords = lineItem.targeting.keywordValues,
           targetsAdTest = lineItem.targeting.hasAdTestTargetting,
         )
       }

--- a/admin/app/views/commercial/liveBlogTopSponsorships.scala.html
+++ b/admin/app/views/commercial/liveBlogTopSponsorships.scala.html
@@ -20,7 +20,7 @@
 
     <p>Last updated: @if(report.updatedTimeStamp) { @{report.updatedTimeStamp} } else { never }</p>
 
-    <p>Pages will show a live blog top slot if you set up a iine item in GAM with the following parameters:</p>
+    <p>Pages will show a live blog top slot if you set up a line item in GAM with the following parameters:</p>
     <ol>
         <li>Is a Sponsorship</li>
         <li>Targets the <pre>liveblog-top</pre> slot</li>

--- a/admin/app/views/commercial/liveBlogTopSponsorships.scala.html
+++ b/admin/app/views/commercial/liveBlogTopSponsorships.scala.html
@@ -20,15 +20,19 @@
 
     <p>Last updated: @if(report.updatedTimeStamp) { @{report.updatedTimeStamp} } else { never }</p>
 
-    <p>Pages will show a liveblog top slot if you set up a LineItem in GAM with the following parameters:</p>
+    <p>Pages will show a live blog top slot if you set up a iine item in GAM with the following parameters:</p>
     <ol>
         <li>Is a Sponsorship</li>
         <li>Targets the <pre>liveblog-top</pre> slot</li>
         <li>Targets the <pre>culture</pre>,<pre>sport</pre> or <pre>football</pre> section</li>
         <li>Targets the <pre>liveblog</pre> content type</li>
         <li>Targets the <pre>mobile</pre> breakpoint</li>
-        <li>Targets an edition</li>
+        <li>[Optional] Targets an edition</li>
+        <li>[Optional] Targets a keyword</li>
     </ol>
+
+    <strong>ANY OTHER TARGETING WILL CAUSE THE SLOT TO APPEAR UNINTENTIONALLY</strong>
+    <p>If you are unsure please contact the <a href="mailto:commercial.dev@@theguardian.com">commercial dev team</a> first.</p>
 
     <h2>Sponsorships</h2>
     <p>Line items that match the above targeting:</p>
@@ -42,6 +46,8 @@
             @for(section <- sponsorship.sections) {
                 <pre>@section</pre>@if(section != sponsorship.sections.last) {, }
             }
+            <br />
+            @if(sponsorship.keywords.nonEmpty) {<small>Keywords:</small> @for(keyword <- sponsorship.keywords) {<pre>@keyword</pre>@if(keyword != sponsorship.keywords.last) {, }}}
             @if(sponsorship.targetsAdTest) {<br /><small>Adtest:</small> <pre>@sponsorship.adTest</pre>}
             @if(!sponsorship.editions.isEmpty) {<br /><small>Editions:</small> @for(edition <- sponsorship.editions.map(_.id)) {<pre>@edition</pre>@if(edition != sponsorship.editions.last.id) {, }}}
   </li>

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -499,7 +499,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
     lazy val dfpHighMerchandisingTagsDataKey = s"$dfpRoot/high-merchandising-tags.json"
     lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v9.json"
-    lazy val dfpLiveBlogTopSponsorshipDataKey = s"$dfpRoot/liveblog-top-sponsorships-v2.json"
+    lazy val dfpLiveBlogTopSponsorshipDataKey = s"$dfpRoot/liveblog-top-sponsorships-v3.json"
     lazy val dfpNonRefreshableLineItemIdsKey = s"$dfpRoot/non-refreshable-lineitem-ids-v1.json"
     lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v7.json"
     lazy val dfpActiveAdUnitListKey = s"$dfpRoot/active-ad-units.csv"

--- a/common/app/common/dfp/LiveBlogTopSponsorshipAgent.scala
+++ b/common/app/common/dfp/LiveBlogTopSponsorshipAgent.scala
@@ -16,20 +16,23 @@ trait LiveBlogTopSponsorshipAgent {
   private[dfp] def findSponsorships(
       edition: Edition,
       sectionId: String,
+      keywords: Seq[Tag],
       adTest: Option[String],
   ): Seq[LiveBlogTopSponsorship] = {
     liveBlogTopSponsorships.filter { sponsorship =>
-      sponsorship.editions.contains(edition) && sponsorship.sections.contains(sectionId) && sponsorship
+      sponsorship.editions.contains(edition) && sponsorship.sections.contains(
+        sectionId,
+      ) && (keywords exists sponsorship.hasTag) && sponsorship
         .matchesTargetedAdTest(adTest)
     }
   }
 
-  def hasLiveBlogTopAd(metadata: MetaData, request: RequestHeader): Boolean = {
+  def hasLiveBlogTopAd(metadata: MetaData, tags: Seq[Tag], request: RequestHeader): Boolean = {
     if (metadata.contentType == Some(DotcomContentType.LiveBlog) && LiveBlogTopSponsorshipSwitch.isSwitchedOn) {
       val adTest = request.getQueryString("adtest")
       val edition = Edition(request)
 
-      findSponsorships(edition, metadata.sectionId, adTest).nonEmpty
+      findSponsorships(edition, metadata.sectionId, tags, adTest).nonEmpty
     } else {
       false
     }

--- a/common/app/common/dfp/LiveblogTopSponsorship.scala
+++ b/common/app/common/dfp/LiveblogTopSponsorship.scala
@@ -2,18 +2,31 @@ package common.dfp
 
 import common.{Edition, GuLogging}
 import play.api.libs.json._
+import model.Tag
 
 case class LiveBlogTopSponsorship(
     lineItemName: String,
     lineItemId: Long,
     sections: Seq[String],
     editions: Seq[Edition],
+    keywords: Seq[String],
     adTest: Option[String],
     targetsAdTest: Boolean,
 ) {
   def matchesTargetedAdTest(adTest: Option[String]): Boolean =
     if (this.targetsAdTest) { adTest == this.adTest }
     else { true }
+
+  private def hasTagId(tags: Seq[String], tagId: String): Boolean =
+    tagId.split('/').lastOption exists { endPart =>
+      tags contains endPart
+    }
+
+  def hasTag(tag: Tag): Boolean =
+    tag.properties.tagType match {
+      case "Keyword" => hasTagId(keywords, tag.id)
+      case _         => false
+    }
 }
 
 object LiveBlogTopSponsorship {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -355,8 +355,8 @@ case class MetaData(
   def hasPageSkin(request: RequestHeader): Boolean =
     DfpAgent.hasPageSkin(fullAdUnitPath, this, request)
 
-  def hasLiveBlogTopAd(request: RequestHeader): Boolean =
-    DfpAgent.hasLiveBlogTopAd(this, request)
+  def hasLiveBlogTopAd(request: RequestHeader, content: Option[Content]): Boolean =
+    DfpAgent.hasLiveBlogTopAd(this, content.map(_.tags.tags).getOrElse(Seq.empty), request)
 
   def omitMPUsFromContainers(edition: Edition): Boolean =
     if (isPressedPage) {

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -46,7 +46,7 @@ object JavaScriptPage {
     val commercialMetaData = Map(
       "dfpHost" -> JsString("pubads.g.doubleclick.net"),
       "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(request)),
-      "hasLiveBlogTopAd" -> JsBoolean(metaData.hasLiveBlogTopAd(request)),
+      "hasLiveBlogTopAd" -> JsBoolean(metaData.hasLiveBlogTopAd(request, content)),
       "shouldHideAdverts" -> JsBoolean(page match {
         case c: ContentPage if c.item.content.shouldHideAdverts => true
         case _: CommercialExpiryPage                            => true


### PR DESCRIPTION
## What does this change?
Check keyword targeting matches the article before displaying the liveblog-top slot.

Also add a warning to the admin page to hopefully avoid the slot appearing unintentionally.

## Screenshots
![Screenshot 2024-07-15 at 12 33 03](https://github.com/user-attachments/assets/6168d2bb-0c77-467a-919e-55a932c0d615)

