### PR TITLE
Remove the Performance section of commercial tools in frontend admin

### DIFF
--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -10,20 +10,6 @@
     <div class="row">
 
         <div class="col-md-4">
-            <h3>Performance</h3>
-            <div class="panel panel-default well--front">
-                <div class="panel-heading">Performance metrics.</div>
-                <div class="panel-body">
-                    <ul>
-                        <li><a href="https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=Commercial">AWS performance</a></li>
-                        <li><a href="https://console.aws.amazon.com/cost-reports/home?region=eu-west-1#/custom?chartStyle%3DGroup%26timeRangeOption%3DLast14days%26granularity%3DDaily%26reportName%3DCommercial%26filter%3D%5B%7B%22dimension%22:%22Service%22,%22values%22:%5B%22Amazon%20Kinesis%20Firehose%22%5D,%22include%22:true,%22children%22:null%7D%5D%26reportType%3DCostUsage%26hasAmortized%3Dfalse&reportType=CostUsage&granularity=Daily&chartStyle=Group&groupBy=None&forecastTimeRangeOption=None&hasBlended=false&hasAmortized=false&excludeRefund=false&excludeCredit=false&excludeRIUpfrontFees=false&excludeRIRecurringCharges=false&excludeOtherSubscriptionCosts=false&excludeTax=false&excludeSupportCharges=false&excludeTaggedResources=false&reportName=Commercial&timeRangeOption=Last14days&filter=%5B%7B%22dimension%22:%22Service%22,%22values%22:%5B%22Amazon%20Kinesis%20Firehose%22%5D,%22include%22:true,%22children%22:null%7D%5D&isTemplate=false">AWS costs</a></li>
-                        <li><a href="https://logs.gutools.co.uk/app/kibana#/discover/e3702cb0-deb0-11e8-8fab-bb8ec5c47fa1?_g%3D(refreshInterval%3A(display%3AOff%2Cpause%3A!f%2Cvalue%3A0)%2Ctime%3A(from%3Anow-15m%2Cmode%3Aquick%2Cto%3Anow))%26_a%3D(columns%3A!(_source)%2Cfilters%3A!((%27%24state%27%3A(store%3AappState)%2Cmeta%3A(alias%3A!n%2Cdisabled%3A!f%2Cindex%3Aafa91900-5e8b-11e8-ba01-2b66550a44f2%2Ckey%3Astack%2Cnegate%3A!f%2Cparams%3A(query%3Afrontend%2Ctype%3Aphrase)%2Ctype%3Aphrase%2Cvalue%3Afrontend)%2Cquery%3A(match%3A(stack%3A(query%3Afrontend%2Ctype%3Aphrase))))%2C(%27%24state%27%3A(store%3AappState)%2Cmeta%3A(alias%3A!n%2Cdisabled%3A!f%2Cindex%3Aafa91900-5e8b-11e8-ba01-2b66550a44f2%2Ckey%3Astage%2Cnegate%3A!f%2Cparams%3A(query%3APROD%2Ctype%3Aphrase)%2Ctype%3Aphrase%2Cvalue%3APROD)%2Cquery%3A(match%3A(stage%3A(query%3APROD%2Ctype%3Aphrase))))%2C(%27%24state%27%3A(store%3AappState)%2Cmeta%3A(alias%3A!n%2Cdisabled%3A!f%2Cindex%3Aafa91900-5e8b-11e8-ba01-2b66550a44f2%2Ckey%3Aapp%2Cnegate%3A!f%2Cparams%3A(query%3Acommercial%2Ctype%3Aphrase)%2Ctype%3Aphrase%2Cvalue%3Acommercial)%2Cquery%3A(match%3A(app%3A(query%3Acommercial%2Ctype%3Aphrase)))))%2Cindex%3Aafa91900-5e8b-11e8-ba01-2b66550a44f2%2Cinterval%3Aauto%2Cquery%3A(language%3Alucene%2Cquery%3A(query_string%3A(analyze_wildcard%3A!t%2Cdefault_field%3A%27*%27%2Cquery%3A%27*%27)))%2Csort%3A!(%27%40timestamp%27%2Cdesc))">Logs</a></li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-
-        <div class="col-md-4">
             <h3>Targeting</h3>
             <div class="panel panel-default well--front">
                 <div class="panel-heading">Troubleshoot targeting problems.</div>

--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -47,10 +47,6 @@
             </div>
         </div>
 
-    </div>
-
-    <div class="row">
-
         <div class="col-md-4">
             <h3>Ad Ops</h3>
             <div class="panel panel-default well--front">
@@ -64,6 +60,9 @@
                 </div>
             </div>
         </div>
+    </div>
+
+    <div class="row">
 
         <div class="col-md-4">
             <h3>Resources</h3>


### PR DESCRIPTION
## What does this change?
Removes the Performance section of the frontend admin commercial tools. The remaining items are just links, which we've now documented in the commercial handbook

## Screenshots
### Before
<img width="1491" alt="Screenshot 2024-10-10 at 15 28 19" src="https://github.com/user-attachments/assets/1f39331f-33df-4749-b343-063ab74491b6">


### After
<img width="1493" alt="Screenshot 2024-10-10 at 15 27 40" src="https://github.com/user-attachments/assets/60131f0b-0e64-44fb-8db5-06e904ee08bb">
