### PR TITLE
Navbar updates

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -110,6 +110,7 @@ object NavLinks {
 
   /* SPORT */
 
+  private val euro2024 = NavLink("Euro 2024", "/football/euro-2024")
   private val olympics2024 = NavLink("Olympics 2024", "/sport/olympic-games-2024")
   private val footballScores = NavLink("Live scores", "/football/live", Some("football/live"))
   private val footballTables = NavLink("Tables", "/football/tables", Some("football/tables"))
@@ -124,7 +125,7 @@ object NavLinks {
     "Football",
     "/football",
     children = List(
-      olympics2024,
+      euro2024,
       footballScores,
       footballTables,
       footballFixtures,
@@ -137,7 +138,7 @@ object NavLinks {
     "Soccer",
     "/us/soccer",
     children = List(
-      olympics2024,
+      euro2024,
       footballScores,
       footballTables,
       soccerSchedules,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -20,7 +20,7 @@ object NavLinks {
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = Some("US news"))
   val usElections2024 = NavLink("US elections 2024", "/us-news/us-elections-2024")
-  val trumpTrials = NavLink("Donald Trump trials", "/us-news/donald-trump-trials")
+  val RNCConvention = NavLink("RNC Convention", "/us-news/republican-national-convention-2024")
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")
@@ -109,7 +109,8 @@ object NavLinks {
   val letters = NavLink("Letters", "/tone/letters")
 
   /* SPORT */
-  private val euro2024 = NavLink("Euro 2024", "/football/euro-2024")
+
+  private val olympics2024 = NavLink("Olympics 2024", "/sport/olympic-games-2024")
   private val footballScores = NavLink("Live scores", "/football/live", Some("football/live"))
   private val footballTables = NavLink("Tables", "/football/tables", Some("football/tables"))
   private val footballFixtures = NavLink("Fixtures", "/football/fixtures", Some("football/fixtures"))
@@ -123,7 +124,7 @@ object NavLinks {
     "Football",
     "/football",
     children = List(
-      euro2024,
+      olympics2024,
       footballScores,
       footballTables,
       footballFixtures,
@@ -136,7 +137,7 @@ object NavLinks {
     "Soccer",
     "/us/soccer",
     children = List(
-      euro2024,
+      olympics2024,
       footballScores,
       footballTables,
       soccerSchedules,
@@ -315,7 +316,7 @@ object NavLinks {
     List(
       usNews,
       usElections2024,
-      trumpTrials,
+      RNCConvention,
       world,
       usEnvironment,
       ukraine,
@@ -392,7 +393,7 @@ object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
-      euro2024,
+      olympics2024,
       football,
       cricket,
       rugbyUnion,
@@ -408,7 +409,7 @@ object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
-      euro2024,
+      olympics2024,
       football,
       AFL,
       NRL,
@@ -422,7 +423,7 @@ object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
-      euro2024,
+      olympics2024,
       usSoccer,
       NFL,
       tennis,
@@ -436,7 +437,7 @@ object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
-      euro2024,
+      olympics2024,
       football,
       cricket,
       rugbyUnion,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -168,8 +168,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -461,8 +461,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -1148,8 +1148,8 @@
 					"url": "/us/soccer",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -1312,8 +1312,8 @@
 					"url": "/us/soccer",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2042,8 +2042,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2662,8 +2662,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2863,8 +2863,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -3672,8 +3672,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},
@@ -3873,8 +3873,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Olympics 2024",
-							"url": "/sport/olympic-games-2024",
+							"title": "Euro 2024",
+							"url": "/football/euro-2024",
 							"children": [],
 							"classList": []
 						},

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -168,8 +168,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},
@@ -451,8 +451,8 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Euro 2024",
-					"url": "/football/euro-2024",
+					"title": "Olympics 2024",
+					"url": "/sport/olympic-games-2024",
 					"children": [],
 					"classList": []
 				},
@@ -461,8 +461,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},
@@ -1031,8 +1031,8 @@
 					"classList": []
 				},
 				{
-					"title": "Donald Trump trials",
-					"url": "/us-news/donald-trump-trials",
+					"title": "RNC Convention",
+					"url": "/us-news/republican-national-convention-2024",
 					"children": [],
 					"classList": []
 				},
@@ -1148,8 +1148,8 @@
 					"url": "/us/soccer",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},
@@ -1302,8 +1302,8 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Euro 2024",
-					"url": "/football/euro-2024",
+					"title": "Olympics 2024",
+					"url": "/sport/olympic-games-2024",
 					"children": [],
 					"classList": []
 				},
@@ -1312,8 +1312,8 @@
 					"url": "/us/soccer",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2032,8 +2032,8 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Euro 2024",
-					"url": "/football/euro-2024",
+					"title": "Olympics 2024",
+					"url": "/sport/olympic-games-2024",
 					"children": [],
 					"classList": []
 				},
@@ -2042,8 +2042,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2662,8 +2662,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},
@@ -2853,8 +2853,8 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Euro 2024",
-					"url": "/football/euro-2024",
+					"title": "Olympics 2024",
+					"url": "/sport/olympic-games-2024",
 					"children": [],
 					"classList": []
 				},
@@ -2863,8 +2863,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},
@@ -3672,8 +3672,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},
@@ -3863,8 +3863,8 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Euro 2024",
-					"url": "/football/euro-2024",
+					"title": "Olympics 2024",
+					"url": "/sport/olympic-games-2024",
 					"children": [],
 					"classList": []
 				},
@@ -3873,8 +3873,8 @@
 					"url": "/football",
 					"children": [
 						{
-							"title": "Euro 2024",
-							"url": "/football/euro-2024",
+							"title": "Olympics 2024",
+							"url": "/sport/olympic-games-2024",
 							"children": [],
 							"classList": []
 						},


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/27325
Closes https://github.com/guardian/dotcom-rendering/issues/11901

Navbar updates:
* RNC Convention replaces Trump Trials for the US edition
* Olympics 2024 replace Euro 2024