### PR TITLE
Add special crossword series to nav

### DIFF
--- a/common/app/crosswords/CrosswordPage.scala
+++ b/common/app/crosswords/CrosswordPage.scala
@@ -63,6 +63,7 @@ class CrosswordSearchPage extends StandalonePage {
     "everyman",
     "azed",
     "weekend",
+    "special",
   )
 
   def queryParameter(crossType: String): String = {

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -238,6 +238,7 @@ object NavLinks {
       NavLink("Azed", "/crosswords/series/azed"),
       NavLink("Genius", "/crosswords/series/genius"),
       NavLink("Weekend", "/crosswords/series/weekend-crossword"),
+      NavLink("Special", "/crosswords/series/special"),
     ),
   )
   val wordiply = NavLink(
@@ -742,6 +743,7 @@ object NavLinks {
     "crosswords/series/genius",
     "crosswords/series/speedy",
     "crosswords/series/everyman",
+    "crosswords/series/special",
     "crosswords/series/azed",
     "fashion/beauty",
     "technology/motoring",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -924,6 +924,12 @@
 						"url": "/crosswords/series/weekend-crossword",
 						"children": [],
 						"classList": []
+					},
+					{
+						"title": "Special",
+						"url": "/crosswords/series/special",
+						"children": [],
+						"classList": []
 					}
 				],
 				"classList": []
@@ -1665,6 +1671,12 @@
 						"url": "/crosswords/series/weekend-crossword",
 						"children": [],
 						"classList": []
+					},
+					{
+						"title": "Special",
+						"url": "/crosswords/series/special",
+						"children": [],
+						"classList": []
 					}
 				],
 				"classList": []
@@ -2362,6 +2374,12 @@
 					{
 						"title": "Weekend",
 						"url": "/crosswords/series/weekend-crossword",
+						"children": [],
+						"classList": []
+					},
+					{
+						"title": "Special",
+						"url": "/crosswords/series/special",
 						"children": [],
 						"classList": []
 					}
@@ -3260,6 +3278,12 @@
 						"url": "/crosswords/series/weekend-crossword",
 						"children": [],
 						"classList": []
+					},
+					{
+						"title": "Special",
+						"url": "/crosswords/series/special",
+						"children": [],
+						"classList": []
 					}
 				],
 				"classList": []
@@ -3401,6 +3425,7 @@
 		"crosswords/series/genius",
 		"crosswords/series/speedy",
 		"crosswords/series/everyman",
+		"crosswords/series/special",
 		"crosswords/series/azed",
 		"fashion/beauty",
 		"technology/motoring",
@@ -4251,6 +4276,12 @@
 					{
 						"title": "Weekend",
 						"url": "/crosswords/series/weekend-crossword",
+						"children": [],
+						"classList": []
+					},
+					{
+						"title": "Special",
+						"url": "/crosswords/series/special",
 						"children": [],
 						"classList": []
 					}


### PR DESCRIPTION
## What does this change?

Updates the nav bar to add on the new Special crossword series https://www.theguardian.com/crosswords/series/special

Also adds the type to the crosswords search page https://www.theguardian.com/crosswords/search

## Screenshots


| Before      | After      |
|-------------|------------|
| <img width="799" alt="image" src="https://github.com/user-attachments/assets/60a4870d-2262-40af-b73e-7f0aee1ad6ec"> | (same but with "Special" on the end) |

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
