### PR TITLE
Document how to point to CODE CAPI

### DIFF
--- a/docs/03-dev-howtos/24-pointing-to-CODE-CAPI.md
+++ b/docs/03-dev-howtos/24-pointing-to-CODE-CAPI.md
@@ -1,0 +1,16 @@
+# Pointing to CODE CAPI
+
+It can be useful when running frontend locally to point it to CODE CAPI. The easiest way to do this is probably to point it to the CODE deployment of [concierge](https://github.com/guardian/content-api/tree/main/concierge). (In PROD and CODE, frontend connects to CAPI through dedicated URLs that allow it to bypass [kong](https://github.com/guardian/content-api/blob/main/gateways/vigile/README.md), but those URLs are relatively locked down and hard to access from dev computers. Concierge requests go through Kong and so are accessible from the public internet but restricted using API keys.)
+
+To do this, follow the instructions in [14-override-default-configuration](./14-override-default-configuration.md), setting `content.api.host` to the url for concierge-CODE (currently `https://content.code.dev-guardianapis.com`), and `content.api.key` to a valid internal-tier key for concierge-CODE.
+
+If you have access to [bonobo-CODE](https://bonobo-code.capi.gutools.co.uk/), you can create yourself a key there. If not, send Content Pipeline a message and they can create a key for you.
+
+To give a complete example, here’s a redacted version of my `~/.gu/frontend.conf` from the last time I did this:
+
+```conf
+devOverrides {
+  content.api.host="https://content.code.dev-guardianapis.com"
+  content.api.key="REDACTED"
+}
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@
 - [Testing Reader Revenue Components](03-dev-howtos/21-test-reader-revenue-components.md)
 - [Access Preview Locally](03-dev-howtos/22-access-preview-locally.md)
 - [Sport Tournaments](03-dev-howtos/23-sport-tournaments.md)
+- [Pointing to CODE CAPI](03-dev-howtos/24-pointing-to-CODE-CAPI.md)
 
 ## [Quality](04-quality/)
 - [Browsers support](04-quality/01-browser-support.md)


### PR DESCRIPTION
## What does this change?

I recently needed to do this and found it a bit awkward to figure out: hopefully this guide should help people in the future.

A question for reviewers: is it ok to put the URLs to concierge and bonobo in the docs? (I reckon it’s fine, but I understand if others feel differently!)

## Checklist

- [-] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [-] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [-] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [-] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [-] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)