### PR TITLE
Extend surrogate cache switches

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -213,7 +213,7 @@ trait PerformanceSwitches {
     "Shorten the surrogate cache time for recent articles for load testing",
     owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
     safeState = Off,
-    sellByDate = LocalDate.of(2024, 10, 1),
+    sellByDate = LocalDate.of(2024, 11, 19),
     exposeClientSide = false,
   )
 
@@ -223,7 +223,7 @@ trait PerformanceSwitches {
     "Shorten the surrogate cache time for older articles for load testing",
     owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
     safeState = Off,
-    sellByDate = LocalDate.of(2024, 10, 1),
+    sellByDate = LocalDate.of(2024, 11, 19),
     exposeClientSide = false,
   )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Extend surrogate cache switches used for load testing 

We may use these switches again in preparation for the US 2024 elections.

We should review post election if we still need the functionality of these switches.

