### PR TITLE
Seperate FlexibleContainers into their own class

### DIFF
--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -35,7 +35,7 @@ object Container extends GuLogging {
       ("nav/media-list", NavMediaList),
       ("news/most-popular", MostPopular),
       ("flexible/special", Flexible(FlexibleSpecial)),
-      ("flexible/general", Flexible(FlexibleSpecial)),
+      ("flexible/general", Flexible(FlexibleGeneral)),
     ) ++ FixedContainers.all.mapV(Fixed.apply) ++ EmailLayouts.all.mapV(Email.apply)
 
   /** So that we don't blow up at runtime, which would SUCK */

--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -11,6 +11,7 @@ import scala.collection.immutable.Iterable
 sealed trait Container
 
 case class Dynamic(get: DynamicContainer) extends Container
+case class Flexible(get: FlexibleContainer) extends Container
 case class Fixed(get: ContainerDefinition) extends Container
 case class Email(get: EmailLayout) extends Container
 case object NavList extends Container
@@ -33,8 +34,8 @@ object Container extends GuLogging {
       ("nav/list", NavList),
       ("nav/media-list", NavMediaList),
       ("news/most-popular", MostPopular),
-      ("flexible/special", Dynamic(FlexibleSpecial)),
-      ("flexible/general", Dynamic(FlexibleGeneral)),
+      ("flexible/special", Flexible(FlexibleSpecial)),
+      ("flexible/general", Flexible(FlexibleSpecial)),
     ) ++ FixedContainers.all.mapV(Fixed.apply) ++ EmailLayouts.all.mapV(Email.apply)
 
   /** So that we don't blow up at runtime, which would SUCK */

--- a/common/app/layout/slices/ContainerDefinition.scala
+++ b/common/app/layout/slices/ContainerDefinition.scala
@@ -25,6 +25,8 @@ object ContainerDefinition {
     container match {
       case Dynamic(dynamicContainer) =>
         dynamicContainer.containerDefinitionFor(items.map(Story.fromFaciaContent))
+      case Flexible(flexibleContainer) =>
+        flexibleContainer.containerDefinitionFor(items.map(Story.fromFaciaContent))
       case Fixed(containerDefinition) =>
         Some(containerDefinition)
       case _ =>

--- a/common/app/layout/slices/DynamicContainers.scala
+++ b/common/app/layout/slices/DynamicContainers.scala
@@ -8,7 +8,6 @@ object DynamicContainers {
     ("dynamic/slow", DynamicSlow),
     ("dynamic/package", DynamicPackage),
     ("dynamic/slow-mpu", DynamicSlowMPU(omitMPU = false, adFree = false)),
-    ("flexible/general", FlexibleGeneral),
   )
 
   def apply(collectionType: Option[String], items: Seq[PressedContent]): Option[ContainerDefinition] = {

--- a/common/app/layout/slices/DynamicContainers.scala
+++ b/common/app/layout/slices/DynamicContainers.scala
@@ -8,7 +8,6 @@ object DynamicContainers {
     ("dynamic/slow", DynamicSlow),
     ("dynamic/package", DynamicPackage),
     ("dynamic/slow-mpu", DynamicSlowMPU(omitMPU = false, adFree = false)),
-    ("flexible/special", FlexibleSpecial),
     ("flexible/general", FlexibleGeneral),
   )
 

--- a/common/app/layout/slices/FlexibleContainer.scala
+++ b/common/app/layout/slices/FlexibleContainer.scala
@@ -1,0 +1,43 @@
+package layout.slices
+
+import common.Seqs._
+import layout.slices.Story._
+
+/** Used for calculating the final slice -- any stories that are not standard are considered 'bigs' for the standard
+  * slice
+  */
+private[slices] case class BigsAndStandards(
+    bigs: Seq[Story],
+    standards: Seq[Story],
+)
+
+private[slices] trait FlexibleContainer {
+  protected def standardSlices(stories: Seq[Story], firstSlice: Option[Slice]): Seq[Slice]
+
+  protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
+    None
+  }
+
+  final def slicesFor(stories: Seq[Story]): Option[Seq[Slice]] = {
+    if (stories.nonEmpty && stories.isDescending && stories.forall(story => story.group >= 0 && story.group <= 3)) {
+      optionalFirstSlice(stories) map { case (firstSlice, remaining) =>
+        Some(firstSlice +: standardSlices(remaining, Some(firstSlice)))
+      } getOrElse {
+        Some(standardSlices(stories, None))
+      }
+    } else {
+      None
+    }
+  }
+
+  final def containerDefinitionFor(stories: Seq[Story]): Option[ContainerDefinition] = {
+    slicesFor(stories) map { slices =>
+      ContainerDefinition(
+        slices,
+        slicesWithoutMPU = slices,
+        mobileShowMore = DesktopBehaviour,
+        Set.empty,
+      )
+    }
+  }
+}

--- a/common/app/layout/slices/FlexibleContainer.scala
+++ b/common/app/layout/slices/FlexibleContainer.scala
@@ -8,7 +8,6 @@ private[slices] trait FlexibleContainer {
 
   protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])]
 
-
   final def slicesFor(stories: Seq[Story]): Option[Seq[Slice]] = {
     if (stories.nonEmpty && stories.isDescending && stories.forall(story => story.group >= 0 && story.group <= 3)) {
       optionalFirstSlice(stories) map { case (firstSlice, remaining) =>

--- a/common/app/layout/slices/FlexibleContainer.scala
+++ b/common/app/layout/slices/FlexibleContainer.scala
@@ -3,20 +3,11 @@ package layout.slices
 import common.Seqs._
 import layout.slices.Story._
 
-/** Used for calculating the final slice -- any stories that are not standard are considered 'bigs' for the standard
-  * slice
-  */
-private[slices] case class BigsAndStandards(
-    bigs: Seq[Story],
-    standards: Seq[Story],
-)
-
 private[slices] trait FlexibleContainer {
   protected def standardSlices(stories: Seq[Story], firstSlice: Option[Slice]): Seq[Slice]
 
-  protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
-    None
-  }
+  protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])]
+
 
   final def slicesFor(stories: Seq[Story]): Option[Seq[Slice]] = {
     if (stories.nonEmpty && stories.isDescending && stories.forall(story => story.group >= 0 && story.group <= 3)) {

--- a/common/app/layout/slices/FlexibleContainers.scala
+++ b/common/app/layout/slices/FlexibleContainers.scala
@@ -6,7 +6,6 @@ object FlexibleContainers {
   val all: Map[String, FlexibleContainer] = Map(
     ("flexible/special", FlexibleSpecial),
     ("flexible/general", FlexibleGeneral),
-
   )
 
   def apply(collectionType: Option[String], items: Seq[PressedContent]): Option[ContainerDefinition] = {

--- a/common/app/layout/slices/FlexibleContainers.scala
+++ b/common/app/layout/slices/FlexibleContainers.scala
@@ -5,6 +5,8 @@ import model.pressed.PressedContent
 object FlexibleContainers {
   val all: Map[String, FlexibleContainer] = Map(
     ("flexible/special", FlexibleSpecial),
+    ("flexible/general", FlexibleGeneral),
+
   )
 
   def apply(collectionType: Option[String], items: Seq[PressedContent]): Option[ContainerDefinition] = {

--- a/common/app/layout/slices/FlexibleContainers.scala
+++ b/common/app/layout/slices/FlexibleContainers.scala
@@ -1,0 +1,17 @@
+package layout.slices
+
+import model.pressed.PressedContent
+
+object FlexibleContainers {
+  val all: Map[String, FlexibleContainer] = Map(
+    ("flexible/special", FlexibleSpecial),
+  )
+
+  def apply(collectionType: Option[String], items: Seq[PressedContent]): Option[ContainerDefinition] = {
+    for {
+      typ <- collectionType
+      flexibleContainer <- all.get(typ)
+      definition <- flexibleContainer.containerDefinitionFor(items.map(Story.fromFaciaContent))
+    } yield definition
+  }
+}

--- a/common/app/layout/slices/FlexibleGeneral.scala
+++ b/common/app/layout/slices/FlexibleGeneral.scala
@@ -2,12 +2,12 @@ package layout.slices
 
 import layout.slices.Story._
 
-object FlexibleGeneral extends DynamicContainer {
+object FlexibleGeneral extends FlexibleContainer {
   override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
     val byGroup = segmentByGroup(stories)
-    val snap = byGroup.getOrElse(1, Seq.empty)
+    val splash = byGroup.getOrElse(1, Seq.empty)
 
-    if (snap.nonEmpty) {
+    if (splash.nonEmpty) {
       Some((FullMedia50, stories.drop(1)))
     } else {
       None

--- a/common/app/layout/slices/FlexibleSpecial.scala
+++ b/common/app/layout/slices/FlexibleSpecial.scala
@@ -2,7 +2,7 @@ package layout.slices
 
 import layout.slices.Story._
 
-object FlexibleSpecial extends DynamicContainer {
+object FlexibleSpecial extends FlexibleContainer {
   override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
     val byGroup = segmentByGroup(stories)
     val snap = byGroup.getOrElse(1, Seq.empty)

--- a/common/app/layout/slices/FlexibleSpecial.scala
+++ b/common/app/layout/slices/FlexibleSpecial.scala
@@ -6,7 +6,6 @@ object FlexibleSpecial extends FlexibleContainer {
   override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
     val byGroup = segmentByGroup(stories)
     val snap = byGroup.getOrElse(1, Seq.empty)
-
     if (snap.nonEmpty) {
       Some((FullMedia50, stories.drop(1)))
     } else {
@@ -23,11 +22,8 @@ object FlexibleSpecial extends FlexibleContainer {
       case 3 => Seq(ThreeQuarterTallQuarter2)
       case 4 => Seq(ThreeQuarterTallQuarter1Ql2)
       case 5 => Seq(FullMedia100, QuarterQuarterQuarterQuarter)
-      // This case doesn't look _quite_ right. We end up with a row of four
-      // and then a row of three, slightly stretched. There isn't a layout
-      // which caters for this currently, we'll follow up on this separately.
-      case _ => Seq(FullMedia100, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
-
+      /* We dont support more than 5 slices in a flexible special so if there are more than 5 we fail and return nil. */
+      case _ => Nil
     }
   }
 }

--- a/common/app/layout/slices/FlexibleSpecial.scala
+++ b/common/app/layout/slices/FlexibleSpecial.scala
@@ -22,8 +22,8 @@ object FlexibleSpecial extends FlexibleContainer {
       case 3 => Seq(ThreeQuarterTallQuarter2)
       case 4 => Seq(ThreeQuarterTallQuarter1Ql2)
       case 5 => Seq(FullMedia100, QuarterQuarterQuarterQuarter)
-      /* We dont support more than 5 slices in a flexible special so if there are more than 5 we fail and return nil. */
-      case _ => Nil
+      /* We dont support more than 5 slices in a flexible special so if there are more than 5 we only render the 5 layout*/
+      case _ => Seq(FullMedia100, QuarterQuarterQuarterQuarter)
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Seperates out the flexible containers into their own classes. Previously, the new flexible general and special containers were a copy and paste of the dynamic containers and extended dynamic containers. This PR cleans up the code leaving only the relevant methods and extracts them into their own classes. This will make the clean up in november easier when old (dynamic) containers start getting deprecated.