### PR TITLE
Centre gallery ad slots

### DIFF
--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -13,5 +13,6 @@
         Map(),
         optId = if(isMobile) Some(s"$slotName--mobile") else None,
         optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
+        useFlexContainer = true
     ){ }
 }

--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -12,7 +12,7 @@
         Seq("gallery-inline", "dark") ++ (if(isMobile) Some("mobile") else None),
         Map(),
         optId = if(isMobile) Some(s"$slotName--mobile") else None,
-        optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
+        optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet"),
         useFlexContainer = true
     ){ }
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -192,7 +192,7 @@
 .ad-slot--gallery-inline,
 .ad-slot--liveblog-inline {
     width: $mpu-original-width;
-    margin: $gs-baseline auto;
+    margin: $gs-baseline 0;
     min-width: $mpu-original-width;
     min-height: $mpu-original-height + $mpu-ad-label-height;
     text-align: center;


### PR DESCRIPTION
## What does this change?
Centres ad slots on galleries. At the moment, gallery ad slots look a little broken as they take up the full width, but are left aligned.

## Screenshots

### Before - MPU
<img width="1474" alt="Screenshot 2024-12-10 at 16 43 46" src="https://github.com/user-attachments/assets/8a84bba6-b341-4ad6-a029-0c0815537bd4">

### After - MPU
<img width="1463" alt="Screenshot 2024-12-10 at 16 42 58" src="https://github.com/user-attachments/assets/d4725b72-0fc6-4ce5-96b7-4ab13107c629">

### Before - Banner
<img width="1482" alt="Screenshot 2024-12-10 at 16 45 38" src="https://github.com/user-attachments/assets/1da454c5-312c-463d-8818-7bb45b8ba01c">

### After - Banner
<img width="1380" alt="Screenshot 2024-12-10 at 16 44 43" src="https://github.com/user-attachments/assets/35956a92-666a-4ff7-b214-0337cd535bdf">
