### PR TITLE
Remove `surveys` switch

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -1,5 +1,4 @@
 @import common.LinkTo
-@import conf.switches.Switches.SurveySwitch
 @import model.{MediaPage, Video, VideoPlayer}
 @import views.support.Commercial.{isAdFree, isPaidContent}
 @import views.support.TrailCssClasses.toneClass
@@ -22,7 +21,7 @@
             )"
             itemscope itemtype="@media.metadata.schemaType" role="main">
 
-                @if(!page.metadata.isFront && SurveySwitch.isSwitchedOn) {
+                @if(!page.metadata.isFront && page.metadata.hasSurveyAd(request)) {
                     @fragments.commercial.survey()
                 }
 

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -68,7 +68,7 @@ object StoryHtmlPage {
       bodyTag(classes = bodyClasses)(
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkin(request),
-        survey() when SurveySwitch.isSwitchedOn,
+        survey() when page.metadata.hasSurveyAd(request),
         header,
         mainContent(),
         content,

--- a/common/app/common/dfp/SurveySponsorshipAgent.scala
+++ b/common/app/common/dfp/SurveySponsorshipAgent.scala
@@ -3,7 +3,6 @@ package common.dfp
 import play.api.mvc.RequestHeader
 import model.{MetaData}
 import model.DotcomContentType
-import conf.switches.Switches.{SurveySwitch}
 import net.liftweb.json.Meta
 
 trait SurveySponsorshipAgent {
@@ -21,7 +20,7 @@ trait SurveySponsorshipAgent {
   }
 
   def hasSurveyAd(fullAdUnitPath: String, metadata: MetaData, request: RequestHeader): Boolean = {
-    if (metadata.contentType == Some(DotcomContentType.Article) && SurveySwitch.isSwitchedOn) {
+    if (metadata.contentType == Some(DotcomContentType.Article) && metadata.hasSurveyAd(request)) {
       val adTest = request.getQueryString("adtest")
 
       findSponsorships(fullAdUnitPath, metadata, adTest).nonEmpty

--- a/common/app/common/dfp/SurveySponsorshipAgent.scala
+++ b/common/app/common/dfp/SurveySponsorshipAgent.scala
@@ -20,7 +20,7 @@ trait SurveySponsorshipAgent {
   }
 
   def hasSurveyAd(fullAdUnitPath: String, metadata: MetaData, request: RequestHeader): Boolean = {
-    if (metadata.contentType == Some(DotcomContentType.Article) && metadata.hasSurveyAd(request)) {
+    if (metadata.contentType == Some(DotcomContentType.Article)) {
       val adTest = request.getQueryString("adtest")
 
       findSponsorships(fullAdUnitPath, metadata, adTest).nonEmpty

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -27,16 +27,6 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val SurveySwitch = Switch(
-    Commercial,
-    "surveys",
-    "For delivering surveys, enables the requesting of the out-of-page slot on non-fronts. Switch OFF if there are no surveys active in GAM",
-    owners = Seq(Owner.withName("unknown")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val ImrWorldwideSwitch = Switch(
     Commercial,
     "imr-worldwide",

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,6 +1,5 @@
 @(projectName: Option[String] = None)(head: Html)(body: Html)(implicit page: model.Page, request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, commercial}
-@import conf.switches.Switches.SurveySwitch
 @import model.Page.getContent
 @import views.support.{Commercial, RenderClasses}
 @import play.api.Mode.Dev
@@ -45,7 +44,7 @@
             @fragments.commercial.pageSkin()
         }
 
-        @if(!page.metadata.isFront && SurveySwitch.isSwitchedOn) {
+        @if(!page.metadata.isFront && page.metadata.hasSurveyAd(request)) {
             @fragments.commercial.survey()
         }
 


### PR DESCRIPTION
## What does this change?

This PR removes the surveys switch and instead checks if we should show a survey ad based on `hasSurveyAd`. 
DCR PR https://github.com/guardian/dotcom-rendering/pull/12413

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
