### PR TITLE
Subnav changes

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -19,7 +19,7 @@ object NavLinks {
   val indigenousAustralia = NavLink("Indigenous Australia", "/australia-news/indigenous-australians")
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = Some("US news"))
-  val usElections2024 = NavLink("US elections 2024", "/us-news/us-elections-2024")
+  val usPolitics = NavLink("US politics", "/us-news/us-politics")
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")
@@ -279,16 +279,16 @@ object NavLinks {
     iconName = Some("home"),
     List(
       ukNews,
-      usElections2024,
+      usPolitics,
       world,
       climateCrisis,
+      middleEast,
       ukraine,
       football,
       newsletters,
       ukBusiness,
       ukEnvironment,
       politics,
-      education,
       society,
       science,
       tech,
@@ -317,9 +317,10 @@ object NavLinks {
   val usNewsPillar = ukNewsPillar.copy(children =
     List(
       usNews,
-      usElections2024,
+      usPolitics,
       world,
       usEnvironment,
+      middleEast,
       ukraine,
       usSoccer,
       usBusiness,
@@ -332,9 +333,10 @@ object NavLinks {
   val intNewsPillar = ukNewsPillar.copy(
     children = List(
       world,
-      usElections2024,
+      usPolitics,
       ukNews,
       climateCrisis,
+      middleEast,
       ukraine,
       ukEnvironment,
       science,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -88,8 +88,8 @@
 					"classList": []
 				},
 				{
-					"title": "US elections 2024",
-					"url": "/us-news/us-elections-2024",
+					"title": "US politics",
+					"url": "/us-news/us-politics",
 					"children": [],
 					"classList": []
 				},
@@ -160,6 +160,12 @@
 				{
 					"title": "Climate crisis",
 					"url": "/environment/climate-crisis",
+					"children": [],
+					"classList": []
+				},
+				{
+					"title": "Middle East",
+					"url": "/world/middleeast",
 					"children": [],
 					"classList": []
 				},
@@ -339,37 +345,6 @@
 					"title": "UK politics",
 					"url": "/politics",
 					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Education",
-					"url": "/education",
-					"children": [
-						{
-							"title": "Schools",
-							"url": "/education/schools",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Teachers",
-							"url": "/teacher-network",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Universities",
-							"url": "/education/universities",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Students",
-							"url": "/education/students",
-							"children": [],
-							"classList": []
-						}
-					],
 					"classList": []
 				},
 				{
@@ -1025,8 +1000,8 @@
 					"classList": []
 				},
 				{
-					"title": "US elections 2024",
-					"url": "/us-news/us-elections-2024",
+					"title": "US politics",
+					"url": "/us-news/us-politics",
 					"children": [],
 					"classList": []
 				},
@@ -1129,6 +1104,12 @@
 							"classList": []
 						}
 					],
+					"classList": []
+				},
+				{
+					"title": "Middle East",
+					"url": "/world/middleeast",
+					"children": [],
 					"classList": []
 				},
 				{
@@ -2510,8 +2491,8 @@
 					"classList": []
 				},
 				{
-					"title": "US elections 2024",
-					"url": "/us-news/us-elections-2024",
+					"title": "US politics",
+					"url": "/us-news/us-politics",
 					"children": [],
 					"classList": []
 				},
@@ -2599,6 +2580,12 @@
 				{
 					"title": "Climate crisis",
 					"url": "/environment/climate-crisis",
+					"children": [],
+					"classList": []
+				},
+				{
+					"title": "Middle East",
+					"url": "/world/middleeast",
 					"children": [],
 					"classList": []
 				},
@@ -3516,8 +3503,8 @@
 					"classList": []
 				},
 				{
-					"title": "US elections 2024",
-					"url": "/us-news/us-elections-2024",
+					"title": "US politics",
+					"url": "/us-news/us-politics",
 					"children": [],
 					"classList": []
 				},
@@ -3605,6 +3592,12 @@
 				{
 					"title": "Climate crisis",
 					"url": "/environment/climate-crisis",
+					"children": [],
+					"classList": []
+				},
+				{
+					"title": "Middle East",
+					"url": "/world/middleeast",
 					"children": [],
 					"classList": []
 				},


### PR DESCRIPTION
## What does this change?

Swaps Us Elections for Us Politics and adds Middle East (on all fronts). Closes #[#27623](https://github.com/guardian/frontend/issues/27623)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][]

[before]: https://github.com/user-attachments/assets/c9093116-6118-412c-a1a8-7574c50ac6af

[after]: https://github.com/user-attachments/assets/afc34579-2854-416d-9fe0-d52b9649e4ca




## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
