### PR TITLE
Extend TagLinkDesign experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -52,6 +52,6 @@ object TagLinkDesign
       name = "tag-link-design",
       description = "Render an updated sticky design for tag links on Olympics articles and liveblogs",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 8, 12),
+      sellByDate = LocalDate.of(2024, 10, 30),
       participationGroup = Perc10A,
     )


### PR DESCRIPTION
## What does this change?

Extend TagLinkDesign experiment. We don't know when we want this experiment to end, so it has a long expiry date. We'll remove it when we want it to end.