### PR TITLE
Extend expiring switches 2024-09-30

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -31,7 +31,7 @@ trait ABTestSwitches {
     "Show new ad block ask component in ad slots when we detect ad blocker usage",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 9, 30)),
+    sellByDate = Some(LocalDate.of(2025, 2, 24)),
     exposeClientSide = true,
   )
 
@@ -41,7 +41,7 @@ trait ABTestSwitches {
     "Test the Opt Out frequency capping feature",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 9, 30)),
+    sellByDate = Some(LocalDate.of(2024, 12, 2)),
     exposeClientSide = true,
   )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -24,7 +24,7 @@ object MastheadWithHighlights
       description =
         "Shows new masthead component, with highlights container, in place of current header/navigation and top bar",
       owners = Seq(Owner.withGithub("cemms1")),
-      sellByDate = LocalDate.of(2024, 9, 30),
+      sellByDate = LocalDate.of(2024, 10, 8),
       participationGroup = Perc50,
     )
 


### PR DESCRIPTION
## What does this change?

Extend expiring switches:
```
ab-ad-block-ask => 2025-02-24
ab-opt-out-frequency-cap => 2024-12-2
masthead-with-highlights => 2024-10-8
```

