### PR TITLE
Get All Of The Latest Crosswords For Editions

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -1,10 +1,17 @@
 package controllers
 
-import com.gu.contentapi.client.model.v1.CrosswordType.{Cryptic, Quick}
-import com.gu.contentapi.client.model.v1.{Crossword, ItemResponse, Content => ApiContent, Section => ApiSection}
+import com.gu.contentapi.client.model.v1.{
+  Crossword,
+  CrosswordType,
+  ItemResponse,
+  SearchResponse,
+  Content => ApiContent,
+  Section => ApiSection,
+}
 import common.{Edition, GuLogging, ImplicitControllerExecutionContext}
 import conf.Static
 import contentapi.ContentApiClient
+import com.gu.contentapi.client.model.SearchQuery
 import crosswords.{
   AccessibleCrosswordPage,
   AccessibleCrosswordRows,
@@ -304,21 +311,35 @@ class CrosswordEditionsController(
   def digitalEdition: Action[AnyContent] = Action.async { implicit request =>
     getCrosswords
       .map(parseCrosswords)
-      .flatMap {
-        case Some(crosswordPage) =>
-          remoteRenderer.getEditionsCrossword(wsClient, crosswordPage)
-        case None => Future.successful(NotFound)
+      .flatMap { crosswords =>
+        remoteRenderer.getEditionsCrossword(wsClient, crosswords)
       }
   }
 
-  private lazy val crosswordsQuery = contentApiClient.item("crosswords")
+  private def getCrosswords: Future[SearchResponse] =
+    contentApiClient.getResponse(crosswordsQuery)
 
-  private def getCrosswords: Future[ItemResponse] = contentApiClient.getResponse(crosswordsQuery)
+  /** Search for playable crosswords sorted by print publication date. This will exclude older, originally print-only
+    * crosswords that happen to have been re-published in a digital format recently.
+    */
+  private lazy val crosswordsQuery =
+    SearchQuery()
+      .tag(crosswordTags)
+      .useDate("newspaper-edition")
+      .pageSize(20)
 
-  private def parseCrosswords(response: ItemResponse): Option[EditionsCrosswordRenderingDataModel] =
-    for {
-      results <- response.results
-      quick <- results.find(_.crossword.exists(_.`type` == Quick)).flatMap(_.crossword)
-      cryptic <- results.find(_.crossword.exists(_.`type` == Cryptic)).flatMap(_.crossword)
-    } yield EditionsCrosswordRenderingDataModel(quick, cryptic)
+  private lazy val crosswordTags = Seq(
+    "crosswords/series/quick",
+    "crosswords/series/cryptic",
+    "crosswords/series/prize",
+    "crosswords/series/weekend-crossword",
+    "crosswords/series/quick-cryptic",
+    "crosswords/series/everyman",
+    "crosswords/series/speedy",
+    "crosswords/series/quiptic",
+  ).mkString("|")
+
+  private def parseCrosswords(response: SearchResponse): EditionsCrosswordRenderingDataModel =
+    EditionsCrosswordRenderingDataModel.fromContent(response.results)
+
 }

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -1,20 +1,37 @@
 package model.dotcomrendering.pageElements
 
-import com.gu.contentapi.client.model.v1.Crossword
+import com.gu.contentapi.client.model.v1.{Content, Crossword}
 import com.gu.contentapi.json.CirceEncoders._
 import io.circe.JsonObject
 import io.circe.syntax._
+import scala.Function.{const, uncurried}
 
 case class EditionsCrosswordRenderingDataModel(
-    quick: Crossword,
-    cryptic: Crossword,
+    crosswords: Iterable[Crossword],
 )
 
 object EditionsCrosswordRenderingDataModel {
   def toJson(model: EditionsCrosswordRenderingDataModel): String = {
     JsonObject(
-      "quick" -> model.quick.asJson.dropNullValues,
-      "cryptic" -> model.cryptic.asJson.dropNullValues,
-    ).asJson.dropNullValues.noSpaces
+      "crosswords" -> model.crosswords.map(_.asJson.dropNullValues).asJson,
+    ).asJson.noSpaces
+  }
+
+  /** Takes a list of CAPI content and filters it to get a maximum of one of each type of crossword. Each crossword
+    * selected will be the earliest of its type in the list. In other words, if the most recent of each type of
+    * crossword is required then the CAPI content must be ordered by "newest".
+    *
+    * @param content
+    *   Some CAPI content containing crosswords
+    */
+  def fromContent(content: Iterable[Content]): EditionsCrosswordRenderingDataModel = {
+    val firstOfEach =
+      content
+        .flatMap(_.crossword)
+        // Group by type of crossword, then take the first in the group
+        .groupMapReduce(_.`type`)(identity)(uncurried(const))
+        .values
+
+    EditionsCrosswordRenderingDataModel(firstOfEach)
   }
 }

--- a/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
@@ -1,0 +1,40 @@
+package model.dotcomrendering
+
+import com.gu.contentapi.client.model.v1.{Content, Crossword, CrosswordType}
+import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
+import org.mockito.Mockito.when
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers with MockitoSugar {
+  "fromContent" should "get the first of each type of crossword" in {
+    val mockQuickCrossword = mock[Crossword]
+    when(mockQuickCrossword.`type`) thenReturn CrosswordType.Quick
+    val mockQuickCrosswordContent = mock[Content]
+    when(mockQuickCrosswordContent.crossword) thenReturn Some(mockQuickCrossword)
+
+    val mockCrypticCrossword = mock[Crossword]
+    when(mockCrypticCrossword.`type`) thenReturn CrosswordType.Cryptic
+    val mockCrypticCrosswordContent = mock[Content]
+    when(mockCrypticCrosswordContent.crossword) thenReturn Some(mockCrypticCrossword)
+
+    val mockCrosswords = Seq(
+      mockQuickCrosswordContent,
+      mockQuickCrosswordContent,
+      mockQuickCrosswordContent,
+      mockCrypticCrosswordContent,
+      mockCrypticCrosswordContent,
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel
+        .fromContent(mockCrosswords)
+        .crosswords
+        .toSeq
+
+    crosswords.length shouldEqual 2
+    crosswords(0).`type` shouldBe CrosswordType.Quick
+    crosswords(1).`type` shouldBe CrosswordType.Cryptic
+  }
+}


### PR DESCRIPTION
Update the editions crossword endpoint to search for all types of recent playable crosswords. Send the most recent instance of each type of crossword to DCAR.

**Note:** The DCAR endpoint will need to be updated to accept the change in the type being sent.
