### PR TITLE
Enable preview to show highlights container

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -23,6 +23,8 @@ case class TerritoryHeader(territory: TargetedTerritory, headerString: String)
 
 object GUHeaders {
   val TERRITORY_HEADER = "X-GU-Territory"
+  val UPDATED_MASTHEAD_HEADER = "X-GU-Experiment-0perc-B"
+  val HIGHLIGHTS_AB_TEST_HEADER = "X-GU-Experiment-0perc-C"
 }
 
 trait Requests {

--- a/preview/app/views/responsive_viewer.scala.html
+++ b/preview/app/views/responsive_viewer.scala.html
@@ -122,6 +122,13 @@
                 }
                 window.location.reload();
             }
+
+            function addVariant() {
+               window.guardian.config.tests.mastheadWithHighlightsVariant = "variant"
+                window.guardian.config.tests.updatedHeaderDesignVariant = "variant"
+            }
+
+            addVariant()
         </script>
     </head>
     <body>


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
