### PR TITLE
Add boostlevel to frontend

### DIFF
--- a/common/app/layout/DisplaySettings.scala
+++ b/common/app/layout/DisplaySettings.scala
@@ -5,7 +5,7 @@ import model.pressed._
 
 case class DisplaySettings(
     isBoosted: Boolean,
-    boostLevel: BoostLevel,
+    boostLevel: Option[BoostLevel],
     showBoostedHeadline: Boolean,
     showQuotedHeadline: Boolean,
     imageHide: Boolean,

--- a/common/app/layout/DisplaySettings.scala
+++ b/common/app/layout/DisplaySettings.scala
@@ -5,7 +5,7 @@ import model.pressed._
 
 case class DisplaySettings(
     isBoosted: Boolean,
-    boostLevel: Option[BoostLevel],
+    boostLevel: BoostLevel,
     showBoostedHeadline: Boolean,
     showQuotedHeadline: Boolean,
     imageHide: Boolean,

--- a/common/app/layout/DisplaySettings.scala
+++ b/common/app/layout/DisplaySettings.scala
@@ -1,10 +1,11 @@
 package layout
 
+import com.gu.facia.api.utils.BoostLevel
 import model.pressed._
 
 case class DisplaySettings(
-    /** TODO check if this should actually be used to determine anything at an item level; if not, remove it */
     isBoosted: Boolean,
+    boostLevel: BoostLevel,
     showBoostedHeadline: Boolean,
     showQuotedHeadline: Boolean,
     imageHide: Boolean,
@@ -15,6 +16,7 @@ object DisplaySettings {
   def fromTrail(faciaContent: PressedContent): DisplaySettings =
     DisplaySettings(
       faciaContent.display.isBoosted,
+      faciaContent.display.boostLevel,
       faciaContent.display.showBoostedHeadline,
       faciaContent.display.showQuotedHeadline,
       faciaContent.display.imageHide,

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -52,22 +52,28 @@ object TimelinesThriftAtomFormat extends Format[com.gu.contentatom.thrift.atom.t
 
 object BoostLevelFormat extends Format[BoostLevel] {
   def reads(json: JsValue): JsResult[BoostLevel] = {
-    (json \ "type").transform[JsString](Reads.JsStringReads) match {
+    println("BoostLevelFormat reads", json)
+    val x = (json \ "type").transform[JsString](Reads.JsStringReads) match {
       case JsSuccess(JsString("default"), _)   => JsSuccess(BoostLevel.Default)
       case JsSuccess(JsString("boost"), _)     => JsSuccess(BoostLevel.Boost)
       case JsSuccess(JsString("megaboost"), _) => JsSuccess(BoostLevel.MegaBoost)
       case JsSuccess(JsString("gigaboost"), _) => JsSuccess(BoostLevel.GigaBoost)
       case _                                   => JsError("Could not convert boostLevel")
     }
+    println("BoostLevelFormat reads result", x)
+    x
   }
 
-  def writes(boostLevel: BoostLevel): JsString =
-    boostLevel match {
+  def writes(boostLevel: BoostLevel): JsValue = {
+    val y = boostLevel match {
       case BoostLevel.Default   => JsString("default")
       case BoostLevel.Boost     => JsString("boost")
       case BoostLevel.MegaBoost => JsString("megaboost")
       case BoostLevel.GigaBoost => JsString("gigaboost")
     }
+    println("BoostLevelFormat writes", y)
+    y
+  }
 }
 
 object CardStyleFormat extends Format[CardStyle] {

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.gu.contentapi.client.utils.DesignType
+import com.gu.facia.api.utils.BoostLevel
 import common.Pagination
 import json.ObjectDeduplication.deduplicate
 import model.content._
@@ -49,7 +50,27 @@ object TimelinesThriftAtomFormat extends Format[com.gu.contentatom.thrift.atom.t
   def writes(timeline: com.gu.contentatom.thrift.atom.timeline.TimelineAtom): JsObject = JsObject(Seq.empty)
 }
 
-object CardStyleFormat extends Format[CardStyle] {
+object BoostLevelFormat extends Format[BoostLevel] {
+    def reads(json: JsValue): JsResult[BoostLevel] = {
+      (json \ "type").transform[JsString](Reads.JsStringReads) match {
+        case JsSuccess(JsString("default"), _)   => JsSuccess(BoostLevel.Default)
+        case JsSuccess(JsString("boost"), _) => JsSuccess(BoostLevel.Boost)
+        case JsSuccess(JsString("megaboost"), _)   => JsSuccess(BoostLevel.MegaBoost)
+        case JsSuccess(JsString("gigaboost"), _)   => JsSuccess(BoostLevel.GigaBoost)
+        case _                                 => JsError("Could not convert boostLevel")
+      }
+    }
+
+    def writes(boostLevel: BoostLevel): JsObject =
+      boostLevel match {
+        case BoostLevel.Default   => JsObject(Seq("type" -> JsString("default")))
+        case BoostLevel.Boost => JsObject(Seq("type" -> JsString("boost")))
+        case BoostLevel.MegaBoost   => JsObject(Seq("type" -> JsString("megaboost")))
+        case BoostLevel.GigaBoost   => JsObject(Seq("type" -> JsString("gigaboost")))
+      }
+  }
+
+  object CardStyleFormat extends Format[CardStyle] {
   def reads(json: JsValue): JsResult[CardStyle] = {
     (json \ "type").transform[JsString](Reads.JsStringReads) match {
       case JsSuccess(JsString("SpecialReport"), _)    => JsSuccess(SpecialReport)
@@ -240,6 +261,7 @@ object PressedContentFormat {
   implicit val itemKickerFormat: ItemKickerFormat.format.type = ItemKickerFormat.format
   implicit val tagKickerFormat: OFormat[TagKicker] = ItemKickerFormat.tagKickerFormat
   implicit val pressedCardHeader: OFormat[PressedCardHeader] = Json.format[PressedCardHeader]
+  implicit val boostLevel: BoostLevelFormat.type = BoostLevelFormat
   implicit val pressedDisplaySettings: OFormat[PressedDisplaySettings] = Json.format[PressedDisplaySettings]
   implicit val pressedDiscussionSettings: OFormat[PressedDiscussionSettings] = Json.format[PressedDiscussionSettings]
   implicit val pressedCard: OFormat[PressedCard] = Json.format[PressedCard]

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -57,7 +57,7 @@ object BoostLevelFormat extends Format[BoostLevel] {
       case JsString("boost")     => JsSuccess(BoostLevel.Boost)
       case JsString("megaboost") => JsSuccess(BoostLevel.MegaBoost)
       case JsString("gigaboost") => JsSuccess(BoostLevel.GigaBoost)
-      case _                     => JsError("Could not convert boostLevel")
+      case _                     => JsError("Could not convert BoostLevel")
     }
   }
 

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -61,12 +61,12 @@ object BoostLevelFormat extends Format[BoostLevel] {
     }
   }
 
-  def writes(boostLevel: BoostLevel): JsObject =
+  def writes(boostLevel: BoostLevel): JsString =
     boostLevel match {
-      case BoostLevel.Default   => JsObject(Seq("type" -> JsString("default")))
-      case BoostLevel.Boost     => JsObject(Seq("type" -> JsString("boost")))
-      case BoostLevel.MegaBoost => JsObject(Seq("type" -> JsString("megaboost")))
-      case BoostLevel.GigaBoost => JsObject(Seq("type" -> JsString("gigaboost")))
+      case BoostLevel.Default   => JsString("default")
+      case BoostLevel.Boost     => JsString("boost")
+      case BoostLevel.MegaBoost => JsString("megaboost")
+      case BoostLevel.GigaBoost => JsString("gigaboost")
     }
 }
 

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -54,10 +54,10 @@ object BoostLevelFormat extends Format[BoostLevel] {
   def reads(json: JsValue): JsResult[BoostLevel] = {
     json match {
       case JsString("default")   => JsSuccess(BoostLevel.Default)
-      case JsString("boost")    => JsSuccess(BoostLevel.Boost)
+      case JsString("boost")     => JsSuccess(BoostLevel.Boost)
       case JsString("megaboost") => JsSuccess(BoostLevel.MegaBoost)
       case JsString("gigaboost") => JsSuccess(BoostLevel.GigaBoost)
-      case _ => JsError("Could not convert boostLevel")
+      case _                     => JsError("Could not convert boostLevel")
     }
   }
 

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -51,26 +51,26 @@ object TimelinesThriftAtomFormat extends Format[com.gu.contentatom.thrift.atom.t
 }
 
 object BoostLevelFormat extends Format[BoostLevel] {
-    def reads(json: JsValue): JsResult[BoostLevel] = {
-      (json \ "type").transform[JsString](Reads.JsStringReads) match {
-        case JsSuccess(JsString("default"), _)   => JsSuccess(BoostLevel.Default)
-        case JsSuccess(JsString("boost"), _) => JsSuccess(BoostLevel.Boost)
-        case JsSuccess(JsString("megaboost"), _)   => JsSuccess(BoostLevel.MegaBoost)
-        case JsSuccess(JsString("gigaboost"), _)   => JsSuccess(BoostLevel.GigaBoost)
-        case _                                 => JsError("Could not convert boostLevel")
-      }
+  def reads(json: JsValue): JsResult[BoostLevel] = {
+    (json \ "type").transform[JsString](Reads.JsStringReads) match {
+      case JsSuccess(JsString("default"), _)   => JsSuccess(BoostLevel.Default)
+      case JsSuccess(JsString("boost"), _)     => JsSuccess(BoostLevel.Boost)
+      case JsSuccess(JsString("megaboost"), _) => JsSuccess(BoostLevel.MegaBoost)
+      case JsSuccess(JsString("gigaboost"), _) => JsSuccess(BoostLevel.GigaBoost)
+      case _                                   => JsError("Could not convert boostLevel")
     }
-
-    def writes(boostLevel: BoostLevel): JsObject =
-      boostLevel match {
-        case BoostLevel.Default   => JsObject(Seq("type" -> JsString("default")))
-        case BoostLevel.Boost => JsObject(Seq("type" -> JsString("boost")))
-        case BoostLevel.MegaBoost   => JsObject(Seq("type" -> JsString("megaboost")))
-        case BoostLevel.GigaBoost   => JsObject(Seq("type" -> JsString("gigaboost")))
-      }
   }
 
-  object CardStyleFormat extends Format[CardStyle] {
+  def writes(boostLevel: BoostLevel): JsObject =
+    boostLevel match {
+      case BoostLevel.Default   => JsObject(Seq("type" -> JsString("default")))
+      case BoostLevel.Boost     => JsObject(Seq("type" -> JsString("boost")))
+      case BoostLevel.MegaBoost => JsObject(Seq("type" -> JsString("megaboost")))
+      case BoostLevel.GigaBoost => JsObject(Seq("type" -> JsString("gigaboost")))
+    }
+}
+
+object CardStyleFormat extends Format[CardStyle] {
   def reads(json: JsValue): JsResult[CardStyle] = {
     (json \ "type").transform[JsString](Reads.JsStringReads) match {
       case JsSuccess(JsString("SpecialReport"), _)    => JsSuccess(SpecialReport)

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -52,27 +52,22 @@ object TimelinesThriftAtomFormat extends Format[com.gu.contentatom.thrift.atom.t
 
 object BoostLevelFormat extends Format[BoostLevel] {
   def reads(json: JsValue): JsResult[BoostLevel] = {
-    println("BoostLevelFormat reads", json)
-    val x = (json \ "type").transform[JsString](Reads.JsStringReads) match {
-      case JsSuccess(JsString("default"), _)   => JsSuccess(BoostLevel.Default)
-      case JsSuccess(JsString("boost"), _)     => JsSuccess(BoostLevel.Boost)
-      case JsSuccess(JsString("megaboost"), _) => JsSuccess(BoostLevel.MegaBoost)
-      case JsSuccess(JsString("gigaboost"), _) => JsSuccess(BoostLevel.GigaBoost)
-      case _                                   => JsError("Could not convert boostLevel")
+    json match {
+      case JsString("default")   => JsSuccess(BoostLevel.Default)
+      case JsString("boost")    => JsSuccess(BoostLevel.Boost)
+      case JsString("megaboost") => JsSuccess(BoostLevel.MegaBoost)
+      case JsString("gigaboost") => JsSuccess(BoostLevel.GigaBoost)
+      case _ => JsError("Could not convert boostLevel")
     }
-    println("BoostLevelFormat reads result", x)
-    x
   }
 
   def writes(boostLevel: BoostLevel): JsValue = {
-    val y = boostLevel match {
+    boostLevel match {
       case BoostLevel.Default   => JsString("default")
       case BoostLevel.Boost     => JsString("boost")
       case BoostLevel.MegaBoost => JsString("megaboost")
       case BoostLevel.GigaBoost => JsString("gigaboost")
     }
-    println("BoostLevelFormat writes", y)
-    y
   }
 }
 

--- a/common/app/model/PressedDisplaySettings.scala
+++ b/common/app/model/PressedDisplaySettings.scala
@@ -1,10 +1,11 @@
 package model.pressed
 
-import com.gu.facia.api.utils.FaciaContentUtils
+import com.gu.facia.api.utils.{BoostLevel, FaciaContentUtils}
 import com.gu.facia.api.{models => fapi}
 
 final case class PressedDisplaySettings(
     isBoosted: Boolean,
+    boostLevel: BoostLevel,
     showBoostedHeadline: Boolean,
     showQuotedHeadline: Boolean,
     imageHide: Boolean,
@@ -17,6 +18,7 @@ object PressedDisplaySettings {
     PressedDisplaySettings(
       imageHide = contentProperties.imageHide,
       isBoosted = FaciaContentUtils.isBoosted(content),
+      boostLevel = FaciaContentUtils.boostLevel(content),
       showBoostedHeadline = FaciaContentUtils.showBoostedHeadline(content),
       showQuotedHeadline = FaciaContentUtils.showQuotedHeadline(content),
       showLivePlayable = FaciaContentUtils.showLivePlayable(content),

--- a/common/app/model/PressedDisplaySettings.scala
+++ b/common/app/model/PressedDisplaySettings.scala
@@ -5,7 +5,7 @@ import com.gu.facia.api.{models => fapi}
 
 final case class PressedDisplaySettings(
     isBoosted: Boolean,
-    boostLevel: Option[BoostLevel],
+    boostLevel: BoostLevel,
     showBoostedHeadline: Boolean,
     showQuotedHeadline: Boolean,
     imageHide: Boolean,
@@ -18,7 +18,7 @@ object PressedDisplaySettings {
     PressedDisplaySettings(
       imageHide = contentProperties.imageHide,
       isBoosted = FaciaContentUtils.isBoosted(content),
-      boostLevel = Some(FaciaContentUtils.boostLevel(content)),
+      boostLevel = FaciaContentUtils.boostLevel(content),
       showBoostedHeadline = FaciaContentUtils.showBoostedHeadline(content),
       showQuotedHeadline = FaciaContentUtils.showQuotedHeadline(content),
       showLivePlayable = FaciaContentUtils.showLivePlayable(content),

--- a/common/app/model/PressedDisplaySettings.scala
+++ b/common/app/model/PressedDisplaySettings.scala
@@ -5,7 +5,7 @@ import com.gu.facia.api.{models => fapi}
 
 final case class PressedDisplaySettings(
     isBoosted: Boolean,
-    boostLevel: BoostLevel,
+    boostLevel: Option[BoostLevel],
     showBoostedHeadline: Boolean,
     showQuotedHeadline: Boolean,
     imageHide: Boolean,
@@ -18,7 +18,7 @@ object PressedDisplaySettings {
     PressedDisplaySettings(
       imageHide = contentProperties.imageHide,
       isBoosted = FaciaContentUtils.isBoosted(content),
-      boostLevel = FaciaContentUtils.boostLevel(content),
+      boostLevel = Some(FaciaContentUtils.boostLevel(content)),
       showBoostedHeadline = FaciaContentUtils.showBoostedHeadline(content),
       showQuotedHeadline = FaciaContentUtils.showQuotedHeadline(content),
       showLivePlayable = FaciaContentUtils.showLivePlayable(content),

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -2,7 +2,7 @@ package common
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
-import com.gu.facia.api.utils.Editorial
+import com.gu.facia.api.utils.{BoostLevel, Editorial}
 import com.sun.syndication.feed.module.mediarss.MediaEntryModule
 import com.sun.syndication.feed.synd.SyndPerson
 import implicits.Dates.jodaToJavaInstant
@@ -335,11 +335,11 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
     // Showcase specifies no markup in text elements; out trail texts often contains strong tags and others.
     // Strip them to provide the least friction to editors
     val bulletItemsWithHtml =
-      """
-        |-<p>Bullet 1</p>
-        |- <strong>Bullet 2</strong>
-        |-<b>Unclosed
-        |""".stripMargin
+    """
+      |-<p>Bullet 1</p>
+      |- <strong>Bullet 2</strong>
+      |-<b>Unclosed
+      |""".stripMargin
 
     val curatedContent = makePressedContent(
       webPublicationDate = wayBackWhen,
@@ -584,8 +584,8 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
     // Showcase specifies 2 or 3 items
     val bulletEncodedTrailText =
       """
-          | - 1 bullet item is not going to be enough
-          |""".stripMargin
+        | - 1 bullet item is not going to be enough
+        |""".stripMargin
 
     val bulletedContent = makePressedContent(
       webPublicationDate = wayBackWhen,
@@ -1306,16 +1306,16 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
   }
 
   private def makePressedContent(
-      webPublicationDate: DateTime = DateTime.now,
-      lastModified: Option[DateTime] = None,
-      trailPicture: Option[ImageMedia] = None,
-      replacedImage: Option[Image] = None,
-      headline: String = "A headline",
-      byline: Option[String] = None,
-      kickerText: Option[String] = None,
-      trailText: Option[String] = Some("Some trail text"),
-      supportingContent: Seq[PressedContent] = Seq.empty,
-  ) = {
+                                  webPublicationDate: DateTime = DateTime.now,
+                                  lastModified: Option[DateTime] = None,
+                                  trailPicture: Option[ImageMedia] = None,
+                                  replacedImage: Option[Image] = None,
+                                  headline: String = "A headline",
+                                  byline: Option[String] = None,
+                                  kickerText: Option[String] = None,
+                                  trailText: Option[String] = Some("Some trail text"),
+                                  supportingContent: Seq[PressedContent] = Seq.empty,
+                                ) = {
     val url = "/sport/2016/apr/12/andy-murray-pierre-hugues-herbert-monte-carlo-masters-match-report"
     val webUrl =
       "https://www.theguardian.com/sport/2016/apr/12/andy-murray-pierre-hugues-herbert-monte-carlo-masters-match-report"
@@ -1404,6 +1404,7 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
 
     val displaySettings = PressedDisplaySettings(
       isBoosted = false,
+      boostLevel = BoostLevel.Default,
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       showLivePlayable = false,

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -2,7 +2,7 @@ package common
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
-import com.gu.facia.api.utils.{BoostLevel, Editorial}
+import com.gu.facia.api.utils.{Editorial}
 import com.sun.syndication.feed.module.mediarss.MediaEntryModule
 import com.sun.syndication.feed.synd.SyndPerson
 import implicits.Dates.jodaToJavaInstant
@@ -1404,7 +1404,7 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
 
     val displaySettings = PressedDisplaySettings(
       isBoosted = false,
-      boostLevel = BoostLevel.Default,
+      boostLevel = None,
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       showLivePlayable = false,

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -335,7 +335,7 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
     // Showcase specifies no markup in text elements; out trail texts often contains strong tags and others.
     // Strip them to provide the least friction to editors
     val bulletItemsWithHtml =
-    """
+      """
       |-<p>Bullet 1</p>
       |- <strong>Bullet 2</strong>
       |-<b>Unclosed
@@ -1306,16 +1306,16 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
   }
 
   private def makePressedContent(
-                                  webPublicationDate: DateTime = DateTime.now,
-                                  lastModified: Option[DateTime] = None,
-                                  trailPicture: Option[ImageMedia] = None,
-                                  replacedImage: Option[Image] = None,
-                                  headline: String = "A headline",
-                                  byline: Option[String] = None,
-                                  kickerText: Option[String] = None,
-                                  trailText: Option[String] = Some("Some trail text"),
-                                  supportingContent: Seq[PressedContent] = Seq.empty,
-                                ) = {
+      webPublicationDate: DateTime = DateTime.now,
+      lastModified: Option[DateTime] = None,
+      trailPicture: Option[ImageMedia] = None,
+      replacedImage: Option[Image] = None,
+      headline: String = "A headline",
+      byline: Option[String] = None,
+      kickerText: Option[String] = None,
+      trailText: Option[String] = Some("Some trail text"),
+      supportingContent: Seq[PressedContent] = Seq.empty,
+  ) = {
     val url = "/sport/2016/apr/12/andy-murray-pierre-hugues-herbert-monte-carlo-masters-match-report"
     val webUrl =
       "https://www.theguardian.com/sport/2016/apr/12/andy-murray-pierre-hugues-herbert-monte-carlo-masters-match-report"

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -1404,7 +1404,7 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
 
     val displaySettings = PressedDisplaySettings(
       isBoosted = false,
-      boostLevel = BoostLevel.Default,
+      boostLevel = Some(BoostLevel.Default),
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       showLivePlayable = false,

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -2,7 +2,7 @@ package common
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
-import com.gu.facia.api.utils.{Editorial}
+import com.gu.facia.api.utils.{BoostLevel, Editorial}
 import com.sun.syndication.feed.module.mediarss.MediaEntryModule
 import com.sun.syndication.feed.synd.SyndPerson
 import implicits.Dates.jodaToJavaInstant
@@ -1404,7 +1404,7 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
 
     val displaySettings = PressedDisplaySettings(
       isBoosted = false,
-      boostLevel = None,
+      boostLevel = BoostLevel.Default,
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       showLivePlayable = false,

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -6,7 +6,6 @@ import model.pressed._
 import model.ContentFormat
 import com.gu.facia.api.utils.BoostLevel
 
-
 object FixtureBuilder {
 
   def mkContent(id: Int): PressedContent = FixtureBuilder.mkPressedCuratedContent(id)

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -4,7 +4,6 @@ import model.facia.PressedCollection
 import model.{FrontProperties, PressedPage, SeoData}
 import model.pressed._
 import model.ContentFormat
-import com.gu.facia.api.utils.BoostLevel
 
 object FixtureBuilder {
 
@@ -111,7 +110,7 @@ object FixtureBuilder {
   def mkDisplay(): PressedDisplaySettings =
     PressedDisplaySettings(
       isBoosted = false,
-      boostLevel = BoostLevel.Default,
+      boostLevel = None,
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       imageHide = false,

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -1,5 +1,6 @@
 package common.facia
 
+import com.gu.facia.api.utils.BoostLevel
 import model.facia.PressedCollection
 import model.{FrontProperties, PressedPage, SeoData}
 import model.pressed._
@@ -110,7 +111,7 @@ object FixtureBuilder {
   def mkDisplay(): PressedDisplaySettings =
     PressedDisplaySettings(
       isBoosted = false,
-      boostLevel = None,
+      boostLevel = BoostLevel.Default,
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       imageHide = false,

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -4,6 +4,8 @@ import model.facia.PressedCollection
 import model.{FrontProperties, PressedPage, SeoData}
 import model.pressed._
 import model.ContentFormat
+import com.gu.facia.api.utils.BoostLevel
+
 
 object FixtureBuilder {
 
@@ -110,6 +112,7 @@ object FixtureBuilder {
   def mkDisplay(): PressedDisplaySettings =
     PressedDisplaySettings(
       isBoosted = false,
+      boostLevel = BoostLevel.Default,
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       imageHide = false,

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -111,7 +111,7 @@ object FixtureBuilder {
   def mkDisplay(): PressedDisplaySettings =
     PressedDisplaySettings(
       isBoosted = false,
-      boostLevel = BoostLevel.Default,
+      boostLevel = Some(BoostLevel.Default),
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       imageHide = false,

--- a/common/test/views/support/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/TrackingCodeBuilderTest.scala
@@ -152,7 +152,7 @@ class TrackingCodeBuilderTest extends AnyFlatSpec with Matchers with BeforeAndAf
         mediaType = None,
         displaySettings = DisplaySettings(
           isBoosted = false,
-          boostLevel = BoostLevel.Default,
+          boostLevel = Some(BoostLevel.Default),
           showBoostedHeadline = false,
           showQuotedHeadline = false,
           imageHide = false,

--- a/common/test/views/support/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/TrackingCodeBuilderTest.scala
@@ -1,17 +1,10 @@
 package views.support
 
 import com.gu.commercial.branding._
+import com.gu.facia.api.utils.BoostLevel
 import common.commercial._
 import layout.cards.Half
-import layout.{
-  ContentCard,
-  DiscussionSettings,
-  DisplaySettings,
-  EditionalisedLink,
-  FaciaCardHeader,
-  ItemClasses,
-  PaidCard,
-}
+import layout.{ContentCard, DiscussionSettings, DisplaySettings, EditionalisedLink, FaciaCardHeader, ItemClasses, PaidCard}
 import model.pressed
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.BeforeAndAfterEach
@@ -151,6 +144,7 @@ class TrackingCodeBuilderTest extends AnyFlatSpec with Matchers with BeforeAndAf
         mediaType = None,
         displaySettings = DisplaySettings(
           isBoosted = false,
+          boostLevel = BoostLevel.Default,
           showBoostedHeadline = false,
           showQuotedHeadline = false,
           imageHide = false,

--- a/common/test/views/support/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/TrackingCodeBuilderTest.scala
@@ -4,7 +4,15 @@ import com.gu.commercial.branding._
 import com.gu.facia.api.utils.BoostLevel
 import common.commercial._
 import layout.cards.Half
-import layout.{ContentCard, DiscussionSettings, DisplaySettings, EditionalisedLink, FaciaCardHeader, ItemClasses, PaidCard}
+import layout.{
+  ContentCard,
+  DiscussionSettings,
+  DisplaySettings,
+  EditionalisedLink,
+  FaciaCardHeader,
+  ItemClasses,
+  PaidCard,
+}
 import model.pressed
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.BeforeAndAfterEach

--- a/common/test/views/support/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/TrackingCodeBuilderTest.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import com.gu.commercial.branding._
+import com.gu.facia.api.utils.BoostLevel
 import common.commercial._
 import layout.cards.Half
 import layout.{
@@ -151,7 +152,7 @@ class TrackingCodeBuilderTest extends AnyFlatSpec with Matchers with BeforeAndAf
         mediaType = None,
         displaySettings = DisplaySettings(
           isBoosted = false,
-          boostLevel = None,
+          boostLevel = BoostLevel.Default,
           showBoostedHeadline = false,
           showQuotedHeadline = false,
           imageHide = false,

--- a/common/test/views/support/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/TrackingCodeBuilderTest.scala
@@ -1,7 +1,6 @@
 package views.support
 
 import com.gu.commercial.branding._
-import com.gu.facia.api.utils.BoostLevel
 import common.commercial._
 import layout.cards.Half
 import layout.{
@@ -152,7 +151,7 @@ class TrackingCodeBuilderTest extends AnyFlatSpec with Matchers with BeforeAndAf
         mediaType = None,
         displaySettings = DisplaySettings(
           isBoosted = false,
-          boostLevel = BoostLevel.Default,
+          boostLevel = None,
           showBoostedHeadline = false,
           showQuotedHeadline = false,
           imageHide = false,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "31.1.0"
-  val faciaVersion = "8.0.1"
+  val faciaVersion = "9.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?

Part of this [fairground ticket](https://trello.com/c/gaN5f1Lw/378-pass-boostlevel-from-facia-scala-client-to-dcr-via-frontend), associated DCR PR [here](https://github.com/guardian/dotcom-rendering/pull/12186/files)

Updates fapi-scala-client to the latest version, which includes adding the BoostLevel to the display property on a card. 



## Screenshots

Having deployed this to code and updated a front to include a megaboosted card, we can now see this appear in the pressed json:

<img width="858" alt="image" src="https://github.com/user-attachments/assets/63015cd3-4ab8-4c53-8c08-b3c41e319e2c">


## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
