### PR TITLE
Editions crossword cryptic and quick data 

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -7,7 +7,15 @@ import common.{Edition, GuLogging, ImplicitControllerExecutionContext}
 import conf.Static
 import contentapi.ContentApiClient
 import pages.{CrosswordHtmlPage, IndexHtmlPage, PrintableCrosswordHtmlPage}
-import crosswords.{AccessibleCrosswordPage, AccessibleCrosswordRows, CrosswordPageWithContent, CrosswordPageWithSvg, CrosswordSearchPageNoResult, CrosswordSearchPageWithResults, CrosswordSvg}
+import crosswords.{
+  AccessibleCrosswordPage,
+  AccessibleCrosswordRows,
+  CrosswordPageWithContent,
+  CrosswordPageWithSvg,
+  CrosswordSearchPageNoResult,
+  CrosswordSearchPageWithResults,
+  CrosswordSvg,
+}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import org.joda.time.{DateTime, LocalDate}
@@ -289,6 +297,8 @@ class CrosswordSearchController(
 class CrosswordEditionsController(
     val contentApiClient: ContentApiClient,
     val controllerComponents: ControllerComponents,
+    val remoteRenderer: DotcomRenderingService = DotcomRenderingService(),
+    val wsClient: WSClient,
 ) extends BaseController
     with GuLogging
     with ImplicitControllerExecutionContext {
@@ -316,6 +326,7 @@ class CrosswordEditionsController(
         crosswords match {
           case Some((quick, cryptic)) =>
             val crosswordPage = EditionsCrosswordRenderingDataModel(quick, cryptic)
+            remoteRenderer.getEditionsCrossword(wsClient, quick, cryptic)
             Future.successful(
               Cached(CacheTime.Default)(
                 RevalidatableResult.Ok(toJson(crosswordPage)),

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -1,12 +1,10 @@
 package controllers
 
-import com.gu.contentapi.client.model.v1.Content.unsafeEmpty.crossword
 import com.gu.contentapi.client.model.v1.CrosswordType.{Cryptic, Quick}
 import com.gu.contentapi.client.model.v1.{Crossword, ItemResponse, Content => ApiContent, Section => ApiSection}
 import common.{Edition, GuLogging, ImplicitControllerExecutionContext}
 import conf.Static
 import contentapi.ContentApiClient
-import pages.{CrosswordHtmlPage, IndexHtmlPage, PrintableCrosswordHtmlPage}
 import crosswords.{
   AccessibleCrosswordPage,
   AccessibleCrosswordRows,
@@ -16,20 +14,20 @@ import crosswords.{
   CrosswordSearchPageWithResults,
   CrosswordSvg,
 }
+import html.HtmlPageHelpers.ContentCSSFile
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
+import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
+import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import org.joda.time.{DateTime, LocalDate}
+import pages.{CrosswordHtmlPage, IndexHtmlPage, PrintableCrosswordHtmlPage}
 import play.api.data.Forms._
 import play.api.data._
-import play.api.mvc.{Action, RequestHeader, Result, _}
-import services.{IndexPage, IndexPageItem}
-import html.HtmlPageHelpers.ContentCSSFile
-import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
-import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel.toJson
-import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import play.api.libs.ws.WSClient
+import play.api.mvc._
 import renderers.DotcomRenderingService
 import services.dotcomrendering.{CrosswordsPicker, RemoteRender}
+import services.{IndexPage, IndexPageItem}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -29,8 +29,7 @@ GET        /crosswords/lookup                                                   
 
 # Crosswords digital edition
 GET        /crosswords/digital-edition                                                                                        controllers.CrosswordEditionsController.digitalEdition
-GET        /crosswordtest                                                                                                      controllers.CrosswordEditionsController.getCrosswords
-
+GET /crosswordtest controllers.CrosswordEditionsController.getCrosswords
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -29,6 +29,7 @@ GET        /crosswords/lookup                                                   
 
 # Crosswords digital edition
 GET        /crosswords/digital-edition                                                                                        controllers.CrosswordEditionsController.digitalEdition
+GET        /crosswordtest                                                                                                      controllers.CrosswordEditionsController.getCrosswords
 
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -29,7 +29,7 @@ GET        /crosswords/lookup                                                   
 
 # Crosswords digital edition
 GET        /crosswords/digital-edition                                                                                        controllers.CrosswordEditionsController.digitalEdition
-GET /crosswordtest controllers.CrosswordEditionsController.getCrosswords
+
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ val common = library("common")
       eTagCachingS3,
       nettyCodecHttp2,
       contentApiClient,
+      contentApiModelsJson,
       enumeratumPlayJson,
       filters,
       commonsLang,

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -1,9 +1,8 @@
 package model.dotcomrendering.pageElements
 
 import com.gu.contentapi.client.model.v1.Crossword
-import model.dotcomrendering.DotcomRenderingUtils.withoutNull
-import play.api.libs.json.{JsValue, Json, Writes}
 import com.gu.contentapi.json.CirceEncoders._
+import io.circe.JsonObject
 import io.circe.syntax._
 
 case class EditionsCrosswordRenderingDataModel(
@@ -12,22 +11,10 @@ case class EditionsCrosswordRenderingDataModel(
 )
 
 object EditionsCrosswordRenderingDataModel {
-  // we Json.parse this into a JsValue to ensure we get the raw JSON
-  // from the Content API rather than a Json.stringified version
-  private def contentApiToJsonValue(crossword: Crossword): JsValue = {
-    Json.parse(crossword.asJson.toString())
-  }
-  implicit val writes: Writes[EditionsCrosswordRenderingDataModel] =
-    new Writes[EditionsCrosswordRenderingDataModel] {
-      def writes(model: EditionsCrosswordRenderingDataModel) = {
-        Json.obj(
-          "quick" -> contentApiToJsonValue(model.quick),
-          "cryptic" -> contentApiToJsonValue(model.cryptic),
-        )
-      }
-    }
   def toJson(model: EditionsCrosswordRenderingDataModel): String = {
-    val jsValue = Json.toJson(model)
-    Json.stringify(withoutNull(jsValue))
+    JsonObject(
+      "quick" -> model.quick.asJson.dropNullValues,
+      "cryptic" -> model.cryptic.asJson.dropNullValues,
+    ).asJson.dropNullValues.noSpaces
   }
 }

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -1,11 +1,10 @@
 package model.dotcomrendering.pageElements
 
 import com.gu.contentapi.client.model.v1.Crossword
-import model.dotcomrendering.DotcomRenderingDataModel
 import model.dotcomrendering.DotcomRenderingUtils.withoutNull
-import org.apache.thrift.protocol.TSimpleJSONProtocol
-import org.apache.thrift.transport.TIOStreamTransport
-import play.api.libs.json.{JsValue, Json, OWrites, Writes}
+import play.api.libs.json.{JsValue, Json, Writes}
+import com.gu.contentapi.json.CirceEncoders._
+import io.circe.syntax._
 
 case class EditionsCrosswordRenderingDataModel(
     quick: Crossword,
@@ -16,13 +15,7 @@ object EditionsCrosswordRenderingDataModel {
   // we Json.parse this into a JsValue to ensure we get the raw JSON
   // from the Content API rather than a Json.stringified version
   private def contentApiToJsonValue(crossword: Crossword): JsValue = {
-    val protocolFactory = new TSimpleJSONProtocol.Factory
-
-    val buffer = new java.io.ByteArrayOutputStream
-    val protocol = protocolFactory.getProtocol(new TIOStreamTransport(buffer))
-
-    Crossword.encode(crossword, protocol)
-    Json.parse(new String(buffer.toByteArray, "UTF-8"))
+    Json.parse(crossword.asJson.toString())
   }
   implicit val writes: Writes[EditionsCrosswordRenderingDataModel] =
     new Writes[EditionsCrosswordRenderingDataModel] {

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -1,0 +1,40 @@
+package model.dotcomrendering.pageElements
+
+import com.gu.contentapi.client.model.v1.Crossword
+import model.dotcomrendering.DotcomRenderingDataModel
+import model.dotcomrendering.DotcomRenderingUtils.withoutNull
+import org.apache.thrift.protocol.TSimpleJSONProtocol
+import org.apache.thrift.transport.TIOStreamTransport
+import play.api.libs.json.{JsValue, Json, OWrites, Writes}
+
+case class EditionsCrosswordRenderingDataModel(
+    quick: Crossword,
+    cryptic: Crossword,
+)
+
+object EditionsCrosswordRenderingDataModel {
+  // we Json.parse this into a JsValue to ensure we get the raw JSON
+  // from the Content API rather than a Json.stringified version
+  private def contentApiToJsonValue(crossword: Crossword): JsValue = {
+    val protocolFactory = new TSimpleJSONProtocol.Factory
+
+    val buffer = new java.io.ByteArrayOutputStream
+    val protocol = protocolFactory.getProtocol(new TIOStreamTransport(buffer))
+
+    Crossword.encode(crossword, protocol)
+    Json.parse(new String(buffer.toByteArray, "UTF-8"))
+  }
+  implicit val writes: Writes[EditionsCrosswordRenderingDataModel] =
+    new Writes[EditionsCrosswordRenderingDataModel] {
+      def writes(model: EditionsCrosswordRenderingDataModel) = {
+        Json.obj(
+          "quick" -> contentApiToJsonValue(model.quick),
+          "cryptic" -> contentApiToJsonValue(model.cryptic),
+        )
+      }
+    }
+  def toJson(model: EditionsCrosswordRenderingDataModel): String = {
+    val jsValue = Json.toJson(model)
+    Json.stringify(withoutNull(jsValue))
+  }
+}

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -1,7 +1,7 @@
 package renderers
 
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
-import com.gu.contentapi.client.model.v1.{Block, Blocks, Content}
+import com.gu.contentapi.client.model.v1.{Block, Blocks, Content, Crossword}
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
@@ -10,6 +10,7 @@ import crosswords.CrosswordPageWithContent
 import http.{HttpPreconnections, ResultWithPreconnectPreload}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.dotcomrendering._
+import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
 import model.{
   CacheTime,
   Cached,
@@ -416,6 +417,16 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomRenderingDataModel.forCrossword(crosswordPage, request, pageType)
     val json = DotcomRenderingDataModel.toJson(dataModel)
     post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
+  }
+
+  def getEditionsCrossword(
+      ws: WSClient,
+      quickCrossword: Crossword,
+      crypticCrossword: Crossword,
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = EditionsCrosswordRenderingDataModel(quickCrossword, crypticCrossword)
+    val json = EditionsCrosswordRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/EditionsCrossword", CacheTime.Facia)
   }
 }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -421,11 +421,9 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
   def getEditionsCrossword(
       ws: WSClient,
-      quickCrossword: Crossword,
-      crypticCrossword: Crossword,
+      crosswords: EditionsCrosswordRenderingDataModel,
   )(implicit request: RequestHeader): Future[Result] = {
-    val dataModel = EditionsCrosswordRenderingDataModel(quickCrossword, crypticCrossword)
-    val json = EditionsCrosswordRenderingDataModel.toJson(dataModel)
+    val json = EditionsCrosswordRenderingDataModel.toJson(crosswords)
     post(ws, json, Configuration.rendering.articleBaseURL + "/EditionsCrossword", CacheTime.Facia)
   }
 }

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -424,7 +424,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       crosswords: EditionsCrosswordRenderingDataModel,
   )(implicit request: RequestHeader): Future[Result] = {
     val json = EditionsCrosswordRenderingDataModel.toJson(crosswords)
-    post(ws, json, Configuration.rendering.articleBaseURL + "/EditionsCrossword", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/EditionsCrossword", CacheTime.Default)
   }
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.16.1"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
+  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "25.1.0"
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.6.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR adds functionality to the Crosswords Controller to send JSON data for the latest cryptic and quick crosswords to DCR
## What does this change?
Resolves https://github.com/guardian/dotcom-rendering/issues/12799
