### PR TITLE
Set opengraph properties on interactive type

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -1009,7 +1009,7 @@ object Interactive {
       adUnitSuffix = section + "/" + contentType.name.toLowerCase,
       twitterPropertiesOverrides = Map("twitter:title" -> fields.linkText),
       contentWithSlimHeader = InteractiveHeaderSwitch.isSwitchedOff,
-      opengraphPropertiesOverrides = opengraphProperties
+      opengraphPropertiesOverrides = opengraphProperties,
     )
     val contentOverrides = content.copy(
       metadata = metadata,

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -995,11 +995,21 @@ object Interactive {
     val fields = content.fields
     val section = content.metadata.sectionId
 
+    val opengraphProperties: Map[String, String] = Map(
+      ("og:type", "article"),
+      ("article:published_time", content.trail.webPublicationDate.toString()),
+      ("article:modified_time", content.fields.lastModified.toString()),
+      ("article:tag", content.tags.keywords.map(_.name).mkString(",")),
+      ("article:section", content.trail.sectionName),
+      ("article:publisher", "https://www.facebook.com/theguardian"),
+    )
+
     val metadata = content.metadata.copy(
       contentType = Some(contentType),
       adUnitSuffix = section + "/" + contentType.name.toLowerCase,
       twitterPropertiesOverrides = Map("twitter:title" -> fields.linkText),
       contentWithSlimHeader = InteractiveHeaderSwitch.isSwitchedOff,
+      opengraphPropertiesOverrides = opengraphProperties
     )
     val contentOverrides = content.copy(
       metadata = metadata,


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

Adds opengraph data to Interactive pages, to ensure Google surfaces the correct update time for these. 

We can't know for sure which meta tags are used for SEO but article:modified_time seems to be a sensible guess 

We have kept the entire opengraph data block from articles for consistency 

## Screenshots
<img width="885" alt="Screenshot 2024-11-06 at 03 51 34" src="https://github.com/user-attachments/assets/41ec2248-9eee-49c9-a8ad-eb4f2f53c31e">


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
