### PR TITLE
Support `flexible/general` container in frontend

### DIFF
--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -34,6 +34,7 @@ object Container extends GuLogging {
       ("nav/media-list", NavMediaList),
       ("news/most-popular", MostPopular),
       ("flexible/special", Dynamic(FlexibleSpecial)),
+      ("flexible/general", Dynamic(FlexibleGeneral)),
     ) ++ FixedContainers.all.mapV(Fixed.apply) ++ EmailLayouts.all.mapV(Email.apply)
 
   /** So that we don't blow up at runtime, which would SUCK */

--- a/common/app/layout/slices/DynamicContainers.scala
+++ b/common/app/layout/slices/DynamicContainers.scala
@@ -9,6 +9,7 @@ object DynamicContainers {
     ("dynamic/package", DynamicPackage),
     ("dynamic/slow-mpu", DynamicSlowMPU(omitMPU = false, adFree = false)),
     ("flexible/special", FlexibleSpecial),
+    ("flexible/general", FlexibleGeneral),
   )
 
   def apply(collectionType: Option[String], items: Seq[PressedContent]): Option[ContainerDefinition] = {

--- a/common/app/layout/slices/FlexibleGeneral.scala
+++ b/common/app/layout/slices/FlexibleGeneral.scala
@@ -1,0 +1,33 @@
+package layout.slices
+
+import layout.slices.Story._
+
+object FlexibleGeneral extends DynamicContainer {
+  override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
+    val byGroup = segmentByGroup(stories)
+    val snap = byGroup.getOrElse(1, Seq.empty)
+
+    if (snap.nonEmpty) {
+      Some((FullMedia50, stories.drop(1)))
+    } else {
+      None
+    }
+  }
+
+  override protected def standardSlices(storiesIncludingBackfill: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] = {
+
+    storiesIncludingBackfill.length match {
+      case 0 => Nil
+      case 1 => Seq(FullMedia100)
+      case 2 => Seq(ThreeQuarterQuarter)
+      case 3 => Seq(ThreeQuarterTallQuarter2)
+      case 4 => Seq(ThreeQuarterTallQuarter1Ql2)
+      case 5 => Seq(FullMedia100, QuarterQuarterQuarterQuarter)
+      // This case doesn't look _quite_ right. We end up with a row of four
+      // and then a row of three, slightly stretched. There isn't a layout
+      // which caters for this currently, we'll follow up on this separately.
+      case _ => Seq(FullMedia100, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
+
+    }
+  }
+}

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -46,6 +46,7 @@ object FrontChecks {
       "news/most-popular",
       "scrollable/highlights",
       "flexible/special",
+      "flexible/general",
     )
 
   def hasOnlySupportedCollections(faciaPage: PressedPage) =

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -250,6 +250,7 @@ import layout.slices.EmailLayouts
         PressedCollectionBuilder.mkPressedCollection("news/most-popular"),
         PressedCollectionBuilder.mkPressedCollection("scrollable/highlights"),
         PressedCollectionBuilder.mkPressedCollection("flexible/special"),
+        PressedCollectionBuilder.mkPressedCollection("flexible/general"),
       ),
     )
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows DCR to render `flexible/general` containers (in https://github.com/guardian/dotcom-rendering/pull/12385)

## What does this change?

Adds basic support for `flexible/general` container layout, by initially copying the structure for `flexible/special`


## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->


> Co-authored-by: @abeddow91 
> Co-authored-by: @Georges-GNM  
