### PR TITLE
Bump commercial to 23.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^10.0.27",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial": "23.7.2",
+		"@guardian/commercial": "23.7.3",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3607,9 +3607,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial@npm:23.7.2":
-  version: 23.7.2
-  resolution: "@guardian/commercial@npm:23.7.2"
+"@guardian/commercial@npm:23.7.3":
+  version: 23.7.3
+  resolution: "@guardian/commercial@npm:23.7.3"
   dependencies:
     "@guardian/prebid.js": "npm:8.52.0-8"
     "@octokit/core": "npm:^6.1.2"
@@ -3626,7 +3626,7 @@ __metadata:
     "@guardian/libs": ^19.1.0
     "@guardian/source": ^8.0.0
     typescript: ~5.5.3
-  checksum: 10c0/bdf9180e0f21be2571e406c307ba4d8d5af343eccbc07ad1c81fd1124f670f87cf7ac1233f9695ee87af36ed09b747acd08fe78ff5b61a3c31cb74d1a907e5f9
+  checksum: 10c0/96d76b6ebb1479a48d574ebd22f062875d00832252e21ba6aa1edc5f4f7df458dfe220898907dc73c4a4839dfdce2c73b0d83860239ebd5086d43880fe0b204f
   languageName: node
   linkType: hard
 
@@ -3699,7 +3699,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^10.0.27"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial": "npm:23.7.2"
+    "@guardian/commercial": "npm:23.7.3"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"


### PR DESCRIPTION
## What does this change?
Bumps commercial to bring in the changes from [23.7.3](https://github.com/guardian/commercial/releases/tag/v23.7.3) and the change [here](https://github.com/guardian/commercial/pull/1676).
