### PR TITLE
Remove Euro2024Header feature switch

### DIFF
--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -74,14 +74,4 @@ trait JournalismSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
-
-  val Euro2024Header = Switch(
-    SwitchGroup.Journalism,
-    name = "euro-2024-header",
-    description = "Show the Euro 2024 interactive atom header on football pages",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    sellByDate = LocalDate.of(2024, 7, 31),
-    exposeClientSide = true,
-  )
 }

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -1,26 +1,19 @@
 package football.controllers
 
 import common.Edition
-import common.ImplicitControllerExecutionContext
 import feed.CompetitionsService
 import football.model._
 import model._
-import model.content.InteractiveAtom
-import contentapi.ContentApiClient
 import java.time.LocalDate
 import pa.FootballTeam
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import scala.concurrent.Future
-import conf.switches.Switches
 
 class FixturesController(
     val competitionsService: CompetitionsService,
     val controllerComponents: ControllerComponents,
-    val contentApiClient: ContentApiClient,
 )(implicit context: ApplicationContext)
     extends MatchListController
-    with CompetitionFixtureFilters
-    with ImplicitControllerExecutionContext {
+    with CompetitionFixtureFilters {
 
   private def fixtures(date: LocalDate): FixturesList = FixturesList(date, competitionsService.competitions)
   private val page = new FootballPage("football/fixtures", "football", "All fixtures")
@@ -87,21 +80,14 @@ class FixturesController(
 
   private def renderTagFixtures(date: LocalDate, tag: String): Action[AnyContent] =
     getTagFixtures(date, tag)
-      .map { case (page, fixtures) =>
-        Action.async { implicit request =>
-          tag match {
-            case "euro-2024" if Switches.Euro2024Header.isSwitchedOn =>
-              val id = "/atom/interactive/interactives/2023/01/euros-2024/match-centre-euros-2024-header"
-              val edition = Edition(request)
-              contentApiClient
-                .getResponse(contentApiClient.item(id, edition))
-                .map(_.interactive.map(InteractiveAtom.make(_)))
-                .recover { case _ => None }
-                .map(renderMatchList(page, fixtures, filters, _))
-            case _ =>
-              Future.successful(renderMatchList(page, fixtures, filters, None))
-          }
-        }
-      }
+      .map(result =>
+        Action { implicit request =>
+          renderMatchList(
+            result._1,
+            result._2,
+            filters,
+          )
+        },
+      )
       .getOrElse(Action(NotFound))
 }

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -134,7 +134,7 @@ class LeagueTableController(
             s"${table.competition.fullName} table",
           )
 
-          val futureAtom = if (Switches.Euro2024Header.isSwitchedOn && competition == "euro-2024") {
+          val futureAtom = if (competition == "euro-2024") {
             val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
             val edition = Edition(request)
             contentApiClient

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -46,7 +46,7 @@ class WallchartController(
           val competitionStages = new CompetitionStage(competitionsService.competitions)
             .stagesFromCompetition(competition, KnockoutSpider.orderings)
           val nextMatch = WallchartController.nextMatch(competition.matches, ZonedDateTime.now())
-          val futureAtom = if (Switches.Euro2024Header.isSwitchedOn && competitionTag == "euro-2024") {
+          val futureAtom = if (competitionTag == "euro-2024") {
             val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
             val edition = Edition(request)
             contentApiClient

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -17,19 +17,14 @@ import org.scalatest.matchers.should.Matchers
     with WithMaterializer
     with BeforeAndAfterAll
     with WithTestApplicationContext
-    with WithTestWsClient
-    with WithTestContentApiClient {
+    with WithTestWsClient {
 
   val fixturesUrl = "/football/fixtures"
   val fixtureForUrl = "/football/fixtures/2012/oct/20"
   val tag = "premierleague"
 
   lazy val fixturesController =
-    new FixturesController(
-      testCompetitionsService,
-      play.api.test.Helpers.stubControllerComponents(),
-      testContentApiClient,
-    )
+    new FixturesController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents())
 
   "can load the all fixtures page" in {
     val result = fixturesController.allFixtures()(TestRequest())


### PR DESCRIPTION
Closes [#12037](https://github.com/guardian/dotcom-rendering/issues/12037)

## What is the value of this and can you measure success?

The competition has finished

## What does this change?

Remove Euro2024Header feature switch
