### PR TITLE
Add `id` to `AudioBlockElement` to fix missing media-id for audio assets on DCR rendered podcast pages

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -10,7 +10,7 @@ import conf.Configuration
 import crosswords.CrosswordPageWithContent
 import experiments.ActiveExperiments
 import model.dotcomrendering.DotcomRenderingUtils._
-import model.dotcomrendering.pageElements.{ImageBlockElement, PageElement, Role, TextCleaner}
+import model.dotcomrendering.pageElements.{AudioBlockElement, ImageBlockElement, PageElement, Role, TextCleaner}
 import model.liveblog.BlockAttributes
 import model.{
   ArticleDateTimes,
@@ -544,11 +544,23 @@ object DotcomRenderingDataModel {
       )
     }
 
-    val mainMediaElements =
-      mainBlock
+    val mainMediaElements = {
+      val pageElements = mainBlock
         .map(toDCRBlock(isMainBlock = true))
         .toList
         .flatMap(_.elements)
+
+      page.metadata.contentType match {
+        case Some(DotcomContentType.Audio) =>
+          pageElements
+            .map {
+              case AudioBlockElement(assets, _) =>
+                AudioBlockElement(assets, Option(content.elements.mainAudio.head.properties.id))
+              case pageElement => pageElement
+            }
+        case _ => pageElements
+      }
+    }
 
     val bodyBlocksDCR =
       bodyBlocks

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -120,7 +120,7 @@ object AudioAtomBlockElement {
 
 // We are currently using AudioBlockElement as a catch all for audio errors, skipping the first definition
 // See comment: 2e5ac4fd-e7f1-4c04-bdcd-ceadd2dc5d4c
-case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
+case class AudioBlockElement(assets: Seq[AudioAsset], id: Option[String] = None) extends PageElement
 object AudioBlockElement {
   implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Add `id` to `AudioBlockElement` to fix missing media-id for audio assets on DCR rendered podcast pages

## What does this change?

Following the Frontend approach 

https://github.com/guardian/frontend/blob/2a8e447d00071debb38fd74acea498d4c587a8aa/applications/app/views/fragments/audioBody.scala.html#L127

Unfortunately the id is applied at quite a high level in the `DotcomRenderingDataModel` call stack as we need `content.elements` available in order to pull out the id.

## Screenshots

### After

<img src="https://github.com/user-attachments/assets/f748d09b-e7cb-4d6d-8246-84d7870b1ce1" width="500px" />

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
