### PR TITLE
Move Email Newsletters To facia-rendering

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -145,7 +145,6 @@ class GuardianConfiguration extends GuLogging {
   }
 
   object rendering {
-    lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
     lazy val articleBaseURL = configuration.getMandatoryStringProperty("article-rendering.baseURL")
     lazy val faciaBaseURL = configuration.getMandatoryStringProperty("facia-rendering.baseURL")
     lazy val tagPageBaseURL = configuration.getMandatoryStringProperty("tag-page-rendering.baseURL")

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -326,7 +326,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = DotcomNewslettersPageRenderingDataModel.apply(page, newsletters, request)
     val json = DotcomNewslettersPageRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/EmailNewsletters", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.faciaBaseURL + "/EmailNewsletters", CacheTime.Facia)
   }
 
   def getImageContent(

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -114,7 +114,6 @@ pa.rugby.api.key=none
 
 # DCR
 rendering.endpoint=http://localhost:3030
-rendering.baseURL=http://localhost:3030
 article-rendering.baseURL=http://localhost:3030
 facia-rendering.baseURL=http://localhost:3030
 tag-page-rendering.baseURL=http://localhost:3030


### PR DESCRIPTION
This is the only page using the old `rendering` stack. If we move it to one of the new stacks we can remove the `rendering` stack.

The four new stacks are `article-rendering`, `facia-rendering`, `tag-page-rendering` and `interactive-rendering`. This page is most similar to a front, so this change moves it to that stack. The alternative would be to create a new stack just for this page.

https://www.theguardian.com/email-newsletters
