### PR TITLE
Add `DCRAudioPages` switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -483,6 +483,16 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
+  val DCRAudioPages = Switch(
+    SwitchGroup.Feature,
+    "dcr-audio-pages",
+    "If this switch is on, we will render audio pages with DCR",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com"), Owner.withEmail("devx.e2e@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
+
   val DCRVideoPages = Switch(
     SwitchGroup.Feature,
     "dcr-video-pages",


### PR DESCRIPTION
## What is the value of this and can you measure success?

Adds a switch to enable rendering audio pages in DCR

## What does this change?

Adds the switch and promotes the check for whether to render audio and video pages in DCR to just the switch state (not another hard-coded check alongside - we weren't sure what that was for?).

co-authored with @oliverabrahams 