### PR TITLE
Use Experiment to decide if rendering of crossword articles is done in DCR.

### DIFF
--- a/applications/app/services/dotcomrendering/CrosswordsPicker.scala
+++ b/applications/app/services/dotcomrendering/CrosswordsPicker.scala
@@ -2,19 +2,12 @@ package services.dotcomrendering
 
 import common.GuLogging
 import crosswords.CrosswordPageWithContent
+import experiments.{ActiveExperiments, DCRCrosswords}
 import model.Cors.RichRequestHeader
 import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
 
 object CrosswordsPicker extends GuLogging {
-
-  /** Add to this function any logic for including/excluding a crossword page from being rendered with DCR
-    *
-    * Currently defaulting to false until we implement crosswords in DCR
-    */
-  private def dcrCouldRender(crosswordPageWithContent: CrosswordPageWithContent): Boolean = {
-    false
-  }
 
   def getTier(
       crosswordPageWithContent: CrosswordPageWithContent,
@@ -22,13 +15,12 @@ object CrosswordsPicker extends GuLogging {
       request: RequestHeader,
   ): RenderType = {
 
-    val participatingInTest = false // until we create a test for this content type
-    val dcrCanRender = dcrCouldRender(crosswordPageWithContent)
+    val participatingInTest = ActiveExperiments.isParticipating(DCRCrosswords)
 
     val tier = {
       if (request.forceDCROff) LocalRender
       else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender && participatingInTest) RemoteRender
+      else if (participatingInTest) RemoteRender
       else LocalRender
     }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
Adds the Crossword Experiment to the crossword picker getTier function. This decides whether to render the crossword in FE or DCR. If the ActiveExperiments.isParticipating(DCRCrosswords) returns `true` the crossword page will be rendered in DCR 

https://github.com/guardian/frontend/blob/main/applications/conf/routes#L22
https://github.com/guardian/frontend/blob/main/dev-build/conf/routes#L24
https://github.com/guardian/frontend/blob/main/preview/conf/routes#L17

applies to theses routes
