### PR TITLE
Add Test Summary To CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,12 @@ jobs:
           -DAPP_SECRET="fake_secret" \
           -Duser.timezone=Australia/Sydney \
           -jar ./bin/sbt-launch.jar clean compile assets scalafmtCheckAll test Universal/packageBin
+      
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "test-results/**/TEST-*.xml"
+        if: always()
 
       - uses: guardian/actions-riff-raff@v4
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ static/src/stylesheets/pasteup/.npmrc
 metals.sbt
 
 .java-version
+test-results/

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -55,8 +55,7 @@ object ProjectSettings {
   def testStage = if (isCi) "DEVINFRA" else "LOCALTEST"
 
   val frontendTestSettings = Seq(
-    // Use ScalaTest https://groups.google.com/d/topic/play-framework/rZBfNoGtC0M/discussion
-    Test / testOptions := Nil,
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o"),
     concurrentRestrictions in Global := List(Tags.limit(Tags.Test, 4)),
     // Copy unit test resources https://groups.google.com/d/topic/play-framework/XD3X6R-s5Mc/discussion
     Test / unmanagedClasspath += (baseDirectory map { bd => Attributed.blank(bd / "test") }).value,


### PR DESCRIPTION
## Why?

Currently when Scala tests fail in CI we have to look through thousands of lines of logs to see what the single failing test is and why it failed. It would be nice to have a summary surfaced to us in the GitHub UI instead, which is something we have available on other projects like:

- `redirect-resolver`: https://github.com/guardian/redirect-resolver/blob/7b322ea1fbd749dcd784b962a201b22c9eee0a85/.github/workflows/ci.yml#L20-L26
- `prout`: https://github.com/guardian/prout/commit/a35f793d93f7d8521ce5419fd4aded7ace8ffa4c

## Changes

Updated our test config to output test summary files. Added a step to the `build` workflow in GitHub actions to read from these files and output a summary in the GitHub UI.

Paired with @rtyley 

Tested on #27641 with GH actions workflow run: https://github.com/guardian/frontend/actions/runs/12145042827

![test-summary](https://github.com/user-attachments/assets/c39344ea-67c2-4c13-84c8-44e50c7ba9f9)
