### PR TITLE
Add blocks apps request format

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -278,6 +278,14 @@ class LiveBlogController(
     }
   }
 
+  private def getAppsBlocksHTML(page: LiveBlogPage, blocks: Seq[Block])(implicit
+      request: RequestHeader,
+  ): Future[Html] = {
+    remoteRenderer.getAppsBlocks(ws, page, blocks) map { result =>
+      new Html(result)
+    }
+  }
+
   private[this] def renderNewerUpdatesJson(
       page: LiveBlogPage,
       lastUpdateBlockId: SinceBlockId,
@@ -297,7 +305,9 @@ class LiveBlogController(
 
     for {
       blocksHtml <-
-        if (remoteRender) {
+        if (remoteRender && request.getRequestFormat == AppsFormat) {
+          getAppsBlocksHTML(page, newCapiBlocks)
+        } else if (remoteRender) {
           getDCRBlocksHTML(page, newCapiBlocks)
         } else {
           Future.successful(views.html.liveblog.liveBlogBlocks(newBlocks, page.article, Edition(request).timezone))

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -236,6 +236,27 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       })
   }
 
+  def getAppsBlocks(
+      ws: WSClient,
+      page: LiveBlogPage,
+      blocks: Seq[Block],
+  )(implicit request: RequestHeader): Future[String] = {
+    val dataModel = DotcomBlocksRenderingDataModel(page, request, blocks)
+    val json = DotcomBlocksRenderingDataModel.toJson(dataModel)
+
+    postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/AppsBlocks")
+      .flatMap(response => {
+        if (response.status == 200)
+          Future.successful(response.body)
+        else
+          Future.failed(
+            DCRRenderingException(
+              s"getBlocks request to DCR failed: status ${response.status}, path: ${request.path}, body: ${response.body}",
+            ),
+          )
+      })
+  }
+
   def getFront(
       ws: WSClient,
       page: PressedPage,


### PR DESCRIPTION
## What is the value of this and can you measure success?
Integrates the apps blocks route into Frontend, enabling it to detect requests formatted for apps. If an apps request is identified, Frontend will utilise the /AppsBlocks route in DCR for handling the response.
## What does this change?
Related DCR change https://github.com/guardian/dotcom-rendering/pull/12697
