### PR TITLE
Add Thumbnail image to DCR model for Audio Articles

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -89,7 +89,7 @@ case class DotcomRenderingDataModel(
     commercialProperties: Map[String, EditionCommercialProperties],
     pageType: PageType,
     starRating: Option[Int],
-    audioArticleImage: Option[Block],
+    audioArticleImage: Option[ImageBlockElement],
     trailText: String,
     nav: Nav,
     showBottomSocialButtons: Boolean,
@@ -504,12 +504,11 @@ object DotcomRenderingDataModel {
 
     val dcrTags = content.tags.tags.map(Tag.apply)
 
-    val audioImageBlock: Option[Block] =
+    val audioImageBlock: Option[ImageBlockElement] =
       if (page.metadata.contentType.contains(DotcomContentType.Audio)) {
         for {
           thumbnail <- page.item.elements.thumbnail
         } yield {
-          val articleDateTimes = ArticleDateTimes.makeDisplayedDateTimesDCR(contentDateTimes, request)
           val imageData = thumbnail.images.allImages.headOption
             .map { d =>
               Map(
@@ -520,35 +519,12 @@ object DotcomRenderingDataModel {
               )
             }
             .getOrElse(Map.empty)
-
-          new Block(
-            id = thumbnail.properties.id,
-            elements = List(
-              ImageBlockElement(
-                thumbnail.images,
-                imageData,
-                Some(true),
-                Role(Some("inline")),
-                Seq.empty,
-              ),
-            ),
-            attributes = BlockAttributes(
-              pinned = false,
-              keyEvent = false,
-              summary = false,
-              membershipPlaceholder = None,
-            ),
-            blockCreatedOn = None,
-            blockCreatedOnDisplay = None,
-            blockLastUpdated = None,
-            blockLastUpdatedDisplay = None,
-            blockFirstPublished = None,
-            blockFirstPublishedDisplay = None,
-            blockFirstPublishedDisplayNoTimezone = None,
-            title = None,
-            contributors = Seq.empty[Contributor],
-            primaryDateLine = articleDateTimes.primaryDateLine,
-            secondaryDateLine = articleDateTimes.secondaryDateLine,
+          ImageBlockElement(
+            thumbnail.images,
+            imageData,
+            Some(true),
+            Role(Some("inline")),
+            Seq.empty,
           )
         }
       } else {

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -197,16 +197,6 @@ object DotcomRenderingDataModel {
     Json.stringify(withoutNull(jsValue))
   }
 
-  private def imageDataFor(element: ImageElement): Map[String, String] = {
-    element.images.allImages.flatMap { d =>
-      Map(
-        "copyright" -> "",
-        "alt" -> d.altText.getOrElse(""),
-        "caption" -> d.caption.getOrElse(""),
-        "credit" -> d.credit.getOrElse(""),
-      )
-    }.toMap
-  }
   def forInteractive(
       page: InteractivePage,
       blocks: APIBlocks,
@@ -521,12 +511,23 @@ object DotcomRenderingDataModel {
           thumbnail <- page.item.elements.thumbnail
         } yield {
           val articleDateTimes = ArticleDateTimes.makeDisplayedDateTimesDCR(contentDateTimes, request)
+          val imageData = thumbnail.images.allImages.headOption
+            .map { d =>
+              Map(
+                "copyright" -> "",
+                "alt" -> d.altText.getOrElse(""),
+                "caption" -> d.caption.getOrElse(""),
+                "credit" -> d.credit.getOrElse(""),
+              )
+            }
+            .getOrElse(Map.empty)
+
           new Block(
             id = thumbnail.properties.id,
             elements = List(
               ImageBlockElement(
                 thumbnail.images,
-                imageDataFor(thumbnail),
+                imageData,
                 Some(true),
                 Role(Some("inline")),
                 Seq.empty,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -89,7 +89,7 @@ case class DotcomRenderingDataModel(
     commercialProperties: Map[String, EditionCommercialProperties],
     pageType: PageType,
     starRating: Option[Int],
-    thumbnailImage: Option[Block],
+    audioArticleImage: Option[Block],
     trailText: String,
     nav: Nav,
     showBottomSocialButtons: Boolean,
@@ -167,7 +167,7 @@ object DotcomRenderingDataModel {
         "commercialProperties" -> model.commercialProperties,
         "pageType" -> model.pageType,
         "starRating" -> model.starRating,
-        "thumbnailImage" -> model.thumbnailImage,
+        "audioArticleImage" -> model.audioArticleImage,
         "trailText" -> model.trailText,
         "nav" -> model.nav,
         "showBottomSocialButtons" -> model.showBottomSocialButtons,
@@ -620,6 +620,7 @@ object DotcomRenderingDataModel {
 
     DotcomRenderingDataModel(
       affiliateLinksDisclaimer = addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks, shouldAddDisclaimer),
+      audioArticleImage = audioImageBlock,
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
       beaconURL = Configuration.debug.beaconUrl,
@@ -674,7 +675,6 @@ object DotcomRenderingDataModel {
       subMetaSectionLinks =
         content.content.submetaLinks.sectionLabels.map(SubMetaLink.apply).filter(_.title.trim.nonEmpty),
       tags = dcrTags,
-      thumbnailImage = audioImageBlock,
       trailText = TextCleaner.sanitiseLinks(edition)(content.trail.fields.trailText.getOrElse("")),
       twitterData = page.getTwitterProperties,
       version = 3,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -5,7 +5,23 @@ import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
-import model.{ArticleDateTimes, Badges, CanonicalLiveBlog, ContentFormat, ContentPage, CrosswordData, DotcomContentType, GUDateTimeFormatNew, GalleryPage, ImageContentPage, ImageElement, InteractivePage, LiveBlogPage, MediaPage, PageWithStoryPackage}
+import model.{
+  ArticleDateTimes,
+  Badges,
+  CanonicalLiveBlog,
+  ContentFormat,
+  ContentPage,
+  CrosswordData,
+  DotcomContentType,
+  GUDateTimeFormatNew,
+  GalleryPage,
+  ImageContentPage,
+  ImageElement,
+  InteractivePage,
+  LiveBlogPage,
+  MediaPage,
+  PageWithStoryPackage,
+}
 import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
 import crosswords.CrosswordPageWithContent

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -5,22 +5,7 @@ import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
-import model.{
-  ArticleDateTimes,
-  Badges,
-  CanonicalLiveBlog,
-  ContentFormat,
-  ContentPage,
-  CrosswordData,
-  DotcomContentType,
-  GUDateTimeFormatNew,
-  GalleryPage,
-  ImageContentPage,
-  InteractivePage,
-  LiveBlogPage,
-  MediaPage,
-  PageWithStoryPackage,
-}
+import model.{ArticleDateTimes, Badges, CanonicalLiveBlog, ContentFormat, ContentPage, CrosswordData, DotcomContentType, GUDateTimeFormatNew, GalleryPage, ImageContentPage, ImageElement, InteractivePage, LiveBlogPage, MediaPage, PageWithStoryPackage}
 import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
 import crosswords.CrosswordPageWithContent
@@ -196,6 +181,16 @@ object DotcomRenderingDataModel {
     Json.stringify(withoutNull(jsValue))
   }
 
+  private def imageDataFor(element: ImageElement): Map[String, String] = {
+    element.images.allImages.flatMap { d =>
+      Map(
+        "copyright" -> "",
+        "alt" -> d.altText.getOrElse(""),
+        "caption" -> d.caption.getOrElse(""),
+        "credit" -> d.credit.getOrElse(""),
+      )
+    }.toMap
+  }
   def forInteractive(
       page: InteractivePage,
       blocks: APIBlocks,
@@ -515,9 +510,9 @@ object DotcomRenderingDataModel {
             elements = List(
               ImageBlockElement(
                 thumbnail.images,
-                Map.empty,
+                imageDataFor(thumbnail),
                 Some(true),
-                Role(Some("thumbnail")),
+                Role(Some("inline")),
                 Seq.empty,
               ),
             ),

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -536,7 +536,7 @@ object DotcomRenderingDataModel {
               pinned = false,
               keyEvent = false,
               summary = false,
-              None,
+              membershipPlaceholder = None,
             ),
             blockCreatedOn = None,
             blockCreatedOnDisplay = None,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -5,12 +5,6 @@ import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
-import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
-import conf.Configuration
-import crosswords.CrosswordPageWithContent
-import experiments.ActiveExperiments
-import model.dotcomrendering.DotcomRenderingUtils._
-import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
   ArticleDateTimes,
   Badges,
@@ -18,6 +12,7 @@ import model.{
   ContentFormat,
   ContentPage,
   CrosswordData,
+  DotcomContentType,
   GUDateTimeFormatNew,
   GalleryPage,
   ImageContentPage,
@@ -26,6 +21,13 @@ import model.{
   MediaPage,
   PageWithStoryPackage,
 }
+import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
+import conf.Configuration
+import crosswords.CrosswordPageWithContent
+import experiments.ActiveExperiments
+import model.dotcomrendering.DotcomRenderingUtils._
+import model.dotcomrendering.pageElements.{ImageBlockElement, PageElement, Role, TextCleaner}
+import model.liveblog.BlockAttributes
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
@@ -87,6 +89,7 @@ case class DotcomRenderingDataModel(
     commercialProperties: Map[String, EditionCommercialProperties],
     pageType: PageType,
     starRating: Option[Int],
+    thumbnailImage: Option[Block],
     trailText: String,
     nav: Nav,
     showBottomSocialButtons: Boolean,
@@ -164,6 +167,7 @@ object DotcomRenderingDataModel {
         "commercialProperties" -> model.commercialProperties,
         "pageType" -> model.pageType,
         "starRating" -> model.starRating,
+        "thumbnailImage" -> model.thumbnailImage,
         "trailText" -> model.trailText,
         "nav" -> model.nav,
         "showBottomSocialButtons" -> model.showBottomSocialButtons,
@@ -500,6 +504,46 @@ object DotcomRenderingDataModel {
 
     val dcrTags = content.tags.tags.map(Tag.apply)
 
+    val audioImageBlock: Option[Block] =
+      if (page.metadata.contentType.contains(DotcomContentType.Audio)) {
+        for {
+          thumbnail <- page.item.elements.thumbnail
+        } yield {
+          val articleDateTimes = ArticleDateTimes.makeDisplayedDateTimesDCR(contentDateTimes, request)
+          new Block(
+            id = thumbnail.properties.id,
+            elements = List(
+              ImageBlockElement(
+                thumbnail.images,
+                Map.empty,
+                Some(true),
+                Role(Some("thumbnail")),
+                Seq.empty,
+              ),
+            ),
+            attributes = BlockAttributes(
+              pinned = false,
+              keyEvent = false,
+              summary = false,
+              None,
+            ),
+            blockCreatedOn = None,
+            blockCreatedOnDisplay = None,
+            blockLastUpdated = None,
+            blockLastUpdatedDisplay = None,
+            blockFirstPublished = None,
+            blockFirstPublishedDisplay = None,
+            blockFirstPublishedDisplayNoTimezone = None,
+            title = None,
+            contributors = Seq.empty[Contributor],
+            primaryDateLine = articleDateTimes.primaryDateLine,
+            secondaryDateLine = articleDateTimes.secondaryDateLine,
+          )
+        }
+      } else {
+        None
+      }
+
     def toDCRBlock(isMainBlock: Boolean = false) = { block: APIBlock =>
       Block(
         block = block,
@@ -619,6 +663,7 @@ object DotcomRenderingDataModel {
       subMetaSectionLinks =
         content.content.submetaLinks.sectionLabels.map(SubMetaLink.apply).filter(_.title.trim.nonEmpty),
       tags = dcrTags,
+      thumbnailImage = audioImageBlock,
       trailText = TextCleaner.sanitiseLinks(edition)(content.trail.fields.trailText.getOrElse("")),
       twitterData = page.getTwitterProperties,
       version = 3,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -5,6 +5,13 @@ import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
+import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
+import conf.Configuration
+import crosswords.CrosswordPageWithContent
+import experiments.ActiveExperiments
+import model.dotcomrendering.DotcomRenderingUtils._
+import model.dotcomrendering.pageElements.{ImageBlockElement, PageElement, Role, TextCleaner}
+import model.liveblog.BlockAttributes
 import model.{
   ArticleDateTimes,
   Badges,
@@ -16,19 +23,11 @@ import model.{
   GUDateTimeFormatNew,
   GalleryPage,
   ImageContentPage,
-  ImageElement,
   InteractivePage,
   LiveBlogPage,
   MediaPage,
   PageWithStoryPackage,
 }
-import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
-import conf.Configuration
-import crosswords.CrosswordPageWithContent
-import experiments.ActiveExperiments
-import model.dotcomrendering.DotcomRenderingUtils._
-import model.dotcomrendering.pageElements.{ImageBlockElement, PageElement, Role, TextCleaner}
-import model.liveblog.BlockAttributes
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader


### PR DESCRIPTION
## What is the value of this and can you measure success?
Add the thumbnail image to the DCR json for the audio Article

## What does this change?
The Json sent for audio articles now contains a new optional field `audioArticleImage`

## Screenshots

| Before      | After      |
|-------------|------------|
|<img width="622" alt="Screenshot 2024-09-17 at 11 12 21" src="https://github.com/user-attachments/assets/62e1c0cb-6acc-4db7-8ef4-87e47934d633"> |<img width="746" alt="Screenshot 2024-09-17 at 11 18 32" src="https://github.com/user-attachments/assets/1d3f4fe1-c507-4f93-864e-01eb9622d2e6">|

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
