### PR TITLE
Add tax strategy links to footers

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -85,6 +85,12 @@ object FooterLinks {
     FooterLink("All writers", "/index/contributors", s"${edition} : footer : all contributors")
   val digitalNewspaperArchive: FooterLink =
     FooterLink("Digital newspaper archive", "https://theguardian.newspapers.com", "digital newspaper archive")
+  def taxStrategy(edition: String): FooterLink =
+    FooterLink(
+      "Tax strategy",
+      "https://uploads.guim.co.uk/2024/08/27/TAX_STRATEGY_FOR_THE_YEAR_ENDED_31_MARCH_2025.pdf",
+      s"${edition} : footer : tax strategy",
+    )
   def facebook(edition: String): FooterLink =
     FooterLink("Facebook", "https://www.facebook.com/theguardian", s"${edition} : footer : facebook")
   def youtube(edition: String): FooterLink =
@@ -110,6 +116,7 @@ object FooterLinks {
       "https://uploads.guim.co.uk/2023/07/25/Modern_Slavery_Statement_GMG_and_Scott_Trust_2023.docx.pdf",
       "uk : footer : modern slavery act statement",
     ),
+    taxStrategy("uk"),
     digitalNewspaperArchive,
     facebook("uk"),
     youtube("uk"),
@@ -123,6 +130,7 @@ object FooterLinks {
     allTopics("us"),
     allWriters("us"),
     digitalNewspaperArchive,
+    taxStrategy("us"),
     facebook("us"),
     youtube("us"),
     instagram("us"),
@@ -136,6 +144,7 @@ object FooterLinks {
     allWriters("au"),
     FooterLink("Events", "/guardian-masterclasses/guardian-masterclasses-australia", "au : footer : masterclasses"),
     digitalNewspaperArchive,
+    taxStrategy("au"),
     facebook("au"),
     youtube("au"),
     instagram("au"),
@@ -148,6 +157,7 @@ object FooterLinks {
     allTopics("international"),
     allWriters("international"),
     digitalNewspaperArchive,
+    taxStrategy("international"),
     facebook("international"),
     youtube("international"),
     instagram("international"),


### PR DESCRIPTION
As requested by CP, this adds a 'Tax Strategy' link to column two of footer links for UK, US, AU, and international.

### Before 

<img width="1584" alt="image" src="https://github.com/user-attachments/assets/e4964bd4-2b6f-4d6c-bfe5-37a576bdbc6f">

### After

<img width="1607" alt="image" src="https://github.com/user-attachments/assets/0f1df8c4-bbfe-4e10-ad2f-7214f334cb0d">
