### PR TITLE
Bump facia version to bring in EditionBranding for the Europe edition

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "10.0.0"
+  val faciaVersion = "10.0.1-PREVIEW.eiadd-branding-eur-edition.2024-09-24T1202.4707cdf8"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "10.0.1-PREVIEW.eiadd-branding-eur-edition.2024-09-24T1202.4707cdf8"
+  val faciaVersion = "10.0.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?
Bumps the version of the facia client to bring in a change to add edition branding for the Europe edition. Tested on CODE, and labs containers now display as expected when the Europe edition is selected.

<img width="1338" alt="Screenshot 2024-09-24 at 17 27 10" src="https://github.com/user-attachments/assets/89b98d54-9b43-48be-8ba6-a0510af3fe88">

