### PR TITLE
Enable ETag-caching & AWS SDK v2 on Facia API requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ val common = library("common")
       awsKinesis,
       awsS3,
       awsSns,
-      awsSts,
+      awsSts, // AWS SDK v1 still used for CAPI-preview related code for now
+      awsV2Sts, // AWS SDK v2 used for Fronts API access
       awsSqs,
       awsSsm,
       eTagCachingS3,

--- a/common/app/services/fronts/FrontsApi.scala
+++ b/common/app/services/fronts/FrontsApi.scala
@@ -1,21 +1,17 @@
 package services.fronts
 
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
-import com.gu.facia.client.{AmazonSdkS3Client, ApiClient}
+import com.gu.etagcaching.aws.sdkv2.s3.S3ObjectFetching
+import com.gu.facia.client.{ApiClient, Environment}
 import conf.Configuration
+import utils.AWSv2.buildS3AsyncClient
+
 import scala.concurrent.ExecutionContext
 
 object FrontsApi {
 
-  def crossAccountClient(implicit ec: ExecutionContext): ApiClient = {
-    val client: AmazonS3 = AmazonS3Client.builder
-      .withCredentials(Configuration.faciatool.crossAccountMandatoryCredentials)
-      .withRegion(conf.Configuration.aws.region)
-      .build()
-    ApiClient(
-      Configuration.faciatool.crossAccountSourceBucket,
-      Configuration.facia.stage.toUpperCase,
-      AmazonSdkS3Client(client),
-    )
-  }
+  def crossAccountClient(implicit ec: ExecutionContext): ApiClient = ApiClient.withCaching(
+    Configuration.faciatool.crossAccountSourceBucket,
+    Environment(Configuration.facia.stage.toUpperCase),
+    S3ObjectFetching.byteArraysWith(buildS3AsyncClient(Configuration.faciatool.crossAccountMandatoryCredentials)),
+  )
 }

--- a/common/app/utils/AWSv2.scala
+++ b/common/app/utils/AWSv2.scala
@@ -6,6 +6,9 @@ import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3AsyncClientBuilder}
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+import software.amazon.awssdk.services.sts.{StsClient, StsClientBuilder}
 
 object AWSv2 {
   val region: Region = EU_WEST_1
@@ -16,10 +19,25 @@ object AWSv2 {
   lazy val credentials: AwsCredentialsProvider =
     credentialsForDevAndProd("frontend", InstanceProfileCredentialsProvider.create())
 
-  def build[T, B <: AwsClientBuilder[B, T]](builder: B): T =
-    builder.credentialsProvider(credentials).region(region).build()
+  def build[T, B <: AwsClientBuilder[B, T]](builder: B, creds: AwsCredentialsProvider = credentials): T =
+    builder.credentialsProvider(creds).region(region).build()
 
-  val S3Async: S3AsyncClient = build[S3AsyncClient, S3AsyncClientBuilder](
+  def buildS3AsyncClient(creds: AwsCredentialsProvider): S3AsyncClient = build[S3AsyncClient, S3AsyncClientBuilder](
     S3AsyncClient.builder().httpClientBuilder(NettyNioAsyncHttpClient.builder().maxConcurrency(250)),
+    creds,
   )
+
+  val S3Async: S3AsyncClient = buildS3AsyncClient(credentials)
+
+  val STS: StsClient = build[StsClient, StsClientBuilder](StsClient.builder())
+
+  def stsCredentials(devProfile: String, roleArn: String): AwsCredentialsProvider = credentialsForDevAndProd(
+    devProfile,
+    StsAssumeRoleCredentialsProvider
+      .builder()
+      .stsClient(STS)
+      .refreshRequest(AssumeRoleRequest.builder.roleSessionName("frontend").roleArn(roleArn).build)
+      .build(),
+  )
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.758"
   val awsSdk2Version = "2.26.27"
   val capiVersion = "33.0.0"
-  val faciaVersion = "14.0.0"
+  val faciaVersion = "14.0.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -19,10 +19,11 @@ object Dependencies {
   val awsEc2 = "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion
   val awsKinesis = "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion
   val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
-  val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "4.0.1"
+  val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
   val awsSes = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion
   val awsSns = "com.amazonaws" % "aws-java-sdk-sns" % awsVersion
   val awsSts = "com.amazonaws" % "aws-java-sdk-sts" % awsVersion
+  val awsV2Sts = "software.amazon.awssdk" % "sts" % awsSdk2Version
   val awsSqs = "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion
   val awsSsm = "com.amazonaws" % "aws-java-sdk-ssm" % awsVersion
   val awsElasticloadbalancing = "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion


### PR DESCRIPTION
With https://github.com/guardian/facia-scala-client/pull/287, the Facia client has been updated so that it can take advantage of ETag-caching, using the [`guardian/etag-caching`](https://github.com/guardian/etag-caching) library already used in Frontend (for loading JSON data _out_ of the pressed-page cache) since August 2023 with https://github.com/guardian/frontend/pull/26338.

As some changes were necessary in the `etag-caching` library to facilitate this, we need to update the version of `etag-caching` used by Frontend to v7.0.0.

We're also upgrading the S3 client (used by Frontend's instance of Facia's `ApiClient`) to AWS SDK v2, as `etag-caching` already provides a convenient implementation of [`S3ByteArrayFetching`](https://github.com/guardian/etag-caching/pull/65) for AWS SDK v2 - if we continued using AWS SDK v1 here in Frontend, we'd have to create an implementation for it.

### Consumers of Facia API data

The FAPI `ApiClient` is used by 3 classes:

* `services.ConfigAgent` ([logs](https://logs.gutools.co.uk/s/dotcom/app/r/s/ZxScx))
* `frontpress.LiveFapiFrontPress` & `frontpress.DraftFapiFrontPress` ([logs](https://logs.gutools.co.uk/s/dotcom/app/r/s/giCLf) - note that logging of `message` is currently obscured within a big chunk of JSON)

## Testing

I've [deployed](https://riffraff.gutools.co.uk/deployment/view/4ebb6d6a-ab64-4920-b69e-8298e56cf291) this to CODE, with deploy completing at 2.17pm, and verified that the logs look ok:

* `services.ConfigAgent` is [still getting Config](https://logs.gutools.co.uk/s/dotcom/app/r/s/9df7P) <img width="1919" alt="image" src="https://github.com/user-attachments/assets/019abe6d-827e-4da5-8217-f4014e7e1556" />
* `frontpress.LiveFapiFrontPress` & `frontpress.DraftFapiFrontPress` are still [pressing fronts](https://logs.gutools.co.uk/s/dotcom/app/r/s/oKQSp):
<img width="1919" alt="image" src="https://github.com/user-attachments/assets/35dc79e0-917a-4d84-b4ed-5b40e74a626e" />


## See also

* https://github.com/guardian/maintaining-scala-projects/issues/9
* https://github.com/guardian/facia-scala-client/pull/287