### PR TITLE
Add onwards content article test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -55,7 +55,18 @@ trait ABTestSwitches {
     "Test the impact of showing the user a component that highlights the Guardians journalism",
     owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2024, 12, 18)),
+    sellByDate = Some(LocalDate.of(2025, 1, 29)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
+  Switch(
+    ABTests,
+    "ab-onwards-content-article",
+    "Test the impact of showing the galleries onwards content component on article pages",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 1, 29)),
     exposeClientSide = true,
     highImpact = false,
   )

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onwards-content-article.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onwards-content-article.js
@@ -1,0 +1,24 @@
+export const onwardsContentArticle = {
+	id: 'onwardsContentArticle',
+	start: '2024-11-25',
+	expiry: '2025-01-29',
+	author: 'dotcom.platform@guardian.co.uk',
+	description:
+		'Test the impact of showing the galleries onwards content component on article pages.',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Article pages',
+	successMeasure:
+		'Users are more likely to click a link in the onward content component.',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: () => {},
+		},
+		{
+			id: 'variant',
+			test: () => {},
+		},
+	],
+};


### PR DESCRIPTION
## What is the value of this and can you measure success?

In this AB test, success will be measured by whether users are more likely to click a link in the onwards content component.

## What does this change?

Adds a switch and an AB test for an experiment that will measure the impact of showing the galleries onwards content component on article pages.