### PR TITLE
Add `contentType` To Editions Crosswords Query

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -332,6 +332,7 @@ class CrosswordEditionsController(
     */
   private lazy val crosswordsQuery =
     SearchQuery()
+      .contentType("crossword")
       .tag(crosswordTags)
       .useDate("newspaper-edition")
       .pageSize(25)


### PR DESCRIPTION
Excludes any crosswords that are not playable. These will not be published with the "crossword" content type.
