### PR TITLE
Prevent Galleries Rendering In DCAR

### DIFF
--- a/applications/app/services/dotcomrendering/GalleryPicker.scala
+++ b/applications/app/services/dotcomrendering/GalleryPicker.scala
@@ -7,37 +7,13 @@ import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
 
 object GalleryPicker extends GuLogging {
-
-  /** Add to this function any logic for including/excluding a gallery article from being rendered with DCR
-    *
-    * Currently defaulting to false until we implement image articles in DCR
-    */
-  private def dcrCouldRender(galleryPage: GalleryPage): Boolean = {
-    false
-  }
-
   def getTier(
       galleryPage: GalleryPage,
   )(implicit
       request: RequestHeader,
   ): RenderType = {
+    DotcomponentsLogger.logger.logRequest(s"path executing in web", Map.empty, galleryPage.gallery)
 
-    val participatingInTest = false // until we create a test for this content type
-    val dcrCanRender = dcrCouldRender(galleryPage)
-
-    val tier = {
-      if (request.forceDCROff) LocalRender
-      else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender && participatingInTest) RemoteRender
-      else LocalRender
-    }
-
-    if (tier == RemoteRender) {
-      DotcomponentsLogger.logger.logRequest(s"path executing in dotcomponents", Map.empty, galleryPage.gallery)
-    } else {
-      DotcomponentsLogger.logger.logRequest(s"path executing in web", Map.empty, galleryPage.gallery)
-    }
-
-    tier
+    LocalRender
   }
 }


### PR DESCRIPTION
Prevent galleries ever rendering in DCAR while we're working on them. This can be reverted or updated when we're ready to release them, most likely with a feature switch as described in https://github.com/guardian/frontend/issues/27553
