### PR TITLE
Add 0% client side test for US big events

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -54,4 +54,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2024, 10, 30)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-us-big-events",
+    "Test revenue impact of using shared id in prebid",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 12, 18)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
+import { usBigEvents } from './tests/us-big-events';
 
 // keep in sync with ab-tests in dotcom-rendering
 // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -9,4 +10,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
+	usBigEvents,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/us-big-events.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/us-big-events.js
@@ -1,0 +1,23 @@
+export const usBigEvents = {
+	id: 'UsBigEvents',
+	start: '2024-10-02',
+	expiry: '2024-12-18',
+	author: 'dotcom.platform@guardian.co.uk',
+	description:
+		'Test the impact of showing the user a component that highlights the Guardians journalism.',
+	audience: 0,
+	audienceOffset: 0,
+	audienceCriteria: 'US-based users that see the US edition.',
+	successMeasure: 'Users are more likely to engage with the site.',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: () => {},
+		},
+		{
+			id: 'variant',
+			test: () => {},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?

Adds a 0% client side test that will be used for showing US users a component informing the user about the Guardian.

Following the instructions in the [DCR AB testing guide](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/development/ab-testing-in-dcr.md#quick-start).