### PR TITLE
Crossword — Remove misleading app link for crosswords on Desktop

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -38,9 +38,6 @@
                     <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-mobile-link">Download the Guardian app</a> for a better puzzles experience
                 </div>
 
-                <div class="hide-until-leftcol crossword__clues-header">
-                    <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-desktop-link">Download the Guardian app</a> for a better puzzles experience
-                </div>
             }
 
             <div class="meta__extras meta__extras--crossword">

--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -38,6 +38,9 @@
                     <a href="https://app.adjust.com/16xt6hai" data-link-name="crossword-mobile-link">Download the Guardian app</a> for a better puzzles experience
                 </div>
 
+                 <div class="hide-until-leftcol crossword__clues-header">
+                </div>
+
             }
 
             <div class="meta__extras meta__extras--crossword">


### PR DESCRIPTION
## What is the value of this and can you measure success?

This is a follow-up from #27483 and #22331. We are currently misleading our desktop users to download our mobile app, which can't be downloaded. 

<img width="1004" alt="Screenshot 2024-10-18 at 14 07 54" src="https://github.com/user-attachments/assets/4c035263-b444-4a98-9b32-70fd2fea5d02">

## What does this change?

Remove noise for our desktop users.

## Screenshots

**Before changes on desktop**

<img width="1277" alt="Screenshot 2024-10-18 at 15 01 17" src="https://github.com/user-attachments/assets/50c4eed5-01a8-4623-b359-09af8f1f4671">



**After changes on desktop**

<img width="1279" alt="Screenshot 2024-10-18 at 15 02 44" src="https://github.com/user-attachments/assets/d73d23ef-d066-4b3f-89bd-5b588ae0e84b">


