### PR TITLE
Add a 0% test for crosswords in DCR

### DIFF
--- a/applications/app/services/dotcomrendering/CrosswordsPicker.scala
+++ b/applications/app/services/dotcomrendering/CrosswordsPicker.scala
@@ -2,19 +2,12 @@ package services.dotcomrendering
 
 import common.GuLogging
 import crosswords.CrosswordPageWithContent
+import experiments.{ActiveExperiments, DCRCrosswords}
 import model.Cors.RichRequestHeader
 import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
 
 object CrosswordsPicker extends GuLogging {
-
-  /** Add to this function any logic for including/excluding a crossword page from being rendered with DCR
-    *
-    * Currently defaulting to false until we implement crosswords in DCR
-    */
-  private def dcrCouldRender(crosswordPageWithContent: CrosswordPageWithContent): Boolean = {
-    false
-  }
 
   def getTier(
       crosswordPageWithContent: CrosswordPageWithContent,
@@ -22,13 +15,12 @@ object CrosswordsPicker extends GuLogging {
       request: RequestHeader,
   ): RenderType = {
 
-    val participatingInTest = false // until we create a test for this content type
-    val dcrCanRender = dcrCouldRender(crosswordPageWithContent)
+    val participatingInTest = ActiveExperiments.isParticipating(DCRCrosswords)
 
     val tier = {
       if (request.forceDCROff) LocalRender
       else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender && participatingInTest) RemoteRender
+      else if (participatingInTest) RemoteRender
       else LocalRender
     }
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     Set(
       EuropeBetaFront,
       CommercialBundleUpdater,
+      DCRCrosswords,
       DarkModeWeb,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
@@ -31,15 +32,6 @@ object EuropeBetaFront
       participationGroup = Perc0A,
     )
 
-object DarkModeWeb
-    extends Experiment(
-      name = "dark-mode-web",
-      description = "Enable dark mode on web",
-      owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 1, 30),
-      participationGroup = Perc0D,
-    )
-
 object CommercialBundleUpdater
     extends Experiment(
       name = "commercial-bundle-updater",
@@ -47,4 +39,22 @@ object CommercialBundleUpdater
       owners = Seq(Owner.withGithub("jakeii")),
       sellByDate = LocalDate.of(2025, 1, 30),
       participationGroup = Perc5A,
+    )
+
+object DCRCrosswords
+    extends Experiment(
+      name = "dcr-crosswords",
+      description = "Render crosswords in DCR",
+      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2025, 2, 26),
+      participationGroup = Perc0C,
+    )
+
+object DarkModeWeb
+    extends Experiment(
+      name = "dark-mode-web",
+      description = "Enable dark mode on web",
+      owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2025, 1, 30),
+      participationGroup = Perc0D,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?

enable previewing of DCR crosswords

## What does this change?

adds a 0% test to render crosswords in DCR

## Todo

- [x] add a 0% test
- [x] render crossword article requests with DCR if the user is in the test