### PR TITLE
Update styling for "The Filter" thrasher form

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -316,6 +316,18 @@
     }
 }
 
+.email-sub__form--thrasher-the-filter {
+    .email-sub__thrasher-embed-label {
+        color: #121212;
+    }
+
+    .email-sub__thrasher-embed-button {
+        background-color: $news-dark;
+        color: $brightness-100;
+        fill: $brightness-100;
+    }
+}
+
 .email-sub__thrasher-embed-icon {
     display: inline-flex;
     height: 100%;


### PR DESCRIPTION
## What is the value of this and can you measure success?
Change colors for form rendered by https://www.theguardian.com/email/form/thrasher/the-filter

## What does this change?

label colors for `.email-sub__form---the-filter`

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2024-11-26 at 10 06 27](https://github.com/user-attachments/assets/237c54ff-3a2c-4722-a82a-902586827e03) | TODO |

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
