### PR TITLE
Add A Feature Switch For DCAR Galleries

### DIFF
--- a/applications/app/services/dotcomrendering/GalleryPicker.scala
+++ b/applications/app/services/dotcomrendering/GalleryPicker.scala
@@ -5,6 +5,7 @@ import model.Cors.RichRequestHeader
 import model.GalleryPage
 import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
+import conf.switches.Switches.DCARGalleryPages
 
 object GalleryPicker extends GuLogging {
 
@@ -22,13 +23,12 @@ object GalleryPicker extends GuLogging {
       request: RequestHeader,
   ): RenderType = {
 
-    val participatingInTest = false // until we create a test for this content type
     val dcrCanRender = dcrCouldRender(galleryPage)
 
     val tier = {
       if (request.forceDCROff) LocalRender
-      else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender && participatingInTest) RemoteRender
+      else if (request.forceDCR && DCARGalleryPages.isSwitchedOn()) RemoteRender
+      else if (dcrCanRender && DCARGalleryPages.isSwitchedOn()) RemoteRender
       else LocalRender
     }
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -512,4 +512,14 @@ trait FeatureSwitches {
     sellByDate = LocalDate.of(2024, 11, 29),
     exposeClientSide = true,
   )
+
+  val DCARGalleryPages = Switch(
+    SwitchGroup.Feature,
+    "dcar-gallery-pages",
+    "If this switch is on, we will render gallery pages with DCAR",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
 }


### PR DESCRIPTION
Makes sure galleries will never be rendered by DCAR while we're working on them. Then allows us to make them available when they're ready, and quickly turn them off if there are any issues.
