### PR TITLE
Add gallery count to pressed card model

### DIFF
--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -1394,6 +1394,7 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
       shortUrlPath = None,
       isLive = true,
       group = "",
+      galleryCount = None,
     )
 
     val discussionSettings = PressedDiscussionSettings(

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -99,6 +99,7 @@ object FixtureBuilder {
       shortUrl = "",
       group = "0",
       isLive = false,
+      galleryCount = None,
     )
 
   def mkDiscussion(): PressedDiscussionSettings =


### PR DESCRIPTION
## What does this change?
Calculates the gallery count of a card to be used by the rendering platform. The count is added to the pressedCardHeader model.

The value is optional and will return a None if no gallery images are found in the content's list of elements. 

## Screenshots

![Screenshot 2024-12-12 at 10 20 29](https://github.com/user-attachments/assets/8865e850-abe9-4297-91d6-822aa1c016e6)


## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
