### PR TITLE
update IpsosTag for thefilter

### DIFF
--- a/common/app/model/IpsosTags.scala
+++ b/common/app/model/IpsosTags.scala
@@ -98,7 +98,8 @@ object IpsosTags {
     "uk/technology" -> "technology", /* There is no US technology tag - should these map to technology? */
     "au/technology" -> "technology",
     "technology" -> "technology", /* Default for technology (including motoring) articles */
-    "the-filter" -> "thefilter",
+    "thefilter" -> "thefilter",
+    "uk/thefilter" -> "thefilter",
     "the-guardian-foundation" -> "foundation",
     "theguardian" -> "theguardian",
     "theobserver" -> "theobserver",


### PR DESCRIPTION
## What is the value of this and can you measure success?
We work with IPSOS Mori to categorise content, enabling advertisers to measure pageviews and assess audience reach. Success is measured by ensuring accurate content tag mappings in their reports.
## What does this change?
This PR adds a new content tag, "The Filter," to the existing IPSOS Mori mapping file. This ensures that content related to "The Filter" is accurately categorised and reported.
This updates and amends the previous `the-filter` 


We can look at the third-party script provided by Ipsos MOR,  from Ipsos MORI's servers based on the locale and other parameters.
This should be `t=thefilter`

## Screenshots
The filter is structured and should be for both `fronts` and `articles`:
Tested on CODE: 
Front: `theguardian.com/uk/thefilter`
Article: `https://m.code.dev-theguardian.com/food/article/2024/dec/26/best-champagne-sparkling-wine`

| Before |
|--------|
| <img width="992" alt="Screenshot 2024-12-27 at 19 16 31" src="https://github.com/user-attachments/assets/189bc419-1df6-45c1-855c-f39140582a8f" />  |

| After |
|--------|
| <img width="993" alt="Screenshot 2024-12-27 at 19 15 50" src="https://github.com/user-attachments/assets/8dab2105-996b-4f79-aae4-f8ca9e626f2b" />  |

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
