### PR TITLE
resize the crossword grid by dimensions, not the type

### DIFF
--- a/applications/app/views/fragments/crosswords/accessibleCrosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/accessibleCrosswordContent.scala.html
@@ -9,7 +9,7 @@
         <div class="content__main tonal__main tonal__main--tone-news">
             <div class="gs-container">
                 <div class="js-content-main-column">
-                    <div class="crossword__container crossword__container--@crosswordPage.crossword.crosswordType.toString.toLowerCase() crossword__container--accessible">
+                    <div class="crossword__container crossword__container--@{crosswordPage.crossword.dimensions.cols}cell crossword__container--accessible">
                         <div class="crossword__accessible-row-data-wrapper">
                             <div class="crossword__accessible-data">
                                 <h3 class="crossword__accessible-data--header">Blanks</h3>

--- a/applications/app/views/fragments/crosswords/accessibleCrosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/accessibleCrosswordContent.scala.html
@@ -9,7 +9,7 @@
         <div class="content__main tonal__main tonal__main--tone-news">
             <div class="gs-container">
                 <div class="js-content-main-column">
-                    <div class="crossword__container crossword__container--@{crosswordPage.crossword.dimensions.cols}cell crossword__container--accessible">
+                    <div class="crossword__container crossword__container--accessible">
                         <div class="crossword__accessible-row-data-wrapper">
                             <div class="crossword__accessible-data">
                                 <h3 class="crossword__accessible-data--header">Blanks</h3>

--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -17,7 +17,7 @@
                             data-crossword-data="@Json.stringify(Json.toJson(crosswordPage.crossword))">
 
                             <div
-                                class="crossword__container crossword__container--@crosswordPage.crossword.crosswordType.toString.toLowerCase()">
+                                class="crossword__container crossword__container--@{crosswordPage.crossword.dimensions.cols}cell">
                                 @* The following is a fallback for when JavaScript is not enabled *@
                                 <div class="crossword__container__grid-wrapper">
                                     <noscript>@crosswordPage.svg</noscript>

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -749,7 +749,7 @@ class Crossword extends Component {
 
 		return (
 			<div
-				className={`crossword__container crossword__container--${this.props.data.crosswordType} crossword__container--react`}
+				className={`crossword__container crossword__container--${this.props.data.dimensions.cols}cell crossword__container--react`}
 				data-link-name="Crosswords"
 			>
 				<div

--- a/static/src/stylesheets/module/crosswords/_cell.scss
+++ b/static/src/stylesheets/module/crosswords/_cell.scss
@@ -33,8 +33,8 @@
     -webkit-font-smoothing: subpixel-antialiased;
     transition: opacity .15s ease-in;
 
-    @each $xword, $cells in $xword-grid-sizes {
-        .crossword__container--#{$xword} & {
+    @each $cells in $xword-cell-sizes {
+        .crossword__container--#{$cells}cell & {
             font-size: ceil(1.2px * $cells);
 
             @include mq(tablet) {

--- a/static/src/stylesheets/module/crosswords/_cell.scss
+++ b/static/src/stylesheets/module/crosswords/_cell.scss
@@ -32,16 +32,6 @@
     opacity: 1;
     -webkit-font-smoothing: subpixel-antialiased;
     transition: opacity .15s ease-in;
-
-    @each $cells in $xword-cell-sizes {
-        .crossword__container--#{$cells}cell & {
-            font-size: ceil(1.2px * $cells);
-
-            @include mq(tablet) {
-                font-size: 1.1px * $cells;
-            }
-        }
-    }
 }
 
 .crossword__cell-text--focussed {

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -5,7 +5,8 @@
 }
 
 @each $cells in $xword-cell-sizes {
-    $size: xword-grid-dimensions($cells);
+    $max-size: 481px; // width of 15-cell grid
+    $size: min($max-size, xword-grid-dimensions($cells));
 
     .crossword__container--#{$cells}cell {
         @include mq(tablet) {

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -4,10 +4,10 @@
     @return $cells * ($xword-cell-width + $xword-border-width) + $xword-border-width;
 }
 
-@each $xword, $cells in $xword-grid-sizes {
+@each $cells in $xword-cell-sizes {
     $size: xword-grid-dimensions($cells);
 
-    .crossword__container--#{$xword} {
+    .crossword__container--#{$cells}cell {
         @include mq(tablet) {
             padding-left: $size;
 

--- a/static/src/stylesheets/module/crosswords/_vars.scss
+++ b/static/src/stylesheets/module/crosswords/_vars.scss
@@ -11,14 +11,4 @@ $xword-focussed-background-colour: #fff7b2;
 
 $xword-clue-number-width: 32px;
 
-$xword-grid-sizes: (
-    quick-cryptic: 11,
-    quick: 13,
-    cryptic: 15,
-    prize: 15,
-    quiptic: 15,
-    genius: 15,
-    speedy: 13,
-    everyman: 15,
-    weekend: 13
-);
+$xword-cell-sizes: 11, 13, 15, 17, 19, 21, 23, 25, 27;


### PR DESCRIPTION
## What is the value of this and can you measure success?

Currently, the crossword grid calculates the size of the text input boxes by looking up the expected width of the crossword by its series. This has worked okay for a long time, but it's annoying because we need to remember to add the new item to the lookup, and once we've chosen a grid size for a crossword type we need to stick with it. Occasionally we'll publish a prize (or other type) crossword called a "jumbo" with larger dimensions, an old example is https://www.theguardian.com/crosswords/prize/22089, and the input box will also appear wrong on these; the cells will reduce in width but the text input box will not. This has been the case for a while, and is unsightly so these crosswords have been opted to be published as static PDFs instead of playable crosswords! https://www.theguardian.com/crosswords/2023/dec/23/prize-crossword-no-29261

## What does this change?

Instead, choose the grid size styling by putting the grid width in cells into the class name (eg. `crossword__container--15cell`), and having SASS generate classes for all the cell widths we care about (grids are always square, odd number of cells wide, between 11 and 23 cells (I've gone up to 27 just to be on the safe side)).

This will unblock us from publishing interactive jumbo crosswords, and from creating or updating series to allow grid sizing to change over time within a series.

Before | After
-- | -- 
<img width="228" alt="image" src="https://github.com/user-attachments/assets/b08ad5b4-4e04-4562-80c2-07dc9ec48fc9"> | <img width="362" alt="image" src="https://github.com/user-attachments/assets/c049c103-2c7c-400b-94f9-0ea6f68db29a">
