### PR TITLE
Support DCR for apps video article requests

### DIFF
--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -5,6 +5,7 @@ import common.JsonComponent.withRefreshStatus
 import common._
 import conf.switches.Switches
 import contentapi.ContentApiClient
+import implicits.{AppsFormat, JsonFormat}
 import model._
 import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import pages.ContentHtmlPage
@@ -104,17 +105,25 @@ class MediaController(
   ): Future[Result] = {
     val pageType = PageType(content, request, context)
 
-    if (request.isJson) {
-      Future.successful(
-        common.renderJson(getDCRJson(content, pageType, blocks), content).as("application/json"),
-      )
-    } else {
-      remoteRenderer.getMedia(
-        wsClient,
-        content,
-        pageType,
-        blocks,
-      )
+    request.getRequestFormat match {
+      case JsonFormat =>
+        Future.successful(
+          common.renderJson(getDCRJson(content, pageType, blocks), content).as("application/json"),
+        )
+      case AppsFormat =>
+        remoteRenderer.getAppsMedia(
+          wsClient,
+          content,
+          pageType,
+          blocks,
+        )
+      case _ =>
+        remoteRenderer.getMedia(
+          wsClient,
+          content,
+          pageType,
+          blocks,
+        )
     }
   }
 }

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -363,6 +363,18 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
   }
 
+  def getAppsMedia(
+      ws: WSClient,
+      mediaPage: MediaPage,
+      pageType: PageType,
+      blocks: Blocks,
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = DotcomRenderingDataModel.forMedia(mediaPage, request, pageType, blocks)
+
+    val json = DotcomRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsArticle", CacheTime.Facia)
+  }
+
   def getGallery(
       ws: WSClient,
       gallery: GalleryPage,


### PR DESCRIPTION
## What does this change?

Support 'DCR for apps' video article requests e.g.

https://www.theguardian.com/uk-news/video/2024/oct/21/king-charles-and-queen-camilla-on-tour-in-canberra-video?dcr=apps

Currently such requests to Frontend do not respect the `?dcr=apps` url parameter.

Therefore Frontend does not send an apps version of the request to DCR.

This change adds handling for a 'DCR for apps' video article request.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/21aee9cb-b4b9-4154-8d28-3a804dd65284
[after]: https://github.com/user-attachments/assets/d66a812e-793d-4bee-b35b-7dd85c40b2bf

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
