### PR TITLE
Remove grey background from responsive viewer body

### DIFF
--- a/preview/app/views/responsive_viewer.scala.html
+++ b/preview/app/views/responsive_viewer.scala.html
@@ -14,7 +14,6 @@
             body {
                 font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 margin-top: 4px;
-                background: #CCCCCC;
                 color: #666666;
             }
 


### PR DESCRIPTION
## What does this change?
Removes grey background from body in responsive viewer.

## Why?
After [this change](https://github.com/guardian/dotcom-rendering/pull/12269) DCR has a transparent background in the root styles and when looking at a front in the responsive viewer, containers get this grey background if they don't have a palette. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/user-attachments/assets/f72825a5-1269-44c9-8055-a792148db2a8) | ![image](https://github.com/user-attachments/assets/a04d7bf1-9f60-40c1-803d-3c37fe54aa4c) |
