### PR TITLE
remove null value fields from crosswords json response

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -4,8 +4,7 @@ import com.gu.contentapi.client.model.v1.Crossword
 import com.gu.contentapi.json.CirceEncoders._
 import io.circe.syntax._
 import implicits.Dates.CapiRichDateTime
-import model.dotcomrendering.DotcomRenderingUtils
-import play.api.libs.json.{JsObject, Json, JsValue}
+import play.api.libs.json.{JsArray, JsNull, JsObject, JsValue, Json}
 
 case class EditionsCrosswordRenderingDataModel(
     crosswords: Iterable[Crossword],
@@ -26,8 +25,20 @@ object EditionsCrosswordRenderingDataModel {
       }
     }))
 
+  def withoutNull(json: JsValue): JsValue = {
+    json match {
+      case JsObject(fields) =>
+        JsObject(fields.collect {
+          case (key, value) if value != JsNull => key -> withoutNull(value)
+        })
+      case JsArray(values) =>
+        JsArray(values.map(withoutNull))
+      case other => other
+    }
+  }
+
   def toJson(model: EditionsCrosswordRenderingDataModel): JsValue =
-    DotcomRenderingUtils.withoutNull(
+    withoutNull(
       Json.obj(
         "crosswords" -> Json.parse(model.crosswords.asJson.toString()),
       ),


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR fixes the editions crossword json response by applying withoutNull Recursively to handle nested objects by recursively applying the transformation. 

The crosswords json response is having some fields with null value and DCR is failing in json validation. 

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:-->

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/user-attachments/assets/c42c02c1-9d93-4356-ba91-697138c19ffd) | ![after][
![image](https://github.com/user-attachments/assets/e5af7e78-6c85-43dc-94d0-3e7644a17f18)
] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
