### PR TITLE
Overridable crossword headlines and standfirsts

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -14,6 +14,12 @@
 
             <h1 itemprop="headline" class="content__headline js-score">@Html(crosswordPage.item.trail.headline)</h1>
 
+            @if(crosswordPage.item.fields.standfirst.isDefined) {
+                <div class="crossword__standfirst">
+                    @fragments.standfirst(crosswordPage.item)
+                </div>
+            }
+
             @if( gridVisable ) {
                 <div class="crossword__links">
                     <div class="crossword__links-related">
@@ -28,7 +34,7 @@
                     @crosswordMeta(crosswordPage)
                 </div>
             }
-            
+
             <div class="hide-from-leftcol crossword__clues-header">
                 <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-mobile-link">Download the Guardian app</a> for a better puzzles experience
             </div>

--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -12,8 +12,8 @@
                 @crosswordMeta(crosswordPage)
             </div>
 
+            <h1 itemprop="headline" class="content__headline js-score">@Html(crosswordPage.item.trail.headline)</h1>
 
-            <h1 itemprop="headline" class="content__headline js-score">@Html(crosswordPage.crossword.name)</h1>
             @if( gridVisable ) {
                 <div class="crossword__links">
                     <div class="crossword__links-related">

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -1054,7 +1054,6 @@ object CrosswordContent {
     val metadata = content.metadata.copy(
       id = crossword.id,
       section = Some(SectionId.fromId("crosswords")),
-      webTitle = crossword.name,
       contentType = Some(contentType),
       iosType = None,
     )

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -171,14 +171,16 @@
     }
 }
 
-.crossword__links-related {
+.crossword__standfirst, .crossword__links-related {
     @include mq(leftCol) {
         top: $gs-baseline * -2;
         padding-bottom: math.div($gs-baseline, 3);
     }
-
     position: relative;
     top: $gs-baseline * -1;
+}
+
+.crossword__links-related {
     font-family: $f-sans-serif-text;
     font-size: 15px;
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Editorial have greater control of crossword pages.

## What does this change?

Currently, headlines for crossword pages come from the crossword data rather than the content data. This means that even if you edit the headline in Composer, the changes won't be displayed on the website or other platforms. While this has been fine, since the appetite to override crossword headlines is extremely infrequent and not very strong, it seems a bit of a waste to offer the control and then ignore it. So let's render the headline from the content data, rather than the crossword. This is slightly more likely to be useful than previously, since the upcoming Special crossword series will feature instalments which will likely be released to coincide with "special events", eg. anniversaries of crossword series, summer puzzle specials, etc., and custom headlines to describe the event may be useful.

While we're here, I've also added in the standfirst, in case a longer description or explanation is desired, and updated webTitle to not be overridden by the crossword data

## Screenshots





| Before      | After      |
|-------------|------------|
| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/b788a0e6-2ec9-4396-9293-939372a7cb34"> | <img width="1500" alt="image" src="https://github.com/user-attachments/assets/ec73c6db-efc9-4d29-a9d8-044dd2c03307"> |
| <img width="488" alt="image" src="https://github.com/user-attachments/assets/b702ad22-4cd3-470e-8b0b-5fe64612e9a5"> | <img width="485" alt="image" src="https://github.com/user-attachments/assets/e04af093-ce2f-476a-9923-2caff8ea859b"> |
| <img width="689" alt="image" src="https://github.com/user-attachments/assets/3873e06e-5a51-4225-aee6-987928607225"> | 





## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
