### PR TITLE
Make feature switches flaggable as 'high impact', with client-side warnings when disabling

### DIFF
--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -48,14 +48,17 @@
                                             }
                                         >
                                             <input id="switch-@switch.name" name="@switch.name" type="checkbox" @if(switch.isSwitchedOn) {
-                                                checked="checked" }/>
+                                                checked="checked" } @if(switch.highImpact) {
+                                                    data-high-impact="true"
+                                                    data-impact-warning="@switch.impactFullMessage"
+                                                }/>
                                             <strong>@switch.name</strong>
                                         </label>
-                                        @if(switch.highImpact) {
-                                            <span>!!!</span>
-                                        }
                                         <span> - @switch.description
                                             @expiry.daysToExpiry.map{ days => <strong> @days</strong> days left}</span>
+                                        @if(switch.highImpact) {
+                                            <span class="switch__high-impact-warning">⚠️ @switch.impactShortMessage</span>
+                                        }
                                     </div>
                                 }
                             }

--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -51,6 +51,9 @@
                                                 checked="checked" }/>
                                             <strong>@switch.name</strong>
                                         </label>
+                                        @if(switch.highImpact) {
+                                            <span>!!!</span>
+                                        }
                                         <span> - @switch.description
                                             @expiry.daysToExpiry.map{ days => <strong> @days</strong> days left}</span>
                                     </div>

--- a/admin/public/css/switchboard.css
+++ b/admin/public/css/switchboard.css
@@ -24,9 +24,10 @@ input[type=text] {
 }
 
 .switch__high-impact-warning {
-    font-size: 0.75rem;
+    font-size: 0.8rem;
     border: 2px solid rgb(243, 193, 0);
     border-radius: 16px;
     background-color: rgba(243, 193, 0, 0.25);
     padding: 4px 8px;
+    margin-left: 4px;
 }

--- a/admin/public/css/switchboard.css
+++ b/admin/public/css/switchboard.css
@@ -22,3 +22,11 @@ input[type=text] {
     position: absolute;
     right: 0;
 }
+
+.switch__high-impact-warning {
+    font-size: 0.75rem;
+    border: 2px solid rgb(243, 193, 0);
+    border-radius: 16px;
+    background-color: rgba(243, 193, 0, 0.25);
+    padding: 4px 8px;
+}

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -13,6 +13,7 @@ trait ABTestSwitches {
     safeState = Off,
     sellByDate = Some(LocalDate.of(2025, 12, 1)),
     exposeClientSide = true,
+    highImpact = false,
   )
 
   Switch(
@@ -23,6 +24,7 @@ trait ABTestSwitches {
     safeState = Off,
     sellByDate = Some(LocalDate.of(2025, 12, 1)),
     exposeClientSide = true,
+    highImpact = false,
   )
 
   Switch(
@@ -33,6 +35,7 @@ trait ABTestSwitches {
     safeState = Off,
     sellByDate = Some(LocalDate.of(2025, 2, 24)),
     exposeClientSide = true,
+    highImpact = false,
   )
 
   Switch(
@@ -43,6 +46,7 @@ trait ABTestSwitches {
     safeState = Off,
     sellByDate = Some(LocalDate.of(2024, 12, 2)),
     exposeClientSide = true,
+    highImpact = false,
   )
 
   Switch(
@@ -53,6 +57,7 @@ trait ABTestSwitches {
     safeState = Off,
     sellByDate = Some(LocalDate.of(2024, 12, 18)),
     exposeClientSide = true,
+    highImpact = false,
   )
 
   Switch(

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,5 +68,6 @@ trait ABTestSwitches {
     safeState = Off,
     sellByDate = Some(LocalDate.of(2024, 12, 2)),
     exposeClientSide = true,
+    highImpact = false,
   )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -26,7 +26,9 @@ trait CommercialSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
-    highImpact = false,
+    highImpact = true,
+    impactShortMessage = Some("Critical for advertising!"),
+    impactFullMessage = Some("Warning: Requires director-level sign-off + notification of global commerical stakeholders. Disabling this switch will cost £160k/day in ad-revenue"),
   )
 
   val ImrWorldwideSwitch = Switch(
@@ -104,7 +106,9 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
-    highImpact = false,
+    highImpact = true,
+    impactShortMessage = Some("Required for 'The Filter'"),
+    impactFullMessage = Some("Warning: Disabling this switch will prevent us from being able to monetize The Filter"),
   )
 
   val AffiliateLinkSections: Switch = Switch(
@@ -138,7 +142,9 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
-    highImpact = false,
+    highImpact = true,
+    impactShortMessage = Some("Required for Amazon A9 (TAM) header bidding"),
+    impactFullMessage = Some("Warning: Disabling this switch will prevent Amazon A9 (TAM) from running"),
   )
 
   val commercialMetrics: Switch = Switch(

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -28,7 +28,9 @@ trait CommercialSwitches {
     exposeClientSide = true,
     highImpact = true,
     impactShortMessage = Some("Critical for advertising!"),
-    impactFullMessage = Some("Warning: Requires director-level sign-off + notification of global commerical stakeholders. Disabling this switch will cost £160k/day in ad-revenue"),
+    impactFullMessage = Some(
+      "Warning: Requires director-level sign-off + notification of global commerical stakeholders. Disabling this switch will cost £160k/day in ad-revenue",
+    ),
   )
 
   val ImrWorldwideSwitch = Switch(

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -15,6 +15,7 @@ trait CommercialSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ShouldLoadGoogleTagSwitch = Switch(
@@ -25,6 +26,7 @@ trait CommercialSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ImrWorldwideSwitch = Switch(
@@ -35,6 +37,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val InizioSwitch = Switch(
@@ -45,6 +48,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val TwitterUwtSwitch = Switch(
@@ -55,6 +59,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val PermutiveSwitch = Switch(
@@ -65,6 +70,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ampAmazon = Switch(
@@ -75,6 +81,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val RemarketingSwitch = Switch(
@@ -85,6 +92,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val AffiliateLinks: Switch = Switch(
@@ -96,6 +104,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val AffiliateLinkSections: Switch = Switch(
@@ -107,6 +116,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val confiantAdVerification: Switch = Switch(
@@ -117,6 +127,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val a9HeaderBidding: Switch = Switch(
@@ -127,6 +138,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val commercialMetrics: Switch = Switch(
@@ -137,6 +149,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val articleEndSlot: Switch = Switch(
@@ -148,6 +161,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 }
 
@@ -161,6 +175,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidAnalytics: Switch = Switch(
@@ -171,6 +186,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ampPrebidPubmatic: Switch = Switch(
@@ -181,6 +197,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ampPrebidCriteo: Switch = Switch(
@@ -191,6 +208,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ampPrebidOzone: Switch = Switch(
@@ -201,6 +219,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidUserSync: Switch = Switch(
@@ -211,6 +230,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val PrebidPermutiveAudience = Switch(
@@ -221,6 +241,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidSonobi: Switch = Switch(
@@ -231,6 +252,7 @@ trait PrebidSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidAppNexus: Switch = Switch(
@@ -241,6 +263,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidAppNexusUKROW: Switch = Switch(
@@ -251,6 +274,7 @@ trait PrebidSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidAppNexusInvcode: Switch = Switch(
@@ -261,6 +285,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidIndexExchange: Switch = Switch(
@@ -271,6 +296,7 @@ trait PrebidSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidOpenx: Switch = Switch(
@@ -281,6 +307,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidOzone: Switch = Switch(
@@ -291,6 +318,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidPubmatic: Switch = Switch(
@@ -301,6 +329,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidTrustx: Switch = Switch(
@@ -311,6 +340,7 @@ trait PrebidSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidTripleLift: Switch = Switch(
@@ -321,6 +351,7 @@ trait PrebidSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidImproveDigital: Switch = Switch(
@@ -331,6 +362,7 @@ trait PrebidSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidImproveDigitalSkins: Switch = Switch(
@@ -341,6 +373,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidXaxis: Switch = Switch(
@@ -351,6 +384,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidAdYouLike: Switch = Switch(
@@ -361,6 +395,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidCriteo: Switch = Switch(
@@ -371,6 +406,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidSmart: Switch = Switch(
@@ -381,6 +417,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidKargo: Switch = Switch(
@@ -391,6 +428,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val prebidMagnite: Switch = Switch(
@@ -401,6 +439,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val sentinelLogger: Switch = Switch(
@@ -411,6 +450,7 @@ trait PrebidSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ampContentABTesting: Switch = Switch(
@@ -421,6 +461,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val optOutAdvertising: Switch = Switch(
@@ -431,6 +472,7 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val youtubeIma: Switch = Switch(
@@ -441,5 +483,6 @@ trait PrebidSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 }

--- a/common/app/conf/switches/DiscussionSwitches.scala
+++ b/common/app/conf/switches/DiscussionSwitches.scala
@@ -11,6 +11,7 @@ trait DiscussionSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val DiscussionAllowAnonymousRecommendsSwitch = Switch(
@@ -21,6 +22,7 @@ trait DiscussionSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val DiscussionFetchExternalAssets = Switch(
@@ -31,6 +33,7 @@ trait DiscussionSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val RegisterWithPhoneNumber = Switch(
@@ -41,6 +44,7 @@ trait DiscussionSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val EnableDiscussionSwitch = Switch(
@@ -51,6 +55,7 @@ trait DiscussionSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
 }

--- a/common/app/conf/switches/FaciaSwitches.scala
+++ b/common/app/conf/switches/FaciaSwitches.scala
@@ -13,6 +13,7 @@ trait FaciaSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val FrontPressJobSwitch = Switch(
@@ -23,6 +24,7 @@ trait FaciaSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val FrontPressJobSwitchStandardFrequency = Switch(
@@ -33,6 +35,7 @@ trait FaciaSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val FaciaPressOnDemand = Switch(
@@ -43,6 +46,7 @@ trait FaciaSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val FaciaInlineEmbeds = Switch(
@@ -53,6 +57,7 @@ trait FaciaSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val FaciaPressStatusNotifications = Switch(
@@ -63,6 +68,7 @@ trait FaciaSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val DCRFronts = Switch(
@@ -73,6 +79,7 @@ trait FaciaSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val DCRNetworkFronts = Switch(
@@ -83,5 +90,6 @@ trait FaciaSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -15,6 +15,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val FixturesAndResultsContainerSwitch = Switch(
@@ -25,6 +26,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val FacebookShareImageLogoOverlay = Switch(
@@ -35,6 +37,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val TwitterShareImageLogoOverlay = Switch(
@@ -45,6 +48,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val GeoMostPopular = Switch(
@@ -55,6 +59,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ExtendedMostPopular = Switch(
@@ -65,6 +70,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ExtendedMostPopularFronts = Switch(
@@ -75,6 +81,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val MostViewedFronts = Switch(
@@ -85,6 +92,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val FontSwitch = Switch(
@@ -95,6 +103,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val FontKerningSwitch = Switch(
@@ -105,6 +114,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val SearchSwitch = Switch(
@@ -115,6 +125,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val IdentityProfileNavigationSwitch = Switch(
@@ -125,6 +136,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val FacebookShareUseTrailPicFirstSwitch = Switch(
@@ -136,6 +148,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val IdentityAvatarUploadSwitch = Switch(
@@ -146,6 +159,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val EnhanceTweetsSwitch = Switch(
@@ -156,6 +170,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val WeatherSwitch = Switch(
@@ -166,6 +181,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val HistoryTags = Switch(
@@ -176,6 +192,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val IdentityBlockSpamEmails = Switch(
@@ -186,6 +203,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val IdentityLogRegistrationsFromTor = Switch(
@@ -196,6 +214,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val CrosswordSvgThumbnailsSwitch = Switch(
@@ -206,6 +225,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val SudokuSwitch = Switch(
@@ -216,6 +236,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val CricketScoresSwitch = Switch(
@@ -226,6 +247,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val RugbyScoresSwitch = Switch(
@@ -236,6 +258,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   // Decommissioned, see marker: 7dde429f00b1
@@ -247,6 +270,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val MissingVideoEndcodingsJobSwitch = Switch(
@@ -257,6 +281,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val EmailInlineInFooterSwitch = Switch(
@@ -267,6 +292,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val UseAtomsSwitch = Switch(
@@ -277,6 +303,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val AmpArticleSwitch = Switch(
@@ -287,6 +314,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val AmpLiveBlogSwitch = Switch(
@@ -297,6 +325,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val R2PagePressServiceSwitch = Switch(
@@ -307,6 +336,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   // Owner: Maria Livia Chiorean
@@ -318,6 +348,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   // Owner: Sam Cutler / Editorial Tools
@@ -329,6 +360,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val InlineEmailStyles = Switch(
@@ -339,6 +371,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val WeAreHiring = Switch(
@@ -349,6 +382,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val Acast = Switch(
@@ -359,6 +393,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   // Simple & Coherent
@@ -370,6 +405,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   // Election interactive header switch
@@ -381,6 +417,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val slotBodyEnd = Switch(
@@ -391,6 +428,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val remoteBanner = Switch(
@@ -401,6 +439,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val remoteHeader = Switch(
@@ -411,6 +450,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val InteractivePickerFeature = Switch(
@@ -421,6 +461,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val StickyVideos = Switch(
@@ -431,6 +472,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val NewsletterOnwards = Switch(
@@ -441,6 +483,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val KeyEventsCarousel = Switch(
@@ -451,6 +494,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val AusRegionSelector = Switch(
@@ -461,6 +505,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val Callout = Switch(
@@ -471,6 +516,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val PersonaliseSignInGateAfterCheckout = Switch(
@@ -481,6 +527,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val DCRAudioPages = Switch(
@@ -491,6 +538,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val DCRVideoPages = Switch(
@@ -501,6 +549,7 @@ trait FeatureSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val DCRTagPages = Switch(
@@ -511,6 +560,7 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val DisableFrontContainerShowHide = Switch(
@@ -521,5 +571,6 @@ trait FeatureSwitches {
     safeState = On,
     sellByDate = LocalDate.of(2024, 11, 29),
     exposeClientSide = true,
+    highImpact = false,
   )
 }

--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -12,6 +12,7 @@ trait IdentitySwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val Okta = Switch(
@@ -22,5 +23,6 @@ trait IdentitySwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 }

--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -13,6 +13,7 @@ trait JournalismSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val AudioOnwardJourneySwitch = Switch(
@@ -23,6 +24,7 @@ trait JournalismSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val FlagshipEmailContainerSwitch = Switch(
@@ -33,6 +35,7 @@ trait JournalismSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val FlagshipEmailContainerDynamicImageSwitch = Switch(
@@ -43,6 +46,7 @@ trait JournalismSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val FlagshipFrontContainerSwitch = Switch(
@@ -53,6 +57,7 @@ trait JournalismSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val Lightbox = Switch(
@@ -63,6 +68,7 @@ trait JournalismSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val AbsoluteServerTimes = Switch(
@@ -73,5 +79,6 @@ trait JournalismSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 }

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -13,6 +13,7 @@ trait MonitoringSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val SentryReporting = Switch(
@@ -23,6 +24,7 @@ trait MonitoringSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ComscoreSwitch = Switch(
@@ -33,6 +35,7 @@ trait MonitoringSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ThirdPartyEmbedTracking = Switch(
@@ -43,6 +46,7 @@ trait MonitoringSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val LogstashLogging = Switch(
@@ -53,6 +57,7 @@ trait MonitoringSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val LogRemovedAmpElements = Switch(
@@ -63,6 +68,7 @@ trait MonitoringSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val CompareVariantDecisions = Switch(
@@ -73,6 +79,7 @@ trait MonitoringSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
 }

--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -13,6 +13,7 @@ trait NewslettersSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val NewslettersRemoveConfirmationStep = Switch(
@@ -23,6 +24,7 @@ trait NewslettersSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val ShowNewPrivacyWordingOnEmailSignupEmbeds = Switch(
@@ -33,6 +35,7 @@ trait NewslettersSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ValidateEmailSignupRecaptchaTokens = Switch(
@@ -43,6 +46,7 @@ trait NewslettersSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val UseDcrNewslettersPage = Switch(
@@ -53,5 +57,6 @@ trait NewslettersSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 }

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -13,6 +13,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   // Performance
@@ -24,6 +25,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val LongCacheSwitch = Switch(
@@ -34,6 +36,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val PanicShedding = Switch(
@@ -44,6 +47,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val interactivePressing = Switch(
@@ -54,6 +58,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val CircuitBreakerSwitch = Switch(
@@ -64,6 +69,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val CircuitBreakerDcrSwitch = Switch(
@@ -74,6 +80,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val AutoRefreshSwitch = Switch(
@@ -84,6 +91,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val RelatedContentSwitch = Switch(
@@ -94,6 +102,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val RichLinkSwitch = Switch(
@@ -104,6 +113,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val InlineCriticalCss = Switch(
@@ -114,6 +124,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val AsyncCss = Switch(
@@ -125,6 +136,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val PolyfillIO = Switch(
@@ -135,6 +147,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val PolyfillIOFallbackMin = Switch(
@@ -145,6 +158,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val ShowAllArticleEmbedsSwitch = Switch(
@@ -155,6 +169,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val ExternalVideoEmbeds = Switch(
@@ -165,6 +180,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val DiscussionPageSizeSwitch = Switch(
@@ -175,6 +191,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ImageServerSwitch = Switch(
@@ -185,6 +202,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val LazyLoadImages = Switch(
@@ -195,6 +213,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val AdaptiveSite = Switch(
@@ -205,6 +224,7 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val ShorterSurrogateCacheForRecentArticles = Switch(
@@ -215,6 +235,7 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = LocalDate.of(2024, 11, 19),
     exposeClientSide = false,
+    highImpact = false,
   )
 
   val ShorterSurrogateCacheForOlderArticles = Switch(
@@ -225,5 +246,6 @@ trait PerformanceSwitches {
     safeState = Off,
     sellByDate = LocalDate.of(2024, 11, 19),
     exposeClientSide = false,
+    highImpact = false,
   )
 }

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -14,5 +14,6 @@ trait PrivacySwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = true,
   )
 }

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -15,5 +15,7 @@ trait PrivacySwitches {
     sellByDate = never,
     exposeClientSide = true,
     highImpact = true,
+    impactShortMessage = Some("Critical for for advertising and SR!"),
+    impactFullMessage = Some("Warning: Requires ExCo sign-off. Disabling this switch will cost £160,000/day in ad-revenue, impact marketing, impact reader revenue..."),
   )
 }

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -16,6 +16,8 @@ trait PrivacySwitches {
     exposeClientSide = true,
     highImpact = true,
     impactShortMessage = Some("Critical for for advertising and SR!"),
-    impactFullMessage = Some("Warning: Requires ExCo sign-off. Disabling this switch will cost £160,000/day in ad-revenue, impact marketing, impact reader revenue..."),
+    impactFullMessage = Some(
+      "Warning: Requires ExCo sign-off. Disabling this switch will cost £160,000/day in ad-revenue, impact marketing, impact reader revenue...",
+    ),
   )
 }

--- a/common/app/conf/switches/ServerSideExperimentSwitches.scala
+++ b/common/app/conf/switches/ServerSideExperimentSwitches.scala
@@ -20,6 +20,7 @@ trait ServerSideExperimentSwitches {
       safeState = Off,
       sellByDate = never,
       exposeClientSide = false,
+      highImpact = false,
     )
   }
 
@@ -31,6 +32,7 @@ trait ServerSideExperimentSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
+    highImpact = false,
   )
 
 }

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -77,6 +77,7 @@ case class Switch(
     safeState: SwitchState,
     sellByDate: Option[LocalDate],
     exposeClientSide: Boolean,
+    highImpact: Boolean,
 ) extends Switchable
     with Initializable[Switch] {
 
@@ -125,6 +126,7 @@ object Switch {
       safeState: SwitchState,
       sellByDate: LocalDate,
       exposeClientSide: Boolean,
+      highImpact: Boolean,
   ): Switch =
     Switch(
       group,
@@ -134,6 +136,7 @@ object Switch {
       safeState,
       Some(sellByDate),
       exposeClientSide,
+      highImpact,
     )
 
   val switches = Box[List[Switch]](Nil)

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -78,6 +78,8 @@ case class Switch(
     sellByDate: Option[LocalDate],
     exposeClientSide: Boolean,
     highImpact: Boolean,
+    impactShortMessage: Option[String] = None,
+    impactFullMessage: Option[String] = None,
 ) extends Switchable
     with Initializable[Switch] {
 

--- a/common/app/conf/switches/TXSwitches.scala
+++ b/common/app/conf/switches/TXSwitches.scala
@@ -11,6 +11,7 @@ trait TXSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val contentCardsSwitch = Switch(
@@ -21,6 +22,7 @@ trait TXSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   val brazeTaylorReport = Switch(
@@ -31,5 +33,6 @@ trait TXSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
+    highImpact = false,
   )
 }

--- a/common/app/experiments/Experiment.scala
+++ b/common/app/experiments/Experiment.scala
@@ -20,6 +20,7 @@ abstract case class Experiment(
     conf.switches.Off,
     sellByDate,
     exposeClientSide = true,
+    highImpact = false,
   )
 
   sealed abstract class ExperimentValue(val value: String)

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -41,6 +41,7 @@ class SwitchesTest extends AnyFlatSpec with Matchers with AppendedClues {
       safeState = Off,
       sellByDate = Some(switchExpiryDate),
       exposeClientSide = true,
+      highImpact = false,
     )
 
   def foreverSwitch: Switch =
@@ -52,6 +53,7 @@ class SwitchesTest extends AnyFlatSpec with Matchers with AppendedClues {
       safeState = Off,
       sellByDate = None,
       exposeClientSide = true,
+      highImpact = false,
     )
 
   "Switches" should "not be near expiry over a week in advance" in {

--- a/static/src/javascripts/bootstraps/admin.js
+++ b/static/src/javascripts/bootstraps/admin.js
@@ -1,4 +1,5 @@
 import { init as initDrama } from 'admin/bootstraps/drama';
+import { init as initWarnings } from 'admin/bootstraps/switchwarnings';
 import { initABTests } from 'admin/bootstraps/abtests';
 import domReady from 'domready';
 
@@ -10,6 +11,7 @@ domReady(() => {
 
         case '/dev/switchboard':
             initDrama();
+            initWarnings();
             break;
 
         default: // do nothing

--- a/static/src/javascripts/projects/admin/bootstraps/switchwarnings.js
+++ b/static/src/javascripts/projects/admin/bootstraps/switchwarnings.js
@@ -4,14 +4,19 @@ const init = () => {
     )));
     if (!$switchboard) return;
 
-    const $highImpactSwitches = $switchboard.querySelectorAll('[data-high-impact="true"]')
+    const $highImpactSwitches = $switchboard.querySelectorAll('[data-high-impact="true"]');
+    const $saveButton = document.querySelector('input[value="Save"]');
 
     if (!$highImpactSwitches.length) return;
 
     $highImpactSwitches.forEach($highImpactSwitch => {
-        $highImpactSwitch.addEventListener('click', (event) => {
-            if (!confirm($highImpactSwitch.dataset.impactWarning)) {
-                event.preventDefault();
+        $highImpactSwitch.addEventListener('change', (event) => {
+            event.preventDefault();
+            const changeCancelled = !confirm($highImpactSwitch.dataset.impactWarning);
+            if (changeCancelled) {
+                event.currentTarget.checked = !event.currentTarget.checked;
+            } else {
+                $saveButton.classList.add('btn-danger');
             }
         });
     })

--- a/static/src/javascripts/projects/admin/bootstraps/switchwarnings.js
+++ b/static/src/javascripts/projects/admin/bootstraps/switchwarnings.js
@@ -1,0 +1,20 @@
+const init = () => {
+    const $switchboard = ((document.querySelector(
+        '#switchboard'
+    )));
+    if (!$switchboard) return;
+
+    const $highImpactSwitches = $switchboard.querySelectorAll('[data-high-impact="true"]')
+
+    if (!$highImpactSwitches.length) return;
+
+    $highImpactSwitches.forEach($highImpactSwitch => {
+        $highImpactSwitch.addEventListener('click', (event) => {
+            if (!confirm($highImpactSwitch.dataset.impactWarning)) {
+                event.preventDefault();
+            }
+        });
+    })
+};
+
+export { init }

--- a/static/src/javascripts/projects/admin/bootstraps/switchwarnings.js
+++ b/static/src/javascripts/projects/admin/bootstraps/switchwarnings.js
@@ -1,25 +1,35 @@
 const init = () => {
-    const $switchboard = ((document.querySelector(
-        '#switchboard'
-    )));
-    if (!$switchboard) return;
+	const $switchboard = document.querySelector('#switchboard');
+	if (!$switchboard) return;
 
-    const $highImpactSwitches = $switchboard.querySelectorAll('[data-high-impact="true"]');
-    const $saveButton = document.querySelector('input[value="Save"]');
+	const $highImpactSwitches = Array.from(
+		$switchboard.querySelectorAll('[data-high-impact="true"]'),
+	);
+	const $saveButton = document.querySelector('input[value="Save"]');
 
-    if (!$highImpactSwitches.length) return;
+	if (!$highImpactSwitches.length) return;
 
-    $highImpactSwitches.forEach($highImpactSwitch => {
-        $highImpactSwitch.addEventListener('change', (event) => {
-            event.preventDefault();
-            const changeCancelled = !confirm($highImpactSwitch.dataset.impactWarning);
-            if (changeCancelled) {
-                event.currentTarget.checked = !event.currentTarget.checked;
-            } else {
-                $saveButton.classList.add('btn-danger');
-            }
-        });
-    })
+	$highImpactSwitches.forEach(($highImpactSwitch) => {
+		$highImpactSwitch.addEventListener('change', (event) => {
+			event.preventDefault();
+
+			const changeCancelled = !confirm(
+				$highImpactSwitch.dataset.impactWarning,
+			);
+			if (changeCancelled) {
+				event.currentTarget.checked = !event.currentTarget.checked;
+			}
+
+			const makeButtonScary = $highImpactSwitches.some(
+				(highImpactSwitch) => !highImpactSwitch.checked,
+			);
+			if (makeButtonScary) {
+				$saveButton.classList.add('btn-danger');
+			} else {
+				$saveButton.classList.remove('btn-danger');
+			}
+		});
+	});
 };
 
-export { init }
+export { init };

--- a/static/src/javascripts/projects/admin/bootstraps/switchwarnings.js
+++ b/static/src/javascripts/projects/admin/bootstraps/switchwarnings.js
@@ -3,7 +3,7 @@ const init = () => {
 	if (!$switchboard) return;
 
 	const $highImpactSwitches = Array.from(
-		$switchboard.querySelectorAll('[data-high-impact="true"]'),
+		$switchboard.querySelectorAll('input[data-high-impact="true"]'),
 	);
 	const $saveButton = document.querySelector('input[value="Save"]');
 
@@ -20,10 +20,10 @@ const init = () => {
 				event.currentTarget.checked = !event.currentTarget.checked;
 			}
 
-			const makeButtonScary = $highImpactSwitches.some(
-				(highImpactSwitch) => !highImpactSwitch.checked,
+			const $makeButtonScary = $highImpactSwitches.some(
+				($hiSwitch) => !$hiSwitch.checked,
 			);
-			if (makeButtonScary) {
+			if ($makeButtonScary) {
 				$saveButton.classList.add('btn-danger');
 			} else {
 				$saveButton.classList.remove('btn-danger');


### PR DESCRIPTION
## What does this change?

This adds the ability to flag a feature switch as 'high impact'. This will display a short warning message in the switchboard client side, as well as a longer message in a native browser confirm prompt when attempting to disable the switch.

## What is the value of this and can you measure success?

Some switches have a fairly minor impact if disabled, whereas others present a major financial or technical risk if turned off, but presently there is no way to distinguish them and no safeguards against accidentally disabling something dangerous. This feature makes it much clearer when changing a switch state carries high organisational risk and prevents accidentally disabling the wrong thing.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2024-11-13 at 12-21-49 Switchboard](https://github.com/user-attachments/assets/b1d03340-205b-41b3-b319-633c5834a980) | ![Screenshot 2024-11-13 at 12-21-20 Switchboard](https://github.com/user-attachments/assets/31de842d-ec55-43af-a7e3-d08ad827f383) |

![Screenshot 2024-11-13 at 12 23 19](https://github.com/user-attachments/assets/92298386-c022-4725-abfb-48e10fc1f9e5)

![Screenshot 2024-11-13 at 12 23 38](https://github.com/user-attachments/assets/69d5110b-610a-48cb-88c6-dfe2411283c9)

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
