### PR TITLE
Limit highlights container to 6 stories

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -323,7 +323,11 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
       treats <- getTreats(collection)
     } yield {
       val doNotTrimContainerOfTypes = Seq("nav/list")
-      val storyCountTotal = curated.length + backfill.length
+      val storyCountTotal = if (collection.collectionConfig.collectionType == "highlights") {
+        6
+      } else {
+        curated.length + backfill.length
+      }
       val storyCountMax: Int = doNotTrimContainerOfTypes
         .contains(collection.collectionConfig.collectionType)
         .toOption(storyCountTotal)

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -332,13 +332,16 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         .contains(collection.collectionConfig.collectionType)
         .toOption(storyCountTotal)
         .getOrElse(Math.min(Configuration.facia.collectionCap, storyCountTotal))
-      val storyCountVisible = Container
-        .storiesCount(
-          CollectionConfig.make(collection.collectionConfig),
-          curated ++ backfill,
-        )
-        .getOrElse(storyCountMax)
-
+      val storyCountVisible = if (collection.collectionConfig.collectionType == "highlights") {
+        6
+      } else {
+        Container
+          .storiesCount(
+            CollectionConfig.make(collection.collectionConfig),
+            curated ++ backfill,
+          )
+          .getOrElse(storyCountMax)
+      }
       val pressedCollection = pressCollection(collection, curated, backfill, treats, storyCountMax)
       PressedCollectionVisibility(pressedCollection, storyCountVisible)
     }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -323,7 +323,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
       treats <- getTreats(collection)
     } yield {
       val doNotTrimContainerOfTypes = Seq("nav/list")
-      val storyCountTotal = if (collection.collectionConfig.collectionType == "highlights") {
+      val storyCountTotal = if (collection.collectionConfig.collectionType == "scrollable/highlights") {
         6
       } else {
         curated.length + backfill.length
@@ -332,7 +332,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         .contains(collection.collectionConfig.collectionType)
         .toOption(storyCountTotal)
         .getOrElse(Math.min(Configuration.facia.collectionCap, storyCountTotal))
-      val storyCountVisible = if (collection.collectionConfig.collectionType == "highlights") {
+      val storyCountVisible = if (collection.collectionConfig.collectionType == "scrollable/highlights") {
         6
       } else {
         Container

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -322,22 +322,22 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
       backfill <- getBackfill(collection)
       treats <- getTreats(collection)
     } yield {
-      val doNotTrimContainerOfTypes = Seq("nav/list")
-      val storyCountTotal = if (collection.collectionConfig.collectionType == "scrollable/highlights") {
-        6
-      } else {
-        curated.length + backfill.length
+      val storyCountTotal = curated.length + backfill.length
+      val storyCountMax: Int = {
+        // nav/list stories should never be capped
+        if (collection.collectionConfig.collectionType == "nav/list") storyCountTotal
+        // scrollable/highlights container is capped at 6 stories
+        else if (collection.collectionConfig.collectionType == "scrollable/highlights") 6
+        // other container types should be capped at a maximum number of stories set in the app config
+        else Math.min(Configuration.facia.collectionCap, storyCountTotal)
       }
-      val storyCountMax: Int = doNotTrimContainerOfTypes
-        .contains(collection.collectionConfig.collectionType)
-        .toOption(storyCountTotal)
-        .getOrElse(Math.min(Configuration.facia.collectionCap, storyCountTotal))
       val storyCountVisible = Container
         .storiesCount(
           CollectionConfig.make(collection.collectionConfig),
           curated ++ backfill,
         )
         .getOrElse(storyCountMax)
+
       val pressedCollection = pressCollection(collection, curated, backfill, treats, storyCountMax)
       PressedCollectionVisibility(pressedCollection, storyCountVisible)
     }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -332,16 +332,12 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         .contains(collection.collectionConfig.collectionType)
         .toOption(storyCountTotal)
         .getOrElse(Math.min(Configuration.facia.collectionCap, storyCountTotal))
-      val storyCountVisible = if (collection.collectionConfig.collectionType == "scrollable/highlights") {
-        6
-      } else {
-        Container
-          .storiesCount(
-            CollectionConfig.make(collection.collectionConfig),
-            curated ++ backfill,
-          )
-          .getOrElse(storyCountMax)
-      }
+      val storyCountVisible = Container
+        .storiesCount(
+          CollectionConfig.make(collection.collectionConfig),
+          curated ++ backfill,
+        )
+        .getOrElse(storyCountMax)
       val pressedCollection = pressCollection(collection, curated, backfill, treats, storyCountMax)
       PressedCollectionVisibility(pressedCollection, storyCountVisible)
     }


### PR DESCRIPTION
## What does this change?

The highlights container is only intended to have 6 stories in it, but the fronts tool doesn't limit the number that can be added - it's been left to the platforms to only render 6. 

[A previous PR](https://github.com/guardian/frontend/pull/27375) set it so that only 6 stories would get added to "lite" version of the pressed front, leaving the full version with any more that were added in the tool. AFAIK the lite version is what normally gets served, but we had reports that suggested the full version was being used. 

We implemented a temporary solution [in DCR](https://github.com/guardian/dotcom-rendering/pull/12339), but it's preferable to tweak the logic upstream, so that when highlights collection gets pressed, it can only have 6 stories. 

## Testing

The only way to really test this, AFAICT, is to deploy the branch, make a change to the highlights container in the fronts tool, and manually check the pressed.json in AWS to confirm it only has six - at the time of writing, this is what the relevant section of the file looks like:

<img width="577" alt="image" src="https://github.com/user-attachments/assets/bad8ec79-a980-4185-9ba5-640796326a2d">

Which matches up with the intention in the tool: 
<img width="419" alt="image" src="https://github.com/user-attachments/assets/d486e5f4-10b6-4db2-b7ad-41e051d45e63">



