### PR TITLE
Add Magnite 1% AB test and bump commercial v20.0.0

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -47,6 +47,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-prebid-magnite",
+    "Integrate Magnite as a new prebid bidder",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 9, 30)),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
     "ab-sticky-live-blog-ask-test",
     "A sticky reader revenue ask on the left column of a liveblog",
     owners = Seq(Owner.withEmail("growth@theguardian.com")),

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial": "19.13.0",
+		"@guardian/commercial": "0.0.0-beta-20240723112208",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial": "0.0.0-beta-20240723112208",
+		"@guardian/commercial": "20.0.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
+import { prebidMagnite } from './tests/prebid-magnite';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -13,4 +14,5 @@ export const concurrentTests: readonly ABTest[] = [
 	remoteRRHeaderLinksTest,
 	mpuWhenNoEpic,
 	stickyLiveBlogAskTest,
+	prebidMagnite
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-magnite.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-magnite.ts
@@ -5,7 +5,7 @@ export const prebidMagnite: ABTest = {
 	author: '@commercial-dev',
 	start: '2024-07-18',
 	expiry: '2024-09-30',
-	audience: 0 / 100,
+	audience: 1 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-magnite.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-magnite.ts
@@ -1,0 +1,28 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const prebidMagnite: ABTest = {
+	id: 'PrebidMagnite',
+	author: '@commercial-dev',
+	start: '2024-07-18',
+	expiry: '2024-09-30',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description: 'Test Magnite as a prebid bidder.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3860,9 +3860,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:0.0.0-beta-20240723112208":
-  version: 0.0.0-beta-20240723112208
-  resolution: "@guardian/commercial@npm:0.0.0-beta-20240723112208"
+"@guardian/commercial@npm:20.0.0":
+  version: 20.0.0
+  resolution: "@guardian/commercial@npm:20.0.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.1.1"
@@ -3883,7 +3883,7 @@ __metadata:
     "@guardian/libs": ^18.0.0
     "@guardian/source": ^6.0.0
     typescript: ~5.5.3
-  checksum: 10c0/7ccce59a8d73843931def3be67f0180cb6e819e7afde34a7f670003fda7674b2b28a4497d1f50892da2054c69c561bb058c834f19a6562d8ac5535d19a61170c
+  checksum: 10c0/6b97046b411e0333590f762038608a30aca3e5efa52fecd0dcbabf1f86704ecd12fec3a09ea5a955c357d406b97b72ae5a7383ce70e3ba6664b6a370611f39a7
   languageName: node
   linkType: hard
 
@@ -3956,7 +3956,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial": "npm:0.0.0-beta-20240723112208"
+    "@guardian/commercial": "npm:20.0.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3860,30 +3860,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:19.13.0":
-  version: 19.13.0
-  resolution: "@guardian/commercial@npm:19.13.0"
+"@guardian/commercial@npm:0.0.0-beta-20240723112208":
+  version: 0.0.0-beta-20240723112208
+  resolution: "@guardian/commercial@npm:0.0.0-beta-20240723112208"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.1.1"
-    "@guardian/prebid.js": "npm:8.52.0"
+    "@guardian/prebid.js": "npm:8.52.0-1"
     "@octokit/core": "npm:^6.1.2"
     fastdom: "npm:^1.0.11"
     lodash-es: "npm:^4.17.21"
     process: "npm:^0.11.10"
     raven-js: "npm:^3.27.2"
     tslib: "npm:^2.6.2"
-    web-vitals: "npm:^3.3.2"
+    web-vitals: "npm:^4.2.1"
     wolfy87-eventemitter: "npm:^5.2.9"
   peerDependencies:
-    "@guardian/ab-core": ^7.0.1
-    "@guardian/core-web-vitals": ^6.0.0
-    "@guardian/identity-auth": ^2.1.0
-    "@guardian/identity-auth-frontend": ^4.0.0
-    "@guardian/libs": ^17.0.0
-    "@guardian/source-foundations": ^14.1.2
-    typescript: ~5.3.3
-  checksum: 10c0/836739ff046e679c8dd44fded6428a54fc928721e9e1c5395fe8a4274cd5e0331f5a10634f9235f9e3c8109bf14b806955bd1b6ff835c250127b6477ab87a042
+    "@guardian/ab-core": ^8.0.0
+    "@guardian/core-web-vitals": ^7.0.0
+    "@guardian/identity-auth": ^3.0.0
+    "@guardian/identity-auth-frontend": ^5.0.0
+    "@guardian/libs": ^18.0.0
+    "@guardian/source": ^6.0.0
+    typescript: ~5.5.3
+  checksum: 10c0/7ccce59a8d73843931def3be67f0180cb6e819e7afde34a7f670003fda7674b2b28a4497d1f50892da2054c69c561bb058c834f19a6562d8ac5535d19a61170c
   languageName: node
   linkType: hard
 
@@ -3956,7 +3956,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial": "npm:19.13.0"
+    "@guardian/commercial": "npm:0.0.0-beta-20240723112208"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:2.1.0"
@@ -4151,9 +4151,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/prebid.js@npm:8.52.0":
-  version: 8.52.0
-  resolution: "@guardian/prebid.js@npm:8.52.0"
+"@guardian/prebid.js@npm:8.52.0-1":
+  version: 8.52.0-1
+  resolution: "@guardian/prebid.js@npm:8.52.0-1"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/plugin-transform-runtime": "npm:^7.18.9"
@@ -4175,7 +4175,7 @@ __metadata:
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: 10c0/c2a06714287addabec1605c065db44b8255799a0f2a562efbb201e566bea99a624ffdd948c7a9db090df45d8bbc8a109a5dc28762a045ef149b2e385982a6ae9
+  checksum: 10c0/dd9baf7ecc2743b3948a631a474953be027abd8a436c52ad6a952545baeab159667fb9fdea512ad475a607324f481123f9a81a1065bea44350931d1f6037d70a
   languageName: node
   linkType: hard
 
@@ -17429,10 +17429,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-vitals@npm:3.5.1, web-vitals@npm:^3.3.2":
+"web-vitals@npm:3.5.1":
   version: 3.5.1
   resolution: "web-vitals@npm:3.5.1"
   checksum: 10c0/2b0239241b40e491aa048fac67191ba50cbc5b9d4a859166455d751d12c33399b70579dd3bf5639c37d32421459ce0f64de69307f4f2adae43c0f6b23010849c
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:^4.2.1":
+  version: 4.2.2
+  resolution: "web-vitals@npm:4.2.2"
+  checksum: 10c0/0e41d016a80d8f48e00c95f3d8405a4cb8c6a12a83ac6677ce49447c85ca6fb2325f40915ae5460bb59f07d1b7d65b66b8b42ea50135594ae7dc892453775004
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?

Add 1% AB test for Magnite, aka Rubicon, a new prebid bidder and bump commercial to [v20.0.0](https://github.com/guardian/commercial/releases/tag/v20.0.0)

Commercial PR https://github.com/guardian/commercial/pull/1467

We already have a Commercial switch `prebid-magnite` in PROD  https://github.com/guardian/frontend/pull/27335

We would also like to test via a 1% AB test which will give us the opportunity to receive data and check if we have the correct key/values of `siteId` and `zoneId` based on the different regions, ad-sizes, slotId and breakpoints. 

This has been tested in CODE and you opt-in by adding `#ab-PrebidMagnite=variant` at the end of the url.
