### PR TITLE
Update AU news subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -185,6 +185,7 @@ object NavLinks {
   val home = NavLink("Home & garden", "/lifeandstyle/home-and-garden")
   val health = NavLink("Health & fitness", "/lifeandstyle/health-and-wellbeing")
   val healthAu = NavLink("Health & fitness", "/au/lifeandstyle/health-and-wellbeing")
+  val healthNewsAu = NavLink("Health", "/australia-news/health")
   val women = NavLink("Women", "/lifeandstyle/women")
   val men = NavLink("Men", "/lifeandstyle/men")
   val recipes = NavLink("Recipes", "/tone/recipes")
@@ -303,6 +304,7 @@ object NavLinks {
       auImmigration,
       media,
       auBusiness,
+      healthNewsAu,
       science,
       tech,
       podcastsAU,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1924,6 +1924,12 @@
 					"classList": []
 				},
 				{
+					"title": "Health",
+					"url": "/australia-news/health",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Science",
 					"url": "/science",
 					"children": [],


### PR DESCRIPTION
## What is the value of this and can you measure success?
Requested by CP
Resolves https://github.com/guardian/dotcom-rendering/issues/12335
## What does this change?
Adds /australia-news/health to Au news subnav
## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/237b75cd-07d9-43f8-ac2e-cb0aaccc815f
[after]: https://github.com/user-attachments/assets/ac085f9a-3c3a-45a1-bece-dd9b47bdbb1b



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
