### PR TITLE
Set US Banner AB test audience to 15%

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/usa-expandable-marketing-card.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/usa-expandable-marketing-card.js
@@ -5,8 +5,8 @@ export const UsaExpandableMarketingCard = {
 	author: 'dotcom.platform@guardian.co.uk',
 	description:
 		'Test the impact of showing the user a component that highlights the Guardians journalism.',
-	audience: 0,
-	audienceOffset: 0,
+	audience: 15 / 100,
+	audienceOffset: 0 / 100,
 	audienceCriteria: 'US-based users that see the US edition.',
 	successMeasure: 'Users are more likely to engage with the site.',
 	canRun: () => true,


### PR DESCRIPTION
## What does this change?

Starts the US banner test. See previous PR's for details:
- https://github.com/guardian/dotcom-rendering/pull/12521
- https://github.com/guardian/dotcom-rendering/pull/12530
- https://github.com/guardian/dotcom-rendering/pull/12567
- https://github.com/guardian/dotcom-rendering/pull/12534
- https://github.com/guardian/dotcom-rendering/pull/12588
- https://github.com/guardian/dotcom-rendering/pull/12590