### PR TITLE
Remove paralympics from sports nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -390,7 +390,6 @@ object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
-      paralympics2024,
       football,
       cricket,
       rugbyUnion,
@@ -406,7 +405,6 @@ object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
-      paralympics2024,
       football,
       AFL,
       NRL,
@@ -420,7 +418,6 @@ object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
-      paralympics2024,
       usSoccer,
       NFL,
       tennis,
@@ -434,7 +431,6 @@ object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
-      paralympics2024,
       football,
       cricket,
       rugbyUnion,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -445,12 +445,6 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Paralympics 2024",
-					"url": "/sport/paralympic-games-2024",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -1284,12 +1278,6 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Paralympics 2024",
-					"url": "/sport/paralympic-games-2024",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "Soccer",
 					"url": "/us/soccer",
 					"children": [
@@ -2007,12 +1995,6 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
-				{
-					"title": "Paralympics 2024",
-					"url": "/sport/paralympic-games-2024",
-					"children": [],
-					"classList": []
-				},
 				{
 					"title": "Football",
 					"url": "/football",
@@ -2816,12 +2798,6 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
-				{
-					"title": "Paralympics 2024",
-					"url": "/sport/paralympic-games-2024",
-					"children": [],
-					"classList": []
-				},
 				{
 					"title": "Football",
 					"url": "/football",
@@ -3814,12 +3790,6 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
-				{
-					"title": "Paralympics 2024",
-					"url": "/sport/paralympic-games-2024",
-					"children": [],
-					"classList": []
-				},
 				{
 					"title": "Football",
 					"url": "/football",


### PR DESCRIPTION
## What is the value of this and can you measure success?
Remove paralympics from sports nav
## What does this change?
Resolves https://github.com/guardian/dotcom-rendering/issues/12349
## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/45b01111-e4da-46ab-8296-c3e4f7ea89d4
[after]: https://github.com/user-attachments/assets/c3598809-9588-4b97-8c7e-69201635e9d6


## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
