### PR TITLE
Don't apply fit-content to top-above-nav ads

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -99,7 +99,6 @@
     }
 }
 
-.ad-slot-container[top-above-nav-ad-rendered='true'],
 .ad-slot-container--centre-slot {
     width: fit-content;
     margin: 0 auto;


### PR DESCRIPTION
## What does this change?
Removes the fit-content and margin styles for top-above-nav ads to fix a display issue for fabric ads. Fabrics and non-fabric ads still display as expected without this styling.

## Screenshots
Before:
<img width="1159" alt="Screenshot 2024-08-09 at 16 01 52" src="https://github.com/user-attachments/assets/fe1d26c5-7bfa-4cb4-a331-3d9804697e93">

After:
<img width="1161" alt="Screenshot 2024-08-09 at 16 02 02" src="https://github.com/user-attachments/assets/1d2b7bb6-5752-41f1-a98d-a9baadf10e3b">
