### PR TITLE
add gpid prebid switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -70,4 +70,14 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+  Switch(
+    ABTests,
+    "ab-gpid-prebid-ad-units",
+    "Test new GPID prebid ad units",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2024, 12, 18)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?
We would like to test the GPID added to ad units in sent to prebid.
## What does this change?
Adds a test switch for client side test `gpidPrebidAdUnits` see [here](https://github.com/guardian/commercial/pull/1651).


## Screenshot

http://localhost:9000/dev/switchboard
<img width="943" alt="Screenshot 2024-11-19 at 12 14 25" src="https://github.com/user-attachments/assets/829c2330-fff7-4a4e-b036-2bed3f0c00e9">

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
