### PR TITLE
Bump editorial-permissions-client to v3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.10"
   val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0"
-  val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "2.15"
+  val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "3.0.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"
   val rome = "rome" % "rome" % romeVersion


### PR DESCRIPTION
## What does this change?

Upgrade `editorial-permissions-client` to v3.0.0. The only expected difference is the addition of logging as a part of ongoing work to limit casual employees' access to editorial tools to times when they have scheduled shifts.

This version bump also pulls in changes from v2.16, but again no functionality changes are expected from this.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, check that permissions for Frontend continue to work as expected.
    - [x] Preview app
    - [x] Admin app
- [x] Add an entry to the CODE `Permissions-casuals-byid` dynamo table in the Workflow account, which contains your Google workspace id as the `userId` (other fields can be left blank). Wait for the permissions cache to refresh and check that your email address is logged as being casual but not on shift:
    - Logs should show up here: https://logs.gutools.co.uk/s/dotcom/goto/aa5a4190-58a3-11ef-873d-bbf7e33f0fc4
    - nb. *access should still be granted as normal*, this is a logging-only change.
- [x] Assuming you're not on a casual contract, you'll be marked as 'no longer casual' in the db once the casual status lambda runs again (once every 15 minutes), so the logging will cease after that point.

<img width="642" alt="screenshot of dynamodb console UI showing an entry with a redacted userId" src="https://github.com/user-attachments/assets/2baa6c70-204c-4a38-b761-5ae1df78e2b6">


-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
