### PR TITLE
Change Editions Crosswords Query

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -4,17 +4,30 @@ import com.gu.contentapi.client.model.v1.Crossword
 import com.gu.contentapi.json.CirceEncoders._
 import io.circe.JsonObject
 import io.circe.syntax._
+import implicits.Dates.CapiRichDateTime
 
 case class EditionsCrosswordRenderingDataModel(
-    quick: Crossword,
-    cryptic: Crossword,
+    crosswords: Iterable[Crossword],
 )
 
 object EditionsCrosswordRenderingDataModel {
+  def apply(crosswords: Iterable[Crossword]): EditionsCrosswordRenderingDataModel =
+    new EditionsCrosswordRenderingDataModel(crosswords.map(crossword => {
+      val shipSolutions =
+        crossword.dateSolutionAvailable
+          .map(_.toJoda.isBeforeNow)
+          .getOrElse(crossword.solutionAvailable)
+
+      if (shipSolutions) {
+        crossword
+      } else {
+        crossword.copy(entries = crossword.entries.map(_.copy(solution = None)))
+      }
+    }))
+
   def toJson(model: EditionsCrosswordRenderingDataModel): String = {
     JsonObject(
-      "quick" -> model.quick.asJson.dropNullValues,
-      "cryptic" -> model.cryptic.asJson.dropNullValues,
-    ).asJson.dropNullValues.noSpaces
+      "crosswords" -> model.crosswords.asJson.deepDropNullValues,
+    ).asJson.noSpaces
   }
 }

--- a/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
@@ -1,0 +1,96 @@
+package model.dotcomrendering
+
+import com.gu.contentapi.client.model.v1.{CapiDateTime, Crossword, CrosswordType, CrosswordDimensions, CrosswordEntry}
+import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
+import org.mockito.Mockito.when
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import org.joda.time.DateTime
+
+class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers with MockitoSugar {
+  val mockEntry = CrosswordEntry(
+    id = "mockId",
+    solution = Some("Mock solution"),
+  )
+
+  val mockCrossword = Crossword(
+    name = "Mock name",
+    `type` = CrosswordType.Quick,
+    number = 1,
+    date = CapiDateTime(DateTime.now().getMillis(), "date"),
+    dimensions = CrosswordDimensions(1, 1),
+    entries = Seq(mockEntry, mockEntry),
+    solutionAvailable = true,
+    hasNumbers = false,
+    randomCluesOrdering = false,
+  )
+
+  "apply" should "provide solutions when 'dateSolutionAvailable' is in the past" in {
+    val crossword = mockCrossword.copy(
+      solutionAvailable = true,
+      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().minusDays(1).getMillis(), "date")),
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword))
+        .crosswords
+        .toSeq
+
+    crosswords(0).entries(0).solution shouldBe Some("Mock solution")
+    crosswords(0).entries(1).solution shouldBe Some("Mock solution")
+    crosswords(1).entries(0).solution shouldBe Some("Mock solution")
+    crosswords(1).entries(1).solution shouldBe Some("Mock solution")
+  }
+
+  "apply" should "provide solutions when 'dateSolutionAvailable' is 'None' and solutionAvailable is 'true'" in {
+    val crossword = mockCrossword.copy(
+      solutionAvailable = true,
+      dateSolutionAvailable = None,
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword))
+        .crosswords
+        .toSeq
+
+    crosswords(0).entries(0).solution shouldBe Some("Mock solution")
+    crosswords(0).entries(1).solution shouldBe Some("Mock solution")
+    crosswords(1).entries(0).solution shouldBe Some("Mock solution")
+    crosswords(1).entries(1).solution shouldBe Some("Mock solution")
+  }
+
+  "apply" should "not provide solutions when 'dateSolutionAvailable' is in the future" in {
+    val crossword = mockCrossword.copy(
+      solutionAvailable = true,
+      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().plusDays(1).getMillis(), "date")),
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword))
+        .crosswords
+        .toSeq
+    
+    crosswords(0).entries(0).solution shouldBe None
+    crosswords(0).entries(1).solution shouldBe None
+    crosswords(1).entries(0).solution shouldBe None
+    crosswords(1).entries(1).solution shouldBe None
+  }
+
+  "apply" should "not provide solutions when 'dateSolutionAvailable' is 'None' and solutionAvailable is 'false'" in {
+    val crossword = mockCrossword.copy(
+      solutionAvailable = false,
+      dateSolutionAvailable = None,
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword))
+        .crosswords
+        .toSeq
+
+    crosswords(0).entries(0).solution shouldBe None
+    crosswords(0).entries(1).solution shouldBe None
+    crosswords(1).entries(0).solution shouldBe None
+    crosswords(1).entries(1).solution shouldBe None
+  }
+}

--- a/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
@@ -33,9 +33,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     )
 
     val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword))
-        .crosswords
-        .toSeq
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword)).crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe Some("Mock solution")
     crosswords(0).entries(1).solution shouldBe Some("Mock solution")
@@ -50,9 +48,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     )
 
     val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword))
-        .crosswords
-        .toSeq
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword)).crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe Some("Mock solution")
     crosswords(0).entries(1).solution shouldBe Some("Mock solution")
@@ -67,10 +63,8 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     )
 
     val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword))
-        .crosswords
-        .toSeq
-    
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword)).crosswords.toSeq
+
     crosswords(0).entries(0).solution shouldBe None
     crosswords(0).entries(1).solution shouldBe None
     crosswords(1).entries(0).solution shouldBe None
@@ -84,9 +78,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     )
 
     val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword))
-        .crosswords
-        .toSeq
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword)).crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe None
     crosswords(0).entries(1).solution shouldBe None


### PR DESCRIPTION
We'd like to send a list of crosswords to DCAR, so this changes the structure of the data model. It also applies some of the solutions logic used in the similar `CrosswordData` model, widens the types of crosswords requested, and switches to a more specific CAPI search query. Note that it uses the CAPI client's `SearchQuery` directly rather than frontend's `contentApiClient.search`, as that includes a number of fields we don't need here.
