### PR TITLE
[Fairground 🎡] Support Flexible/special container in DCR

### DIFF
--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -33,7 +33,7 @@ object Container extends GuLogging {
       ("nav/list", NavList),
       ("nav/media-list", NavMediaList),
       ("news/most-popular", MostPopular),
-      ("flexible/special", Dynamic(FlexibleSpecial))
+      ("flexible/special", Dynamic(FlexibleSpecial)),
     ) ++ FixedContainers.all.mapV(Fixed.apply) ++ EmailLayouts.all.mapV(Email.apply)
 
   /** So that we don't blow up at runtime, which would SUCK */

--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -33,6 +33,7 @@ object Container extends GuLogging {
       ("nav/list", NavList),
       ("nav/media-list", NavMediaList),
       ("news/most-popular", MostPopular),
+      ("flexible/special", Dynamic(FlexibleSpecial))
     ) ++ FixedContainers.all.mapV(Fixed.apply) ++ EmailLayouts.all.mapV(Email.apply)
 
   /** So that we don't blow up at runtime, which would SUCK */

--- a/common/app/layout/slices/DynamicContainers.scala
+++ b/common/app/layout/slices/DynamicContainers.scala
@@ -8,6 +8,7 @@ object DynamicContainers {
     ("dynamic/slow", DynamicSlow),
     ("dynamic/package", DynamicPackage),
     ("dynamic/slow-mpu", DynamicSlowMPU(omitMPU = false, adFree = false)),
+    ("flexible/special", FlexibleSpecial),
   )
 
   def apply(collectionType: Option[String], items: Seq[PressedContent]): Option[ContainerDefinition] = {

--- a/common/app/layout/slices/FlexibleSpecial.scala
+++ b/common/app/layout/slices/FlexibleSpecial.scala
@@ -17,12 +17,12 @@ object FlexibleSpecial extends DynamicContainer {
   override protected def standardSlices(storiesIncludingBackfill: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] = {
 
     storiesIncludingBackfill.length match {
-      case 0     => Nil
-      case 1     => Seq(FullMedia100)
-      case 2     => Seq(ThreeQuarterQuarter)
-      case 3     => Seq(ThreeQuarterTallQuarter2)
-      case 4     => Seq(ThreeQuarterTallQuarter1Ql2)
-      case 5     => Seq(FullMedia100, QuarterQuarterQuarterQuarter)
+      case 0 => Nil
+      case 1 => Seq(FullMedia100)
+      case 2 => Seq(ThreeQuarterQuarter)
+      case 3 => Seq(ThreeQuarterTallQuarter2)
+      case 4 => Seq(ThreeQuarterTallQuarter1Ql2)
+      case 5 => Seq(FullMedia100, QuarterQuarterQuarterQuarter)
       // This case doesn't look _quite_ right. We end up with a row of four
       // and then a row of three, slightly stretched. There isn't a layout
       // which caters for this currently, we'll follow up on this separately.

--- a/common/app/layout/slices/FlexibleSpecial.scala
+++ b/common/app/layout/slices/FlexibleSpecial.scala
@@ -1,0 +1,33 @@
+package layout.slices
+
+import layout.slices.Story._
+
+object FlexibleSpecial extends DynamicContainer {
+  override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
+    val byGroup = segmentByGroup(stories)
+    val snap = byGroup.getOrElse(1, Seq.empty)
+
+    if (snap.nonEmpty) {
+      Some((FullMedia50, stories.drop(1)))
+    } else {
+      None
+    }
+  }
+
+  override protected def standardSlices(storiesIncludingBackfill: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] = {
+
+    storiesIncludingBackfill.length match {
+      case 0     => Nil
+      case 1     => Seq(FullMedia100)
+      case 2     => Seq(ThreeQuarterQuarter)
+      case 3     => Seq(ThreeQuarterTallQuarter2)
+      case 4     => Seq(ThreeQuarterTallQuarter1Ql2)
+      case 5     => Seq(FullMedia100, QuarterQuarterQuarterQuarter)
+      // This case doesn't look _quite_ right. We end up with a row of four
+      // and then a row of three, slightly stretched. There isn't a layout
+      // which caters for this currently, we'll follow up on this separately.
+      case _ => Seq(FullMedia100, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
+
+    }
+  }
+}

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -44,6 +44,7 @@ object FrontChecks {
       "nav/media-list",
       "news/most-popular",
       "fixed/highlights",
+      "flexible/special",
     )
 
   def hasOnlySupportedCollections(faciaPage: PressedPage) =

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -249,6 +249,7 @@ import layout.slices.EmailLayouts
         PressedCollectionBuilder.mkPressedCollection("nav/media-list"),
         PressedCollectionBuilder.mkPressedCollection("news/most-popular"),
         PressedCollectionBuilder.mkPressedCollection("fixed/highlights"),
+        PressedCollectionBuilder.mkPressedCollection("flexible/special"),
       ),
     )
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Adds support for the flexible special container, allowing DCR to render it through [this change](https://github.com/guardian/dotcom-rendering/pull/12137). 

For swiftness of development, we're reusing some existing dynamic container logic as the flexible container is an evolution of the dynamic package one
