### PR TITLE
Add tv-and-radio to isLiveblogTopTargetingSection in Dfp

### DIFF
--- a/admin/app/views/commercial/liveBlogTopSponsorships.scala.html
+++ b/admin/app/views/commercial/liveBlogTopSponsorships.scala.html
@@ -24,7 +24,7 @@
     <ol>
         <li>Is a Sponsorship</li>
         <li>Targets the <pre>liveblog-top</pre> slot</li>
-        <li>Targets the <pre>culture</pre>,<pre>sport</pre> or <pre>football</pre> section</li>
+        <li>Targets the <pre>culture</pre>, <pre>tv-and-radio</pre>, <pre>sport</pre> or <pre>football</pre> section</li>
         <li>Targets the <pre>liveblog</pre> content type</li>
         <li>Targets the <pre>mobile</pre> breakpoint</li>
         <li>[Optional] Targets an edition</li>

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -76,6 +76,11 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
   def isPlatform(value: String): Boolean = isPositive("p") && values.contains(value)
   def isNotPlatform(value: String): Boolean = isNegative("p") && values.contains(value)
 
+  def matchesLiveBlogTopTargeting: Boolean = {
+    val liveBlogTopSectionTargets = List("culture", "football", "sport", "tv-and-radio")
+    values.intersect(liveBlogTopSectionTargets).nonEmpty
+  }
+
   val isHighMerchandisingSlot = isSlot("merchandising-high")
 
   val isLiveblogTopSlot = isSlot("liveblog-top")
@@ -91,7 +96,7 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
   val isSectionTag = isPositive("s")
 
   val isLiveBlogTopTargetedSection =
-    isSectionTag && (values.contains("culture") || values.contains("sport") || values.contains("football"))
+    isSectionTag && matchesLiveBlogTopTargeting
 }
 
 object CustomTarget {


### PR DESCRIPTION
## What does this change?

This extends the Dfp custom targeting check for liveblog top sponsorships to also include the tv-and-radio section.
