### PR TITLE
Add leading zero to podcast duration if needed

### DIFF
--- a/common/app/model/PressedCard.scala
+++ b/common/app/model/PressedCard.scala
@@ -78,7 +78,10 @@ object PressedCard {
         audioDurationSeconds(fc).get.headOption
       } else None
       if (minutes.isDefined && seconds.isDefined) {
-        val duration = minutes.get.toString + ":" + seconds.get.toString
+        // adds a leading zero if the values are less than 10
+        val formattedMinutes = f"${minutes.get}%02d"
+        val formattedSeconds = f"${seconds.get}%02d"
+        val duration = s"$formattedMinutes:$formattedSeconds"
         Some(duration)
       } else None
     }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Noticed when testing the associated DCR PR that durations of less than 10 require a leading zero, which this adds.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/d0c6f417-3358-44b5-a8a2-22c463e57d35
[after]: https://github.com/user-attachments/assets/0b70bdf7-31ab-4fa6-a9c5-e2c74b5b7278



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
