### PR TITLE
Upgrade to Panda v7 - support key rotation

### DIFF
--- a/common/app/http/GuardianAuthWithExemptions.scala
+++ b/common/app/http/GuardianAuthWithExemptions.scala
@@ -4,7 +4,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
-import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
+import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher, S3BucketLoader}
 import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 import common.Environment.stage
 import conf.Configuration.aws.mandatoryCredentials
@@ -54,14 +54,11 @@ class GuardianAuthWithExemptions(
       case _      => s"local.dev-gutools.co.uk" // covers DEV, LOCAL, tests etc.
     }
 
-  override lazy val panDomainSettings =
-    new PanDomainAuthSettingsRefresher(
-      domain = toolsDomainSuffix,
-      system,
-      bucketName = "pan-domain-auth-settings",
-      settingsFileKey = s"$toolsDomainSuffix.settings",
-      s3Client,
-    )
+  override lazy val panDomainSettings = PanDomainAuthSettingsRefresher(
+    domain = toolsDomainSuffix,
+    system,
+    S3BucketLoader.forAwsSdkV1(s3Client, "pan-domain-auth-settings"),
+  )
 
   override def authCallbackUrl = s"https://$toolsDomainPrefix.$toolsDomainSuffix$oauthCallbackPath"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.5.9" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.12"
-  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "5.0.0"
+  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0"
   val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "3.0.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"


### PR DESCRIPTION
This upgrades Panda from v5 to v7, allowing us to use key rotation as introduced with https://github.com/guardian/pan-domain-authentication/pull/150.

* Panda v6 updates:
  * https://github.com/guardian/pan-domain-authentication/pull/151 introduced the new `S3BucketLoader` abstraction, which simplifies constructing a `PanDomainAuthSettingsRefresher` and means that Panda is no longer _tied_ to AWS SDK v1 - an alternative AWS SDK v2 implementation of `S3BucketLoader` could be introduced.

See also:

* https://github.com/guardian/pan-domain-authentication/issues/160

Panda was re-introduced to Frontend with https://github.com/guardian/frontend/pull/27012 in May 2024, where it became the authentication system around pages like https://frontend.gutools.co.uk/.

### Testing

This has been successfully [deployed](https://riffraff.gutools.co.uk/deployment/view/cf34a83c-6c8a-499a-b1bb-fd743a65396a) to CODE, and I've verified that I can successfully re-authenticate at https://frontend.code.dev-gutools.co.uk/admin:

https://github.com/user-attachments/assets/53e513a0-0790-46ae-9b9a-602d03287738
