### PR TITLE
Start Onwards Content AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/onwards-content-article.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onwards-content-article.js
@@ -5,8 +5,8 @@ export const onwardsContentArticle = {
 	author: 'dotcom.platform@guardian.co.uk',
 	description:
 		'Test the impact of showing the galleries onwards content component on article pages.',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
+	audience: 50 / 100,
+	audienceOffset: 50 / 100,
 	audienceCriteria: 'Article pages',
 	successMeasure:
 		'Users are more likely to click a link in the onward content component.',


### PR DESCRIPTION
## What does this change?

Starts the Onwards Content [AB test](https://github.com/guardian/frontend/pull/27632).

The control and the variant will each use 25% of the eligible population.