### PR TITLE
Don't check allowed sections or default off tags for affiliate links in frontend

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -27,7 +27,6 @@
             page.item.lightbox.containsAffiliateableLinks && AffiliateLinksCleaner.shouldAddAffiliateLinks(
                 switchedOn = Switches.AffiliateLinks.isSwitchedOn,
                 showAffiliateLinks = page.gallery.content.fields.showAffiliateLinks,
-                defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
                 alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
                 tagPaths = page.gallery.content.tags.tags.map(_.id),
             )

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -26,9 +26,7 @@
             page,
             page.item.lightbox.containsAffiliateableLinks && AffiliateLinksCleaner.shouldAddAffiliateLinks(
                 switchedOn = Switches.AffiliateLinks.isSwitchedOn,
-                section = page.gallery.content.metadata.sectionId,
                 showAffiliateLinks = page.gallery.content.fields.showAffiliateLinks,
-                supportedSections = Configuration.affiliateLinks.affiliateLinkSections,
                 defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
                 alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
                 tagPaths = page.gallery.content.tags.tags.map(_.id),

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -42,7 +42,6 @@ object GalleryCaptionCleaners {
       GalleryCaptionCleaner,
       AffiliateLinksCleaner(
         request.uri,
-        page.gallery.content.metadata.sectionId,
         page.gallery.content.fields.showAffiliateLinks,
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -80,7 +80,6 @@ object BodyProcessor {
       GarnettQuoteCleaner,
       AffiliateLinksCleaner(
         pageUrl = request.uri,
-        sectionId = article.content.metadata.sectionId,
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         tags = article.content.tags.tags.map(_.id),
       ),

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -289,8 +289,6 @@ class GuardianConfiguration extends GuLogging {
     lazy val bucket: Option[String] = configuration.getStringProperty("skimlinks.bucket")
     lazy val domainsKey = "skimlinks/skimlinks-domains.csv"
     lazy val skimlinksId = configuration.getMandatoryStringProperty("skimlinks.id")
-    lazy val defaultOffTags: Set[String] =
-      configuration.getStringProperty("affiliatelinks.default.off.tags").getOrElse("").split(",").toSet
     lazy val alwaysOffTags: Set[String] =
       configuration.getStringProperty("affiliatelinks.always.off.tags").getOrElse("").split(",").toSet
   }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -289,8 +289,6 @@ class GuardianConfiguration extends GuLogging {
     lazy val bucket: Option[String] = configuration.getStringProperty("skimlinks.bucket")
     lazy val domainsKey = "skimlinks/skimlinks-domains.csv"
     lazy val skimlinksId = configuration.getMandatoryStringProperty("skimlinks.id")
-    lazy val affiliateLinkSections: Set[String] =
-      configuration.getStringProperty("affiliatelinks.sections").getOrElse("").split(",").toSet
     lazy val defaultOffTags: Set[String] =
       configuration.getStringProperty("affiliatelinks.default.off.tags").getOrElse("").split(",").toSet
     lazy val alwaysOffTags: Set[String] =

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -113,18 +113,6 @@ trait CommercialSwitches {
     impactFullMessage = Some("Warning: Disabling this switch will prevent us from being able to monetize The Filter"),
   )
 
-  val AffiliateLinkSections: Switch = Switch(
-    group = Commercial,
-    name = "affiliate-links-sections",
-    description =
-      "Add affiliate links to all content in sections in affiliateLinkSections config property when no override exists in capi (showAffiliateLinks field).",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-    highImpact = false,
-  )
-
   val confiantAdVerification: Switch = Switch(
     group = Commercial,
     name = "confiant-ad-verification",

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -258,7 +258,6 @@ object DotcomRenderingUtils {
         AffiliateLinksCleaner.shouldAddAffiliateLinks(
           switchedOn = Switches.AffiliateLinks.isSwitchedOn,
           showAffiliateLinks = content.content.fields.showAffiliateLinks,
-          defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
           alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
           tagPaths = content.content.tags.tags.map(_.id),
         )

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -257,9 +257,7 @@ object DotcomRenderingUtils {
       if (firstEl.tagName == "p" && secondEl.tagName == "p" && secondEl.text().length >= 150) {
         AffiliateLinksCleaner.shouldAddAffiliateLinks(
           switchedOn = Switches.AffiliateLinks.isSwitchedOn,
-          section = content.metadata.sectionId,
           showAffiliateLinks = content.content.fields.showAffiliateLinks,
-          supportedSections = Configuration.affiliateLinks.affiliateLinkSections,
           defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
           alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
           tagPaths = content.content.tags.tags.map(_.id),

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -934,7 +934,7 @@ object AffiliateLinksCleaner {
     if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && switchedOn) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
-      }
+      } else false
     } else false
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -864,7 +864,6 @@ object GarnettQuoteCleaner extends HtmlCleaner {
 
 case class AffiliateLinksCleaner(
     pageUrl: String,
-    sectionId: String,
     showAffiliateLinks: Option[Boolean],
     appendDisclaimer: Option[Boolean] = None,
     tags: List[String],
@@ -875,9 +874,7 @@ case class AffiliateLinksCleaner(
     if (
       AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.shouldAddAffiliateLinks(
         AffiliateLinks.isSwitchedOn,
-        sectionId,
         showAffiliateLinks,
-        affiliateLinkSections,
         defaultOffTags,
         alwaysOffTags,
         tags,
@@ -929,9 +926,7 @@ object AffiliateLinksCleaner {
 
   def shouldAddAffiliateLinks(
       switchedOn: Boolean,
-      section: String,
       showAffiliateLinks: Option[Boolean],
-      supportedSections: Set[String],
       defaultOffTags: Set[String],
       alwaysOffTags: Set[String],
       tagPaths: List[String],
@@ -942,7 +937,7 @@ object AffiliateLinksCleaner {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
       } else {
-        supportedSections.contains(section) && !tagPaths.exists(path => defaultOffTags.contains(path))
+        !tagPaths.exists(path => defaultOffTags.contains(path))
       }
     } else false
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -875,7 +875,6 @@ case class AffiliateLinksCleaner(
       AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.shouldAddAffiliateLinks(
         AffiliateLinks.isSwitchedOn,
         showAffiliateLinks,
-        defaultOffTags,
         alwaysOffTags,
         tags,
       )
@@ -927,7 +926,6 @@ object AffiliateLinksCleaner {
   def shouldAddAffiliateLinks(
       switchedOn: Boolean,
       showAffiliateLinks: Option[Boolean],
-      defaultOffTags: Set[String],
       alwaysOffTags: Set[String],
       tagPaths: List[String],
   ): Boolean = {
@@ -936,8 +934,6 @@ object AffiliateLinksCleaner {
     if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && switchedOn) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
-      } else {
-        !tagPaths.exists(path => defaultOffTags.contains(path))
       }
     } else false
   }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -21,55 +21,35 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
       switchedOn = false,
       None,
       Set.empty,
-      Set.empty,
       List.empty,
     ) should be(false)
-    shouldAddAffiliateLinks(
-      switchedOn = true,
-      None,
-      Set.empty,
-      Set.empty,
-      List.empty,
-    ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       Some(false),
       Set.empty,
-      Set.empty,
       List.empty,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       Some(true),
       Set.empty,
-      Set.empty,
       List.empty,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
       None,
-      Set("bereavement"),
-      Set.empty,
-      List("bereavement"),
-    ) should be(false)
-    shouldAddAffiliateLinks(
-      switchedOn = true,
-      None,
-      Set("bereavement"),
       Set.empty,
       List("tech"),
-    ) should be(true)
+    ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       Some(true),
-      Set.empty,
       Set("bereavement"),
       List("bereavement"),
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
       Some(true),
-      Set.empty,
       Set("bereavement"),
       List("tech"),
     ) should be(true)

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -16,85 +16,59 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
   }
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
-    val supportedSections = Set("film", "books", "fashion")
 
     shouldAddAffiliateLinks(
       switchedOn = false,
-      "film",
       None,
-      supportedSections,
       Set.empty,
       Set.empty,
       List.empty,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
-      "film",
       None,
-      supportedSections,
       Set.empty,
       Set.empty,
       List.empty,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
-      "film",
       Some(false),
-      supportedSections,
       Set.empty,
       Set.empty,
       List.empty,
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
-      "news",
       Some(true),
-      supportedSections,
       Set.empty,
       Set.empty,
       List.empty,
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
-      "news",
       None,
-      supportedSections,
       Set("bereavement"),
       Set.empty,
       List("bereavement"),
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
-      "news",
       None,
-      supportedSections,
-      Set("bereavement"),
-      Set.empty,
-      List("tech"),
-    ) should be(false)
-    shouldAddAffiliateLinks(
-      switchedOn = true,
-      "fashion",
-      None,
-      supportedSections,
       Set("bereavement"),
       Set.empty,
       List("tech"),
     ) should be(true)
     shouldAddAffiliateLinks(
       switchedOn = true,
-      "fashion",
       Some(true),
-      supportedSections,
       Set.empty,
       Set("bereavement"),
       List("bereavement"),
     ) should be(false)
     shouldAddAffiliateLinks(
       switchedOn = true,
-      "fashion",
       Some(true),
-      supportedSections,
       Set.empty,
       Set("bereavement"),
       List("tech"),

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -16,37 +16,42 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
   }
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
-
+    // the switch is respected
     shouldAddAffiliateLinks(
       switchedOn = false,
       None,
       Set.empty,
       List.empty,
     ) should be(false)
+    // affiliate links are not added when showAffiliateLinks is false
     shouldAddAffiliateLinks(
       switchedOn = true,
       Some(false),
       Set.empty,
       List.empty,
     ) should be(false)
+    // affiliate links are added when showAffiliateLinks is true and there are no alwaysOff tags present
     shouldAddAffiliateLinks(
       switchedOn = true,
       Some(true),
       Set.empty,
       List.empty,
     ) should be(true)
+    // affiliate links are not added when showAffiliateLinks is not defined
     shouldAddAffiliateLinks(
       switchedOn = true,
       None,
       Set.empty,
       List("tech"),
     ) should be(false)
+    // affiliate links are not added when an always off tag is present on the article
     shouldAddAffiliateLinks(
       switchedOn = true,
       Some(true),
       Set("bereavement"),
       List("bereavement"),
     ) should be(false)
+    // affiliate links are added when the tags are considered safe
     shouldAddAffiliateLinks(
       switchedOn = true,
       Some(true),


### PR DESCRIPTION
## What does this change?
This change removes the check for supported sections and default off tags for articles where showAffiliateLinks is not defined. We are moving to treat Composer as the source of truth for affiliate links, so if showAffiliateLinks is not defined for an article, we will default to not showing affiliate links. If affiliate links should be shown on an article, showAffiliateLinks should be defined.

This change has meant we can simplify the logic and function in frontend, and I have updated and removed some tests to reflect the logic change. I've also added comments to document the tests, as they were pretty opaque. The diff isn't super helpful for the test file, might be easier to read without the diff highlighting