### PR TITLE
Remove `updateLogoAdPartner` switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -159,17 +159,6 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
-
-  val updateLogoAdPartner: Switch = Switch(
-    group = Commercial,
-    name = "update-logo-ad-partner",
-    description =
-      "Enable the updated logo styling for advertising partner and exclusive advertising partner US labels.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = LocalDate.of(2024, 8, 7),
-    exposeClientSide = true,
-  )
 }
 
 trait PrebidSwitches {


### PR DESCRIPTION
## What does this change?

Removes the switch for updated logo "Advertising partner" US work as we don't need it after having a live campaign and everything works as expected. 

The logic has been updated in DCR to apply the styling without depending on a switch as one of the conditions which you can find it in here https://github.com/guardian/dotcom-rendering/pull/12064

The PR were the switch has been added https://github.com/guardian/frontend/pull/27184

## Checklist

- [x] Tested locally, and on CODE if necessary
