### PR TITLE
Add experiment to allow viewing `/europe-beta` front when opted in

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     Set(
       RemoveLiteFronts,
       MastheadWithHighlights,
+      EuropeBetaFront,
       DarkModeWeb,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
@@ -26,6 +27,19 @@ object MastheadWithHighlights
       owners = Seq(Owner.withGithub("cemms1"), Owner.withEmail("project.fairground@theguardian.com")),
       sellByDate = LocalDate.of(2024, 10, 15),
       participationGroup = Perc50,
+    )
+
+object EuropeBetaFront
+    extends Experiment(
+      name = "europe-beta-front",
+      description = "Allows viewing the beta version of the Europe network front",
+      owners = Seq(
+        Owner.withGithub("cemms1"),
+        Owner.withEmail("project.fairground@theguardian.com"),
+        Owner.withEmail("dotcom.platform@theguardian.com"),
+      ),
+      sellByDate = LocalDate.of(2025, 4, 2),
+      participationGroup = Perc0A,
     )
 
 object DarkModeWeb


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows non developers to preview new containers behind a 0% test ahead of the whole front AB test

## What does this change?

Adds a new 0% server side experiment to allow viewing the `europe-beta` front in production

If trying to view the front `/europe-beta` and not in the test variant group, it will return a `404` not found. If you are participating in the experiment, you should be able to view the front. 

Inspired by https://github.com/guardian/frontend/pull/25444

See the [Europe beta test plan](https://docs.google.com/document/d/16qPJsPU5efUppLXfR54k4euVacqvSXcCyhgE44BIFqM/edit?usp=sharing) for more details
