### PR TITLE
update URL's for advertise with us footer

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -178,7 +178,7 @@ object FooterLinks {
   val usListThree = List(
     FooterLink(
       "Advertise with us",
-      "https://advertising.theguardian.com/us/advertising",
+      "https://usadvertising.theguardian.com",
       "us : footer : advertise with us",
     ),
     FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
@@ -189,7 +189,7 @@ object FooterLinks {
     FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
     FooterLink(
       "Advertise with us",
-      "https://advertising.theguardian.com/au/advertising",
+      "https://ausadvertising.theguardian.com/",
       "au : footer : advertise with us",
     ),
     cookiePolicy,


### PR DESCRIPTION
## What is the value of this and can you measure success?
The “Advertise with us” link at the footer is useful for advertisers getting in touch with the relevant global ads team.

We would like to update the target URL to be specific for each geo location (AUS, UK and US)
## What does this change?

https://advertising.theguardian.com/ (UK homepage)

https://usadvertising.theguardian.com/ (US homepage)

https://ausadvertising.theguardian.com/ (AUS homepage)


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
