### PR TITLE
Retrieve only matching football competition by tag

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -26,7 +26,7 @@ trait Competitions extends implicits.Football {
       competitions.filter(_.url == path),
     )
 
-  def competitionsWithTag(tag: String): Option[Competition] = competitions.find(_.url.endsWith(tag))
+  def competitionsWithTag(tag: String): Option[Competition] = competitions.find(_.url.endsWith(s"/$tag"))
 
   def competitionsWithId(compId: String): Option[Competition] = competitions.find(_.id == compId)
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

The competition by tag search only compares the tag we are looking for with the end of the competition tag.

If a competition tag ends with the same string as another competition tag, this can lead to an incorrect competition being sent.

Examples of tags in the `competitions` list:
```
/football/womens-super-league
/football/championsleague
/football/euro-2024
/football/euro-2024
/football/world-cup-2022-qualifiers
/football/uefa-europa-league
/football/women-s-nations-league
/football/nations-league
```
([full list](https://github.com/guardian/frontend/blob/1b6eac8efa74360254f016f01e94b40cf52b8c69/sport/app/football/feed/Competitions.scala#L125))

In the above example, if we passed the tag `"nations-league"` to this function, the function would find the competition `"/football/women-s-nations-league"` before `"/football/nations-league"`


## What does this change?

Ensure we are matching everything after `football/` in the tag name, rather than the end of the tag

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e9de15e2-ba1a-4563-bae1-7a9c664e46be
[after]: https://github.com/user-attachments/assets/85f6e2c3-6620-453f-8156-eb2248425612


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
