### PR TITLE
Increase timeout for post to DCR fronts in dev

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -151,7 +151,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val interactiveBaseURL = configuration.getMandatoryStringProperty("interactive-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
-    lazy val timeout = 2.seconds
+    lazy val timeout = 9.seconds
     lazy val circuitBreakerMaxFailures = 10 // we should increase this as DCR sees increasing usage
   }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -151,7 +151,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val interactiveBaseURL = configuration.getMandatoryStringProperty("interactive-rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
-    lazy val timeout = 9.seconds
+    lazy val timeout = 2.seconds
     lazy val circuitBreakerMaxFailures = 10 // we should increase this as DCR sees increasing usage
   }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -96,7 +96,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       payload: String,
       endpoint: String,
       cacheTime: CacheTime,
-      timeout: Duration = if (Configuration.environment.stage == "DEV") Configuration.rendering.timeout * 5 else Configuration.rendering.timeout,
+      timeout: Duration = Configuration.rendering.timeout,
   )(implicit request: RequestHeader): Future[Result] = {
     def handler(response: WSResponse): Result = {
       response.status match {
@@ -258,6 +258,13 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       })
   }
 
+  private def getTimeout: Duration = {
+    if (Configuration.environment.stage == "DEV")
+      Configuration.rendering.timeout * 5
+    else
+      Configuration.rendering.timeout
+  }
+
   def getFront(
       ws: WSClient,
       page: PressedPage,
@@ -278,7 +285,8 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     )
 
     val json = DotcomFrontsRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.faciaBaseURL + "/Front", CacheTime.Facia)
+    val timeout = getTimeout
+    post(ws, json, Configuration.rendering.faciaBaseURL + "/Front", CacheTime.Facia, timeout)
   }
 
   def getTagPage(

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -96,7 +96,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       payload: String,
       endpoint: String,
       cacheTime: CacheTime,
-      timeout: Duration = Configuration.rendering.timeout,
+      timeout: Duration = Configuration.rendering.timeout * 5,
   )(implicit request: RequestHeader): Future[Result] = {
     def handler(response: WSResponse): Result = {
       response.status match {

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -96,7 +96,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       payload: String,
       endpoint: String,
       cacheTime: CacheTime,
-      timeout: Duration = Configuration.rendering.timeout * 5,
+      timeout: Duration = if (Configuration.environment.stage == "DEV") Configuration.rendering.timeout * 5 else Configuration.rendering.timeout,
   )(implicit request: RequestHeader): Future[Result] = {
     def handler(response: WSResponse): Result = {
       response.status match {


### PR DESCRIPTION
## What is the value of this and can you measure success?
Network fronts requests when developing locally constantly timeout due to the larger size of these fronts. They can take up to 10 seconds so I have changed the timeout in dev to allow for this.

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/cf5168e6-d607-491a-b8c0-5b7ddc7193f0
[after]: https://github.com/user-attachments/assets/a2985b9c-b1dd-4761-9627-c368e793c902



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
