### PR TITLE
Stop logging to stdout

### DIFF
--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -15,14 +15,6 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <!-- DFP API logging -->
     <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="WARN"/>
     <logger name="com.google.api.client.http.HttpTransport" level="OFF"/>
@@ -30,7 +22,6 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="STDOUT"/>
     </root>
 
 </configuration>

--- a/common/test/resources/logback.xml
+++ b/common/test/resources/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -15,21 +15,12 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <!-- DFP API logging -->
     <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="OFF"/>
     <logger name="com.google.api.client.http.HttpTransport" level="OFF"/>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="STDOUT"/>
     </root>
 
 </configuration>

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -15,20 +15,11 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <logger name="exactTarget" level="DEBUG" />
     <logger name="org.apache.http.wire" level="WARN" />
     <logger name="org.apache.http.headers" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 </configuration>

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -15,17 +15,8 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
## What is the value of this and can you measure success?
Introduced in this PR https://github.com/guardian/frontend/pull/27403
## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
