### PR TITLE
Add verification for bluesky

### DIFF
--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -18,6 +18,8 @@ GET        /.well-known/security.txt.asc                                        
 
 GET        /.well-known/amphtml/apikey.pub                                          controllers.FaciaController.ampRsaPublicKey()
 
+GET        /.well-known/atproto-did.txt                                             controllers.Assets.at(path="/public", file="atproto-did.txt")
+
 # AMP
 GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "")
 GET        /container/count/:count/offset/:offset/section/:section/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -18,7 +18,7 @@ GET        /.well-known/security.txt.asc                                        
 
 GET        /.well-known/amphtml/apikey.pub                                          controllers.FaciaController.ampRsaPublicKey()
 
-GET        /.well-known/atproto-did.txt                                             controllers.Assets.at(path="/public", file="atproto-did.txt")
+GET        /.well-known/atproto-did                                             controllers.Assets.at(path="/public", file="atproto-did.txt")
 
 # AMP
 GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "")

--- a/facia/public/atproto-did.txt
+++ b/facia/public/atproto-did.txt
@@ -1,0 +1,1 @@
+did:plc:vovinwhtulbsx4mwfw26r5ni


### PR DESCRIPTION
Adds the DID identifier of our Bluesky account (this is OK to be public) and routing.

Docs: https://blueskyweb.zendesk.com/hc/en-us/articles/19001802873101-How-to-Set-your-Domain-as-your-Handle