### PR TITLE
Extend highlights experiment by a week

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -24,7 +24,7 @@ object MastheadWithHighlights
       description =
         "Shows new masthead component, with highlights container, in place of current header/navigation and top bar",
       owners = Seq(Owner.withGithub("cemms1")),
-      sellByDate = LocalDate.of(2024, 10, 8),
+      sellByDate = LocalDate.of(2024, 10, 15),
       participationGroup = Perc50,
     )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -23,7 +23,7 @@ object MastheadWithHighlights
       name = "masthead-with-highlights",
       description =
         "Shows new masthead component, with highlights container, in place of current header/navigation and top bar",
-      owners = Seq(Owner.withGithub("cemms1")),
+      owners = Seq(Owner.withGithub("cemms1"), Owner.withEmail("project.fairground@theguardian.com")),
       sellByDate = LocalDate.of(2024, 10, 15),
       participationGroup = Perc50,
     )


### PR DESCRIPTION
## What does this change?

Extends the Highlights experiment for one week and adds the Fairground email as an owner so that we receive a notification when it's about to expire.
