### PR TITLE
Adjust collection level logic to default to Primary

### DIFF
--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -41,12 +41,12 @@ object CollectionConfig {
     )
 
     /** Collection level is a concept that allows the platforms to style containers differently based on their "level"
-      * If there is a SecondaryLevel tag in the metadata, we set collectionLevel to "Secondary". Otherwise we default it
-      * to "Primary" for beta collections or leave as None for non beta (legacy) collections
+      * If there is a Secondary tag in the metadata, we set collectionLevel to "Secondary". Otherwise we default it to
+      * "Primary" for beta collections or leave as None for non beta (legacy) collections
       */
     val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {
-        case SecondaryLevel                                       => "Secondary"
+        case Secondary                                            => "Secondary"
         case _ if betaCollections.contains(config.collectionType) => "Primary"
       }
     }

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -29,7 +29,7 @@ object CollectionConfig {
 
   def make(config: fapi.CollectionConfig): CollectionConfig = {
 
-    val betaCollections = Array(
+    val betaCollections = List(
       "flexible/special",
       "flexible/general",
       "scrollable/highlights",
@@ -41,7 +41,8 @@ object CollectionConfig {
     )
 
     /** Collection level is a concept that allows the platforms to style containers differently based on their "level"
-      * If there is a SecondaryLevel tag in the metadata, we set collectionLevel to "Secondary". Otherwise we default it to "Primary" for beta collections or leave as None for non beta (legacy) collections
+      * If there is a SecondaryLevel tag in the metadata, we set collectionLevel to "Secondary". Otherwise we default it
+      * to "Primary" for beta collections or leave as None for non beta (legacy) collections
       */
     val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -29,14 +29,25 @@ object CollectionConfig {
 
   def make(config: fapi.CollectionConfig): CollectionConfig = {
 
+    val betaCollections = Array(
+      "flexible/special",
+      "flexible/general",
+      "scrollable/highlights",
+      "scrollable/small",
+      "scrollable/medium",
+      "scrollable/feature",
+      "static/medium/4",
+      "static/feature/2",
+    )
+
     /** Collection level is a concept that allows the platforms to style containers differently based on their "level"
-      * All containers will have a `primary` or `secondary` collection level based on the tags in the metadata. If there
-      * is a SecondaryLevel tag, we set collectionLevel to "Secondary". Otherwise, we default to "Primary".
+      * If there is a SecondaryLevel tag in the metadata, we set collectionLevel to "Secondary". Otherwise, we default
+      * the containerLevel for beta collections to "Primary".
       */
     val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {
-        case SecondaryLevel => "Secondary"
-        case _              => "Primary"
+        case SecondaryLevel                                       => "Secondary"
+        case _ if betaCollections.contains(config.collectionType) => "Primary"
       }
     }
 

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -41,8 +41,7 @@ object CollectionConfig {
     )
 
     /** Collection level is a concept that allows the platforms to style containers differently based on their "level"
-      * If there is a SecondaryLevel tag in the metadata, we set collectionLevel to "Secondary". Otherwise, we default
-      * the containerLevel for beta collections to "Primary".
+      * If there is a SecondaryLevel tag in the metadata, we set collectionLevel to "Secondary". Otherwise we default it to "Primary" for beta collections or leave as None for non beta (legacy) collections
       */
     val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -1,7 +1,7 @@
 package model.pressed
 
 import com.gu.facia.api.{models => fapi}
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata, CollectionPlatform, Primary, Secondary}
+import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata, CollectionPlatform, Secondary}
 
 final case class CollectionConfig(
     displayName: Option[String],

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -29,13 +29,14 @@ object CollectionConfig {
 
   def make(config: fapi.CollectionConfig): CollectionConfig = {
 
-    /** Extract `primary` or `secondary` collection level tag from metadata if present. Collection level is a concept
-      * that allows the platforms to style containers differently based on their "level"
+    /** Collection level is a concept that allows the platforms to style containers differently based on their "level"
+      * All containers will have a `primary` or `secondary` collection level based on the tags in the metadata. If there
+      * is a SecondaryLevel tag, we set collectionLevel to "Secondary". Otherwise, we default to "Primary".
       */
     val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
       metadataList.collectFirst {
-        case Primary   => "Primary"
-        case Secondary => "Secondary"
+        case SecondaryLevel => "Secondary"
+        case _              => "Primary"
       }
     }
 

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -40,15 +40,17 @@ object CollectionConfig {
       "static/feature/2",
     )
 
-    /** Collection level is a concept that allows the platforms to style containers differently based on their "level"
-      * If there is a Secondary tag in the metadata, we set collectionLevel to "Secondary". Otherwise we default it to
-      * "Primary" for beta collections or leave as None for non beta (legacy) collections
+    /** Collection level is a concept that allows the platforms to style containers differently based on their "level".
+      * Beta collections are "Secondary" if tagged as such or "Primary" otherwise. Legacy containers have no container
+      * level set.
       */
-    val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
-      metadataList.collectFirst {
-        case Secondary                                            => "Secondary"
-        case _ if betaCollections.contains(config.collectionType) => "Primary"
+    val collectionLevel: Option[String] = if (betaCollections.contains(config.collectionType)) {
+      config.metadata.getOrElse(List.empty).find(_ == Secondary) match {
+        case Some(_) => Some("Secondary")
+        case None    => Some("Primary")
       }
+    } else {
+      None
     }
 
     CollectionConfig(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "12.1.0"
+  val faciaVersion = "13.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
Also requires a facia scala client dependency bump when [this PR](https://github.com/guardian/facia-scala-client/pull/334) is released. 

## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
