### PR TITLE
Pin actions-riff-raff to 4.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           paths: "test-results/**/TEST-*.xml"
         if: always()
 
-      - uses: guardian/actions-riff-raff@v4
+      - uses: guardian/actions-riff-raff@v4.1.2
         env:
           GU_RIFF_RAFF_ROLE_ARN: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
         if: ${{ env.GU_RIFF_RAFF_ROLE_ARN }}


### PR DESCRIPTION
## What does this change?
Should fix an issue with later versions uploading artifacts to riff-raff