### PR TITLE
Editions crossword json route

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -24,6 +24,7 @@ import html.HtmlPageHelpers.ContentCSSFile
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
+import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel.toJson
 import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import org.joda.time.{DateTime, LocalDate}
 import pages.{CrosswordHtmlPage, IndexHtmlPage, PrintableCrosswordHtmlPage}
@@ -312,6 +313,14 @@ class CrosswordEditionsController(
       .map(parseCrosswords)
       .flatMap { crosswords =>
         remoteRenderer.getEditionsCrossword(wsClient, crosswords)
+      }
+  }
+
+  def digitalEditionJson: Action[AnyContent] = Action.async { implicit request =>
+    getCrosswords
+      .map(parseCrosswords)
+      .map { crosswords =>
+        Cached(CacheTime.Default)(RevalidatableResult.Ok(toJson(crosswords))).as("application/json")
       }
   }
 

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -29,6 +29,7 @@ GET        /crosswords/lookup                                                   
 
 # Crosswords digital edition
 GET        /crosswords/digital-edition                                                                                        controllers.CrosswordEditionsController.digitalEdition
+GET        /crosswords/digital-edition.json                                                                                   controllers.CrosswordEditionsController.digitalEditionJson
 
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -31,6 +31,7 @@ GET            /crosswords/lookup                                               
 
 # Crosswords digital edition
 GET        /crosswords/digital-edition                                                                                        controllers.CrosswordEditionsController.digitalEdition
+GET        /crosswords/digital-edition.json                                                                                 controllers.CrosswordEditionsController.digitalEditionJson
 
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)


### PR DESCRIPTION
## What is the value of this and can you measure success?
Introduces a new JSON route for serving crossword data for editions

## What does this change?
Part of https://github.com/guardian/dotcom-rendering/issues/12801

