### PR TITLE
US navbar updates

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -20,7 +20,6 @@ object NavLinks {
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = Some("US news"))
   val usElections2024 = NavLink("US elections 2024", "/us-news/us-elections-2024")
-  val RNCConvention = NavLink("RNC Convention", "/us-news/republican-national-convention-2024")
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")
@@ -314,10 +313,10 @@ object NavLinks {
     List(
       usNews,
       usElections2024,
-      RNCConvention,
       world,
       usEnvironment,
       ukraine,
+      olympics2024,
       usSoccer,
       usBusiness,
       usTech,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1019,12 +1019,6 @@
 					"classList": []
 				},
 				{
-					"title": "RNC Convention",
-					"url": "/us-news/republican-national-convention-2024",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "World",
 					"url": "/world",
 					"longTitle": "World news",
@@ -1128,6 +1122,12 @@
 				{
 					"title": "Ukraine",
 					"url": "/world/ukraine",
+					"children": [],
+					"classList": []
+				},
+				{
+					"title": "Olympics 2024",
+					"url": "/sport/olympic-games-2024",
 					"children": [],
 					"classList": []
 				},


### PR DESCRIPTION
## What does this change?

* Remove RNC Convention
* Add Olympics 2024 to the main navbar

## Why?
Asked by CP
