### PR TITLE
Set Remove Lite Fronts experiment to 1%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -19,15 +19,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
 
-object RemoveLiteFronts
-    extends Experiment(
-      name = "remove-lite-fronts",
-      description = "Get the full pressed page of a front instead of the lite version",
-      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2024, 10, 30),
-      participationGroup = Perc0A,
-    )
-
 object UpdatedHeaderDesign
     extends Experiment(
       name = "updated-header-design",
@@ -54,4 +45,13 @@ object DarkModeWeb
       owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 10, 30),
       participationGroup = Perc0D,
+    )
+
+object RemoveLiteFronts
+    extends Experiment(
+      name = "remove-lite-fronts",
+      description = "Get the full pressed page of a front instead of the lite version",
+      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2024, 10, 30),
+      participationGroup = Perc1A,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?

Another step towards [decommissioning /lite.json endpoints](https://github.com/guardian/frontend/issues/27143).

I have opted in to the test and checked that fronts and tag fronts are still working correctly.
