### PR TITLE
Upgrade to content-api-client 31.1.0 for special crossword support

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.25"
   val awsVersion = "1.12.758"
-  val capiVersion = "31.0.3"
+  val capiVersion = "31.1.0"
   val faciaVersion = "8.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?

Upgrade the content-api-client, to get the latest version of CAPI models, which includes support for the upcoming "special crosswords" series.

Normally we'd need to also add the new series name to many of the [crossword](https://github.com/guardian/frontend/blob/12ce055553176605f338b4aed1258ebd70a5cbb7/applications/conf/routes#L20-L24) [route](https://github.com/guardian/frontend/blob/12ce055553176605f338b4aed1258ebd70a5cbb7/dev-build/conf/routes#L22-L26) [regexes](https://github.com/guardian/frontend/blob/12ce055553176605f338b4aed1258ebd70a5cbb7/preview/conf/routes#L17), but they already contain "special", presumably for some previous version of special crosswords.

We no longer need to update the crossword player CSS, since #27336

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
