### PR TITLE
Add partial overs to cricket scores

### DIFF
--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -28,7 +28,7 @@ object InningsBatter {
   implicit val writes: OWrites[InningsBatter] = Json.writes[InningsBatter]
 }
 
-case class InningsBowler(name: String, order: Int, overs: Int, maidens: Int, runs: Int, wickets: Int)
+case class InningsBowler(name: String, order: Int, overs: Int, maidens: Int, runs: Int, wickets: Int, balls: Int)
 
 object InningsBowler {
   implicit val writes: OWrites[InningsBowler] = Json.writes[InningsBowler]

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -130,6 +130,7 @@ object Parser {
           getStatistic(bowler, "maidens") toInt,
           getStatistic(bowler, "runs-conceded") toInt,
           getStatistic(bowler, "wickets-taken") toInt,
+          getStatistic(bowler, "balls") toInt,
         )
       }
       .toList

--- a/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
+++ b/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
@@ -104,7 +104,7 @@
 				@for(bowler <- innings.bowlers) {
 				<tr>
 					<td>@bowler.name</td>
-					<td>@bowler.overs</td>
+					<td>@bowler.balls / 6</td>
 					<td>@bowler.maidens</td>
 					<td>@bowler.runs</td>
 					<td>@bowler.wickets</td>

--- a/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
+++ b/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
@@ -104,7 +104,7 @@
 				@for(bowler <- innings.bowlers) {
 				<tr>
 					<td>@bowler.name</td>
-					<td>@bowler.balls / 6</td>
+					<td>@(f"${bowler.balls.toFloat / 6}%.1f")</td>
 					<td>@bowler.maidens</td>
 					<td>@bowler.runs</td>
 					<td>@bowler.wickets</td>

--- a/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
+++ b/sport/app/cricket/views/fragments/cricketFullScorecard.scala.html
@@ -104,7 +104,7 @@
 				@for(bowler <- innings.bowlers) {
 				<tr>
 					<td>@bowler.name</td>
-					<td>@(f"${bowler.balls.toFloat / 6}%.1f")</td>
+					<td>@(s"${bowler.balls / 6}.${bowler.balls % 6}")</td>
 					<td>@bowler.maidens</td>
 					<td>@bowler.runs</td>
 					<td>@bowler.wickets</td>


### PR DESCRIPTION
## What is the value of this and can you measure success?
We had a request to add partial overs for bowlers. This now has parity with the BBC data.
## What does this change?
Resolves https://github.com/guardian/dotcom-rendering/issues/11971
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/44f77733-0758-4e0b-9a2e-e556ccb90d03
[after]: https://github.com/user-attachments/assets/7119a60b-ef9e-4cbc-a2e0-9ee0c8c7bc9e



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
