### PR TITLE
Replace collections on `europe` front if participating in the Europe beta test

### DIFF
--- a/common/test/helpers/FaciaTestData.scala
+++ b/common/test/helpers/FaciaTestData.scala
@@ -70,6 +70,22 @@ trait FaciaTestData extends ModelHelper {
       "/commentisfree/2013/oct/07/feminism-rebranding-man-hater",
     )
 
+  val europeFrontTrailIds: Seq[String] = Seq(
+    "/world/2024/nov/27/plan-to-cut-berlin-arts-budget-will-destroy-citys-culture-directors-warn",
+    "/stage/2024/nov/27/afd-threats-to-german-democracy-on-stage-maximilian-steinbeis-a-citizen-of-the-people",
+    "/commentisfree/2024/nov/27/france-cannabis-consumption-europe-tax-decriminalisation-crime",
+    "/football/2024/nov/27/bodo-glimt-manchester-united-europa-league",
+    "/books/2024/nov/26/freedom-by-angela-merkel-review-settling-scores-with-silence",
+  )
+
+  val europeBetaFrontTrailIds: Seq[String] = Seq(
+    "/business/2024/nov/27/just-eat-to-delist-from-london-stock-exchange-to-cut-complexity-and-costs",
+    "/world/2024/nov/26/uk-labour-cabinet-ministers-sanctions-russia-storm-shadow-missiles",
+    "/business/2024/nov/27/fining-budget-airlines-will-make-flying-more-expensive-says-easyjet-boss",
+    "/world/2024/nov/26/irish-pm-simon-harris-slump-drops-points-polls-election-fine-gael",
+    "/commentisfree/2024/nov/25/the-guardian-view-on-romanias-presidential-election-a-stable-ukrainian-ally-wobblese",
+  )
+
   val cultureTrailIds: Seq[String] =
     Seq(
       "/film/2013/oct/08/gravity-science-astrophysicist",
@@ -82,6 +98,8 @@ trait FaciaTestData extends ModelHelper {
   val ukFrontTrails: Seq[PressedContent] = ukFrontTrailIds map TestContent.newFaciaContent
   val usFrontTrails: Seq[PressedContent] = usFrontTrailIds map TestContent.newFaciaContent
   val auFrontTrails: Seq[PressedContent] = auFrontTrailIds map TestContent.newFaciaContent
+  val europeFrontTrails: Seq[PressedContent] = europeFrontTrailIds map TestContent.newFaciaContent
+  val europeBetaFrontTrails: Seq[PressedContent] = europeBetaFrontTrailIds map TestContent.newFaciaContent
 
   val cultureFrontTrails: Seq[PressedContent] = cultureTrailIds map TestContent.newFaciaContent
 
@@ -168,6 +186,64 @@ trait FaciaTestData extends ModelHelper {
         config = CollectionConfig.empty,
         hasMore = false,
         targetedTerritory = None,
+      ),
+    ),
+  )
+
+  val europeFaciaPage: PressedPage = PressedPage(
+    id = "europe",
+    SeoData.fromPath("europe"),
+    FrontProperties.empty,
+    collections = List(
+      PressedCollection(
+        id = "europe/news/regular-stories",
+        displayName = "",
+        curated = europeFrontTrails.toList,
+        backfill = Nil,
+        treats = Nil,
+        lastUpdated = None,
+        href = None,
+        description = None,
+        collectionType = "",
+        groups = None,
+        uneditable = false,
+        showTags = false,
+        showSections = false,
+        hideKickers = false,
+        showDateHeader = false,
+        showLatestUpdate = false,
+        config = CollectionConfig.empty,
+        hasMore = false,
+        targetedTerritory = None,
+      ),
+    ),
+  )
+
+  val europeBetaFaciaPageWithTargetedTerritory: PressedPage = PressedPage(
+    id = "europe-beta",
+    SeoData.fromPath("europe-beta"),
+    FrontProperties.empty,
+    collections = List(
+      PressedCollection(
+        id = "europe-beta/news/regular-stories",
+        displayName = "",
+        curated = europeBetaFrontTrails.toList,
+        backfill = Nil,
+        treats = Nil,
+        lastUpdated = None,
+        href = None,
+        description = None,
+        collectionType = "",
+        groups = None,
+        uneditable = false,
+        showTags = false,
+        showSections = false,
+        hideKickers = false,
+        showDateHeader = false,
+        showLatestUpdate = false,
+        config = CollectionConfig.empty,
+        hasMore = false,
+        targetedTerritory = Some(EU27Territory),
       ),
     ),
   )
@@ -334,6 +410,8 @@ trait FaciaTestData extends ModelHelper {
     ("uk", new TestPageFront("uk", Uk, ukFaciaPage)),
     ("us", new TestPageFront("us", Us, usFaciaPage)),
     ("au", new TestPageFront("au", Au, auFaciaPage)),
+    ("europe", new TestPageFront("europe", Au, europeFaciaPage)),
+    ("europe-beta", new TestPageFront("europe-beta", Au, europeBetaFaciaPageWithTargetedTerritory)),
     ("uk/culture", new TestPageFront("uk/culture", Uk, ukCultureFaciaPage)),
     ("us/culture", new TestPageFront("us/culture", Us, usCultureFaciaPage)),
     ("au/culture", new TestPageFront("au/culture", Au, auCultureFaciaPage)),

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -277,12 +277,12 @@ import scala.concurrent.{Await, Future}
     val result = faciaController invokePrivate replaceFaciaPageCollections(europePage, europeBetaPage)
     val (resultPressedPage, targetedTerritories) = result.get
     // The page metadata should remain unchanged
+    resultPressedPage.id should be("europe")
     resultPressedPage.id should not be "europe-beta"
     // The collections should come from the replacement page not the original page
     resultPressedPage.collections.exists(_ == europeBetaFaciaPageWithTargetedTerritory.collections(0)) should be(true)
     resultPressedPage.collections.exists(_ == europeFaciaPage.collections(0)) should be(false)
     // The value for targetedTerritories should come from the page with replacement collections
     targetedTerritories should be(true)
-
   }
 }

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -4,9 +4,12 @@ import agents.{DeeplyReadAgent, MostViewedAgent}
 import com.fasterxml.jackson.core.JsonParseException
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import common.editions.{Uk, Us}
+import common.facia.FixtureBuilder
 import controllers.{Assets, FaciaControllerImpl}
+import experiments.{ActiveExperiments, EuropeBetaFront, ParticipationGroups}
 import helpers.FaciaTestData
 import implicits.FakeRequests
+import model.{FrontProperties, PressedPage, SeoData}
 import org.mockito.Matchers.{any, anyString}
 import org.mockito.Mockito.when
 import org.scalatest._
@@ -35,7 +38,8 @@ import scala.concurrent.{Await, Future}
     with MockitoSugar
     with WithTestFrontJsonFapi
     with WithTestContentApiClient
-    with WithAssets {
+    with WithAssets
+    with PrivateMethodTester {
 
   lazy val wsClient = mockWsResponse()
 
@@ -87,6 +91,7 @@ import scala.concurrent.{Await, Future}
           "uk" -> frontJson,
           "au/media" -> frontJson,
           "email/uk/daily" -> frontJson,
+          "europe" -> frontJson,
         ),
         collections = Map.empty,
       ),
@@ -256,5 +261,28 @@ import scala.concurrent.{Await, Future}
     val result = faciaController.renderFront("uk")(fakeRequest)
     status(result) should be(200)
     header("X-GU-Dotcomponents", result) should be(None)
+  }
+
+  "FaciaController.replaceFaciaPageCollections" should "replace the collections of a pressed page with those on another pressed page" in {
+    val europePage: Option[(PressedPage, Boolean)] = Some(
+      europeFaciaPage,
+      false,
+    )
+    val europeBetaPage: Option[(PressedPage, Boolean)] = Some(
+      europeBetaFaciaPageWithTargetedTerritory,
+      true,
+    )
+    val replaceFaciaPageCollections =
+      PrivateMethod[Option[(PressedPage, Boolean)]](Symbol("replaceFaciaPageCollections"))
+    val result = faciaController invokePrivate replaceFaciaPageCollections(europePage, europeBetaPage)
+    val (resultPressedPage, targetedTerritories) = result.get
+    // The page metadata should remain unchanged
+    resultPressedPage.id should not be "europe-beta"
+    // The collections should come from the replacement page not the original page
+    resultPressedPage.collections.exists(_ == europeBetaFaciaPageWithTargetedTerritory.collections(0)) should be(true)
+    resultPressedPage.collections.exists(_ == europeFaciaPage.collections(0)) should be(false)
+    // The value for targetedTerritories should come from the page with replacement collections
+    targetedTerritories should be(true)
+
   }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Setting up phase 2 of the [Europe beta experiment test plan](https://docs.google.com/document/d/16qPJsPU5efUppLXfR54k4euVacqvSXcCyhgE44BIFqM/edit?usp=sharing) to show the containers on the Europe beta front instead of those on the Europe front for users participating in the test:

- If a user requests the `europe` front
  - and is participating in the test, the `europe` front is returned with the collections swapped out for the ones on the hidden `europe-beta` front
  - and is not participating in the test, the `europe` collections are returned as usual.

- If a user requests any other front and is either participating or not participating in the Europe beta test, the collections configured for that front are unchanged.

_Table to demonstrate the above logic:_

| front requested | in test | not in test |
| ----- | ----- | ----- |
| `europe` | `europe` front with `europe-beta` collections | `europe` front with `europe` collections | 
| `europe-beta` | 404 not found | 404 not found | 
| `uk` | `uk` front with `uk` collections | `uk` front with `uk` collections |

[Trello ticket link](https://trello.com/c/rekHrkBX/748-configure-europe-beta-front-in-web)

## What does this change?

Adjusts the logic in `renderFrontPressResult` for fetching the `futureFaciaPage` to swap the collections returned in the response if a user is participating in the Europe beta test and they are requesting the Europe front.

All other fields remain the same apart from `collections` which returns those on the hidden `europe-beta` front instead of the usual collections returned from the `europe` front.



## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### How to test

- Deploy to the `CODE` environment
- Head to the [`/europe`](https://code.dev-theguardian.com/europe) page
  - Take note of the containers on the page
- Opt in to the Europe beta experiment (https://code.dev-theguardian.com/opt/in/europe-beta-front)
- Reload the page
  - This should have different containers configured to appear on the page
- Opt out of the Europe beta experiment (https://code.dev-theguardian.com/opt/out/europe-beta-front)
- Reload the page
  - You should see the original containers configured for the Europe front 