### PR TITLE
Pass collection level on the Frontend config model

### DIFF
--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -29,13 +29,12 @@ object CollectionConfig {
 
   def make(config: fapi.CollectionConfig): CollectionConfig = {
 
-
     /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
-     * that allows the platforms to style containers differently based on their "level"
-     */
+      * that allows the platforms to style containers differently based on their "level"
+      */
     val collectionLevel: Option[Metadata] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {
-        case Primary => Primary
+        case Primary   => Primary
         case Secondary => Secondary
       }
     }

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -1,7 +1,7 @@
 package model.pressed
 
 import com.gu.facia.api.{models => fapi}
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata, CollectionPlatform}
+import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata, CollectionPlatform, Primary, Secondary}
 
 final case class CollectionConfig(
     displayName: Option[String],
@@ -29,11 +29,15 @@ object CollectionConfig {
 
   def make(config: fapi.CollectionConfig): CollectionConfig = {
 
+
     /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
-      * that allows the platforms to style containers differently based on their "level"
-      */
+     * that allows the platforms to style containers differently based on their "level"
+     */
     val collectionLevel: Option[Metadata] = config.metadata.flatMap { metadataList =>
-      metadataList.find(tag => tag == "primary" || tag == "secondary")
+      metadataList.collectFirst {
+        case Primary => Primary
+        case Secondary => Secondary
+      }
     }
 
     CollectionConfig(

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -8,7 +8,7 @@ final case class CollectionConfig(
     backfill: Option[Backfill],
     metadata: Option[Seq[Metadata]],
     collectionType: String,
-    collectionLevel: Option[Metadata],
+    collectionLevel: Option[String],
     href: Option[String],
     description: Option[String],
     groups: Option[List[String]],
@@ -32,10 +32,10 @@ object CollectionConfig {
     /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
       * that allows the platforms to style containers differently based on their "level"
       */
-    val collectionLevel: Option[Metadata] = config.metadata.flatMap { metadataList =>
+    val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {
-        case Primary   => Primary
-        case Secondary => Secondary
+        case Primary   => "Primary"
+        case Secondary => "Secondary"
       }
     }
 

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -8,6 +8,7 @@ final case class CollectionConfig(
     backfill: Option[Backfill],
     metadata: Option[Seq[Metadata]],
     collectionType: String,
+    collectionLevel: Option[Metadata],
     href: Option[String],
     description: Option[String],
     groups: Option[List[String]],
@@ -25,12 +26,22 @@ final case class CollectionConfig(
 )
 
 object CollectionConfig {
+
   def make(config: fapi.CollectionConfig): CollectionConfig = {
+
+    /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
+      * that allows the platforms to style containers differently based on their "level"
+      */
+    val collectionLevel: Option[Metadata] = config.metadata.flatMap { metadataList =>
+      metadataList.find(tag => tag == "primary" || tag == "secondary")
+    }
+
     CollectionConfig(
       displayName = config.displayName,
       backfill = config.backfill,
       metadata = config.metadata,
       collectionType = config.collectionType,
+      collectionLevel = collectionLevel,
       href = config.href,
       description = config.description,
       groups = config.groups.map(_.groups),

--- a/common/test/common/facia/PressedCollectionBuilder.scala
+++ b/common/test/common/facia/PressedCollectionBuilder.scala
@@ -22,6 +22,7 @@ object PressedCollectionBuilder {
       backfill = None,
       metadata = None,
       collectionType = "",
+      collectionLevel = None,
       href = None,
       description = None,
       groups = None,

--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -77,6 +77,7 @@ class ShouldServeFrontTest
         frontsToolSettings = None,
         userVisibility = None,
         targetedTerritory = None,
+        suppressImages = None,
       ),
     ),
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "10.0.1"
+  val faciaVersion = "12.1.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
> [!NOTE]
> This PR needs this DCR PR to be merged first: https://github.com/guardian/dotcom-rendering/pull/12828

## What does this change?
Separates the collection level from the rest of the metadata tags onto its own property on the collection config. Currently, all tags come through as one metadata object to DCR but this primarily used for container palette tags by the platform and requires enhancement there to extract the collection level from the other container tags. This brings that transformation closer to the source. 

## Testing

On code, we can now see the collection level property come through in the pressed lite json for a container with a container level tag: 

<img width="468" alt="image" src="https://github.com/user-attachments/assets/062a13d6-714b-4ffe-a4fa-923a0994e708">



## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
