### PR TITLE
Add DCR JSON support to the football/live endpoint 

### DIFF
--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -36,17 +36,18 @@ trait MatchListController extends BaseController with Requests {
           pageType = matchesList.pageType,
           matchesList = DotcomRenderingFootballDataModel.getMatchesList(matchesList.matchesGroupedByDateAndCompetition),
           nextPage = matchesList.nextPage,
+          previousPage = matchesList.previousPage,
         )
 
         JsonComponent.fromWritable(model)
-      } else if (request.isJson) {
+      } else if (request.isJson)
         JsonComponent(
           "html" -> football.views.html.matchList.matchesComponent(matchesList),
           "next" -> Html(matchesList.nextPage.getOrElse("")),
           "previous" -> Html(matchesList.previousPage.getOrElse("")),
           "atom" -> atom.isDefined,
         )
-      } else
+      else
         RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters, atom))
     }
   }

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -35,6 +35,7 @@ trait MatchListController extends BaseController with Requests {
           pageTitle = matchesList.getPageTitle(Edition(request)),
           pageType = matchesList.pageType,
           matchesList = DotcomRenderingFootballDataModel.getMatchesList(matchesList.matchesGroupedByDateAndCompetition),
+          nextPage = matchesList.nextPage,
         )
 
         JsonComponent.fromWritable(model)

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -32,8 +32,6 @@ trait MatchListController extends BaseController with Requests {
     Cached(10) {
       if (request.isJson && request.forceDCR) {
         val model = DotcomRenderingFootballDataModel(
-          pageTitle = matchesList.getPageTitle(Edition(request)),
-          pageType = matchesList.pageType,
           matchesList = DotcomRenderingFootballDataModel.getMatchesList(matchesList.matchesGroupedByDateAndCompetition),
           nextPage = matchesList.nextPage,
           previousPage = matchesList.previousPage,

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -2,10 +2,10 @@ package football.controllers
 
 import common.{Edition, JsonComponent}
 import feed.Competitions
-import football.model.MatchesList
+import football.model.{CompetitionMatches, DateCompetitionMatches, MatchesList, LiveScores}
 import implicits.Requests
 import model.Cached.RevalidatableResult
-import model.{ApplicationContext, Cached, Competition, TeamMap}
+import model.{ApplicationContext, CacheTime, Cached, Competition, TeamMap}
 
 import java.time.LocalDate
 import pa.FootballTeam
@@ -28,17 +28,31 @@ trait MatchListController extends BaseController with Requests {
       filters: Map[String, Seq[CompetitionFilter]],
       atom: Option[InteractiveAtom] = None,
   )(implicit request: RequestHeader, context: ApplicationContext) = {
-    Cached(10) {
-      if (request.isJson)
-        JsonComponent(
-          "html" -> football.views.html.matchList.matchesComponent(matchesList),
-          "next" -> Html(matchesList.nextPage.getOrElse("")),
-          "previous" -> Html(matchesList.previousPage.getOrElse("")),
-          "atom" -> atom.isDefined,
-        )
-      else
-        RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters, atom))
+
+    if (request.isJson && request.forceDCR) {
+      val model = LiveScores(
+        pageTitle = matchesList.getPageTitle(Edition(request)),
+        pageType = matchesList.pageType,
+        matchesGroupedByDateAndCompetition = matchesList.matchesGroupedByDateAndCompetition.map { item =>
+          DateCompetitionMatches(date = item._1, competitions = item._2.map(a => CompetitionMatches(a._1, a._2)))
+        },
+        nextPage = None,
+      )
+      Cached(CacheTime.Default)(RevalidatableResult.Ok(LiveScores.toJson(model))).as("application/json")
+    } else {
+      Cached(10) {
+        if (request.isJson)
+          JsonComponent(
+            "html" -> football.views.html.matchList.matchesComponent(matchesList),
+            "next" -> Html(matchesList.nextPage.getOrElse("")),
+            "previous" -> Html(matchesList.previousPage.getOrElse("")),
+            "atom" -> atom.isDefined,
+          )
+        else
+          RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters, atom))
+      }
     }
+
   }
 
   protected def renderMoreMatches(

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -31,6 +31,7 @@ case class DotcomRenderingFootballDataModel(
     pageType: String,
     matchesList: Seq[MatchesByDateAndCompetition],
     nextPage: Option[String],
+    previousPage: Option[String],
 )
 
 object DotcomRenderingFootballDataModel {
@@ -96,14 +97,14 @@ object DotcomRenderingFootballDataModelImplicits {
   implicit val leagueTeamWrites: Writes[LeagueTeam] = Json.writes[LeagueTeam]
   implicit val leagueTableEntryWrites: Writes[LeagueTableEntry] = Json.writes[LeagueTableEntry]
 
-  implicit val competitionFormat: Writes[CompetitionSummary] = new Writes[CompetitionSummary] {
-    def writes(competition: CompetitionSummary): JsValue = Json.obj(
+  implicit val competitionFormat: Writes[CompetitionSummary] = (competition: CompetitionSummary) =>
+    Json.obj(
       "id" -> competition.id,
       "url" -> competition.url,
       "fullName" -> competition.fullName,
       "shortName" -> competition.shortName,
+      "nation" -> competition.nation,
     )
-  }
   implicit val competitionMatchesFormat: Writes[CompetitionMatches] = Json.writes[CompetitionMatches]
   implicit val dateCompetitionMatchesFormat: Writes[MatchesByDateAndCompetition] =
     Json.writes[MatchesByDateAndCompetition]

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -1,7 +1,7 @@
 package football.model
 
-import model.{Competition, CompetitionSummary}
 import model.dotcomrendering.DotcomRenderingUtils.withoutNull
+import model.{Competition, CompetitionSummary}
 import pa.{
   Fixture,
   FootballMatch,
@@ -18,7 +18,7 @@ import pa.{
   Venue,
   Competition => PaCompetition,
 }
-import play.api.libs.json.{JsObject, JsString, JsValue, Json, Writes}
+import play.api.libs.json._
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -30,6 +30,7 @@ case class DotcomRenderingFootballDataModel(
     pageTitle: String,
     pageType: String,
     matchesList: Seq[MatchesByDateAndCompetition],
+    nextPage: Option[String],
 )
 
 object DotcomRenderingFootballDataModel {

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -100,7 +100,6 @@ object DotcomRenderingFootballDataModelImplicits {
       "id" -> competition.id,
       "url" -> competition.url,
       "fullName" -> competition.fullName,
-      "shortName" -> competition.shortName,
       "nation" -> competition.nation,
     )
   implicit val competitionMatchesFormat: Writes[CompetitionMatches] = Json.writes[CompetitionMatches]
@@ -108,9 +107,4 @@ object DotcomRenderingFootballDataModelImplicits {
     Json.writes[MatchesByDateAndCompetition]
 
   implicit val SportsFormat: Writes[DotcomRenderingFootballDataModel] = Json.writes[DotcomRenderingFootballDataModel]
-
-  def toJson(model: DotcomRenderingFootballDataModel): String = {
-    val jsValue = Json.toJson(model)
-    Json.stringify(withoutNull(jsValue))
-  }
 }

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -27,8 +27,6 @@ case class CompetitionMatches(competitionSummary: CompetitionSummary, matches: L
 case class MatchesByDateAndCompetition(date: LocalDate, competitionMatches: List[CompetitionMatches])
 
 case class DotcomRenderingFootballDataModel(
-    pageTitle: String,
-    pageType: String,
     matchesList: Seq[MatchesByDateAndCompetition],
     nextPage: Option[String],
     previousPage: Option[String],

--- a/sport/app/football/model/LiveScores.scala
+++ b/sport/app/football/model/LiveScores.scala
@@ -1,0 +1,90 @@
+package football.model
+
+import model.Competition
+import model.dotcomrendering.DotcomRenderingUtils.withoutNull
+import pa.{
+  Fixture,
+  FootballMatch,
+  LeagueStats,
+  LeagueTableEntry,
+  LeagueTeam,
+  LiveMatch,
+  MatchDay,
+  MatchDayTeam,
+  Official,
+  Result,
+  Round,
+  Stage,
+  Venue,
+  Competition => PaCompetition,
+}
+import play.api.libs.json.{JsObject, JsString, Json, Writes}
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+case class CompetitionMatches(competition: Competition, matches: List[FootballMatch])
+case class DateCompetitionMatches(date: LocalDate, competitions: List[CompetitionMatches])
+
+case class LiveScores(
+    pageTitle: String,
+    pageType: String,
+    matchesGroupedByDateAndCompetition: Seq[DateCompetitionMatches],
+    nextPage: Option[String],
+)
+
+object LiveScores {
+  implicit val localDateWrites: Writes[LocalDate] = Writes[LocalDate] { date =>
+    JsString(date.format(DateTimeFormatter.ISO_LOCAL_DATE))
+  }
+
+  implicit val stageFormat: Writes[Stage] = Json.writes[Stage]
+  implicit val roundFormat: Writes[Round] = Json.writes[Round]
+  implicit val matchDayTeamFormat: Writes[MatchDayTeam] = Json.writes[MatchDayTeam]
+  implicit val venueFormat: Writes[Venue] = Json.writes[Venue]
+  implicit val paCompetitionFormat: Writes[PaCompetition] = Json.writes[PaCompetition]
+  implicit val officialFormat: Writes[Official] = Json.writes[Official]
+
+  // Writes for Fixture with a type discriminator
+  implicit val fixtureWrites: Writes[Fixture] = Writes { fixture =>
+    Json.writes[Fixture].writes(fixture).as[JsObject] + ("type" -> JsString("Fixture"))
+  }
+
+  // Writes for MatchDay with a type discriminator
+  implicit val matchDayWrites: Writes[MatchDay] = Writes { matchDay =>
+    Json.writes[MatchDay].writes(matchDay).as[JsObject] + ("type" -> JsString("MatchDay"))
+  }
+
+  // Writes for Result with a type discriminator
+  implicit val resultWrites: Writes[Result] = Writes { result =>
+    Json.writes[Result].writes(result).as[JsObject] + ("type" -> JsString("Result"))
+  }
+
+  // Writes for LiveMatch with a type discriminator
+  implicit val liveMatchWrites: Writes[LiveMatch] = Writes { liveMatch =>
+    Json.writes[LiveMatch].writes(liveMatch).as[JsObject] + ("type" -> JsString("LiveMatch"))
+  }
+
+  implicit val footballMatchWrites: Writes[FootballMatch] = Writes { matchInstance =>
+    matchInstance match {
+      case f: Fixture   => Json.toJson(f)(fixtureWrites)
+      case m: MatchDay  => Json.toJson(m)(matchDayWrites)
+      case r: Result    => Json.toJson(r)(resultWrites)
+      case l: LiveMatch => Json.toJson(l)(liveMatchWrites)
+    }
+  }
+
+  implicit val leagueStatsWrites: Writes[LeagueStats] = Json.writes[LeagueStats]
+  implicit val leagueTeamWrites: Writes[LeagueTeam] = Json.writes[LeagueTeam]
+  implicit val leagueTableEntryWrites: Writes[LeagueTableEntry] = Json.writes[LeagueTableEntry]
+
+  implicit val competitionFormat: Writes[Competition] = Json.writes[Competition]
+  implicit val competitionMatchesFormat: Writes[CompetitionMatches] = Json.writes[CompetitionMatches]
+  implicit val dateCompetitionMatchesFormat: Writes[DateCompetitionMatches] = Json.writes[DateCompetitionMatches]
+  implicit val SportsFormat: Writes[LiveScores] = Json.writes[LiveScores]
+
+  def toJson(model: LiveScores): String = {
+    val jsValue = Json.toJson(model)
+    Json.stringify(withoutNull(jsValue))
+  }
+}

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -6,6 +6,13 @@ import pa.MatchDayTeam
 import java.awt.Color
 import java.time.LocalDate
 
+trait CompetitionSummary {
+  def id: String
+  def url: String
+  def fullName: String
+  def shortName: String
+}
+
 /** @param tableDividers
   *   divides the league table into zones for promotion/relegation, or for qualification to another competition. Only
   *   add a table divider where the boundaries for progression are clear, e.g do not add a divider in Euro group stages
@@ -23,7 +30,8 @@ case class Competition(
     showInTeamsList: Boolean = false,
     tableDividers: List[Int] = Nil,
     finalMatchSVG: Option[String] = None,
-) extends implicits.Football {
+) extends implicits.Football
+    with CompetitionSummary {
 
   lazy val hasMatches = matches.nonEmpty
   lazy val hasLiveMatches = matches.exists(_.isLive)

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -11,6 +11,7 @@ trait CompetitionSummary {
   def url: String
   def fullName: String
   def shortName: String
+  def nation: String
 }
 
 /** @param tableDividers

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -10,7 +10,6 @@ trait CompetitionSummary {
   def id: String
   def url: String
   def fullName: String
-  def shortName: String
   def nation: String
 }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR adds DCR JSON support to the football/live endpoint (http://localhost:9000/football/live.json?dcr=true). 

While the focus was on football/live, this change also affects the fixtures and results endpoints since they share the same renderMatchList method. But we need to revisit the frontend implementations in more detail to make sure we are returning the proper data set.

**Summary of changes**
- Introduces a new generic data model: DotcomRenderingFootballDataModel.
- The existing Twirl template uses the type Seq[(LocalDate, List[(Competition, List[FootballMatch])])].
- For the DCR model, new structured types were created to improve JSON parsing and validation:
   - MatchesByDateAndCompetition
   - CompetitionMatches
   - CompetitionSummary

Following is an example of the returned json:
```
{
  "matchesList": [
    {
      "date": "2025-02-05",
      "competitionMatches": [
        {
          "competitionSummary": {
            "id": "301",
            "url": "/football/carabao-cup",
            "fullName": "Carabao Cup",
            "shortName": "Carabao Cup",
            "nation": "English"
          },
          "matches": [
            {
              "id": "4481559",
              "date": "2025-02-05T20:00:00Z[Europe/London]",
              "stage": {
                "stageNumber": "1"
              },
              "round": {
                "roundNumber": "6",
                "name": "Carabao Cup Semi-Final Second Leg"
              },
              "leg": "2",
              "homeTeam": {
                "id": "31",
                "name": "Newcastle"
              },
              "awayTeam": {
                "id": "1006",
                "name": "Arsenal"
              },
              "venue": {
                "id": "50",
                "name": "St James' Park"
              },
              "type": "Fixture"
            }
          ]
        }
      ]
    }
  ]
}
```