### PR TITLE
bump commercial version to 23.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial": "23.1.0",
+		"@guardian/commercial": "23.2.1",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3843,9 +3843,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:23.1.0":
-  version: 23.1.0
-  resolution: "@guardian/commercial@npm:23.1.0"
+"@guardian/commercial@npm:23.2.1":
+  version: 23.2.1
+  resolution: "@guardian/commercial@npm:23.2.1"
   dependencies:
     "@changesets/cli": "npm:^2.26.2"
     "@guardian/prebid.js": "npm:8.52.0-7"
@@ -3863,7 +3863,7 @@ __metadata:
     "@guardian/libs": ^19.1.0
     "@guardian/source": ^8.0.0
     typescript: ~5.5.3
-  checksum: 10c0/33104cc9313131b30d06f94419c188363449455d58b1257857ca6399e880e268d50ec2f405a9a9b5b9c6b0d7506360f1b8a552dc7cca93653f7e4fb64d425fe5
+  checksum: 10c0/b40a97068cb3c87ba3020e928d3267b6fa463632a17d1993231fa67a8923abe36032711852a38e0ae48d9c931296c2a3c5670acf6f23dc3b7d96a6d928f342f9
   languageName: node
   linkType: hard
 
@@ -3936,7 +3936,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial": "npm:23.1.0"
+    "@guardian/commercial": "npm:23.2.1"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Bumping the commercial to 23.2.1
## What does this change?
Bringing in the changes from commercial: https://github.com/guardian/commercial/pull/1640
