### PR TITLE
Turn off AMP for certain tagged content

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -88,19 +88,23 @@ final case class Content(
   lazy val isImmersive =
     fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists { tag => tag.id == "tone/advertisement-features" }
+  lazy val isUsNews: Boolean = tags.tags.exists { tag => tag.id == "us-news/us-news" }
+  lazy val isUsElectionNews: Boolean = tags.tags.exists { tag => tag.id == "us-news/us-elections-2024" }
+  lazy val isTheFilter: Boolean = tags.tags.exists { tag => tag.id == "thefilter/series/the-filter" }
+
   lazy val campaigns: List[Campaign] =
     _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 
   lazy val shouldAmplify: Boolean = {
     val shouldAmplifyContent = {
       if (tags.isLiveBlog) {
-        AmpLiveBlogSwitch.isSwitchedOn
+        AmpLiveBlogSwitch.isSwitchedOn && !isUsNews && !isUsElectionNews
       } else if (tags.isArticle) {
         val hasBodyBlocks: Boolean = fields.blocks.exists(b => b.body.nonEmpty)
         // Some Labs pages have quiz atoms but are not tagged as quizzes
         val hasQuizAtoms: Boolean = atoms.exists(a => a.quizzes.nonEmpty)
 
-        AmpArticleSwitch.isSwitchedOn && hasBodyBlocks && !tags.isQuiz && !hasQuizAtoms
+        AmpArticleSwitch.isSwitchedOn && hasBodyBlocks && !tags.isQuiz && !hasQuizAtoms && !isUsNews && !isUsElectionNews && !isTheFilter
       } else {
         false
       }


### PR DESCRIPTION
## What is the value of this and can you measure success?

We would like to temporarily disable AMP for contents with the following tags over the post-election period:

- `us-news/us-news`
- `us-news/us-elections-2024`

We also want to permanently disable content with the following tag:

- `thefilter/series/the-filter`

## What does this change?

Update `shouldAmplify` logic to turn off content with certain tags in AMP

We use this mechanism _in addition_ to [the one used in dotcom-rendering](https://github.com/guardian/dotcom-rendering/blob/8236e522cafa4c72a5246326611676f3d202ac21/dotcom-rendering/src/components/Elements.amp.tsx#L82), although both are necessary as they do different things. 

The mechanism in dotcom-rendering avoids adding an `amphtml` link to the final markup, and also ensures AMP pages with unsupported elements return a 415 (not supported) error.

This change avoids making an unnecessary request to DCR and associated redirect to canonical page. 

See guardian/dotcom-rendering#12776, guardian/dotcom-rendering#12771, guardian/dotcom-rendering#12664)