### PR TITLE
Hide the second tier of most popular (most commented/shared)

### DIFF
--- a/static/src/stylesheets/module/_most-popular.scss
+++ b/static/src/stylesheets/module/_most-popular.scss
@@ -208,11 +208,12 @@
 }
 
 .most-popular__second-tier {
+    display: none;
     margin-top: $gs-baseline * 2;
 
     @include mq(tablet) {
         border-top: 1px solid $brightness-86;
-        display: flex !important;
+        display: none;
     }
 }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

CSS in frontend scares me, but this looks to be the right place to add a display none to hide the most commented and most shared sections in the most popular component: they were [removed from DCR ](https://github.com/guardian/dotcom-rendering/pull/10129)earlier in the year, and it looks like we intended to do the same in frontend. 

I opted for display none rather than removing chunks of code. Again, css in frontend scares me and is not something we do anymore anyway, so I wanted to find a fast and simple way that would feel the least impactful if it caused an issue. Better suggestions welcome though.

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]:https://github.com/user-attachments/assets/e9a62516-76d4-4452-ba11-5a2f0905ab92
[after]:https://github.com/user-attachments/assets/286b2a40-de4b-4f86-8100-d5b783131f1f



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
