### PR TITLE
Add variant to UsaExpandableMarketingCard AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -2,7 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
-import { usBigEvents } from './tests/us-big-events';
+import { UsaExpandableMarketingCard } from './tests/usa-expandable-marketing-card';
 
 // keep in sync with ab-tests in dotcom-rendering
 // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -10,5 +10,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
-	usBigEvents,
+	UsaExpandableMarketingCard,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/us-big-events.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/us-big-events.js
@@ -16,7 +16,11 @@ export const usBigEvents = {
 			test: () => {},
 		},
 		{
-			id: 'variant',
+			id: 'variant-free',
+			test: () => {},
+		},
+		{
+			id: 'variant-bubble',
 			test: () => {},
 		},
 	],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/usa-expandable-marketing-card.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/usa-expandable-marketing-card.js
@@ -1,5 +1,5 @@
-export const usBigEvents = {
-	id: 'UsBigEvents',
+export const UsaExpandableMarketingCard = {
+	id: 'UsaExpandableMarketingCard',
 	start: '2024-10-02',
 	expiry: '2024-12-18',
 	author: 'dotcom.platform@guardian.co.uk',


### PR DESCRIPTION
## What does this change?

- Renames `UsBigEvents` experiment to `UsaExpandableMarketingCard`
- Adds a new variant, as we'll be testing two different copies

## Screenshots

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4a0bbef9-720b-4db4-bff6-34cab8d76a4c">
