### PR TITLE
Increase the Remove Lite Fronts experiment to 20%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -43,5 +43,5 @@ object RemoveLiteFronts
       description = "Get the full pressed page of a front instead of the lite version",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2024, 10, 30),
-      participationGroup = Perc10A,
+      participationGroup = Perc20A,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?

[Removing lite fronts](https://github.com/guardian/frontend/issues/27143)

## What does this change?

Increase the Remove Lite Fronts experiment to 20%. Metrics look OK.