### PR TITLE
Increase commercial bundle test to 1%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -46,5 +46,5 @@ object CommercialBundleUpdater
       description = "Enable the commercial bundle updater",
       owners = Seq(Owner.withGithub("jakeii")),
       sellByDate = LocalDate.of(2025, 1, 30),
-      participationGroup = Perc0B,
+      participationGroup = Perc1A,
     )


### PR DESCRIPTION
## What does this change?
Increase test of code introduced in https://github.com/guardian/frontend/pull/27578 to 1%

