### PR TITLE
Bump commercial to 20.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial": "20.6.3",
+		"@guardian/commercial": "20.6.4",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,9 +4039,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:20.6.3":
-  version: 20.6.3
-  resolution: "@guardian/commercial@npm:20.6.3"
+"@guardian/commercial@npm:20.6.4":
+  version: 20.6.4
+  resolution: "@guardian/commercial@npm:20.6.4"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/prebid.js": "npm:8.52.0-1"
@@ -4061,7 +4061,7 @@ __metadata:
     "@guardian/libs": ^18.0.0
     "@guardian/source": ^6.0.0
     typescript: ~5.5.3
-  checksum: 10c0/8511bd858d4ae088a94c582468fd512929a7d81ede67f954beebfdf3a7dffc3a1db5c91079b20014007416f9ec338195c61366990c0a73c2cbd5d0b882deb5df
+  checksum: 10c0/0d427a94cb7718fcc610fd2f9ceb7f61684d0c9e21a4721741aa0a17bbd90e509591bf277393911c3c249ac41447b4e5af4ef55cf37d314fb792f330162f7f20
   languageName: node
   linkType: hard
 
@@ -4134,7 +4134,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial": "npm:20.6.3"
+    "@guardian/commercial": "npm:20.6.4"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"


### PR DESCRIPTION
## What does this change?
Bring in the changes from [v20.6.4](https://github.com/guardian/commercial/releases/tag/v20.6.4)