### PR TITLE
Pass suppress images property

### DIFF
--- a/common/app/layout/DisplaySettings.scala
+++ b/common/app/layout/DisplaySettings.scala
@@ -2,6 +2,7 @@ package layout
 
 import com.gu.facia.api.utils.BoostLevel
 import model.pressed._
+import play.twirl.api.TwirlFeatureImports.twirlOptionToBoolean
 
 case class DisplaySettings(
     isBoosted: Boolean,
@@ -13,13 +14,13 @@ case class DisplaySettings(
 )
 
 object DisplaySettings {
-  def fromTrail(faciaContent: PressedContent): DisplaySettings =
+  def fromTrail(faciaContent: PressedContent, config: CollectionConfig): DisplaySettings =
     DisplaySettings(
       faciaContent.display.isBoosted,
       faciaContent.display.boostLevel,
       faciaContent.display.showBoostedHeadline,
       faciaContent.display.showQuotedHeadline,
-      faciaContent.display.imageHide,
+      Some(config.suppressImages) || faciaContent.display.imageHide,
       faciaContent.display.showLivePlayable,
     )
 }

--- a/common/app/layout/FaciaCard.scala
+++ b/common/app/layout/FaciaCard.scala
@@ -62,7 +62,7 @@ object FaciaCard {
       faciaContent.card.webPublicationDateOption.filterNot(const(faciaContent.shouldHidePublicationDate)),
       faciaContent.card.trailText,
       faciaContent.card.mediaType,
-      DisplaySettings.fromTrail(faciaContent),
+      DisplaySettings.fromTrail(faciaContent, config),
       faciaContent.card.isLive,
       if (config.showTimestamps) Option(DateTimestamp) else None,
       faciaContent.card.shortUrlPath,

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -29,13 +29,12 @@ object CollectionConfig {
 
   def make(config: fapi.CollectionConfig): CollectionConfig = {
 
-
     /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
-     * that allows the platforms to style containers differently based on their "level"
-     */
+      * that allows the platforms to style containers differently based on their "level"
+      */
     val collectionLevel: Option[Metadata] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {
-        case Primary => Primary
+        case Primary   => Primary
         case Secondary => Secondary
       }
     }

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -1,7 +1,7 @@
 package model.pressed
 
 import com.gu.facia.api.{models => fapi}
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata, CollectionPlatform}
+import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata, CollectionPlatform, Primary, Secondary}
 
 final case class CollectionConfig(
     displayName: Option[String],
@@ -29,11 +29,15 @@ object CollectionConfig {
 
   def make(config: fapi.CollectionConfig): CollectionConfig = {
 
+
     /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
-      * that allows the platforms to style containers differently based on their "level"
-      */
+     * that allows the platforms to style containers differently based on their "level"
+     */
     val collectionLevel: Option[Metadata] = config.metadata.flatMap { metadataList =>
-      metadataList.find(tag => tag == "primary" || tag == "secondary")
+      metadataList.collectFirst {
+        case Primary => Primary
+        case Secondary => Secondary
+      }
     }
 
     CollectionConfig(

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -8,7 +8,7 @@ final case class CollectionConfig(
     backfill: Option[Backfill],
     metadata: Option[Seq[Metadata]],
     collectionType: String,
-    collectionLevel: Option[Metadata],
+    collectionLevel: Option[String],
     href: Option[String],
     description: Option[String],
     groups: Option[List[String]],
@@ -32,10 +32,10 @@ object CollectionConfig {
     /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
       * that allows the platforms to style containers differently based on their "level"
       */
-    val collectionLevel: Option[Metadata] = config.metadata.flatMap { metadataList =>
+    val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {
-        case Primary   => Primary
-        case Secondary => Secondary
+        case Primary   => "Primary"
+        case Secondary => "Secondary"
       }
     }
 

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -8,6 +8,7 @@ final case class CollectionConfig(
     backfill: Option[Backfill],
     metadata: Option[Seq[Metadata]],
     collectionType: String,
+    collectionLevel: Option[Metadata],
     href: Option[String],
     description: Option[String],
     groups: Option[List[String]],
@@ -25,12 +26,22 @@ final case class CollectionConfig(
 )
 
 object CollectionConfig {
+
   def make(config: fapi.CollectionConfig): CollectionConfig = {
+
+    /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
+      * that allows the platforms to style containers differently based on their "level"
+      */
+    val collectionLevel: Option[Metadata] = config.metadata.flatMap { metadataList =>
+      metadataList.find(tag => tag == "primary" || tag == "secondary")
+    }
+
     CollectionConfig(
       displayName = config.displayName,
       backfill = config.backfill,
       metadata = config.metadata,
       collectionType = config.collectionType,
+      collectionLevel = collectionLevel,
       href = config.href,
       description = config.description,
       groups = config.groups.map(_.groups),

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -23,6 +23,7 @@ final case class CollectionConfig(
     hideShowMore: Boolean,
     displayHints: Option[DisplayHints],
     platform: Option[CollectionPlatform] = None,
+    suppressImages: Option[Boolean],
 )
 
 object CollectionConfig {
@@ -59,6 +60,7 @@ object CollectionConfig {
       hideShowMore = config.hideShowMore,
       displayHints = config.displayHints.map(DisplayHints.make),
       platform = Some(config.platform),
+      suppressImages = Some(config.suppressImages),
     )
   }
 

--- a/common/test/common/facia/PressedCollectionBuilder.scala
+++ b/common/test/common/facia/PressedCollectionBuilder.scala
@@ -22,6 +22,7 @@ object PressedCollectionBuilder {
       backfill = None,
       metadata = None,
       collectionType = "",
+      collectionLevel = None,
       href = None,
       description = None,
       groups = None,

--- a/common/test/common/facia/PressedCollectionBuilder.scala
+++ b/common/test/common/facia/PressedCollectionBuilder.scala
@@ -36,6 +36,7 @@ object PressedCollectionBuilder {
       showTimestamps = false,
       hideShowMore,
       displayHints = None,
+      suppressImages = None,
     )
 
     PressedCollection(

--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -77,6 +77,7 @@ class ShouldServeFrontTest
         frontsToolSettings = None,
         userVisibility = None,
         targetedTerritory = None,
+        suppressImages = None,
       ),
     ),
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "10.0.1"
+  val faciaVersion = "12.1.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

The new property is appearing in the config json (taken from the code europe front for the scrollable suppressed container)
![image](https://github.com/user-attachments/assets/e92ba4cd-69e2-4fb8-b70f-9399c1b06ef9)


## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
