### PR TITLE
Bump commercial to v19.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "7.0.1",
-		"@guardian/commercial": "19.10.0",
+		"@guardian/commercial": "19.12.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3822,9 +3822,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:19.10.0":
-  version: 19.10.0
-  resolution: "@guardian/commercial@npm:19.10.0"
+"@guardian/commercial@npm:19.12.0":
+  version: 19.12.0
+  resolution: "@guardian/commercial@npm:19.12.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.1.1"
@@ -3845,7 +3845,7 @@ __metadata:
     "@guardian/libs": ^17.0.0
     "@guardian/source-foundations": ^14.1.2
     typescript: ~5.3.3
-  checksum: 10c0/be76cc2811b74e0a71e9360e823c9b62475c07f364215c19794f48f5f1c8a610bb1cbe62d14badd535bdad6fac97d3eb1a64510cbc54ab80dcb1a85cd09a61a4
+  checksum: 10c0/47626bddc9d424cea055851d4ac6056ec361ae37f49a6765e4b53e67d4e4ccc9f10ca6d60fdfec69fb4dbe669f067f5d29fafdf5c7b45b1a8cc8e0f756841da6
   languageName: node
   linkType: hard
 
@@ -3918,7 +3918,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:7.0.1"
-    "@guardian/commercial": "npm:19.10.0"
+    "@guardian/commercial": "npm:19.12.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"


### PR DESCRIPTION
## What does this change?
Brings in the changes from [v19.12.0](https://github.com/guardian/commercial/releases/tag/v19.12.0)