### PR TITLE
Update SBT to 1.10.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.10.2


### PR DESCRIPTION
## What is the value of this and can you measure success?

Use the latest version of SBT: [1.10.2 Changelog](https://github.com/sbt/sbt/releases/tag/v1.10.2). 

Unfortunately I think the [most interesting change](https://github.com/sbt/zinc/pull/1395) for us will only be available in scala `2.13.15` (see https://github.com/scala/scala/pull/10860).
Still interesting to see if this impact build time.  