### PR TITLE
Add thefilter to editionalised sections

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -32,6 +32,7 @@ abstract class Edition(
       "lifeandstyle",
       "travel",
       "tv-and-radio",
+      "thefilter",
     ),
     val navigationLinks: EditionNavLinks,
 ) {

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -6,7 +6,6 @@ import java.util.Locale
 import org.joda.time.DateTimeZone
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import experiments.ActiveExperiments
 
 import java.time.ZoneId
 
@@ -17,23 +16,7 @@ abstract class Edition(
     val timezone: DateTimeZone,
     val locale: Option[Locale],
     val networkFrontId: String,
-    val editionalisedSections: Seq[String] = Seq(
-      "", // network front
-      "business",
-      "business-to-business",
-      "commentisfree",
-      "culture",
-      "money",
-      "sport",
-      "technology",
-      "media",
-      "environment",
-      "film",
-      "lifeandstyle",
-      "travel",
-      "tv-and-radio",
-      "thefilter",
-    ),
+    val editionalisedSections: Seq[String] = Edition.commonEditionalisedSections,
     val navigationLinks: EditionNavLinks,
 ) {
   val homePagePath: String = s"/$networkFrontId"
@@ -63,6 +46,23 @@ object Edition {
       edition <- allEditions
       locale <- edition.locale
     } yield edition -> locale).toMap
+
+  lazy val commonEditionalisedSections: Seq[String] = Seq(
+    "", // network front
+    "business",
+    "business-to-business",
+    "commentisfree",
+    "culture",
+    "money",
+    "sport",
+    "technology",
+    "media",
+    "environment",
+    "film",
+    "lifeandstyle",
+    "travel",
+    "tv-and-radio",
+  )
 
   private def editionFromRequest(request: RequestHeader): String = {
     // override for Ajax calls
@@ -162,29 +162,3 @@ object Editionalise {
 }
 
 case class EditionLink(edition: Edition, path: String, locale: Locale)
-
-object InternationalEdition {
-
-  private val variants = Seq("control", "international")
-
-  def apply(request: RequestHeader): Option[String] = {
-
-    // This is all a bit hacky.
-    // we can get rid of it once we are done with the opt-in message.
-    val editionIsIntl = request.headers.get("X-GU-Edition").map(_.toLowerCase).contains("intl")
-    val editionSetByCookie = request.headers.get("X-GU-Edition-From-Cookie").contains("true")
-    val fromInternationalHeader = request.headers.get("X-GU-International").map(_.toLowerCase)
-    val setByCookie = request.cookies.get("GU_EDITION").map(_.value.toLowerCase).contains("intl")
-
-    // environments NOT behind the CDN will not have these. In this case assume they are in the
-    // "international" bucket
-    val noInternationalHeader = request.headers.get("X-GU-International").isEmpty
-
-    if (setByCookie || (editionIsIntl && (editionSetByCookie || noInternationalHeader))) {
-      Some("international")
-    } else {
-      fromInternationalHeader
-        .filter(variants.contains(_) && editionIsIntl)
-    }
-  }
-}

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -12,6 +12,7 @@ object Uk
       timezone = DateTimeZone.forID("Europe/London"),
       locale = Some(Locale.forLanguageTag("en-gb")),
       networkFrontId = "uk",
+      editionalisedSections = Edition.commonEditionalisedSections :+ "thefilter",
       navigationLinks = EditionNavLinks(
         NavLinks.ukNewsPillar,
         NavLinks.ukOpinionPillar,

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -127,8 +127,8 @@ class LinkToTest extends AnyFlatSpec with Matchers with implicits.FakeRequests {
     TheGuardianLinkTo("/thefilter", Europe) should endWith(s"www.theguardian.com/uk/thefilter")
   }
 
-  it should "correctly editionalise thefilter US" in {
-    TheGuardianLinkTo("/thefilter", Us) should endWith(s"www.theguardian.com/us/thefilter")
+  it should "correctly editionalise thefilter US to point to uk/thefilter temporarily until we create us/thefilter" in {
+    TheGuardianLinkTo("/thefilter", Us) should endWith(s"www.theguardian.com/uk/thefilter")
   }
 
   object TestCanonicalLink extends CanonicalLink

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -119,6 +119,18 @@ class LinkToTest extends AnyFlatSpec with Matchers with implicits.FakeRequests {
     }
   }
 
+  it should "correctly editionalise thefilter uk" in {
+    TheGuardianLinkTo("/thefilter", Uk) should endWith(s"www.theguardian.com/uk/thefilter")
+  }
+
+  it should "correctly editionalise thefilter europe" in {
+    TheGuardianLinkTo("/thefilter", Europe) should endWith(s"www.theguardian.com/uk/thefilter")
+  }
+
+  it should "correctly editionalise thefilter US" in {
+    TheGuardianLinkTo("/thefilter", Us) should endWith(s"www.theguardian.com/us/thefilter")
+  }
+
   object TestCanonicalLink extends CanonicalLink
 
   "CanonicalLink" should "be the gatekeeper for significant parameters" in {


### PR DESCRIPTION
## What does this change?

- This adds "thefilter" to editionalised sections of the UK edition
- As "thefilter" is only editionalised in the uk, all network fronts will redirect to uk/thefilter

#To-Do:

Merge https://github.com/guardian/platform/pull/1634 after merging this PR

Closes #1630