### PR TITLE
direct advertise link to aus

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -187,7 +187,11 @@ object FooterLinks {
 
   val auListThree = List(
     FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
-    FooterLink("Advertise with us", "https://advertising.theguardian.com/", "au : footer : advertise with us"),
+    FooterLink(
+      "Advertise with us",
+      "https://advertising.theguardian.com/au/advertising",
+      "au : footer : advertise with us",
+    ),
     cookiePolicy,
   )
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
The “Advertise with us” link at the footer is useful for advertisers getting in touch with the relevant global ads team. 

The 'advertise with us' directs readers through to the UK trade site rather than AU, even if they on the AU edition.

## What does this change?
This adds the `au` edition link as the url value.

## Screenshots

| Selecting `advertise with us`      | 
|-------------|
| <img width="1277" alt="Screenshot 2024-10-21 at 10 46 24" src="https://github.com/user-attachments/assets/74289e4e-5ec4-4105-ba2b-776ab2e37e4d"> | 


| successfully reaching: `https://advertising.theguardian.com/au/advertising`     | 
|------------|
| <img width="914" alt="Screenshot 2024-10-21 at 10 47 52" src="https://github.com/user-attachments/assets/5ffdf707-da60-4c00-93d4-eefa1215033e"> |


<!-- Please use the following table template to make image comparison easier to parse:



[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
