### PR TITLE
Remove prebid shared id test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -47,16 +47,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-prebid-shared-id",
-    "Test revenue impact of using shared id in prebid",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 10, 30)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-us-big-events",
     "Test revenue impact of using shared id in prebid",
     owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),


### PR DESCRIPTION
## What does this change?
We've now finished this test and removed references to it from commercial, so we can remove the switch.
