### PR TITLE
Set Spacefinder optimisation test to 5%

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial": "20.6.2",
+		"@guardian/commercial": "20.6.3",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",

--- a/static/src/javascripts/projects/common/modules/experiments/tests/optimise-spacefinder-inline.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/optimise-spacefinder-inline.ts
@@ -5,7 +5,7 @@ export const optimiseSpacefinderInline: ABTest = {
 	author: '@commercial-dev',
 	start: '2024-08-08',
 	expiry: '2024-09-13',
-	audience: 0 / 100,
+	audience: 5 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,9 +4039,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:20.6.2":
-  version: 20.6.2
-  resolution: "@guardian/commercial@npm:20.6.2"
+"@guardian/commercial@npm:20.6.3":
+  version: 20.6.3
+  resolution: "@guardian/commercial@npm:20.6.3"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/prebid.js": "npm:8.52.0-1"
@@ -4061,7 +4061,7 @@ __metadata:
     "@guardian/libs": ^18.0.0
     "@guardian/source": ^6.0.0
     typescript: ~5.5.3
-  checksum: 10c0/ebbc06006acaa8da7b817df70eac3be9e1b8658e78e9149f556107664993b88a3d4d65b0e39baaee472e32c536ec9f9095bc57823d58b7e38446c4cf339c0bce
+  checksum: 10c0/8511bd858d4ae088a94c582468fd512929a7d81ede67f954beebfdf3a7dffc3a1db5c91079b20014007416f9ec338195c61366990c0a73c2cbd5d0b882deb5df
   languageName: node
   linkType: hard
 
@@ -4134,7 +4134,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial": "npm:20.6.2"
+    "@guardian/commercial": "npm:20.6.3"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"


### PR DESCRIPTION
## What does this change?
Sets the spacefinder inline1 optimisation test to 5% now that we have sample sizes from D&I. Also bumps commercial to bring in the updated test percentage in the commercial bundle.