### PR TITLE
Add feature switch to control showing or hiding front containers

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -502,4 +502,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
+
+  val DisableFrontContainerShowHide = Switch(
+    group = SwitchGroup.Feature,
+    name = "disable-front-container-show-hide",
+    description = "For users with no currently hidden containers on a front, removes the ability to hide containers",
+    owners = Seq(Owner.withGithub("cemms1")),
+    safeState = On,
+    sellByDate = LocalDate.of(2024, 11, 29),
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

New front containers will not be toggleable in the same way current ones are.
In order to soften the blow when new containers are launched, we are removing the ability to show/hide containers for users who do not currently use the feature on a front page.

We are developing this behaviour behind a switch so that we can revert quickly, and without engineers, if needed.

## What does this change?

Adds a feature switch for use in DCR which will control whether users are able to toggle front containers between expanded and collapses states.
