### PR TITLE
Remove Paralympics from nav in US pillar

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -109,7 +109,6 @@ object NavLinks {
 
   /* SPORT */
 
-  private val paralympics2024 = NavLink("Paralympics 2024", "/sport/paralympic-games-2024")
   private val footballScores = NavLink("Live scores", "/football/live", Some("football/live"))
   private val footballTables = NavLink("Tables", "/football/tables", Some("football/tables"))
   private val footballFixtures = NavLink("Fixtures", "/football/fixtures", Some("football/fixtures"))
@@ -318,7 +317,6 @@ object NavLinks {
       world,
       usEnvironment,
       ukraine,
-      paralympics2024,
       usSoccer,
       usBusiness,
       usTech,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1120,12 +1120,6 @@
 					"classList": []
 				},
 				{
-					"title": "Paralympics 2024",
-					"url": "/sport/paralympic-games-2024",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "Soccer",
 					"url": "/us/soccer",
 					"children": [


### PR DESCRIPTION
Remove Paralympics from nav in US pillar

## Screenshots

| Before | After |
| - | - |
| ![before] | ![after] |

[before]: https://github.com/user-attachments/assets/416cfe00-351f-49f3-af92-fa5f5e63c82a
[after]: https://github.com/user-attachments/assets/9beac441-19ce-409e-8c3c-2ee5abff1a08
