### PR TITLE
Add crossword digital edition endpoint

### DIFF
--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -20,6 +20,7 @@ trait ApplicationsControllers {
   lazy val siteMapController = wire[SiteMapController]
   lazy val crosswordPageController = wire[CrosswordPageController]
   lazy val crosswordSearchController = wire[CrosswordSearchController]
+  lazy val crosswordEditionsController = wire[CrosswordEditionsController]
   lazy val tagIndexController = wire[TagIndexController]
   lazy val embedController = wire[EmbedController]
   lazy val AtomPageController = wire[AtomPageController]

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -289,3 +289,18 @@ class CrosswordSearchController(
 
   case class CrosswordLookup(crosswordType: String, id: Int)
 }
+
+class CrosswordEditionsController(val controllerComponents: ControllerComponents)
+    extends BaseController
+    with GuLogging
+    with ImplicitControllerExecutionContext {
+
+  def digitalEdition: Action[AnyContent] =
+    Action.async { implicit request =>
+      Future.successful(
+        Cached(CacheTime.Default)(
+          RevalidatableResult.Ok("Digital Edition Crossword Entry Point"),
+        ),
+      )
+    }
+}

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -27,6 +27,9 @@ GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|quick-cry
 GET        /crosswords/search                                                                                                controllers.CrosswordSearchController.search()
 GET        /crosswords/lookup                                                                                                controllers.CrosswordSearchController.lookup()
 
+# Crosswords digital edition
+GET        /crosswords/digital-edition                                                                                        controllers.CrosswordEditionsController.digitalEdition
+
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -29,6 +29,9 @@ GET            /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|quick
 GET            /crosswords/search                                                                                                controllers.CrosswordSearchController.search()
 GET            /crosswords/lookup                                                                                                controllers.CrosswordSearchController.lookup()
 
+# Crosswords digital edition
+GET        /crosswords/digital-edition                                                                                        controllers.CrosswordEditionsController.digitalEdition
+
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)


### PR DESCRIPTION
## What is the value of this and can you measure success?

Creates an endpoint in frontend. This will act as the entry point for crosswords from the Guardian Digital Editions app.

Closes #[#12797](https://github.com/guardian/dotcom-rendering/issues/12797)

Why are we doing this? See [#12665](https://github.com/guardian/dotcom-rendering/issues/12665)

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [X]  Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
