### PR TITLE
Bump `micromatch` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
 	"prettier": "@guardian/prettier",
 	"packageManager": "yarn@4.1.1",
 	"resolutions": {
-		"micromatch": "4.0.7",
+		"micromatch": "4.0.8",
 		"unset-value": "^2.0.1"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13445,13 +13445,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:4.0.7":
-  version: 4.0.7
-  resolution: "micromatch@npm:4.0.7"
+"micromatch@npm:4.0.8":
+  version: 4.0.8
+  resolution: "micromatch@npm:4.0.8"
   dependencies:
     braces: "npm:^3.0.3"
     picomatch: "npm:^2.3.1"
-  checksum: 10c0/58fa99bc5265edec206e9163a1d2cec5fabc46a5b473c45f4a700adce88c2520456ae35f2b301e4410fb3afb27e9521fb2813f6fc96be0a48a89430e0916a772
+  checksum: 10c0/166fa6eb926b9553f32ef81f5f531d27b4ce7da60e5baf8c021d043b27a388fb95e46a8038d5045877881e673f8134122b59624d5cecbd16eb50a42e7a6b5ca8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?

Bumps `micromatch` to keep dependencies up-to-date.