### PR TITLE
Remove deprecated `fixed/highlights` container

### DIFF
--- a/common/app/layout/slices/FixedContainers.scala
+++ b/common/app/layout/slices/FixedContainers.scala
@@ -55,7 +55,6 @@ object FixedContainers {
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/thrasher", thrasher),
     ("fixed/showcase", showcaseSingleStories),
-    ("fixed/highlights", highlights),
     ("scrollable/highlights", highlights),
   ) ++ (if (Configuration.faciatool.showTestContainers)
           Map(

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -44,8 +44,6 @@ object FrontChecks {
       "nav/list",
       "nav/media-list",
       "news/most-popular",
-      // TODO - 28/08/24 remove fixed/highlights once migrated to scrollable/highlights
-      "fixed/highlights",
       "scrollable/highlights",
       "flexible/special",
     )

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -248,7 +248,6 @@ import layout.slices.EmailLayouts
         PressedCollectionBuilder.mkPressedCollection("nav/list"),
         PressedCollectionBuilder.mkPressedCollection("nav/media-list"),
         PressedCollectionBuilder.mkPressedCollection("news/most-popular"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/highlights"),
         PressedCollectionBuilder.mkPressedCollection("scrollable/highlights"),
         PressedCollectionBuilder.mkPressedCollection("flexible/special"),
       ),


### PR DESCRIPTION
## What does this change?

As a follow-up from https://github.com/guardian/frontend/pull/27445, this PR removes the `fixed/highlights` container now that usages have been migrated to the `scrollable/highlights` type

