### PR TITLE
Override `logServerError` in facia to add the `isFullFrontRequest` field

### DIFF
--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -16,7 +16,7 @@ import model.ApplicationIdentity
 import services.ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
-import play.api.http.HttpRequestHandler
+import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api.libs.ws.WSClient
@@ -73,6 +73,8 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
     DCRMetrics.DCRLatencyMetric,
     DCRMetrics.DCRRequestCountMetric,
   )
+
+  override lazy val httpErrorHandler: HttpErrorHandler = wire[FaciaErrorHandler]
 
   val frontendBuildInfo: FrontendBuildInfo = frontend.facia.BuildInfo
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters

--- a/facia/app/FaciaErrorHandler.scala
+++ b/facia/app/FaciaErrorHandler.scala
@@ -1,0 +1,26 @@
+import common.GuLogging
+import common.LoggingField.LogFieldBoolean
+import experiments.{ActiveExperiments, RemoveLiteFronts}
+import play.api._
+import play.api.http.DefaultHttpErrorHandler
+import play.api.mvc._
+import play.api.routing.Router
+import play.core.SourceMapper
+
+class FaciaErrorHandler(env: Environment, config: Configuration, sourceMapper: Option[SourceMapper], router: => Router)
+    extends DefaultHttpErrorHandler(env, config, sourceMapper, Some(router))
+    with GuLogging {
+
+  override def logServerError(request: RequestHeader, usefulException: UsefulException): Unit = {
+    lazy val isFullFrontRequest = ActiveExperiments.isParticipating(RemoveLiteFronts)(request)
+
+    logErrorWithCustomFields(
+      """
+        |
+        |! @%s - Internal server error, for (%s) [%s] ->
+        | """.stripMargin.format(usefulException.id, request.method, request.uri),
+      usefulException,
+      List(LogFieldBoolean("isFullFrontRequest", isFullFrontRequest)),
+    )
+  }
+}


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are running an [experiment](https://github.com/guardian/frontend/pull/27389) to test whether we can stop using the lite version of fronts. We want our server error logs to tell us whether the user was in this experiment, to see if there is a relationship between 500s and users in this experiment.

## What does this change?

Overrides `logServerError` in facia to add the `isFullFrontRequest` field to the log message.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
