### PR TITLE
Log if tests are running in CI (rather than on local developer laptop)

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -51,8 +51,13 @@ object ProjectSettings {
       .withWarnScalaVersionEviction(false),
   )
 
-  def isCi = sys.env.get("CI").getOrElse("false") == "true"
-  def testStage = if (isCi) "DEVINFRA" else "LOCALTEST"
+  val testStage = {
+    // 'CI' is a default variable in GitHub Runners - https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+    if (sys.env.get("CI").contains("true")) {
+      println(s"Tests are running in CI")
+      "DEVINFRA"
+    } else "LOCALTEST"
+  }
 
   val frontendTestSettings = Seq(
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o"),


### PR DESCRIPTION
This change follows on from https://github.com/guardian/frontend/pull/26973 - I was trying to work out how the Frontend test suite varies its behaviour between running locally on a developer's machine, and running in CI on GitHub Runner (there are some critical differences in behaviour, ie around the test database resources, where missing database resources should *not* be tolerated in CI, but should be freshly downloaded if missing in local development) - I couldn't work out where the `CI="true"` environment variable was coming from, and I thought [maybe](https://github.com/guardian/frontend/pull/26973#discussion_r1908874466) it wasn't being set, which was alarming!

@cemms1 kindly pointed me to the [relevant documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables), which explains that the default environment variable `CI` is always set to true in GitHub Runners.

<img width="735" alt="image" src="https://github.com/user-attachments/assets/1d4b9d65-08f9-4708-ae78-1ad61cdb52ce" />

To make this a little clearer, I'm changing the code now to [log](https://github.com/guardian/frontend/actions/runs/12694006472/job/35382852989#step:10:201) an informative statement if we're running the tests in CI:

<img width="1300" alt="image" src="https://github.com/user-attachments/assets/3e067ffe-e005-4cd6-b83b-72d8351cfb17" />

This message does not appear when running locally in a non-CI environment, to avoid exposing developers to unnecessary noise.