### PR TITLE
Use Circe's `deepDropNullValues` instead of `withoutNull`

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -27,9 +27,7 @@ object EditionsCrosswordRenderingDataModel {
     }))
 
   def toJson(model: EditionsCrosswordRenderingDataModel): JsValue =
-    DotcomRenderingUtils.withoutNull(
-      Json.obj(
-        "crosswords" -> Json.parse(model.crosswords.asJson.toString()),
-      ),
+    Json.obj(
+      "crosswords" -> Json.parse(model.crosswords.asJson.deepDropNullValues.toString()),
     )
 }


### PR DESCRIPTION
`DotcomRenderingUtils.withoutNull` is not recursive, therefore nested `null` fields make it through to DCAR, causing validation errors.

Issue introduced in #27641.
