### PR TITLE
Remove support-dotcom-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 		"@guardian/source-foundations": "14.2.2",
 		"@guardian/source-react-components": "22.1.0",
 		"@guardian/source-react-components-development-kitchen": "19.0.0",
-		"@guardian/support-dotcom-components": "1.1.3",
 		"@types/googletag": "^3.1.3",
 		"@types/jest": "29.5.12",
 		"@types/lodash-es": "^4.17.4",

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
@@ -12,7 +12,6 @@ import {
 	accountDataUpdateWarning,
 	getLastOneOffContributionTimestamp,
 	getLastRecurringContributionDate,
-	getPurchaseInfo,
 	isAdFreeUser,
 	isPayingMember,
 	isRecurringContributor,
@@ -650,31 +649,5 @@ describe('isPostAskPauseOneOffContributor', () => {
 		global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
 		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
 		expect(isPostAskPauseOneOffContributor()).toBe(true);
-	});
-});
-
-describe('getPurchaseInfo', () => {
-	afterEach(() => {
-		removeCookie('GU_CO_COMPLETE');
-	});
-
-	it('returns decoded cookie data', () => {
-		addCookie(
-			'GU_CO_COMPLETE',
-			'%7B%22userType%22%3A%22guest%22%2C%22product%22%3A%22DigitalPack%22%7D',
-		);
-		expect(getPurchaseInfo()).toEqual({
-			userType: 'guest',
-			product: 'DigitalPack',
-		});
-	});
-
-	it('returns undefined if cookie unset', () => {
-		expect(getPurchaseInfo()).toBeUndefined();
-	});
-
-	it('returns undefined if cookie data invalid', () => {
-		addCookie('GU_CO_COMPLETE', 'utter-nonsense');
-		expect(getPurchaseInfo()).toBeUndefined();
 	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -1,5 +1,4 @@
 import { getCookie, isObject, removeCookie, setCookie } from '@guardian/libs';
-import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { noop } from 'lib/noop';
 import { fetchJson } from '../../../../lib/fetch-json';
 import { dateDiffDays } from '../../../../lib/time-utils';
@@ -378,25 +377,6 @@ const extendContribsCookieExpiry = (): void => {
 	}
 };
 
-type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
-const getPurchaseInfo = (): PurchaseInfo => {
-	const purchaseInfoRaw = getCookie({ name: 'GU_CO_COMPLETE' });
-
-	if (!purchaseInfoRaw) {
-		return undefined;
-	}
-
-	let purchaseInfo: PurchaseInfo = undefined;
-
-	try {
-		purchaseInfo = JSON.parse(
-			decodeURIComponent(purchaseInfoRaw),
-		) as PurchaseInfo;
-	} catch {} // eslint-disable-line no-empty -- silently handle error
-
-	return purchaseInfo;
-};
-
 const _ = {
 	isRecentOneOffContributor,
 	isDigitalSubscriber,
@@ -417,7 +397,6 @@ export {
 	getLastOneOffContributionTimestamp,
 	getLastOneOffContributionDate,
 	getLastRecurringContributionDate,
-	getPurchaseInfo,
 	readerRevenueRelevantCookies,
 	fakeOneOffContributor,
 	extendContribsCookieExpiry,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3929,7 +3929,6 @@ __metadata:
     "@guardian/source-foundations": "npm:14.2.2"
     "@guardian/source-react-components": "npm:22.1.0"
     "@guardian/source-react-components-development-kitchen": "npm:19.0.0"
-    "@guardian/support-dotcom-components": "npm:1.1.3"
     "@types/googletag": "npm:^3.1.3"
     "@types/jest": "npm:29.5.12"
     "@types/lodash-es": "npm:^4.17.4"
@@ -4206,13 +4205,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/ceeffbea73b27f63b1d23a6167de6978dfad4708967f82c50d86bc2b8e003995287946b072d13c2b2761c16457a7c5b0825d73cb3e362d0b46ade7bd2f5eb566
-  languageName: node
-  linkType: hard
-
-"@guardian/support-dotcom-components@npm:1.1.3":
-  version: 1.1.3
-  resolution: "@guardian/support-dotcom-components@npm:1.1.3"
-  checksum: 10c0/b214be3947bbfac3e0d434e43d9c005326f04fd2905fb9cbf2ef1d1fad9ff55a3edd52d137a07fcf39b04e3ad569007089c88a2b492a07764b5903324695bf2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We previously removed reader revenue messaging (via support-dotcom-components) from Frontend: https://github.com/guardian/frontend/pull/27231

This PR removes the dependency, and a bit of unused code.