### PR TITLE
Add multi-byline fields

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -366,6 +366,10 @@ case class ListItem(
     title: Option[String],
     bio: Option[String],
     endNote: Option[String],
+    contributorIds: Option[scala.collection.Seq[String]],
+    byline: Option[String],
+    bylineHtml: Option[String],
+    contributorImageOverrideUrl: Option[String],
 ) extends PageElement
 object ListItem {
   implicit val listItemWrites: Writes[ListItem] = Json.writes[ListItem]
@@ -1590,6 +1594,10 @@ object PageElement {
       title = item.title,
       bio = item.bio,
       endNote = item.endNote,
+      contributorIds = item.contributorIds,
+      byline = item.byline,
+      bylineHtml = item.bylineHtml,
+      contributorImageOverrideUrl = item.contributorImageOverrideUrl,
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
-  val capiVersion = "32.0.1"
-  val faciaVersion = "13.1.0"
+  val capiVersion = "33.0.0"
+  val faciaVersion = "14.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -32,7 +32,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.16.1"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "25.1.0"
+  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "26.0.0"
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.6.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion


### PR DESCRIPTION
## What does this change?

This adds support for the new fields included in Multi-byline fields.

These fields have been available content-api-client since [v33.0.0](https://github.com/guardian/content-api-scala-client/releases/tag/v33.0.0).

dotcom-rendering is already able to render these fields, since https://github.com/guardian/dotcom-rendering/pull/12496

## Screenshots

| Before | After |
|--------|--------|
| ![Screenshot 2025-01-09 at 12 14 53](https://github.com/user-attachments/assets/d0e5d58b-ce38-4c21-b903-c077a5875ff9) | ![Screenshot 2025-01-09 at 12 14 45](https://github.com/user-attachments/assets/081dfd64-8a11-464d-a34f-163587763c4b) | 