### PR TITLE
add colours for .email-sub__form--thrasher-the-long-wave

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -292,6 +292,18 @@
     }
 }
 
+.email-sub__form--thrasher-the-long-wave {
+    .email-sub__thrasher-embed-label {
+        color: $brightness-7;
+    }
+
+    .email-sub__thrasher-embed-button {
+        background-color: $news-dark;
+        color: $brightness-100;
+        fill: $brightness-100;
+    }
+}
+
 .email-sub__thrasher-embed-icon {
     display: inline-flex;
     height: 100%;


### PR DESCRIPTION
## What is the value of this and can you measure success?
change colors for form rendered by https://www.theguardian.com/email/form/thrasher/the-long-wave

## What does this change?

button and label colors for `.email-sub__form--thrasher-the-long-wave`

## Screenshots



| Before      | After      |
|-------------|------------|
| <img width="424" alt="Screenshot 2024-10-28 at 14 12 37" src="https://github.com/user-attachments/assets/f2652c35-ec15-458a-bba9-f5e47e910fbb"> | <img width="424" alt="Screenshot 2024-10-28 at 14 12 18" src="https://github.com/user-attachments/assets/360bc3f3-728c-4a94-9c44-2dc44a48bb17"> |






## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
