### PR TITLE
Bump `@guardian/identity-auth-frontend` to fix sign in issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",
-		"@guardian/identity-auth-frontend": "4.0.0",
+		"@guardian/identity-auth-frontend": "6.0.3",
 		"@guardian/libs": "19.1.0",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3703,7 +3703,7 @@ __metadata:
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"
-    "@guardian/identity-auth-frontend": "npm:4.0.0"
+    "@guardian/identity-auth-frontend": "npm:6.0.3"
     "@guardian/libs": "npm:19.1.0"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
@@ -3832,18 +3832,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@guardian/identity-auth-frontend@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@guardian/identity-auth-frontend@npm:4.0.0"
+"@guardian/identity-auth-frontend@npm:6.0.3":
+  version: 6.0.3
+  resolution: "@guardian/identity-auth-frontend@npm:6.0.3"
   peerDependencies:
-    "@guardian/identity-auth": ^2.1.0
-    "@guardian/libs": ^16.0.0
+    "@guardian/identity-auth": ^4.0.1
+    "@guardian/libs": ^19.0.0
     tslib: ^2.6.2
-    typescript: ~5.3.3
+    typescript: ~5.5.2
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/b56e78e9a0477534e074936e4c93ae55c219e56fd0ded1c26a063c20ad5dbef09210fd404776f0ad96ef7ca34f209568eb61f3a296695afc3ea9329d8f61b8bc
+  checksum: 10c0/cf39465b55f07dd02a99cbdf10937f0a74797042430b9a50d1259c0f655e272aa1d6a086efece26ace22cde4fa45aab502c16fb155a125f08419b7756084cb1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What are you changing?

Bumps `@guardian/identity-auth-frontend` to fix issue described below.

The patch checks for the users origin (domain) and sets the correct `redirect_uri` accordingly, i.e the `profile` subdomain if the page is loaded from `profile`, or default domain otherwise.

## Why?

On a user's "Comments and Replies" page, e.g. https://profile.theguardian.com/user/id/101796494?page=1, the user doesn't appear signed in, even if they already are.

This is because we kept getting returned an `OAuthError`

<img width="1190" alt="Screenshot 2024-12-12 at 08 31 16" src="https://github.com/user-attachments/assets/eb2c55a4-7253-4755-bad6-028b34ef8df6" />

This is because the `redirect_uri` for performing OAuth on frontend is set to `https://www.theguardian.com/`, but the comments and replies page is on the `https://profile.theguardian.com/` domain, despite the code for this page living in [guardian/frontend](https://github.com/guardian/frontend/tree/main/identity) but in the `identity` sub-project (which runs on the `profile` subdomain).

This meant when users went to this page, they don't appear to be signed in.

## Related

Sibling PR in `csnx` to update the package: https://github.com/guardian/csnx/pull/1848

Sibling PR in `identity-platform` to update our OAuth configuration: https://github.com/guardian/identity-platform/pull/791