### PR TITLE
Allow viewing europe-beta front in preview

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -224,7 +224,7 @@ trait FaciaController
     // Europe beta experiment
     // Phase 1 prevents users from being able to view the europe-beta front unless opted into the test
     val inEuropeBetaTest = ActiveExperiments.isParticipating(EuropeBetaFront)
-    if (path == "europe-beta" && !inEuropeBetaTest) {
+    if (path == "europe-beta" && !inEuropeBetaTest && !context.isPreview) {
       return successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
     }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

This PR prevents `europe-beta` resulting in a 404 page when being requested via the preview app.

Resolves [this Trello ticket](https://trello.com/c/0NL1Clv4/714-remove-europe-beta-404-restriction-in-frontend)

## What does this change?

Adds condition `!context.isPreview` to the `europe-beta` logic to ensure we only return a 404 Not Found result when:
- the requested front is `europe-beta`
- the user is not opted into the Europe beta front test
- the user is not requesting the front via the preview app
