### PR TITLE
Press interactive

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -139,6 +139,7 @@ object PressedContent {
     "/lifeandstyle/ng-interactive/2018/apr/21/great-lengths",
     "/technology/ng-interactive/2018/apr/24/bezoss-empire-how-amazon-became-the-worlds-biggest-retailer",
     "/world/2018/apr/26/lynchings-sadism-white-men-why-america-must-atone",
+    "/uk-news/ng-interactive/2018/may/14/lives-of-grenfell-tower-victims-fire",
     "/technology/ng-interactive/2018/may/15/the-guardian-app",
     "/world/ng-interactive/2018/jul/03/thailand-cave-rescue-where-were-the-boys-found-and-how-can-they-be-rescued",
     "/info/ng-interactive/2018/jul/24/working-report",


### PR DESCRIPTION
## What does this change?

Adds https://www.theguardian.com/uk-news/ng-interactive/2018/may/14/lives-of-grenfell-tower-victims-fire to the list of pressed content.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/user-attachments/assets/49814ad8-97c8-44ad-b211-7e83694519ea) | ![image](https://github.com/user-attachments/assets/112bee93-e467-4a99-9b3b-213d5b6376ba) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png
