### PR TITLE
Suppress Sass deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
 		"requireindex": "^1.1.0",
 		"rimraf": "^2.6.1",
 		"rxjs": "^6.6.7",
-		"sass": "1.77.8",
+		"sass": "1.78.0",
 		"sass-graph": "4.0.1",
 		"sass-loader": "14.2.1",
 		"sass-mq": "5.0.1",

--- a/static/src/stylesheets/admin/_bootstrap.graun.scss
+++ b/static/src/stylesheets/admin/_bootstrap.graun.scss
@@ -56,7 +56,7 @@ $btn-primary-color: $brightness-7;
 $btn-primary-bg: $brand-secondary;
 $btn-primary-border: $brand-secondary;
 
-@import '../../../../node_modules/bootstrap-sass/assets/stylesheets/_bootstrap';
+@import 'bootstrap-sass/assets/stylesheets/_bootstrap';
 
 .container--global {
     margin: 0 auto;

--- a/tools/compile-css.mjs
+++ b/tools/compile-css.mjs
@@ -28,6 +28,7 @@ const SASS_SETTINGS = {
 	outputStyle: 'compressed',
 	sourceMap: true,
 	precision: 5,
+    quietDeps: true,
 };
 
 const BROWSERS_LIST = [

--- a/tools/compile-css.mjs
+++ b/tools/compile-css.mjs
@@ -29,6 +29,7 @@ const SASS_SETTINGS = {
 	sourceMap: true,
 	precision: 5,
     quietDeps: true,
+    silenceDeprecations: ['mixed-decls'],
 };
 
 const BROWSERS_LIST = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7277,17 +7277,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001587":
-  version: 1.0.30001615
-  resolution: "caniuse-lite@npm:1.0.30001615"
-  checksum: 10c0/49029ff6cdbb35cf84cc9d9d4782dff3a8fb6afb547a83f3e43f13addcb0c4ac6015dc528a42f0f78846dc06261b3fab16555e3979114ad20e15cf7a91e64c33
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001669":
-  version: 1.0.30001673
-  resolution: "caniuse-lite@npm:1.0.30001673"
-  checksum: 10c0/0e73a2b0f06973052e563dec9990a6fd440d510fa2ff54fa50310e736abb86e96c96b43c10e609fc22f2109f98fe76428b70441baf6b1a49f69ccf50c1879f6b
+"caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001587, caniuse-lite@npm:^1.0.30001669":
+  version: 1.0.30001692
+  resolution: "caniuse-lite@npm:1.0.30001692"
+  checksum: 10c0/fca5105561ea12f3de593f3b0f062af82f7d07519e8dbcb97f34e7fd23349bcef1b1622a9a6cd2164d98e3d2f20059ef7e271edae46567aef88caf4c16c7708a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3792,7 +3792,7 @@ __metadata:
     requireindex: "npm:^1.1.0"
     rimraf: "npm:^2.6.1"
     rxjs: "npm:^6.6.7"
-    sass: "npm:1.77.8"
+    sass: "npm:1.78.0"
     sass-graph: "npm:4.0.1"
     sass-loader: "npm:14.2.1"
     sass-mq: "npm:5.0.1"
@@ -14768,16 +14768,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:1.77.8":
-  version: 1.77.8
-  resolution: "sass@npm:1.77.8"
+"sass@npm:1.78.0":
+  version: 1.78.0
+  resolution: "sass@npm:1.78.0"
   dependencies:
     chokidar: "npm:>=3.0.0 <4.0.0"
     immutable: "npm:^4.0.0"
     source-map-js: "npm:>=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: 10c0/2bfd62794070352c804f949e69bd8bb5b4ec846deeb924251b2c3f7b503170fb1ae186f513f0166907749eb34e0277dee747edcb78c886fb471aac01be1e864c
+  checksum: 10c0/6577a87c00b03a5a50f3a11b4b6592f28abce34e61812e381535a3b712151bd94db3ca06467d20395431e0f38a23f99e616d6859d771fb6d4617c359f590c48c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

- Reduces noise in terminal when compiling Sass
- Individual warnings can be enabled / disabled which is helpful when focussing on updating a specific deprecation

## What does this change?

- Disables deprecation warnings from external dependencies
- Updates Sass compiler to 1.78.0 which backports the `silenceDeprecations` option to the legacy API
- Updates `caniuse-lite` so Browserslist has up-to-date browser data (removing the warning message)
 
## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
