### PR TITLE
Opt out of server-side tests properly

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -25,7 +25,8 @@ class OptInController(val controllerComponents: ControllerComponents) extends Ba
       case "delete" => optDelete(feature)
     }
   def optIn(cookieName: String): Result = SeeOther("/").withCookies(Cookie(cookieName, "true", maxAge = Some(lifetime)))
-  def optOut(cookieName: String): Result = SeeOther("/").discardingCookies(DiscardingCookie(cookieName))
+  def optOut(cookieName: String): Result =
+    SeeOther("/").withCookies(Cookie(cookieName, "false", maxAge = Some(lifetime)))
   def optDelete(cookieName: String): Result = SeeOther("/").discardingCookies(DiscardingCookie(cookieName))
 
   def reset(): Action[AnyContent] =


### PR DESCRIPTION
## What is the value of this and can you measure success?

Even if the user is in the bucker from their MVT ID after opting out, they still get the control behaviour.

## What does this change?

We do not simply remove the cookie, but set it to `false`, so we get a sense of how many people have conciously opted out!