### PR TITLE
Don't log to stdout in dev

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,1 @@
+-DSTAGE=DEV

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,1 +1,0 @@
--DSTAGE=DEV

--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -30,7 +30,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ val common = library("common")
       pekkoSlf4j,
       pekkoSerializationJackson,
       pekkoActorTyped,
+      janino,
     ) ++ jackson,
     TestAssets / mappings ~= filterAssets,
   )

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="STDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="STDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/common/test/resources/logback.xml
+++ b/common/test/resources/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -29,11 +29,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <if condition='!property("STAGE").contains("DEV")'>
-            <then>
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </then>
-        </if>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -29,7 +29,11 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="STDOUT"/>
+        <if condition='!property("STAGE").contains("dev")'>
+            <then>
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </then>
+        </if>
     </root>
 
 </configuration>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -29,7 +29,7 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <if condition='!property("STAGE").contains("dev")'>
+        <if condition='!property("STAGE").contains("DEV")'>
             <then>
                 <appender-ref ref="ASYNCSTDOUT"/>
             </then>

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -29,6 +29,12 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 </configuration>

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,6 +88,7 @@ object Dependencies {
 
   val logstash = ("net.logstash.logback" % "logstash-logback-encoder" % "8.0")
     .excludeAll(ExclusionRule("com.fasterxml.jackson.core")) // Avoid conflicts with Play's Jackson dependency
+  val janino = "org.codehaus.janino" % "janino" % "3.1.12"
 
   val targetingClient = "com.gu.targeting-client" %% "client-play-json-v30" % "1.1.9"
   val scanamo = "org.scanamo" %% "scanamo" % "2.0.0"

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>

--- a/sbt
+++ b/sbt
@@ -59,4 +59,5 @@ export APP_SECRET="this_is_not_a_real_secret_just_for_tests"
 java $FRONTEND_JVM_ARGS  \
   $DEBUG_PARAMS \
   -Duser.timezone=Australia/Sydney \
+  -DSTAGE=DEV \
   -jar `dirname $0`/bin/sbt-launch.jar "$@"

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -25,7 +25,13 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
+    <if condition='!property("STAGE").contains("DEV")'>
+        <then>
+            <root level="INFO">
+                <appender-ref ref="ASYNCSTDOUT"/>
+            </root>
+        </then>
+    </if>
 
 </configuration>


### PR DESCRIPTION
## What is the value of this and can you measure success?
We do not wish to log to stdout in dev as this is hindering the developer experience with the high output of logs. 
This was introduced when we switched to using dev-x logs https://github.com/guardian/frontend/pull/27403 

Resolves https://github.com/guardian/frontend/issues/27653

## What does this change?
This PR disables stdout logging when running locally when stage is equal to dev.

Added the system variable -DSTAGE=DEV to the sbt bash script

Added Janino as necessary for conditional rendering https://logback.qos.ch/manual/configuration.html#conditional 

Deployed to [code](https://riffraff.gutools.co.uk/deployment/view/dc7c7983-970e-4d89-b931-6bccaf452957). Still sending  [logs](https://logs.gutools.co.uk/s/dotcom/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(columns:!(ShippedBy,message),dataSource:(dataViewId:'30b53647-82f1-5f16-b66b-630273e9fda3',type:dataView),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'50201630-bd0f-11e9-92b3-f10623802d36',key:app.keyword,negate:!f,params:(query:article),type:phrase),query:(match_phrase:(app.keyword:article))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'50201630-bd0f-11e9-92b3-f10623802d36',key:stage.keyword,negate:!f,params:(query:CODE),type:phrase),query:(match_phrase:(stage.keyword:CODE)))),grid:(columns:(ShippedBy:(width:173))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))) 

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
