### PR TITLE
Fix: ensure `contributionsServiceUrl` is included in the JSON writes model

### DIFF
--- a/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
@@ -63,6 +63,7 @@ object DotcomTagPagesRenderingDataModel {
         "pageFooter" -> model.pageFooter,
         "isAdFreeUser" -> model.isAdFreeUser,
         "canonicalUrl" -> model.canonicalUrl,
+        "contributionsServiceUrl" -> model.contributionsServiceUrl,
       )
     }
   }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/guardian/frontend/pull/27332 since the `contributionsServiceUrl` wasn't making its way through in the frontend POST request to DCR