### PR TITLE
red button with white text, black label for thrasher-fighting-back

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -292,6 +292,18 @@
     }
 }
 
+.email-sub__form--thrasher-fighting-back {
+    .email-sub__thrasher-embed-label {
+        color: $brightness-100;
+    }
+
+    .email-sub__thrasher-embed-button {
+        background-color: $news-dark;
+        color: $brightness-100;
+        fill: $brightness-100;
+    }
+}
+
 .email-sub__form--thrasher-the-long-wave {
     .email-sub__thrasher-embed-label {
         color: $brightness-7;


### PR DESCRIPTION
## What is the value of this and can you measure success?
change colors for form rendered by https://www.theguardian.com/email/form/thrasher/fighting-back

## What does this change?

button and label colors for `.email-sub__form---fighting-back`

note - the  form `label` is white, but the thrasher will have a dark background

## Screenshots



| Before      | After      |
|-------------|------------|
| <img width="424" alt="Screenshot 2024-10-28 at 14 12 37" src="https://github.com/user-attachments/assets/f2652c35-ec15-458a-bba9-f5e47e910fbb"> | <img width="453" alt="Screenshot 2024-11-12 at 11 56 44" src="https://github.com/user-attachments/assets/6f0e94a9-db9e-434f-95a0-88770ec766b5"> |







## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
