### PR TITLE
Set scrollable medium story cap to 8

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -328,7 +328,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         case "nav/list" => storyCountTotal
         // scrollable feature containers are capped at 3 stories
         case "scrollable/feature" => 3
-        // scrollable highlights  are capped at 6 stories
+        // scrollable highlights containers are capped at 6 stories
         case "scrollable/highlights" => 6
         // scrollable small and medium containers are capped at 8 stories
         case "scrollable/small" | "scrollable/medium" => 8

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -328,10 +328,10 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         case "nav/list" => storyCountTotal
         // scrollable feature containers are capped at 3 stories
         case "scrollable/feature" => 3
-        // scrollable highlights and medium containers are capped at 6 stories
-        case "scrollable/highlights" | "scrollable/medium" => 6
-        // scrollable/small containers are capped at 8 stories
-        case "scrollable/small" => 8
+        // scrollable highlights  are capped at 6 stories
+        case "scrollable/highlights" => 6
+        // scrollable small and medium containers are capped at 8 stories
+        case "scrollable/small" | "scrollable/medium" => 8
         // other container types should be capped at a maximum number of stories set in the app config
         case _ => Math.min(Configuration.facia.collectionCap, storyCountTotal)
       }


### PR DESCRIPTION
## What is the value of this and can you measure success?

[Resolves this F+C ticket
](https://trello.com/c/fot1SQkO/873-qa-scrollable-medium-and-small-should-cap-at-8?filter=member:georgeslebreton4)

## What does this change?

Scrollable medium containers should be able to show up to 8 stories - the number of visible stories get capped in the pressing process. 

## Screenshots



| First 4 stories     | Second 4 stories      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/76a367f7-dca4-4647-9065-215e0959b54e
[after]: https://github.com/user-attachments/assets/3978d44c-aa5b-4ffc-b72a-120c91962ac5



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
