### PR TITLE
Remove DNC nav link

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -99,9 +99,6 @@ object NavLinks {
 
   val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate, retail))
 
-  val democraticNationalConvention =
-    NavLink("Democratic national convention", "/us-news/democratic-national-convention-2024")
-
   /* OPINION */
   val columnists = NavLink("Columnists", "/index/contributors")
   val auColumnists = NavLink("Columnists", "/au/index/contributors")
@@ -316,7 +313,6 @@ object NavLinks {
     List(
       usNews,
       usElections2024,
-      democraticNationalConvention,
       world,
       usEnvironment,
       ukraine,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1019,12 +1019,6 @@
 					"classList": []
 				},
 				{
-					"title": "Democratic national convention",
-					"url": "/us-news/democratic-national-convention-2024",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "World",
 					"url": "/world",
 					"longTitle": "World news",


### PR DESCRIPTION
As requested by CP, with the Democratic National Convention over it's time to remove it from the site nav. This does so.

### Before

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/5cc58470-b2b1-4855-af88-3609c834091f">

### After 

<img width="1314" alt="image" src="https://github.com/user-attachments/assets/3954a485-6095-495d-9dbc-584a17d7f8f0">
