### PR TITLE
[Fairground 🎡]  Bump updated header design test to 50 % of users

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -24,7 +24,7 @@ object UpdatedHeaderDesign
       description = "Shows updated design of Header and Nav components",
       owners = Seq(Owner.withGithub("cemms1")),
       sellByDate = LocalDate.of(2024, 9, 30),
-      participationGroup = Perc0B,
+      participationGroup = Perc50,
     )
 
 object MastheadWithHighlights


### PR DESCRIPTION
## What does this change?

Moves the header test to a 50% participation group. The test is due to go live Thursday 22 August 
# Do not merge before 22nd August 2024.