### PR TITLE
Fix breaking changes in v1.0.0

### DIFF
--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -5,8 +5,7 @@ const execa = require('execa');
 const chalk = require('chalk');
 const fs = require('fs');
 
-execa
-    .shell('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD')
+execa('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD', {shell: true})
     .then(result => {
         const changedFiles = result.stdout.split('\n');
 

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -15,8 +15,7 @@ const confirmIfMainMessage = `${chalk.red(
         'You are about to push main!'
     )}\nIs that what you intended?`
 )} [y/N]`;
-const confirmIfMain = execa
-    .shell(
+const confirmIfMain = execa(
         `
         protected_branch='main'
         current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\\(.*\\),\\1,')
@@ -34,9 +33,9 @@ const confirmIfMain = execa
             exit 0 # push will execute
         fi
         `,
-        {
+        {   shell: true,
             stdio: 'inherit',
-        }
+        },
     )
     .catch(() => Promise.reject(new Error('Ok, stopping 😉')));
 const validate = () =>

--- a/tools/__tasks__/validate-head/javascript.mjs
+++ b/tools/__tasks__/validate-head/javascript.mjs
@@ -27,9 +27,8 @@ const task = {
 								proc.then(() =>
 									Promise.all(
 										batchedFiles.map((filePath) =>
-											execa
-												.shell(
-													`git show HEAD:${filePath} | eslint --stdin --stdin-filename ${filePath}`,
+											execa(
+													`git show HEAD:${filePath} | eslint --stdin --stdin-filename ${filePath}`, {shell: true}
 												)
 												.catch((e) => {
 													errors.push(e);

--- a/tools/__tasks__/validate-head/sass.mjs
+++ b/tools/__tasks__/validate-head/sass.mjs
@@ -23,9 +23,8 @@ const task = {
 								proc.then(() =>
 									Promise.all(
 										batchedFiles.map((filePath) =>
-											execa
-												.shell(
-													`git show HEAD:${filePath} | yarn stylelint --max-warnings 0 '${filePath}'`,
+											execa(
+													`git show HEAD:${filePath} | yarn stylelint --max-warnings 0 '${filePath}'`, {shell: true}
 												)
 												.catch((e) => {
 													errors.push(e);


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
