### PR TITLE
crosswords: make the solutionAvailable field on crossword data reflect the current time

### DIFF
--- a/common/app/model/CrosswordData.scala
+++ b/common/app/model/CrosswordData.scala
@@ -155,7 +155,7 @@ object CrosswordData {
       crossword.date.toJoda,
       content.webPublicationDate.fold(crossword.date.toJoda)(_.toJoda),
       sortedNewEntries.toSeq,
-      crossword.solutionAvailable,
+      solutionAvailable = shipSolutions,
       crossword.dateSolutionAvailable.map(_.toJoda),
       CrosswordDimensions(crossword.dimensions.cols, crossword.dimensions.rows),
       crosswordType,


### PR DESCRIPTION
Updates the `solutionAvailable` field placed in `CrosswordData` to be the result of comparing `dateSolutionAvailable` against the current timestamp 

## The problem:

The crossword players offer options to help users who are struggling - they can check whether their answer is correct, or reveal the answer if they don't have an idea. But some crosswords offer a prize for correct solutions, so these helpers aren't available for a period of time (usually a week) to allow for clean(er) competition.

The CAPI data includes the solutions, regardless of whether that period of time has passed or not. It has therefore been the responsibility of frontend to compare the `dateSolutionAvailable` field with the current time, and strip the solutions if required -- which it has done for a long time without problem.

However, there is another field on the data called `solutionAvailable` which appears to be a useful flag that can be used to decide whether to show the check and reveal options - but this can be misleading since it is also not updated in CAPI - so the field will show whether the solutions should have been available _when the crossword was originally sent to CAPI_ -- ie. for quick and cryptic crosswords it will always be true, but for prize crosswords it will always be false (except in the case of a very late filing!).

You can see one consequence of this problem already: Prize crosswords' accessible pages all/mostly say "Sorry, solutions are not available for this puzzle yet", despite the day quoted for release of the solutions being in the past!

eg: (current date is 15th Nov)
![image](https://github.com/user-attachments/assets/13fc213c-1035-4deb-bc03-9dca51285465)

## The solution:

It would probably be best for consumers to check that the entries do contain solution data, or compare against the `dateSolutionAvailable` field. That said, since this field exists and removing would be complicated, it's probably best to make frontend also update the field when it is building its crossword data, after comparing `dateSolutionAvailable` to the current time, so this commit does exactly that.
