### PR TITLE
Bump commercial to v21.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial": "21.0.2",
+		"@guardian/commercial": "21.0.3",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,12 +4039,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:21.0.2":
-  version: 21.0.2
-  resolution: "@guardian/commercial@npm:21.0.2"
+"@guardian/commercial@npm:21.0.3":
+  version: 21.0.3
+  resolution: "@guardian/commercial@npm:21.0.3"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
-    "@guardian/prebid.js": "npm:8.52.0-2"
+    "@guardian/prebid.js": "npm:8.52.0-3"
     "@octokit/core": "npm:^6.1.2"
     fastdom: "npm:^1.0.11"
     lodash-es: "npm:^4.17.21"
@@ -4060,7 +4060,7 @@ __metadata:
     "@guardian/libs": ^18.0.0
     "@guardian/source": ^6.0.0
     typescript: ~5.5.3
-  checksum: 10c0/9e976537dec9649ef2caac0eb21ac91ee745468f0d32c768d0d2d72d90db61f6a0bdc317a51c4b8281893a6c673df24785f24d8967c488484f0efe0d969a3efc
+  checksum: 10c0/bc116298f0407c36d1b69147dfb75b9b77be97603172817caf74355dbe2187cb5cf49317782b49dc806c94149d0790dd5aacca3015e4a31e90b1bfb2d8391fa5
   languageName: node
   linkType: hard
 
@@ -4133,7 +4133,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial": "npm:21.0.2"
+    "@guardian/commercial": "npm:21.0.3"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"
@@ -4321,9 +4321,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/prebid.js@npm:8.52.0-2":
-  version: 8.52.0-2
-  resolution: "@guardian/prebid.js@npm:8.52.0-2"
+"@guardian/prebid.js@npm:8.52.0-3":
+  version: 8.52.0-3
+  resolution: "@guardian/prebid.js@npm:8.52.0-3"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/plugin-transform-runtime": "npm:^7.18.9"
@@ -4336,7 +4336,7 @@ __metadata:
     criteo-direct-rsa-validate: "npm:^1.1.0"
     crypto-js: "npm:^4.2.0"
     dlv: "npm:1.1.3"
-    dset: "npm:3.1.2"
+    dset: "npm:3.1.4"
     express: "npm:^4.15.4"
     fsevents: "npm:^2.3.2"
     fun-hooks: "npm:^0.9.9"
@@ -4346,7 +4346,7 @@ __metadata:
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: 10c0/1223d9d5d66f16b917b3e78e2138e34ac1c92d961b7b6b2c71e73839c225f673ce48a236d599190537fd0af1dd2227ceff7adb1577ec14dd2ffabf1fec71f1bd
+  checksum: 10c0/3274a1718213ae2ebedd2082ecee916fcc3b2e99c93b4624459c56be56c8322c16b32f06333a11f7f33f42a9a7fe0058687dcaa83358bfdc598121f881517ecd
   languageName: node
   linkType: hard
 
@@ -9145,10 +9145,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dset@npm:3.1.2":
-  version: 3.1.2
-  resolution: "dset@npm:3.1.2"
-  checksum: 10c0/a10d5f214ccd53e7d2e79215473256b74cb98fd3f20ad4f4684ab575b19bac71e5dda524d6febcf42854062e3f575a2dbfca4d53d2ffb9ae238eecdcc97a095b
+"dset@npm:3.1.4":
+  version: 3.1.4
+  resolution: "dset@npm:3.1.4"
+  checksum: 10c0/b67bbd28dd8a539e90c15ffb61100eb64ef995c5270a124d4f99bbb53f4d82f55a051b731ba81f3215dd9dce2b4c8d69927dc20b3be1c5fc88bab159467aa438
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?
Bumps commercial to v[21.0.3](https://github.com/guardian/commercial/releases/tag/v21.0.3). This resolves a high severity vulnerability in dset.