### PR TITLE
Pin jackson dependencies to 2.17.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ val common = library("common")
       pekkoSlf4j,
       pekkoSerializationJackson,
       pekkoActorTyped,
-    ),
+    ) ++ jackson,
     TestAssets / mappings ~= filterAssets,
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -109,4 +109,31 @@ object Dependencies {
   val react = "org.webjars" % "react" % "16.5.2"
   val epoch = "org.webjars.npm" % "epoch-charting" % "0.8.4"
   val d3 = "org.webjars.npm" % "d3" % "7.9.0"
+
+  /*
+    The versions are currently set as they are because of:
+    https://github.com/orgs/playframework/discussions/11222
+   */
+  val jacksonVersion = "2.17.2"
+  val jacksonDatabindVersion = "2.17.2"
+  val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+  val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
+  val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
+  val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
+  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
+  val jacksonParameterName = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion
+  val jackModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
+  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+
+  val jackson =
+    Seq(
+      jacksonCore,
+      jacksonAnnotations,
+      jacksonDataTypeJdk8,
+      jacksonDataType,
+      jacksonDataFormat,
+      jacksonParameterName,
+      jackModule,
+      jacksonDatabind,
+    )
 }

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -93,6 +93,7 @@ object ProjectSettings {
       .disablePlugins(PlayPekkoHttpServer)
       .settings(frontendCompilationSettings)
       .settings(frontendRootSettings)
+      .settings(libraryDependencies ++= jackson)
 
   def application(applicationName: String): Project = {
     Project(applicationName, file(applicationName))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,39 +1,11 @@
 // Additional information on initialization
 logLevel := Level.Warn
 
-/*
-    The versions are currently set as they are because of:
-    https://github.com/orgs/playframework/discussions/11222
-   */
-val jacksonVersion = "2.17.2"
-val jacksonDatabindVersion = "2.17.2"
-val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
-val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
-val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
-val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
-val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
-val jacksonParameterName = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion
-val jackModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
-val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
-
-val jackson =
-  Seq(
-    jacksonCore,
-    jacksonAnnotations,
-    jacksonDataTypeJdk8,
-    jacksonDataType,
-    jacksonDataFormat,
-    jacksonParameterName,
-    jackModule,
-    jacksonDatabind,
-  )
-
-
 // Dependencies used by the VersionInfo plugin
 libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.12.7",
   "org.joda" % "joda-convert" % "2.2.3",
-) ++ jackson
+)
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,39 @@
 // Additional information on initialization
 logLevel := Level.Warn
 
+/*
+    The versions are currently set as they are because of:
+    https://github.com/orgs/playframework/discussions/11222
+   */
+val jacksonVersion = "2.17.2"
+val jacksonDatabindVersion = "2.17.2"
+val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
+val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
+val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
+val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
+val jacksonParameterName = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion
+val jackModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
+val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+
+val jackson =
+  Seq(
+    jacksonCore,
+    jacksonAnnotations,
+    jacksonDataTypeJdk8,
+    jacksonDataType,
+    jacksonDataFormat,
+    jacksonParameterName,
+    jackModule,
+    jacksonDatabind,
+  )
+
+
 // Dependencies used by the VersionInfo plugin
 libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.12.7",
   "org.joda" % "joda-convert" % "2.2.3",
-)
+) ++ jackson
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 


### PR DESCRIPTION
## What does this change?
Pins jackson libraries to 2.17.2

## Why?
Because of: https://github.com/orgs/playframework/discussions/11222. We'll keep this until Play upgrades to jackson 2.17.2

- [x] Tested on CODE 
