### PR TITLE
Update Facia & CAPI clients (and ETag-caching library)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "33.0.0"
-  val faciaVersion = "14.0.0"
+  val faciaVersion = "14.0.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -19,7 +19,7 @@ object Dependencies {
   val awsEc2 = "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion
   val awsKinesis = "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion
   val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
-  val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "4.0.1"
+  val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
   val awsSes = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion
   val awsSns = "com.amazonaws" % "aws-java-sdk-sns" % awsVersion
   val awsSts = "com.amazonaws" % "aws-java-sdk-sts" % awsVersion


### PR DESCRIPTION
## What is the value of this and can you measure success?

With https://github.com/guardian/facia-scala-client/pull/287, the Facia client has been updated so that it can take advantage of ETag-caching, using the [`guardian/etag-caching`](https://github.com/guardian/etag-caching) library already used in Frontend since August 2023 with https://github.com/guardian/frontend/pull/26338.

## What does this change?

As some changes were necessary to the `etag-caching` library to facilitate this, we need to update the version of `etag-caching` used by Frontend to v7.0.0. We also need to use an updated version of CAPI, as the CAPI version used by Facia was recently updated with https://github.com/guardian/facia-scala-client/pull/341.

Although this change upgrades to the latest version of the Facia client, it _doesn't_ turn on the new ETag-caching support there - that can come in a later PR, as it does involve switching to AWS SDK v2 (not everywhere in Frontend, just for where we use the Facia client, but that's still a significant change as the AWS STS credential creation has got more elaborate with AWS SDK v2).

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
