### PR TITLE
Remove switch to disable show hide functionality on front containers

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -552,14 +552,4 @@ trait FeatureSwitches {
     highImpact = false,
   )
 
-  val DisableFrontContainerShowHide = Switch(
-    group = SwitchGroup.Feature,
-    name = "disable-front-container-show-hide",
-    description = "For users with no currently hidden containers on a front, removes the ability to hide containers",
-    owners = Seq(Owner.withEmail("project.fairground@theguardian.com")),
-    safeState = On,
-    sellByDate = LocalDate.of(2025, 2, 4),
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }


### PR DESCRIPTION

## What does this change?
Removes the switch implemented here that allows us to toggle show/hide functionality on fronts containers. 

## Why
Previously, it was thought that new containers wouldn't have show/hide capabilities. However, this decision has been reverted and we will now support this functionality. 

We are no longer using - and no longer require - the switch to toggle this functionality.
