### PR TITLE
Add US Election 2024 link to UK, Int and Europe subnavs

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -279,6 +279,7 @@ object NavLinks {
     iconName = Some("home"),
     List(
       ukNews,
+      usElections2024,
       world,
       climateCrisis,
       ukraine,
@@ -331,6 +332,7 @@ object NavLinks {
   val intNewsPillar = ukNewsPillar.copy(
     children = List(
       world,
+      usElections2024,
       ukNews,
       climateCrisis,
       ukraine,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -88,6 +88,12 @@
 					"classList": []
 				},
 				{
+					"title": "US elections 2024",
+					"url": "/us-news/us-elections-2024",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "World",
 					"url": "/world",
 					"longTitle": "World news",
@@ -2504,6 +2510,12 @@
 					"classList": []
 				},
 				{
+					"title": "US elections 2024",
+					"url": "/us-news/us-elections-2024",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "UK",
 					"url": "/uk-news",
 					"longTitle": "UK news",
@@ -3501,6 +3513,12 @@
 							"classList": []
 						}
 					],
+					"classList": []
+				},
+				{
+					"title": "US elections 2024",
+					"url": "/us-news/us-elections-2024",
+					"children": [],
 					"classList": []
 				},
 				{


### PR DESCRIPTION
## What is the value of this and can you measure success?

Increase prominence, discoverability of our US Election 2024 coverage.


## What does this change?

- Add US Election 2024 link to UK, Int and Europe subnavs
- Update `reference-navigation.json` file

Editorial have not asked us to update the Australia news subnav, so we're excluding this for now.

## Screenshots

![Screenshot 2024-11-01 at 11 57 44](https://github.com/user-attachments/assets/a51a4918-7914-4c6c-9e64-1c74f1276f46)

