### PR TITLE
Revert "Add verification for bluesky"

### DIFF
--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -18,8 +18,6 @@ GET        /.well-known/security.txt.asc                                        
 
 GET        /.well-known/amphtml/apikey.pub                                          controllers.FaciaController.ampRsaPublicKey()
 
-GET        /.well-known/atproto-did                                             controllers.Assets.at(path="/public", file="atproto-did.txt")
-
 # AMP
 GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "")
 GET        /container/count/:count/offset/:offset/section/:section/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section)

--- a/facia/public/atproto-did.txt
+++ b/facia/public/atproto-did.txt
@@ -1,1 +1,0 @@
-did:plc:vovinwhtulbsx4mwfw26r5ni


### PR DESCRIPTION
Reverts guardian/frontend#27606

The DIDs for Bluesky are now verifiable as TXT records against our domain. This is easier than creating a subdomain for every sub-handle. We will remove the `well-known` DID file from frontend.

DIDs are recorded in [this sheet](https://docs.google.com/spreadsheets/d/1U2AD-7p9CmtMn8g-EzUYgvvBO6caYN0TrCqpP4o-7wo)

First we need to merge: guardian/platform#1641