### PR TITLE
Enable correct pressing of highlights container by adding it to fixed/containers

### DIFF
--- a/common/app/layout/slices/FixedContainers.scala
+++ b/common/app/layout/slices/FixedContainers.scala
@@ -37,6 +37,8 @@ object FixedContainers {
 
   val showcaseSingleStories = slices(ShowcaseSingleStories)
 
+  val fixedHighlights = slices(Highlights)
+
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(FullMedia75)),
     ("fixed/small/slow-III", slices(HalfQQ)),
@@ -53,6 +55,7 @@ object FixedContainers {
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/thrasher", thrasher),
     ("fixed/showcase", showcaseSingleStories),
+    ("fixed/highlights", fixedHighlights),
   ) ++ (if (Configuration.faciatool.showTestContainers)
           Map(
             (

--- a/common/app/layout/slices/Slice.scala
+++ b/common/app/layout/slices/Slice.scala
@@ -1104,28 +1104,52 @@ case object TTMpu extends Slice {
 }
 
 /*
- * The Highlights layout is used to display select features in the header for apps and web
+ * The Highlights layout is used to display select features in the header for apps and web, notably via a carousel.
+ * The implementation on platforms effectively limits the display to 2-4 cards, with a peeking card.
+ * We don't limit the slice definition here to 4, because of how fronts are pressed in facia-press.
+ * This ensures the full number of cards get loaded by default, and can then be appropriately displayed by the carousel.
  *
  * Desktop:
- * .____________.____________.____________.
- * |       #####|       #####|       #####|
- * |       #####|       #####|       #####|
- * |       #####|       #####|       #####|
- * '--------------------------------------'
+ * .____________.____________.____________.____________.____________.____________.
+ * |       #####|       #####|       #####|       #####|       #####|       #####|
+ * |       #####|       #####|       #####|       #####|       #####|       #####|
+ * |       #####|       #####|       #####|       #####|       #####|       #####|
+ * '-----------------------------------------------------------------------------'
  *
  * Mobile:
- * .___________.___________.___________.
- * |           |           |           |
- * |           |           |           |
- * |_#########_|_#########_|_#########_|
- * |_#########_|_#########_|_#########_|
- * |_#########_|_#########_|_#########_|
- * `-----------------------------------'
+ * .___________.___________.___________.___________.___________.___________.
+ * |           |           |           |           |           |           |
+ * |           |           |           |           |           |           |
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|_#########_|_#########_|_#########_|
+ * `-----------------------------------------------------------------------'
  */
 case object Highlights extends Slice {
   val layout = SliceLayout(
-    cssClassName = "t-t-t",
+    cssClassName = "t-t-t-t-t-t",
     columns = Seq(
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
       SingleItem(
         colSpan = 1,
         ItemClasses(

--- a/common/app/layout/slices/Slice.scala
+++ b/common/app/layout/slices/Slice.scala
@@ -1102,3 +1102,51 @@ case object TTMpu extends Slice {
     ),
   )
 }
+
+/*
+ * The Highlights layout is used to display select features in the header for apps and web
+ *
+ * Desktop:
+ * .____________.____________.____________.
+ * |       #####|       #####|       #####|
+ * |       #####|       #####|       #####|
+ * |       #####|       #####|       #####|
+ * '--------------------------------------'
+ *
+ * Mobile:
+ * .___________.___________.___________.
+ * |           |           |           |
+ * |           |           |           |
+ * |_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|
+ * |_#########_|_#########_|_#########_|
+ * `-----------------------------------'
+ */
+case object Highlights extends Slice {
+  val layout = SliceLayout(
+    cssClassName = "t-t-t",
+    columns = Seq(
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = Standard,
+          tablet = MediaList,
+        ),
+      ),
+    ),
+  )
+}

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -26,6 +26,7 @@ import play.api.libs.ws.{WSClient, WSResponse}
 import services.{ConfigAgent, S3FrontsApi}
 import implicits.Booleans._
 import layout.slices.Container
+import play.api.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -336,13 +337,13 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         )
         .getOrElse(storyCountMax)
       if (collectionId == "cb4cc3b5-b5fc-466a-aa47-9dc6b9847967") {
-        println(
-          "storyCountTotal",
-          storyCountTotal,
-          "storyCountMax",
-          storyCountMax,
-          "storyCountVisible",
-          storyCountVisible,
+        log.info(
+          "storyCountTotal" +
+            storyCountTotal +
+            "storyCountMax" +
+            storyCountMax +
+            "storyCountVisible" +
+            storyCountVisible,
         )
       }
       val pressedCollection = pressCollection(collection, curated, backfill, treats, storyCountMax)

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -322,7 +322,8 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
       backfill <- getBackfill(collection)
       treats <- getTreats(collection)
     } yield {
-      val doNotTrimContainerOfTypes = Seq("nav/list")
+
+      val doNotTrimContainerOfTypes = Seq("nav/list", "fixed/highlights")
       val storyCountTotal = curated.length + backfill.length
       val storyCountMax: Int = doNotTrimContainerOfTypes
         .contains(collection.collectionConfig.collectionType)
@@ -334,7 +335,16 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
           curated ++ backfill,
         )
         .getOrElse(storyCountMax)
-
+      if (collectionId == "cb4cc3b5-b5fc-466a-aa47-9dc6b9847967") {
+        println(
+          "storyCountTotal",
+          storyCountTotal,
+          "storyCountMax",
+          storyCountMax,
+          "storyCountVisible",
+          storyCountVisible,
+        )
+      }
       val pressedCollection = pressCollection(collection, curated, backfill, treats, storyCountMax)
       PressedCollectionVisibility(pressedCollection, storyCountVisible)
     }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -336,16 +336,16 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
           curated ++ backfill,
         )
         .getOrElse(storyCountMax)
-      if (collectionId == "cb4cc3b5-b5fc-466a-aa47-9dc6b9847967") {
-        log.info(
-          "storyCountTotal" +
-            storyCountTotal +
-            "storyCountMax" +
-            storyCountMax +
-            "storyCountVisible" +
-            storyCountVisible,
-        )
-      }
+      log.info(
+        "collection " + collectionId + " of type " + collection.collectionConfig.collectionType +
+          "storyCountTotal " +
+          storyCountTotal +
+          "storyCountMax " +
+          storyCountMax +
+          "storyCountVisible " +
+          storyCountVisible,
+      )
+
       val pressedCollection = pressCollection(collection, curated, backfill, treats, storyCountMax)
       PressedCollectionVisibility(pressedCollection, storyCountVisible)
     }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -26,7 +26,6 @@ import play.api.libs.ws.{WSClient, WSResponse}
 import services.{ConfigAgent, S3FrontsApi}
 import implicits.Booleans._
 import layout.slices.Container
-import play.api.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -323,8 +322,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
       backfill <- getBackfill(collection)
       treats <- getTreats(collection)
     } yield {
-
-      val doNotTrimContainerOfTypes = Seq("nav/list", "fixed/highlights")
+      val doNotTrimContainerOfTypes = Seq("nav/list")
       val storyCountTotal = curated.length + backfill.length
       val storyCountMax: Int = doNotTrimContainerOfTypes
         .contains(collection.collectionConfig.collectionType)
@@ -336,15 +334,6 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
           curated ++ backfill,
         )
         .getOrElse(storyCountMax)
-      log.info(
-        "collection " + collectionId + " of type " + collection.collectionConfig.collectionType +
-          "storyCountTotal " +
-          storyCountTotal +
-          "storyCountMax " +
-          storyCountMax +
-          "storyCountVisible " +
-          storyCountVisible,
-      )
 
       val pressedCollection = pressCollection(collection, curated, backfill, treats, storyCountMax)
       PressedCollectionVisibility(pressedCollection, storyCountVisible)


### PR DESCRIPTION
## What is the value of this and can you measure success?

Part of the homepage redesign, resolves [this issue](https://trello.com/c/2CcQg85w/310-highlightscontainer-investigate-why-container-content-is-being-limited-to-4-cards)

## What does this change?

This adds a layout definition for the highlights container in the list of fixed containers. The number of slices in the layout is set to 6, as this is currently the number of cards that we're intending to have load on the page (to enable the carousel implemented by DCR to function as intended)

This is notably used when facia-press is pressing the page to generate its lite version, it will include the desired 6 cards. 

## Testing

Aside from checking the generated json file, this video confirms the carousel rendered by DCR is correctly showing the desired cards:

https://github.com/user-attachments/assets/e34ad698-efb1-4b92-a075-63d76b63cf42


-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
