### PR TITLE
Bump commercial to 20.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial": "20.2.1",
+		"@guardian/commercial": "20.3.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,9 +3998,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:20.2.1":
-  version: 20.2.1
-  resolution: "@guardian/commercial@npm:20.2.1"
+"@guardian/commercial@npm:20.3.0":
+  version: 20.3.0
+  resolution: "@guardian/commercial@npm:20.3.0"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/ophan-tracker-js": "npm:2.1.1"
@@ -4021,7 +4021,7 @@ __metadata:
     "@guardian/libs": ^18.0.0
     "@guardian/source": ^6.0.0
     typescript: ~5.5.3
-  checksum: 10c0/15178b27d87799bba30c3741d2b1bcf278dceed1fb09a9610219ca114ab9c11d4215cb883da8e3073703611ed2166f22bda24ba81575c072698ea8f79b7b0fb6
+  checksum: 10c0/22f46eda911b9473e01341525b45a8e99fc6c3f54bce7918844dcfa23fdf35128581d63a0da641dc1f606c2dae465697790c87a0e09bcc3a9b2051921c3cc658
   languageName: node
   linkType: hard
 
@@ -4094,7 +4094,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial": "npm:20.2.1"
+    "@guardian/commercial": "npm:20.3.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"


### PR DESCRIPTION
## What does this change?
Bump commercial to 20.3.0

[Changelog](https://github.com/guardian/commercial/blob/main/CHANGELOG.md#2030)
