### PR TITLE
Add aria label for star ratings in email

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -49,7 +49,7 @@
 
     @card.starRating.map { numberOfStars =>
         @row(Seq("review-stars")) {
-            <span class="review-stars-bg">
+            <span class="review-stars-bg" role="img" aria-label="Rating: @numberOfStars out of 5 stars" >
                 @for(i <- 0 to 4) {
                     @defining(if(i < numberOfStars) "golden" else "grey") { positiveOrNegative =>
                         @icon("star-" + positiveOrNegative, isLarge)


### PR DESCRIPTION
## What is the value of this and can you measure success?

Current star ratings in email are not correctly described.
Follow up of https://github.com/guardian/frontend/pull/15787

## What does this change?

Follow web guidance on accessibility by adding an [img role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role) to the `span`.
[See example](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#examples).  
