### PR TITLE
Update UsaExpandableMarketingCard test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/usa-expandable-marketing-card.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/usa-expandable-marketing-card.js
@@ -1,7 +1,7 @@
 export const UsaExpandableMarketingCard = {
 	id: 'UsaExpandableMarketingCard',
-	start: '2024-10-02',
-	expiry: '2024-12-18',
+	start: '2024-11-18',
+	expiry: '2024-01-29',
 	author: 'dotcom.platform@guardian.co.uk',
 	description:
 		'Test the impact of showing the user a component that highlights the Guardians journalism.',
@@ -21,6 +21,10 @@ export const UsaExpandableMarketingCard = {
 		},
 		{
 			id: 'variant-bubble',
+			test: () => {},
+		},
+		{
+			id: 'variant-billionaire',
 			test: () => {},
 		},
 	],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/usa-expandable-marketing-card.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/usa-expandable-marketing-card.js
@@ -5,7 +5,7 @@ export const UsaExpandableMarketingCard = {
 	author: 'dotcom.platform@guardian.co.uk',
 	description:
 		'Test the impact of showing the user a component that highlights the Guardians journalism.',
-	audience: 15 / 100,
+	audience: 40 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'US-based users that see the US edition.',
 	successMeasure: 'Users are more likely to engage with the site.',


### PR DESCRIPTION
## What is the value of this and can you measure success?

We want to rerun this test with an extra variant.

## What does this change?

Adds a third variant to the UsaExpandableMarketingCard test
Updates date

Related DCR PR: https://github.com/guardian/dotcom-rendering/pull/12857