### PR TITLE
[fairground] Suppress images if indicated by the collection config

### DIFF
--- a/common/app/model/PressedDisplaySettings.scala
+++ b/common/app/model/PressedDisplaySettings.scala
@@ -13,10 +13,11 @@ final case class PressedDisplaySettings(
 )
 
 object PressedDisplaySettings {
-  def make(content: fapi.FaciaContent): PressedDisplaySettings = {
+  def make(content: fapi.FaciaContent, suppressImages: Option[Boolean]): PressedDisplaySettings = {
+    val shouldSuppressImages = suppressImages.getOrElse(false)
     val contentProperties = PressedProperties.getProperties(content)
     PressedDisplaySettings(
-      imageHide = contentProperties.imageHide,
+      imageHide = shouldSuppressImages || contentProperties.imageHide,
       isBoosted = FaciaContentUtils.isBoosted(content),
       boostLevel = Some(FaciaContentUtils.boostLevel(content)),
       showBoostedHeadline = FaciaContentUtils.showBoostedHeadline(content),

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -50,9 +50,9 @@ sealed trait PressedContent {
 }
 
 object PressedContent {
-  def make(content: fapi.FaciaContent): PressedContent =
+  def make(content: fapi.FaciaContent, suppressImages: Boolean): PressedContent =
     content match {
-      case curatedContent: fapi.CuratedContent => CuratedContent.make(curatedContent)
+      case curatedContent: fapi.CuratedContent => CuratedContent.make(curatedContent, suppressImages)
       case supportingCuratedContent: fapi.SupportingCuratedContent =>
         SupportingCuratedContent.make(supportingCuratedContent)
       case linkSnap: fapi.LinkSnap     => LinkSnap.make(linkSnap)
@@ -78,15 +78,15 @@ final case class CuratedContent(
 }
 
 object CuratedContent {
-  def make(content: fapi.CuratedContent): CuratedContent = {
+  def make(content: fapi.CuratedContent, suppressImages: Boolean): CuratedContent = {
     CuratedContent(
       properties = PressedProperties.make(content),
       header = PressedCardHeader.make(content),
       card = PressedCard.make(content),
       discussion = PressedDiscussionSettings.make(content),
-      display = PressedDisplaySettings.make(content),
+      display = PressedDisplaySettings.make(content, Some(suppressImages)),
       format = ContentFormat.fromFapiContentFormat(content.format),
-      supportingContent = content.supportingContent.map(PressedContent.make),
+      supportingContent = content.supportingContent.map((sc) => PressedContent.make(sc, false)),
       cardStyle = CardStyle.make(content.cardStyle),
       enriched = Some(EnrichedContent.empty),
     )
@@ -112,7 +112,7 @@ object SupportingCuratedContent {
       header = PressedCardHeader.make(content),
       card = PressedCard.make(content),
       discussion = PressedDiscussionSettings.make(content),
-      display = PressedDisplaySettings.make(content),
+      display = PressedDisplaySettings.make(content, None),
       format = ContentFormat.fromFapiContentFormat(content.format),
       cardStyle = CardStyle.make(content.cardStyle),
     )
@@ -140,7 +140,7 @@ object LinkSnap {
       header = PressedCardHeader.make(content),
       card = PressedCard.make(content),
       discussion = PressedDiscussionSettings.make(content),
-      display = PressedDisplaySettings.make(content),
+      display = PressedDisplaySettings.make(content, None),
       enriched = Some(EnrichedContent.empty),
       format = ContentFormat.defaultContentFormat,
     )
@@ -166,7 +166,7 @@ object LatestSnap {
       header = PressedCardHeader.make(content),
       card = PressedCard.make(content),
       discussion = PressedDiscussionSettings.make(content),
-      display = PressedDisplaySettings.make(content),
+      display = PressedDisplaySettings.make(content, None),
       format = ContentFormat.fromFapiContentFormat(content.format),
     )
   }

--- a/common/app/services/FaciaContentConvert.scala
+++ b/common/app/services/FaciaContentConvert.scala
@@ -41,6 +41,6 @@ object FaciaContentConvert {
         .toMap,
     )
 
-    PressedContent.make(curated)
+    PressedContent.make(curated, false)
   }
 }

--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -77,6 +77,7 @@ class ShouldServeFrontTest
         frontsToolSettings = None,
         userVisibility = None,
         targetedTerritory = None,
+        suppressImages = None,
       ),
     ),
   )

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -53,7 +53,7 @@ class LiveFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: Con
   ): Response[List[PressedContent]] =
     FAPI
       .liveCollectionContentWithSnaps(collection, adjustSearchQuery, adjustSnapItemQuery)
-      .map(_.map(PressedContent.make))
+      .map(_.map((item) => PressedContent.make(item, collection.collectionConfig.suppressImages)))
 }
 
 class DraftFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: ContentApiClient)(implicit
@@ -81,7 +81,7 @@ class DraftFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: Co
   ): Response[List[PressedContent]] =
     FAPI
       .draftCollectionContentWithSnaps(collection, adjustSearchQuery, adjustSnapItemQuery)
-      .map(_.map(PressedContent.make))
+      .map(_.map((item) => PressedContent.make(item, collection.collectionConfig.suppressImages)))
 }
 
 // This is the json structure we expect for an embed (know as a snap at render-time).
@@ -403,7 +403,9 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
   private def getTreats(
       collection: Collection,
   )(implicit executionContext: ExecutionContext): Response[List[PressedContent]] = {
-    FAPI.getTreatsForCollection(collection, searchApiQuery, itemApiQuery).map(_.map(PressedContent.make))
+    FAPI
+      .getTreatsForCollection(collection, searchApiQuery, itemApiQuery)
+      .map(_.map((item) => PressedContent.make(item, false)))
   }
 
   private def getBackfill(
@@ -411,7 +413,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
   )(implicit executionContext: ExecutionContext): Response[List[PressedContent]] = {
     FAPI
       .backfillFromConfig(collection.collectionConfig, searchApiQuery, itemApiQuery)
-      .map(_.map(PressedContent.make))
+      .map(_.map(((item) => PressedContent.make(item, false))))
   }
 
   def generatePressedVersions(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "10.0.1"
+  val faciaVersion = "12.1.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What is the value of this and can you measure success?

Part of the fairground project, resolves [this ticket](https://trello.com/c/kRpHvUHT/687-frontend-pick-up-image-suppression-option-from-fronts-tool). 

## What does this change?

Makes use of the suppress images property getting sent in the config. This gets passed through to end up getting used in the `PressedDisplaySettings` to determine the `imageHide` value.

## Testing

This logic gets executed when a page gets pressed, so the only way to test is to deploy to code, create a container with a suppress images option, launch it from the v2 fronts tool, and then you should be able to verify that images get hidden.

## Screenshots

A collection with images suppressed on DCR: 
<img width="1343" alt="image" src="https://github.com/user-attachments/assets/0da56156-bb51-4ee2-91c0-8948495463ec">

the corresponding collection in the fronts tool config: 
<img width="507" alt="image" src="https://github.com/user-attachments/assets/7b881c87-92a8-4c30-b3f5-6ca6a064ec00">



## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
