### PR TITLE
Add aspect ratio to frontend collection config

### DIFF
--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -23,7 +23,7 @@ final case class CollectionConfig(
     hideShowMore: Boolean,
     displayHints: Option[DisplayHints],
     platform: Option[CollectionPlatform] = None,
-    aspectRatio: String,
+    aspectRatio: Option[String],
 )
 
 object CollectionConfig {
@@ -76,7 +76,7 @@ object CollectionConfig {
       hideShowMore = config.hideShowMore,
       displayHints = config.displayHints.map(DisplayHints.make),
       platform = Some(config.platform),
-      aspectRatio = aspectRatio,
+      aspectRatio = Some(aspectRatio),
     )
   }
 

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -23,6 +23,7 @@ final case class CollectionConfig(
     hideShowMore: Boolean,
     displayHints: Option[DisplayHints],
     platform: Option[CollectionPlatform] = None,
+    aspectRatio: String,
 )
 
 object CollectionConfig {
@@ -53,6 +54,8 @@ object CollectionConfig {
       None
     }
 
+    val aspectRatio: String = fapi.CollectionConfig.AspectRatio.getAspectRatio(config.collectionType).label
+
     CollectionConfig(
       displayName = config.displayName,
       backfill = config.backfill,
@@ -73,6 +76,7 @@ object CollectionConfig {
       hideShowMore = config.hideShowMore,
       displayHints = config.displayHints.map(DisplayHints.make),
       platform = Some(config.platform),
+      aspectRatio = aspectRatio,
     )
   }
 

--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -54,7 +54,7 @@ object CollectionConfig {
       None
     }
 
-    val aspectRatio: String = fapi.CollectionConfig.AspectRatio.getAspectRatio(config.collectionType).label
+    val aspectRatio: String = fapi.CollectionConfig.getAspectRatio(config).label
 
     CollectionConfig(
       displayName = config.displayName,

--- a/common/test/common/facia/PressedCollectionBuilder.scala
+++ b/common/test/common/facia/PressedCollectionBuilder.scala
@@ -36,7 +36,7 @@ object PressedCollectionBuilder {
       showTimestamps = false,
       hideShowMore,
       displayHints = None,
-      aspectRatio = "5:3",
+      aspectRatio = Some(""),
     )
 
     PressedCollection(

--- a/common/test/common/facia/PressedCollectionBuilder.scala
+++ b/common/test/common/facia/PressedCollectionBuilder.scala
@@ -36,6 +36,7 @@ object PressedCollectionBuilder {
       showTimestamps = false,
       hideShowMore,
       displayHints = None,
+      aspectRatio = "5:3",
     )
 
     PressedCollection(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "13.1.0-PREVIEW.glaspect-ratio.2024-11-21T0922.ecaf8409"
+  val faciaVersion = "13.1.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.6.0"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % "12.2.0-PREVIEW.glaspect-ratio.2024-11-19T1531.f7f1aaba"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 
   /** There can only be one version of `scala-xml`. We will evict all v1.x

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "13.0.0"
+  val faciaVersion = "12.2.0-PREVIEW.glaspect-ratio.2024-11-19T1531.f7f1aaba"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -33,7 +33,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.6.0"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % "12.2.0-PREVIEW.glaspect-ratio.2024-11-19T1531.f7f1aaba"
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 
   /** There can only be one version of `scala-xml`. We will evict all v1.x

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "32.0.0"
-  val faciaVersion = "12.2.0-PREVIEW.glaspect-ratio.2024-11-19T1531.f7f1aaba"
+  val faciaVersion = "13.1.0-PREVIEW.glaspect-ratio.2024-11-21T0922.ecaf8409"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What is the value of this and can you measure success?

Part of this [fairground ticket](https://trello.com/c/EXKFyjhe/600-add-aspect-ratio-to-fronts-config-model)

Requires this [DCR PR](https://github.com/guardian/dotcom-rendering/pull/12878), as well as this [facia-scala-client ](https://github.com/guardian/facia-scala-client/pull/335/files) one which adds the logic to get the aspect ratio from the collection type. Once the facia scala client PR has been approved and the update released, I'll update this branch with the latest version of the library. 

Supports aspectRatio as an optional property in the frontend collection config. 

Deployed to code and, after relaunching the fairground front, checked we could see the value appear in the pressed json: 
<img width="361" alt="image" src="https://github.com/user-attachments/assets/34758f12-90ec-4620-865b-479927839469">

With the DCR PR, I could also see the expected value come through (rendered here through a div inserted on the front with the following: `<div>{collection.collectionType}, aspect ratio: {collection.aspectRatio}</div>`

<img width="335" alt="image" src="https://github.com/user-attachments/assets/2bc76a7c-b52b-4ce9-a8c9-d04ce6c6c249">

