### PR TITLE
Create 0% test to use non-lite versions of fronts

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,12 +11,22 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      DarkModeWeb,
+      RemoveLiteFronts,
       UpdatedHeaderDesign,
       MastheadWithHighlights,
+      DarkModeWeb,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
+
+object RemoveLiteFronts
+    extends Experiment(
+      name = "remove-lite-fronts",
+      description = "Get the full pressed page of a front instead of the lite version",
+      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2024, 10, 30),
+      participationGroup = Perc0A,
+    )
 
 object UpdatedHeaderDesign
     extends Experiment(

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -136,7 +136,7 @@ trait FaciaController
         FrontHeadline.headlineNotFound
       }
 
-      val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) liteRequestType else fullRequestType
+      val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else liteRequestType
 
       if (!ConfigAgent.frontExistsInConfig(path)) {
         successful(Cached(CacheTime.Facia)(notFound()))
@@ -183,7 +183,7 @@ trait FaciaController
           Cached(CacheTime.Facia)(JsonComponent.fromWritable(JsObject(Nil))),
         )
       } else {
-        val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) liteRequestType else fullRequestType
+        val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else liteRequestType
 
         frontJsonFapi.get(path, requestType).map { resp =>
           Cached(CacheTime.Facia)(JsonComponent.fromWritable(resp match {
@@ -225,8 +225,8 @@ trait FaciaController
 
   import PressedPage.pressedPageFormat
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader): Future[Result] = {
-    val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) liteRequestType else fullRequestType
-    val NonAdFreeType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) LiteType else FullType
+    val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else liteRequestType
+    val NonAdFreeType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) FullType else LiteType
 
     val futureFaciaPage: Future[Option[(PressedPage, Boolean)]] = frontJsonFapi.get(path, requestType).flatMap {
       case Some(faciaPage: PressedPage) =>

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -136,8 +136,6 @@ trait FaciaController
         FrontHeadline.headlineNotFound
       }
 
-      val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else liteRequestType
-
       if (!ConfigAgent.frontExistsInConfig(path)) {
         successful(Cached(CacheTime.Facia)(notFound()))
       } else {
@@ -183,8 +181,6 @@ trait FaciaController
           Cached(CacheTime.Facia)(JsonComponent.fromWritable(JsObject(Nil))),
         )
       } else {
-        val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else liteRequestType
-
         frontJsonFapi.get(path, requestType).map { resp =>
           Cached(CacheTime.Facia)(JsonComponent.fromWritable(resp match {
             case Some(pressedPage) => FapiFrontJsonMinimal.get(pressedPage)
@@ -225,7 +221,6 @@ trait FaciaController
 
   import PressedPage.pressedPageFormat
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader): Future[Result] = {
-    val requestType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else liteRequestType
     val NonAdFreeType = if (ActiveExperiments.isParticipating(RemoveLiteFronts)) FullType else LiteType
 
     val futureFaciaPage: Future[Option[(PressedPage, Boolean)]] = frontJsonFapi.get(path, requestType).flatMap {
@@ -535,6 +530,8 @@ trait FaciaController
     if (request.isAdFree) FullAdFreeType else FullType
   def liteRequestType(implicit request: RequestHeader): PressedPageType =
     if (request.isAdFree) LiteAdFreeType else LiteType
+  def requestType(implicit request: RequestHeader): PressedPageType =
+    if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else fullRequestType
 
   def ampRsaPublicKey: Action[AnyContent] = {
     Action {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -531,7 +531,7 @@ trait FaciaController
   def liteRequestType(implicit request: RequestHeader): PressedPageType =
     if (request.isAdFree) LiteAdFreeType else LiteType
   def requestType(implicit request: RequestHeader): PressedPageType =
-    if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else fullRequestType
+    if (ActiveExperiments.isParticipating(RemoveLiteFronts)) fullRequestType else liteRequestType
 
   def ampRsaPublicKey: Action[AnyContent] = {
     Action {


### PR DESCRIPTION
## What is the value of this and can you measure success?

The first step towards removing the lite versions of pressed fronts, to [free up memory](https://github.com/guardian/frontend/issues/27143)

## What does this change?

Introduces an experiment that will use the regular version of the pressed front as opposed to the lite version.
