### PR TITLE
Add Paralympics To Subnavs

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -112,6 +112,7 @@ object NavLinks {
 
   /* SPORT */
 
+  private val paralympics2024 = NavLink("Paralympics 2024", "/sport/paralympic-games-2024")
   private val footballScores = NavLink("Live scores", "/football/live", Some("football/live"))
   private val footballTables = NavLink("Tables", "/football/tables", Some("football/tables"))
   private val footballFixtures = NavLink("Fixtures", "/football/fixtures", Some("football/fixtures"))
@@ -319,6 +320,7 @@ object NavLinks {
       world,
       usEnvironment,
       ukraine,
+      paralympics2024,
       usSoccer,
       usBusiness,
       usTech,
@@ -392,6 +394,7 @@ object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
+      paralympics2024,
       football,
       cricket,
       rugbyUnion,
@@ -407,6 +410,7 @@ object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
+      paralympics2024,
       football,
       AFL,
       NRL,
@@ -420,6 +424,7 @@ object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
+      paralympics2024,
       usSoccer,
       NFL,
       tennis,
@@ -433,6 +438,7 @@ object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
+      paralympics2024,
       football,
       cricket,
       rugbyUnion,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -445,6 +445,12 @@
 			"iconName": "home",
 			"children": [
 				{
+					"title": "Paralympics 2024",
+					"url": "/sport/paralympic-games-2024",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -1126,6 +1132,12 @@
 					"classList": []
 				},
 				{
+					"title": "Paralympics 2024",
+					"url": "/sport/paralympic-games-2024",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Soccer",
 					"url": "/us/soccer",
 					"children": [
@@ -1277,6 +1289,12 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
+				{
+					"title": "Paralympics 2024",
+					"url": "/sport/paralympic-games-2024",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Soccer",
 					"url": "/us/soccer",
@@ -1995,6 +2013,12 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
+				{
+					"title": "Paralympics 2024",
+					"url": "/sport/paralympic-games-2024",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Football",
 					"url": "/football",
@@ -2798,6 +2822,12 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
+				{
+					"title": "Paralympics 2024",
+					"url": "/sport/paralympic-games-2024",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Football",
 					"url": "/football",
@@ -3790,6 +3820,12 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
+				{
+					"title": "Paralympics 2024",
+					"url": "/sport/paralympic-games-2024",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Football",
 					"url": "/football",


### PR DESCRIPTION
Request from CP. The main US news subnav and the UK, US, AU and international sport subnavs.

Queued behind #27419, which removes Olympics 2024.
