### PR TITLE
Upgrade dynamodb to AWS v2 & scanamo to the latest version

### DIFF
--- a/common/app/services/DynamoDB.scala
+++ b/common/app/services/DynamoDB.scala
@@ -1,25 +1,20 @@
 package services
 
-import com.amazonaws.services.dynamodbv2.{
-  AmazonDynamoDB,
-  AmazonDynamoDBAsync,
-  AmazonDynamoDBAsyncClient,
-  AmazonDynamoDBClient,
-}
-import conf.Configuration
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.{DynamoDbAsyncClient, DynamoDbClient}
+import utils.AWSv2
 
 object DynamoDB {
-  private lazy val credentials = Configuration.aws.mandatoryCredentials
 
-  lazy val asyncClient: AmazonDynamoDBAsync = AmazonDynamoDBAsyncClient
-    .asyncBuilder()
-    .withCredentials(credentials)
-    .withRegion(conf.Configuration.aws.region)
+  lazy val asyncClient: DynamoDbAsyncClient = DynamoDbAsyncClient
+    .builder()
+    .credentialsProvider(AWSv2.credentials)
+    .region(Region.of(conf.Configuration.aws.region))
     .build()
 
-  lazy val syncClient: AmazonDynamoDB = AmazonDynamoDBClient
+  lazy val syncClient: DynamoDbClient = DynamoDbClient
     .builder()
-    .withCredentials(credentials)
-    .withRegion(conf.Configuration.aws.region)
+    .credentialsProvider(AWSv2.credentials)
+    .region(Region.of(conf.Configuration.aws.region))
     .build()
 }

--- a/common/app/services/RedirectService.scala
+++ b/common/app/services/RedirectService.scala
@@ -1,9 +1,8 @@
 package services
 
 import java.net.URL
-import org.scanamo.error.MissingProperty
 import org.scanamo.syntax._
-import org.scanamo.{DynamoFormat, Scanamo, ScanamoAsync, Table}
+import org.scanamo.{DynamoFormat, MissingProperty, Scanamo, ScanamoAsync, Table}
 import common.GuLogging
 import conf.Configuration
 

--- a/common/app/services/RedirectService.scala
+++ b/common/app/services/RedirectService.scala
@@ -40,16 +40,19 @@ object RedirectService {
   }
 
   implicit val destinationFormat: AnyRef with DynamoFormat[Destination] =
-    DynamoFormat.xmap[Destination, Map[String, String]] {
-      // map -> destination (i.e. reads)
-      case m if m.contains("destination") => Right(PermanentRedirect(m("source"), m("destination")))
-      case m if m.contains("archive")     => Right(ArchiveRedirect(m("source"), m("archive")))
-      case _                              => Left(MissingProperty)
-    } {
-      // destination -> map (i.e. writes)
-      case PermanentRedirect(source, destination) => Map("source" -> source, "destination" -> destination)
-      case ArchiveRedirect(source, archive)       => Map("source" -> source, "archive" -> archive)
-    }
+    DynamoFormat.xmap[Destination, Map[String, String]](
+      {
+        // map -> destination (i.e. reads)
+        case m if m.contains("destination") => Right(PermanentRedirect(m("source"), m("destination")))
+        case m if m.contains("archive")     => Right(ArchiveRedirect(m("source"), m("archive")))
+        case _                              => Left(MissingProperty)
+      },
+      {
+        // destination -> map (i.e. writes)
+        case PermanentRedirect(source, destination) => Map("source" -> source, "destination" -> destination)
+        case ArchiveRedirect(source, archive)       => Map("source" -> source, "archive" -> archive)
+      },
+    )
 
   // This is a permanent 3XX redirect - it could be guardian/non-guardian address
   case class PermanentRedirect(source: String, location: String) extends Destination
@@ -119,7 +122,7 @@ class RedirectService(implicit executionContext: ExecutionContext) extends GuLog
   def lookupRedirectDestination(source: String): Future[Option[Destination]] = {
     val fullUrl = if (source.head == '/') expectedSourceHost + source else s"$expectedSourceHost/$source"
     ScanamoAsync(DynamoDB.asyncClient)
-      .exec(table.get("source" -> fullUrl))
+      .exec(table.get("source" === fullUrl))
       .map({
         case Some(Right(destination)) => Some(destination)
         case _                        => None
@@ -154,7 +157,7 @@ class RedirectService(implicit executionContext: ExecutionContext) extends GuLog
   def remove(source: String): Boolean =
     normaliseSource(source).exists { src =>
       log.info(s"Removing redirect in: $tableName to: $src")
-      Scanamo(DynamoDB.syncClient).exec(table.delete("source" -> src))
+      Scanamo(DynamoDB.syncClient).exec(table.delete("source" === src))
       true
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.25"
   val awsVersion = "1.12.758"
+  val awsSdk2Version = "2.26.27"
   val capiVersion = "31.1.0"
   val faciaVersion = "8.0.0"
   val dispatchVersion = "0.13.1"
@@ -14,7 +15,7 @@ object Dependencies {
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.14.0"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion
-  val awsDynamodb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion
+  val awsDynamodb = "software.amazon.awssdk" % "dynamodb" % awsSdk2Version
   val awsEc2 = "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion
   val awsKinesis = "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion
   val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
@@ -89,7 +90,7 @@ object Dependencies {
 
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.4"
   val targetingClient = "com.gu.targeting-client" %% "client-play-json-v30" % "1.1.9"
-  val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
+  val scanamo = "org.scanamo" %% "scanamo" % "2.0.0"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.8.1"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.3"
   val playJson = "org.playframework" %% "play-json" % playJsonVersion


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/27368

I recommend hiding whitespace.

## What does this change?
* Upgrade to latest Scanamo version
* Upgrade dynamodb to AWS SDK v2. It's a prerequisite for the scanamo update.

## Background
We have a DynamoDB that stores redirects. 

![image](https://github.com/user-attachments/assets/46296a90-ab5c-4ed4-be93-59ef7f51e8fe)

These can be:
* Old articles (mostly R2) that redirect to the archive S3 bucket where the original html of the article is stored, e.g. https://www.theguardian.com/info/developer-blog/2011/jul/15/jquery-overlay-plugin
* Any other url that redirects to a specific destination, e.g. http://www.theguardian.com/crossword/java/new/0,,-30476,.html

This DB is accessed by fetch, put and delete operations.

### Fetch

The flow for requesting an article that has a redirect is:
1. They hit the usual controllers, e.g. ArticleController or FaciaController
2. CAPI lookup of content returns 404 
3. ArchiveController receives a [404 request](https://github.com/guardian/frontend/blob/main/archive/conf/routes#L11)
4. It looks up to the DynamoDB
5. If there is an entry with the path requested in the source column, it redirects to either `s3-archive/<path>` or the specified destination

![image](https://github.com/user-attachments/assets/8436ef63-184d-41cf-bc31-ae8b442b8850)

### Put / Delete

Redirects can be created and deleted in the [admin tool](https://frontend.code.dev-gutools.co.uk/redirects).

1. The user sets or deletes a redirect via the admin tool
2. [RedirectService](https://github.com/guardian/frontend/blob/462a5779e6af2c8dec6b4d1568966417bc57ff50/common/app/services/RedirectService.scala#L148-L159) sets or removes the redirect from DynamoDB

![image](https://github.com/user-attachments/assets/ac5008f9-e836-475a-96df-6771366ef1ea)


## Testing

- [x] Tested the above flows on CODE

Successfully deleted and set a redirect

![image](https://github.com/user-attachments/assets/93952a39-3dbb-4341-8a49-27a6bbcdfe1b)

Successfully requested articles that redirect to:

* a destination

![image](https://github.com/user-attachments/assets/a7dff33e-546f-45fb-8952-a3303264c21d)

* the archive bucket

![image](https://github.com/user-attachments/assets/cf162595-f1a9-485c-b068-bba1c5c3ce3e)


