### PR TITLE
Adjust logic for deriving collectionLevel from metadata

### DIFF
--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -40,15 +40,17 @@ object CollectionConfig {
       "static/feature/2",
     )
 
-    /** Collection level is a concept that allows the platforms to style containers differently based on their "level"
-      * If there is a Secondary tag in the metadata, we set collectionLevel to "Secondary". Otherwise we default it to
-      * "Primary" for beta collections or leave as None for non beta (legacy) collections
+    /** Collection level is a concept that allows the platforms to style containers differently based on their "level".
+      * Beta collections are "Secondary" if tagged as such or "Primary" otherwise. Legacy containers have no container
+      * level set.
       */
-    val collectionLevel: Option[String] = config.metadata.flatMap { metadataList =>
-      metadataList.collectFirst {
-        case Secondary                                            => "Secondary"
-        case _ if betaCollections.contains(config.collectionType) => "Primary"
+    val collectionLevel: Option[String] = if (betaCollections.contains(config.collectionType)) {
+      config.metadata.getOrElse(List.empty).find(_ == Secondary) match {
+        case Some(_) => Some("Secondary")
+        case None    => Some("Primary")
       }
+    } else {
+      None
     }
 
     CollectionConfig(


### PR DESCRIPTION
## What does this change?

When testing the `gl/collection-level` branch on CODE, it wasn't deriving the `"Primary"` collectionLevel value as expected.

This PR ensures that when `config.metadata` is `None` (ie the container has no tags set), it is treated appropriately and returns `"Primary"` rather than `None`

This PR also prevents the `"Secondary"` containerLevel from being applied to non beta collections, which is probably safer for now
