### PR TITLE
Cricket Players Unique Name

### DIFF
--- a/sport/app/cricket/feed/PlayerNames.scala
+++ b/sport/app/cricket/feed/PlayerNames.scala
@@ -1,0 +1,13 @@
+package cricket.feed
+
+import cricketModel.Player
+
+object PlayerNames {
+
+  def uniqueNames(players: List[Player]) = (for {
+    playersGroupedByName <- players.groupBy(_.lastName).values
+    player <- playersGroupedByName
+  } yield {
+    player.id -> { if (playersGroupedByName.size > 1) s"${player.name} ${player.lastName}" else player.lastName }
+  }).toMap
+}

--- a/sport/app/cricket/feed/PlayerNames.scala
+++ b/sport/app/cricket/feed/PlayerNames.scala
@@ -8,6 +8,6 @@ object PlayerNames {
     playersGroupedByName <- players.groupBy(_.lastName).values
     player <- playersGroupedByName
   } yield {
-    player.id -> { if (playersGroupedByName.size > 1) s"${player.name} ${player.lastName}" else player.lastName }
+    player.id -> { if (playersGroupedByName.size > 1) s"${player.firstName} ${player.lastName}" else player.lastName }
   }).toMap
 }

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -3,7 +3,12 @@ package cricketModel
 import play.api.libs.json._
 import java.time.LocalDateTime
 
-case class Team(name: String, id: String, home: Boolean, lineup: List[String])
+case class Player(id: String, name: String, firstName: String, lastName: String, initials: String)
+
+object Player {
+  implicit val writes: OWrites[Player] = Json.writes[Player]
+}
+case class Team(name: String, id: String, home: Boolean, lineup: List[String], players: List[Player])
 
 object Team {
   implicit val writes: OWrites[Team] = Json.writes[Team]

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -1,6 +1,8 @@
 package cricketModel
 
+import cricket.feed.PlayerNames
 import play.api.libs.json._
+
 import java.time.LocalDateTime
 
 case class Player(id: String, name: String, firstName: String, lastName: String, initials: String)
@@ -8,7 +10,9 @@ case class Player(id: String, name: String, firstName: String, lastName: String,
 object Player {
   implicit val writes: OWrites[Player] = Json.writes[Player]
 }
-case class Team(name: String, id: String, home: Boolean, lineup: List[String], players: List[Player])
+case class Team(name: String, id: String, home: Boolean, lineup: List[String], players: List[Player]) {
+  lazy val uniquePlayerNames = PlayerNames.uniqueNames(players)
+}
 
 object Team {
   implicit val writes: OWrites[Team] = Json.writes[Team]

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -115,19 +115,19 @@ object Parser {
       .toList
       .sortBy(_.order)
 
-//  def descriptionWithUniqueNames(
-//      bowlingTeam: Option[Team],
-//      catcherId: String,
-//      bowlerId: String,
-//      description: String,
-//  ): String = {
-//    val players = bowlingTeam.map(team => PlayerNames.uniqueNames(team.players)).get
-//
-//    description
-//      .replaceFirst("c\\s+\\w+\\s?", s"c ${players.getOrElse(catcherId, "")} ")
-//      .replaceFirst("st\\s+\\w+\\s?", s"st ${players.getOrElse(catcherId, "")} ")
-//      .replaceFirst("b\\s+\\w+\\s?", s"b ${players.getOrElse(bowlerId, "")}")
-//  }
+  def descriptionWithUniqueNames(
+      bowlingTeam: Option[Team],
+      catcherId: String,
+      bowlerId: String,
+      description: String,
+  ): String = {
+    val players = bowlingTeam.map(team => PlayerNames.uniqueNames(team.players)).get
+
+    description
+      .replaceFirst("c\\s+\\w+\\s?", s"c ${players.getOrElse(catcherId, "")} ")
+      .replaceFirst("st\\s+\\w+\\s?", s"st ${players.getOrElse(catcherId, "")} ")
+      .replaceFirst("b\\s+\\w+\\s?", s"b ${players.getOrElse(bowlerId, "")}")
+  }
 
   private def parseInningsBatters(batters: NodeSeq, bowlingTeam: Option[Team]): List[InningsBatter] = {
 

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -149,8 +149,7 @@ object Parser {
           getStatistic(batter, "fours") toInt,
           getStatistic(batter, "sixes") toInt,
           (batter \ "status").text == "batted",
-          (batter \ "dismissal" \ "description").text,
-//          descriptionWithUniqueNames(bowlingTeam, dismissalDescription, catcherId, bowlerId),
+          descriptionWithUniqueNames(bowlingTeam, dismissalDescription, catcherId, bowlerId),
           getStatistic(batter, "on-strike").toInt > 0,
           getStatistic(batter, "runs-scored").toInt > 0,
         )

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -64,12 +64,21 @@ object Parser {
 
   private def parseTeams(teams: NodeSeq): List[Team] =
     teams.map { team =>
-      Team((team \ "name").text, (team \ "@id").text, (team \ "home").text == "true", parseTeamLineup(team \ "player"))
+      val players = parseTeamLineup(team \ "player")
+      Team((team \ "name").text, (team \ "@id").text, (team \ "home").text == "true", players.map(_.name), players)
 
     }.toList
 
-  private def parseTeamLineup(lineup: NodeSeq): List[String] =
-    lineup.map { player => (player \ "name").text }.toList
+  private def parseTeamLineup(lineup: NodeSeq): List[Player] =
+    lineup.map { player =>
+      Player(
+        id = (player \ "id").text,
+        name = (player \ "name").text,
+        firstName = (player \ "firstName").text,
+        lastName = (player \ "lastName").text,
+        initials = (player \ "initials").text,
+      )
+    }.toList
 
   private def getStatistic(statistics: NodeSeq, statistic: String): String =
     (statistics \ "statistic").find(node => (node \ "@type").text == statistic).map(_.text).getOrElse("")

--- a/sport/test/cricket/feed/CricketPaDeserialisationTest.scala
+++ b/sport/test/cricket/feed/CricketPaDeserialisationTest.scala
@@ -1,0 +1,184 @@
+package cricket.feed
+
+import conf.cricketPa.Parser.descriptionWithUniqueNames
+import cricketModel.{Player, Team}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CricketPaDeserialisationTest extends AnyFlatSpec with Matchers {
+
+  val teamWithPlayersWithUniqueSurnames = Team(
+    name = "Sri Lanka",
+    id = "0cbc23be-e7cc-9574-611a-06561460eb8b",
+    home = false,
+    lineup = List("Asitha Fernando", "Dimuth Karunaratne", "Kusal Mendis"),
+    players = List(
+      Player(
+        id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+        name = "Asitha Fernando",
+        firstName = "Asitha",
+        lastName = "Fernando",
+        initials = "A M",
+      ),
+      Player(
+        id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812",
+        name = "Dimuth Karunaratne",
+        firstName = "Frank",
+        lastName = "Karunaratne",
+        initials = "F D M",
+      ),
+      Player(
+        id = "b96e5130-0348-9659-e3c6-ba887f306eeb",
+        name = "Kusal Mendis",
+        firstName = "Balapuwaduge",
+        lastName = "Mendis",
+        initials = "B K G",
+      ),
+      Player(
+        id = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
+        name = "Dinesh Chandimal",
+        firstName = "Lokuge",
+        lastName = "Chandimal",
+        initials = "L D",
+      ),
+    ),
+  )
+
+  val teamWithPlayersWithTheSameSurname = Team(
+    name = "Sri Lanka",
+    id = "0cbc23be-e7cc-9574-611a-06561460eb8b",
+    home = false,
+    lineup = List("Asitha Fernando", "Dimuth Karunaratne", "Nishan Madushka"),
+    players = List(
+      Player(
+        id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+        name = "Asitha Fernando",
+        firstName = "Asitha",
+        lastName = "Fernando",
+        initials = "A M",
+      ),
+      Player(
+        id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812",
+        name = "Dimuth Karunaratne",
+        firstName = "Frank",
+        lastName = "Karunaratne",
+        initials = "F D M",
+      ),
+      Player(
+        id = "d29c8d1c-29b4-517e-5b62-1277065801b2",
+        name = "Nishan Madushka",
+        firstName = "Kottasinghakkarage",
+        lastName = "Fernando",
+        initials = "K N M",
+      ),
+      Player(
+        id = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
+        name = "Dinesh Chandimal",
+        firstName = "Lokuge",
+        lastName = "Chandimal",
+        initials = "L D",
+      ),
+    ),
+  )
+
+  "descriptionWithUniqueNames" should "include catcher's and bowler's surname if this is enough to determine their unique name when dismissal type is caught" in {
+
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithUniqueSurnames),
+      catcherId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
+      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      description = "c Chandimal b Fernando",
+    ) shouldEqual "c Chandimal b Fernando"
+
+  }
+
+  it should "include catcher's first name and surname if other player with the same surname exists in the same team when dismissal type is caught" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
+      catcherId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      bowlerId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
+      description = "c Chandimal b Fernando",
+    ) shouldEqual "c Asitha Fernando b Chandimal"
+  }
+
+  it should "include bowler's first name and surname if other player with the same surname exists in the same team when dismissal type is caught" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
+      catcherId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
+      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      description = "c Chandimal b Fernando",
+    ) shouldEqual "c Chandimal b Asitha Fernando"
+  }
+
+  it should "include bowler's surname if this is enough to determine their unique name when dismissal type is bowled" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithUniqueSurnames),
+      catcherId = "",
+      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      description = "b Fernando",
+    ) shouldEqual "b Fernando"
+  }
+
+  it should "include bowler's first name and surname if other player with the same surname exists in the same team when dismissal type is bowled" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
+      catcherId = "",
+      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      description = "b Fernando",
+    ) shouldEqual "b Asitha Fernando"
+  }
+
+  it should "include catcher's surname if this is enough to determine their unique name when dismissal type is stumped" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithUniqueSurnames),
+      catcherId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
+      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      description = "st Chandimal b Fernando",
+    ) shouldEqual "st Chandimal b Fernando"
+  }
+
+  it should "include catcher's first name and surname if other player with the same surname exists in the same team when dismissal type is stumped" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
+      catcherId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
+      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      description = "st Chandimal b Fernando",
+    ) shouldEqual "st Chandimal b Asitha Fernando"
+  }
+
+  it should "include bowler's surname if this is enough to determine their unique name when dismissal type is lbw" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithUniqueSurnames),
+      catcherId = "",
+      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      description = "lbw b Fernando",
+    ) shouldEqual "lbw b Fernando"
+  }
+
+  it should "include bowler's first name and surname if other player with the same surname exists in the same team when dismissal type is lbw" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
+      catcherId = "",
+      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      description = "lbw b Fernando",
+    ) shouldEqual "lbw b Asitha Fernando"
+  }
+
+  it should "be the same as initial description when dismissal type is not-out" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
+      catcherId = "",
+      bowlerId = "",
+      description = "Not Out",
+    ) shouldEqual "Not Out"
+  }
+
+  it should "be the same as initial description when dismissal type is yet-to-bat" in {
+    descriptionWithUniqueNames(
+      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
+      catcherId = "",
+      bowlerId = "",
+      description = "Yet to Bat",
+    ) shouldEqual "Yet to Bat"
+  }
+}

--- a/sport/test/cricket/feed/CricketPaDeserialisationTest.scala
+++ b/sport/test/cricket/feed/CricketPaDeserialisationTest.scala
@@ -1,184 +1,37 @@
 package cricket.feed
 
-import conf.cricketPa.Parser.descriptionWithUniqueNames
-import cricketModel.{Player, Team}
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
+import conf.cricketPa.PaFeed
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import test.{
+  ConfiguredTestSuite,
+  WithMaterializer,
+  WithTestApplicationContext,
+  WithTestExecutionContext,
+  WithTestWsClient,
+}
 
-class CricketPaDeserialisationTest extends AnyFlatSpec with Matchers {
+@DoNotDiscover class CricketPaDeserialisationTest
+    extends AnyFlatSpec
+    with Matchers
+    with ConfiguredTestSuite
+    with BeforeAndAfterAll
+    with WithMaterializer
+    with WithTestWsClient
+    with WithTestApplicationContext
+    with WithTestExecutionContext
+    with ScalaFutures
+    with IntegrationPatience {
+  val actorSystem = PekkoActorSystem()
+  val paFeed = new PaFeed(wsClient, actorSystem, materializer)
 
-  val teamWithPlayersWithUniqueSurnames = Team(
-    name = "Sri Lanka",
-    id = "0cbc23be-e7cc-9574-611a-06561460eb8b",
-    home = false,
-    lineup = List("Asitha Fernando", "Dimuth Karunaratne", "Kusal Mendis"),
-    players = List(
-      Player(
-        id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-        name = "Asitha Fernando",
-        firstName = "Asitha",
-        lastName = "Fernando",
-        initials = "A M",
-      ),
-      Player(
-        id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812",
-        name = "Dimuth Karunaratne",
-        firstName = "Frank",
-        lastName = "Karunaratne",
-        initials = "F D M",
-      ),
-      Player(
-        id = "b96e5130-0348-9659-e3c6-ba887f306eeb",
-        name = "Kusal Mendis",
-        firstName = "Balapuwaduge",
-        lastName = "Mendis",
-        initials = "B K G",
-      ),
-      Player(
-        id = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
-        name = "Dinesh Chandimal",
-        firstName = "Lokuge",
-        lastName = "Chandimal",
-        initials = "L D",
-      ),
-    ),
-  )
+  whenReady(paFeed.getMatch("39145392-3f2e-8022-35f3-eac0b0654610")) { cricketMatch =>
+    {
+      cricketMatch.innings.head.batters.head.howOut shouldBe ""
 
-  val teamWithPlayersWithTheSameSurname = Team(
-    name = "Sri Lanka",
-    id = "0cbc23be-e7cc-9574-611a-06561460eb8b",
-    home = false,
-    lineup = List("Asitha Fernando", "Dimuth Karunaratne", "Nishan Madushka"),
-    players = List(
-      Player(
-        id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-        name = "Asitha Fernando",
-        firstName = "Asitha",
-        lastName = "Fernando",
-        initials = "A M",
-      ),
-      Player(
-        id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812",
-        name = "Dimuth Karunaratne",
-        firstName = "Frank",
-        lastName = "Karunaratne",
-        initials = "F D M",
-      ),
-      Player(
-        id = "d29c8d1c-29b4-517e-5b62-1277065801b2",
-        name = "Nishan Madushka",
-        firstName = "Kottasinghakkarage",
-        lastName = "Fernando",
-        initials = "K N M",
-      ),
-      Player(
-        id = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
-        name = "Dinesh Chandimal",
-        firstName = "Lokuge",
-        lastName = "Chandimal",
-        initials = "L D",
-      ),
-    ),
-  )
-
-  "descriptionWithUniqueNames" should "include catcher's and bowler's surname if this is enough to determine their unique name when dismissal type is caught" in {
-
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithUniqueSurnames),
-      catcherId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
-      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      description = "c Chandimal b Fernando",
-    ) shouldEqual "c Chandimal b Fernando"
-
-  }
-
-  it should "include catcher's first name and surname if other player with the same surname exists in the same team when dismissal type is caught" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
-      catcherId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      bowlerId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
-      description = "c Chandimal b Fernando",
-    ) shouldEqual "c Asitha Fernando b Chandimal"
-  }
-
-  it should "include bowler's first name and surname if other player with the same surname exists in the same team when dismissal type is caught" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
-      catcherId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
-      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      description = "c Chandimal b Fernando",
-    ) shouldEqual "c Chandimal b Asitha Fernando"
-  }
-
-  it should "include bowler's surname if this is enough to determine their unique name when dismissal type is bowled" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithUniqueSurnames),
-      catcherId = "",
-      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      description = "b Fernando",
-    ) shouldEqual "b Fernando"
-  }
-
-  it should "include bowler's first name and surname if other player with the same surname exists in the same team when dismissal type is bowled" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
-      catcherId = "",
-      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      description = "b Fernando",
-    ) shouldEqual "b Asitha Fernando"
-  }
-
-  it should "include catcher's surname if this is enough to determine their unique name when dismissal type is stumped" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithUniqueSurnames),
-      catcherId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
-      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      description = "st Chandimal b Fernando",
-    ) shouldEqual "st Chandimal b Fernando"
-  }
-
-  it should "include catcher's first name and surname if other player with the same surname exists in the same team when dismissal type is stumped" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
-      catcherId = "46a55cb7-49f5-e9f7-7560-c7110b0f68ec",
-      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      description = "st Chandimal b Fernando",
-    ) shouldEqual "st Chandimal b Asitha Fernando"
-  }
-
-  it should "include bowler's surname if this is enough to determine their unique name when dismissal type is lbw" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithUniqueSurnames),
-      catcherId = "",
-      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      description = "lbw b Fernando",
-    ) shouldEqual "lbw b Fernando"
-  }
-
-  it should "include bowler's first name and surname if other player with the same surname exists in the same team when dismissal type is lbw" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
-      catcherId = "",
-      bowlerId = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
-      description = "lbw b Fernando",
-    ) shouldEqual "lbw b Asitha Fernando"
-  }
-
-  it should "be the same as initial description when dismissal type is not-out" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
-      catcherId = "",
-      bowlerId = "",
-      description = "Not Out",
-    ) shouldEqual "Not Out"
-  }
-
-  it should "be the same as initial description when dismissal type is yet-to-bat" in {
-    descriptionWithUniqueNames(
-      bowlingTeam = Some(teamWithPlayersWithTheSameSurname),
-      catcherId = "",
-      bowlerId = "",
-      description = "Yet to Bat",
-    ) shouldEqual "Yet to Bat"
+    }
   }
 }

--- a/sport/test/cricket/feed/PlayerNamesTest.scala
+++ b/sport/test/cricket/feed/PlayerNamesTest.scala
@@ -1,0 +1,29 @@
+package cricket.feed
+
+import cricketModel.Player
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PlayerNamesTest extends AnyFlatSpec with Matchers {
+
+  "uniqueNames" should "be determined by lastName if players have different last names" in {
+    val player1 = Player(id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405", name = "Asitha Fernando", firstName = "Asitha", lastName = "Fernando", initials = "A M")
+    val player2 = Player(id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812", name = "Dimuth Karunaratne", firstName= "Frank", lastName = "Karunaratne", initials = "F D M")
+    val player3 = Player(id = "b96e5130-0348-9659-e3c6-ba887f306eeb", name = "Kusal Mendis", firstName = "Balapuwaduge", lastName = "Mendis", initials = "B K G")
+
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain ("Fernando")
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain ("Mendis")
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain ("Karunaratne")
+  }
+
+  "uniqueNames" should "be determined by full name and lastName if players have the same last name" in {
+    val player1 = Player(id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405", name = "Asitha Fernando", firstName = "Asitha", lastName = "Fernando", initials = "A M")
+    val player2 = Player(id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812", name = "Dimuth Karunaratne", firstName= "Frank", lastName = "Karunaratne", initials = "F D M")
+    val player3 = Player(id = "d29c8d1c-29b4-517e-5b62-1277065801b2", name = "Nishan Madushka", firstName = "Kottasinghakkarage", lastName = "Fernando", initials = "K N M")
+
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Asitha Fernando")
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Karunaratne")
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Kottasinghakkarage Fernando")
+  }
+}
+

--- a/sport/test/cricket/feed/PlayerNamesTest.scala
+++ b/sport/test/cricket/feed/PlayerNamesTest.scala
@@ -7,23 +7,58 @@ import org.scalatest.matchers.should.Matchers
 class PlayerNamesTest extends AnyFlatSpec with Matchers {
 
   "uniqueNames" should "be determined by lastName if players have different last names" in {
-    val player1 = Player(id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405", name = "Asitha Fernando", firstName = "Asitha", lastName = "Fernando", initials = "A M")
-    val player2 = Player(id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812", name = "Dimuth Karunaratne", firstName= "Frank", lastName = "Karunaratne", initials = "F D M")
-    val player3 = Player(id = "b96e5130-0348-9659-e3c6-ba887f306eeb", name = "Kusal Mendis", firstName = "Balapuwaduge", lastName = "Mendis", initials = "B K G")
+    val player1 = Player(
+      id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      name = "Asitha Fernando",
+      firstName = "Asitha",
+      lastName = "Fernando",
+      initials = "A M",
+    )
+    val player2 = Player(
+      id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812",
+      name = "Dimuth Karunaratne",
+      firstName = "Frank",
+      lastName = "Karunaratne",
+      initials = "F D M",
+    )
+    val player3 = Player(
+      id = "b96e5130-0348-9659-e3c6-ba887f306eeb",
+      name = "Kusal Mendis",
+      firstName = "Balapuwaduge",
+      lastName = "Mendis",
+      initials = "B K G",
+    )
 
-    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain ("Fernando")
-    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain ("Mendis")
-    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain ("Karunaratne")
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Fernando")
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Mendis")
+    PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Karunaratne")
   }
 
-  "uniqueNames" should "be determined by full name and lastName if players have the same last name" in {
-    val player1 = Player(id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405", name = "Asitha Fernando", firstName = "Asitha", lastName = "Fernando", initials = "A M")
-    val player2 = Player(id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812", name = "Dimuth Karunaratne", firstName= "Frank", lastName = "Karunaratne", initials = "F D M")
-    val player3 = Player(id = "d29c8d1c-29b4-517e-5b62-1277065801b2", name = "Nishan Madushka", firstName = "Kottasinghakkarage", lastName = "Fernando", initials = "K N M")
+  it should "be determined by full name and lastName if players have the same last name" in {
+    val player1 = Player(
+      id = "ae5e0dbf-d6af-70ec-76ef-1f8e83230405",
+      name = "Asitha Fernando",
+      firstName = "Asitha",
+      lastName = "Fernando",
+      initials = "A M",
+    )
+    val player2 = Player(
+      id = "c32cd9c7-d38a-93e7-e874-f5f4a5197812",
+      name = "Dimuth Karunaratne",
+      firstName = "Frank",
+      lastName = "Karunaratne",
+      initials = "F D M",
+    )
+    val player3 = Player(
+      id = "d29c8d1c-29b4-517e-5b62-1277065801b2",
+      name = "Nishan Madushka",
+      firstName = "Kottasinghakkarage",
+      lastName = "Fernando",
+      initials = "K N M",
+    )
 
     PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Asitha Fernando")
     PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Karunaratne")
     PlayerNames.uniqueNames(List(player1, player2, player3)).values.toList should contain("Kottasinghakkarage Fernando")
   }
 }
-


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/27442

We need to be able to distinguish between bowlers and catchers that have the same surname. This is a first step to be able to know their unique name.

## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
