### PR TITLE
Update server side experiments (extend dark mode test)

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -43,8 +43,8 @@ object DarkModeWeb
     extends Experiment(
       name = "dark-mode-web",
       description = "Enable dark mode on web",
-      owners = Seq(Owner.withGithub("jakeii"), Owner.withGithub("mxdvl")),
-      sellByDate = LocalDate.of(2024, 7, 30),
+      owners = Seq(Owner.withGithub("jakeii")),
+      sellByDate = LocalDate.of(2024, 10, 30),
       participationGroup = Perc0D,
     )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -43,7 +43,7 @@ object DarkModeWeb
     extends Experiment(
       name = "dark-mode-web",
       description = "Enable dark mode on web",
-      owners = Seq(Owner.withGithub("jakeii")),
+      owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 10, 30),
       participationGroup = Perc0D,
     )
@@ -52,7 +52,7 @@ object UseSourcepointPropertyId
     extends Experiment(
       name = "use-sourcepoint-property-id",
       description = "Use Sourcepoint propertyId instead of propertyHref",
-      owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
+      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2024, 7, 30),
       participationGroup = Perc5A,
     )
@@ -61,7 +61,7 @@ object TagLinkDesign
     extends Experiment(
       name = "tag-link-design",
       description = "Render an updated sticky design for tag links on Olympics articles and liveblogs",
-      owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
+      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 8, 12),
       participationGroup = Perc10A,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?

Was looking at the CODE switchboard today and realised a couple of tests were about to expire. 

## What does this change?

- Added 3 months to the dark mode AB test expiry date
- Swapped @mxdvl for @guardian/dotcom-platform in the ownership 😢 
- Updated other uses of `Owner.withGithub` to `Owner.withEmail` where the ownership is represented by an email group rather than a Github username

On that note, `use-sourcepoint-property-id` expires tomorrow FYI @guardian/commercial-dev
