### PR TITLE
Add `scrollable/highlights` to replace `fixed/highlights` container type

### DIFF
--- a/common/app/layout/slices/FixedContainers.scala
+++ b/common/app/layout/slices/FixedContainers.scala
@@ -37,7 +37,7 @@ object FixedContainers {
 
   val showcaseSingleStories = slices(ShowcaseSingleStories)
 
-  val fixedHighlights = slices(Highlights)
+  val highlights = slices(Highlights)
 
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(FullMedia75)),
@@ -55,7 +55,8 @@ object FixedContainers {
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/thrasher", thrasher),
     ("fixed/showcase", showcaseSingleStories),
-    ("fixed/highlights", fixedHighlights),
+    ("fixed/highlights", highlights),
+    ("scrollable/highlights", highlights),
   ) ++ (if (Configuration.faciatool.showTestContainers)
           Map(
             (

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -44,7 +44,9 @@ object FrontChecks {
       "nav/list",
       "nav/media-list",
       "news/most-popular",
+      // TODO - 28/08/24 remove fixed/highlights once migrated to scrollable/highlights
       "fixed/highlights",
+      "scrollable/highlights",
       "flexible/special",
     )
 

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -249,6 +249,7 @@ import layout.slices.EmailLayouts
         PressedCollectionBuilder.mkPressedCollection("nav/media-list"),
         PressedCollectionBuilder.mkPressedCollection("news/most-popular"),
         PressedCollectionBuilder.mkPressedCollection("fixed/highlights"),
+        PressedCollectionBuilder.mkPressedCollection("scrollable/highlights"),
         PressedCollectionBuilder.mkPressedCollection("flexible/special"),
       ),
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?

After [agreeing on a naming convention for the new front containers](https://docs.google.com/spreadsheets/d/1yVS2jFcZfCztJ3epLhsTcoShJWtdlzYyrpKLBZlYx94/edit?usp=sharing) we agreed to [rename `fixed/highlights` to `scrollable/highlights`](https://trello.com/c/YGbWyF1z/403-rename-fixed-highlights-to-scrollable-highlights)

## What does this change?

This PR adds `scrollable/highlights` with the same configuration as `fixed/highlights` so that we can begin migrating uses of `fixed/highlights` to `scrollable/highlights`. 

This PR deliberately avoids removing `fixed/highlights` as this will be done once we have confirmed uses have been migrated across. This is a necessary step due to this container type being used in production environments already.
