### PR TITLE
Change champions league dividers

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -398,12 +398,18 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
   // Avoid fetching very old results from PA by restricting to most recent 2 seasons
   private def oldestRelevantCompetitionSeasons(competitions: List[Season]): List[Season] =
     competitionDefinitions.flatMap { compDef =>
-      competitions
+      val filteredCompetitions = competitions
         .filter(_.competitionId == compDef.id)
         .sortBy(_.startDate.atStartOfDay().toLocalDate)
         .reverse
-        .take(2) // Take most recent 2 seasons
-        .lastOption // Use the older of these for the start date
+
+      val relevantSeasons = if (compDef.id == "/football/championsleague") {
+        filteredCompetitions.take(1)
+      } else {
+        filteredCompetitions.take(2)
+      }
+
+      relevantSeasons.lastOption
     }
 
   override val teamNameBuilder = new TeamNameBuilder(this)

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -209,7 +209,7 @@ object CompetitionsProvider {
       "Champions League",
       "Champions League",
       "European",
-      tableDividers = List(2, 6, 21),
+      tableDividers = List(8, 24),
     ),
     Competition(
       "750", // This ID was also used for the 2020 Euros

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -244,7 +244,7 @@ object CompetitionsProvider {
       "Europa League",
       "European",
       showInTeamsList = true,
-      tableDividers = List(2),
+      tableDividers = List(8,24),
     ),
     Competition(
       "995",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -403,7 +403,8 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
         .sortBy(_.startDate.atStartOfDay().toLocalDate)
         .reverse
 
-      val relevantSeasons = if (compDef.id == "750") {
+      // Champions league format has changes in 2024/2025 so data from the last season vs this season is inconsistent
+      val relevantSeasons = if (compDef.id == "500") {
         filteredCompetitions.take(1)
       } else {
         filteredCompetitions.take(2)

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -395,22 +395,14 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
     DateTimeComparator.getInstance.asInstanceOf[Comparator[DateTime]],
   )
 
-  // Avoid fetching very old results from PA by restricting to most recent 2 seasons
+  // Avoid fetching very old results from PA by restricting to most recent season
   private def oldestRelevantCompetitionSeasons(competitions: List[Season]): List[Season] =
     competitionDefinitions.flatMap { compDef =>
-      val filteredCompetitions = competitions
+      competitions
         .filter(_.competitionId == compDef.id)
         .sortBy(_.startDate.atStartOfDay().toLocalDate)
         .reverse
-
-      // If Champions League, only get current season as format has changed in 24/25 leading to data inconsistencies
-      val relevantSeasons = if (compDef.id == "500") {
-        filteredCompetitions.take(1)
-      } else {
-        filteredCompetitions.take(2)
-      }
-
-      relevantSeasons.lastOption
+        .headOption // get most recent season only
     }
 
   override val teamNameBuilder = new TeamNameBuilder(this)

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -403,7 +403,7 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
         .sortBy(_.startDate.atStartOfDay().toLocalDate)
         .reverse
 
-      // Champions league format has changes in 2024/2025 so data from the last season vs this season is inconsistent
+      // If Champions League, only get current season as format has changed in 24/25 leading to data inconsistencies
       val relevantSeasons = if (compDef.id == "500") {
         filteredCompetitions.take(1)
       } else {

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -85,7 +85,13 @@ object Table {
         case IsNumber(num) => num.toInt
         case other         => 0
       })
-    Table(competition, groups)
+
+    // Champions league format has changed for 24/25 season - this is to remove last years groups which are no longer relevant
+    if (competition.id == "500") {
+      Table(competition, Seq(groups(0)))
+    } else {
+      Table(competition, groups)
+    }
   }
 }
 

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -86,7 +86,7 @@ object Table {
         case other         => 0
       })
 
-    // Champions league format has changed for 24/25 season - this is to remove last years groups which are no longer relevant
+    // If Champions League, ignore rest of groups as format has changed in 24/25
     if (competition.id == "500") {
       Table(competition, Seq(groups(0)))
     } else {


### PR DESCRIPTION
## What does this change?
Closes #27515
Tweaks to avoid data inconsistencies due to the Champions League format changing this season.

- Fix qualification dividers for Champions League and Europa League

| Before      | After      |
|-------------|------------|
| ![before](https://github.com/user-attachments/assets/a99200ae-3212-4445-bb3c-013c691724ff) | ![after](https://github.com/user-attachments/assets/c9254d34-5d06-48cd-ac01-8a85b1fed78a) |


- Remove groups as there is now only one group
- Remove last season's data to avoid inconsistencies in form data

| Before      | After      |
|-------------|------------|
| ![before](https://github.com/user-attachments/assets/d8e1ad5a-3a9d-4287-9922-010603b97968) | ![after](https://github.com/user-attachments/assets/3b593294-e1f6-40d8-8352-986687b421b0) |




## Checklist

- [X ] Tested locally, and on CODE if necessary
- [X ] Will not break dotcom-rendering
- [X ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [X] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
