### PR TITLE
Add support for Mini profiles fields to ListItem

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1589,6 +1589,8 @@ object PageElement {
         )
       }.toSeq,
       title = item.title,
+      bio = item.bio,
+      endNote = item.endNote
     )
   }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -365,6 +365,8 @@ object InstagramBlockElement {
 case class ListItem(
     elements: Seq[PageElement],
     title: Option[String],
+    bio: Option[String],
+    endNote: Option[String]
 ) extends PageElement
 object ListItem {
   implicit val listItemWrites: Writes[ListItem] = Json.writes[ListItem]

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -366,7 +366,7 @@ case class ListItem(
     elements: Seq[PageElement],
     title: Option[String],
     bio: Option[String],
-    endNote: Option[String]
+    endNote: Option[String],
 ) extends PageElement
 object ListItem {
   implicit val listItemWrites: Writes[ListItem] = Json.writes[ListItem]
@@ -1590,7 +1590,7 @@ object PageElement {
       }.toSeq,
       title = item.title,
       bio = item.bio,
-      endNote = item.endNote
+      endNote = item.endNote,
     )
   }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
This adds support for the new fields included in Mini profiles fields.

These fields have already been available `content-api-client` since [v31.0.0](https://github.com/guardian/content-api-scala-client/compare/v30.0.0...v31.0.0) (`frontend` is currently using`31.0.3`) - `content-api-client` in turn uses `content-api-model` v [`25.0.0`](https://github.com/guardian/content-api-models/releases/tag/v25.0.0), which provides the models that contain the new fields.

`dotcom-rendering` is already able to render these fields, since [this PR](https://github.com/guardian/dotcom-rendering/pull/11923).