### PR TITLE
Extend front container show/hide switch and reassign owner

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -567,9 +567,9 @@ trait FeatureSwitches {
     group = SwitchGroup.Feature,
     name = "disable-front-container-show-hide",
     description = "For users with no currently hidden containers on a front, removes the ability to hide containers",
-    owners = Seq(Owner.withGithub("cemms1")),
+    owners = Seq(Owner.withEmail("project.fairground@theguardian.com")),
     safeState = On,
-    sellByDate = LocalDate.of(2024, 11, 29),
+    sellByDate = LocalDate.of(2025, 2, 4),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

- Revives the expired switch `DisableFrontContainerShowHide`

## What does this change?


- Extends the life of the show/hide switch for front containers until Feb 2025
- Reassigns the switch owner from an individual (me) to the Fairground group email
