### PR TITLE
Add `FaciaPage` case class to `FaciaController`

### DIFF
--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -8,7 +8,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import helpers.FaciaTestData
-import test.FaciaControllerTest
 import model.facia.PressedCollection
 import layout.slices.EmailLayouts
 


### PR DESCRIPTION
## What does this change?

A small refactor to add the case class `FaciaPage` to `FaciaController`

Primarily so we can use named properties to make the purpose of `hasTargetedCollections` clearer where it's used rather than a tuple containing true or false.





