### PR TITLE
Fix previewing audio content with no audio file selected

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -555,7 +555,7 @@ object DotcomRenderingDataModel {
           pageElements
             .map {
               case AudioBlockElement(assets, _) =>
-                AudioBlockElement(assets, Option(content.elements.mainAudio.head.properties.id))
+                AudioBlockElement(assets, content.elements.mainAudio.map(_.properties.id))
               case pageElement => pageElement
             }
         case _ => pageElements


### PR DESCRIPTION
We recently had a report that audio content was failing in preview when there was no audio file selected. Error logs point to this line in the code which calls `.head` on a Optional AudioElement which throws a `NoSuchElementException` if the optional is empty.

The id passed into the AudioBlockElement is optional anyway, so using `.map` instead of `.head` produces the same results without throwing an error and the id will be None if there is no AudioElement.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="377" alt="Screenshot 2025-01-13 at 13 56 54" src="https://github.com/user-attachments/assets/5bfbe01d-8c4d-4267-9a29-90f2cae135f4" /> | <img width="377" alt="Screenshot 2025-01-13 at 14 06 33" src="https://github.com/user-attachments/assets/5ff6b8c5-4857-45a2-ad02-bcac1ae9bca6" /> |

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Will not break our database – if updating CAPI, [updated and committed the database files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
