### PR TITLE
Update audio image to include type and elementId

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -89,7 +89,7 @@ case class DotcomRenderingDataModel(
     commercialProperties: Map[String, EditionCommercialProperties],
     pageType: PageType,
     starRating: Option[Int],
-    audioArticleImage: Option[ImageBlockElement],
+    audioArticleImage: Option[PageElement],
     trailText: String,
     nav: Nav,
     showBottomSocialButtons: Boolean,

--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -10,18 +10,19 @@ import play.api.libs.json.{Json, _}
 object ElementsEnhancer {
 
   def enhanceElement(element: JsValue): JsValue = {
-    // Add an elementId to the element
-    val elementWithId = element.as[JsObject] ++ Json.obj("elementId" -> java.util.UUID.randomUUID.toString)
-    // Extract element type
-    val elementType = elementWithId.value("_type").as[String]
+    // Check if the element is a JsObject before proceeding
+    element match {
+      case obj: JsObject =>
+        val elementWithId = obj ++ Json.obj("elementId" -> java.util.UUID.randomUUID.toString)
+        val elementType = elementWithId.value("_type").as[String]
 
-    // If element has further nesting, continue to enhance. otherwise, return the enhanced element
-    elementType match {
-      case "model.dotcomrendering.pageElements.ListBlockElement"     => enhanceListBlockElement(elementWithId)
-      case "model.dotcomrendering.pageElements.TimelineBlockElement" => enhanceTimelineBlockElement(elementWithId)
-      case _                                                         => elementWithId;
+        elementType match {
+          case "model.dotcomrendering.pageElements.ListBlockElement"     => enhanceListBlockElement(elementWithId)
+          case "model.dotcomrendering.pageElements.TimelineBlockElement" => enhanceTimelineBlockElement(elementWithId)
+          case _                                                         => elementWithId;
+        }
+      case _ => element
     }
-
   }
   def enhanceListBlockElement(elementWithId: JsObject): JsObject = {
     val listItems = elementWithId.value("items").as[JsArray]
@@ -75,6 +76,5 @@ object ElementsEnhancer {
       Json.obj("pinnedPost" -> enhanceObjectWithElements(obj.value("pinnedPost"))) ++
       Json.obj("promotedNewsletter" -> obj.value("promotedNewsletter")) ++
       Json.obj("audioArticleImage" -> enhanceElement(obj.value("audioArticleImage")))
-
   }
 }

--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -73,6 +73,8 @@ object ElementsEnhancer {
       Json.obj("mainMediaElements" -> enhanceElements(obj.value("mainMediaElements"))) ++
       Json.obj("keyEvents" -> enhanceObjectsWithElements(obj.value("keyEvents"))) ++
       Json.obj("pinnedPost" -> enhanceObjectWithElements(obj.value("pinnedPost"))) ++
-      Json.obj("promotedNewsletter" -> obj.value("promotedNewsletter"))
+      Json.obj("promotedNewsletter" -> obj.value("promotedNewsletter")) ++
+      Json.obj("audioArticleImage" -> enhanceElement(obj.value("audioArticleImage")))
+
   }
 }

--- a/common/test/model/dotcomrendering/ElementEnhancerTest.scala
+++ b/common/test/model/dotcomrendering/ElementEnhancerTest.scala
@@ -10,9 +10,9 @@ class ElementEnhancerTest extends AnyFlatSpec with Matchers {
   "enhanceElement" should "add elementId and enhance ListBlockElement" in {
     val mockElement: JsObject = Json.obj(
       "_type" -> "model.dotcomrendering.pageElements.ListBlockElement",
-      "items" -> Json.arr(Json.obj(
-        "elements" -> Json.arr(Json.obj("_type" -> "model.dotcomrendering.pageElements.TextElement")))
-      )
+      "items" -> Json.arr(
+        Json.obj("elements" -> Json.arr(Json.obj("_type" -> "model.dotcomrendering.pageElements.TextElement"))),
+      ),
     )
 
     val result = ElementsEnhancer.enhanceElement(mockElement)
@@ -31,10 +31,10 @@ class ElementEnhancerTest extends AnyFlatSpec with Matchers {
       "sections" -> Json.arr(
         Json.obj(
           "events" -> Json.arr(
-            Json.obj("body" -> Json.arr(Json.obj("_type" -> "model.dotcomrendering.pageElements.TextElement")))
-          )
-        )
-      )
+            Json.obj("body" -> Json.arr(Json.obj("_type" -> "model.dotcomrendering.pageElements.TextElement"))),
+          ),
+        ),
+      ),
     )
 
     val result = ElementsEnhancer.enhanceElement(mockElement)
@@ -51,7 +51,7 @@ class ElementEnhancerTest extends AnyFlatSpec with Matchers {
   "enhanceElement" should "return the original element with elementId for unknown types" in {
     val mockElement: JsObject = Json.obj(
       "_type" -> "model.dotcomrendering.pageElements.TextElement",
-      "someField" -> "someValue"
+      "someField" -> "someValue",
     )
 
     val result = ElementsEnhancer.enhanceElement(mockElement)

--- a/common/test/model/dotcomrendering/ElementEnhancerTest.scala
+++ b/common/test/model/dotcomrendering/ElementEnhancerTest.scala
@@ -1,0 +1,68 @@
+package model.dotcomrendering
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsArray, JsNull, JsObject, JsValue, Json}
+import model.dotcomrendering.ElementsEnhancer
+
+class ElementEnhancerTest extends AnyFlatSpec with Matchers {
+
+  "enhanceElement" should "add elementId and enhance ListBlockElement" in {
+    val mockElement: JsObject = Json.obj(
+      "_type" -> "model.dotcomrendering.pageElements.ListBlockElement",
+      "items" -> Json.arr(Json.obj(
+        "elements" -> Json.arr(Json.obj("_type" -> "model.dotcomrendering.pageElements.TextElement")))
+      )
+    )
+
+    val result = ElementsEnhancer.enhanceElement(mockElement)
+
+    (result \ "elementId").asOpt[String] should not be empty
+    val items = (result \ "items").as[JsArray]
+    items.value.size shouldEqual 1
+    val elements = (items(0) \ "elements").as[JsArray]
+    elements.value.size shouldEqual 1
+    (elements(0) \ "elementId").as[String] should not be empty
+  }
+
+  "enhanceElement" should "add elementId and enhance TimelineBlockElement" in {
+    val mockElement: JsObject = Json.obj(
+      "_type" -> "model.dotcomrendering.pageElements.TimelineBlockElement",
+      "sections" -> Json.arr(
+        Json.obj(
+          "events" -> Json.arr(
+            Json.obj("body" -> Json.arr(Json.obj("_type" -> "model.dotcomrendering.pageElements.TextElement")))
+          )
+        )
+      )
+    )
+
+    val result = ElementsEnhancer.enhanceElement(mockElement)
+
+    (result \ "elementId").asOpt[String] should not be empty
+
+    val sections = (result \ "sections").as[JsArray]
+    val events = (sections(0) \ "events").as[JsArray]
+    val body = (events(0) \ "body").as[JsArray]
+    val bodyElementIds = (body(0) \ "elementId").as[String]
+    bodyElementIds should not be empty
+  }
+
+  "enhanceElement" should "return the original element with elementId for unknown types" in {
+    val mockElement: JsObject = Json.obj(
+      "_type" -> "model.dotcomrendering.pageElements.TextElement",
+      "someField" -> "someValue"
+    )
+
+    val result = ElementsEnhancer.enhanceElement(mockElement)
+
+    (result \ "elementId").asOpt[String] should not be empty
+    (result \ "someField").asOpt[String] shouldEqual Some("someValue")
+  }
+
+  "enhanceElement" should "return JsNull if JsNull is passed" in {
+    val result = ElementsEnhancer.enhanceElement(JsNull)
+
+    result shouldEqual JsNull
+  }
+}


### PR DESCRIPTION
## What does this change?
Adds Type and element ID to the audioArticleImage. This means we don't have to add these things in DCR. It reuses the logic here rather than recreating it in DCR

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[after]: https://github.com/user-attachments/assets/140950c8-e648-4312-b95b-3a56528c3483
[before]: https://github.com/user-attachments/assets/b8781e9a-cc9a-4c64-a97e-85ed41c0b6f4





## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
