### PR TITLE
Add prebid Magnite commercial switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -414,6 +414,16 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
+  val prebidMagnite: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-magnite",
+    description = "Include the Magnite adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
   val sentinelLogger: Switch = Switch(
     group = Commercial,
     name = "sentinel-logger",


### PR DESCRIPTION
## What does this change?

This PR adds prebid Magnite Commercial switch for this work https://github.com/guardian/commercial/pull/1467.

This switch will be used in CODE and it will be much easier to test the switch without the need to deploy in CODE. It also won't cause a problem if we even switch it on in PROD as it isn't being used yet.





