### PR TITLE
Add a server side AB test for the user-benefits api

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,6 +14,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeBetaFront,
       DCRCrosswords,
       DarkModeWeb,
+      UseUserBenefitsApi,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -47,4 +48,13 @@ object DarkModeWeb
       owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 1, 30),
       participationGroup = Perc0D,
+    )
+
+object UseUserBenefitsApi
+    extends Experiment(
+      name = "use-user-benefits-api",
+      description = "Enable the switch from members-data-api to the new user-benefits API",
+      owners = Seq(Owner.withGithub("rupertbates")),
+      sellByDate = LocalDate.of(2025, 6, 30),
+      participationGroup = Perc0C,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -56,5 +56,5 @@ object UseUserBenefitsApi
       description = "Enable the switch from members-data-api to the new user-benefits API",
       owners = Seq(Owner.withGithub("rupertbates")),
       sellByDate = LocalDate.of(2025, 6, 30),
-      participationGroup = Perc0C,
+      participationGroup = Perc0B,
     )


### PR DESCRIPTION
## What does this change?
This PR sets up a server side AB test to be used in the staged roll out of the new user-benefits API. The corresponding DCR PR is here https://github.com/guardian/dotcom-rendering/pull/13137
## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
