### PR TITLE
refactor adlabel for center alignment

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -625,10 +625,9 @@
     position: relative;
     height: $mpu-ad-label-height;
     background-color: $brightness-97;
-    padding: 0 math.div($gs-baseline, 3)*2;
     border-top: 1px solid $brightness-86;
     color: $brightness-46;
-    text-align: left;
+    text-align: center;
     box-sizing: border-box;
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }
@@ -641,10 +640,9 @@
     position: relative;
     height: $mpu-ad-label-height;
     background-color: transparent;
-    padding: 0 math.div($gs-baseline, 3)*2;
     border-top: 1px solid $brightness-20;
     color: $brightness-86;
-    text-align: left;
+    text-align: center;
     box-sizing: border-box;
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }
@@ -655,11 +653,10 @@
     visibility: visible;
     height: $mpu-ad-label-height;
     background-color: transparent;
-    padding: 0 math.div($gs-baseline, 3)*2;
     border: 0;
     border-top: 1px solid $brightness-20;
     color: $brightness-86;
-    text-align: left;
+    text-align: center;
     box-sizing: border-box;
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
     position: absolute;


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

This is part of a bigger body of work to align the text ad label to centre.
Related PR's commercial: [here](https://github.com/guardian/commercial/pull/1484) and here.

This will of course specifically keep the ad label positioning for the Frontend rendered page (eg. crosswords and Gallery) 

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1325" alt="Screenshot 2024-07-31 at 10 50 20" src="https://github.com/user-attachments/assets/0aea7a79-dee7-41fa-b60d-75f0ebf3e991"> | <img width="1481" alt="Screenshot 2024-07-31 at 10 49 35" src="https://github.com/user-attachments/assets/169b372f-9a0b-492f-a45a-60966daaa4b0"> |
| <img width="517" alt="Screenshot 2024-07-31 at 10 51 44" src="https://github.com/user-attachments/assets/09067b39-e646-41bf-8253-47a596b12f36"> | <img width="514" alt="Screenshot 2024-07-31 at 10 52 38" src="https://github.com/user-attachments/assets/e73d40a1-4fa9-4bde-9fbb-536224f55332"> |


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
