### PR TITLE
Add fastlyRequestId to logs and pass the value to DCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           -DAPP_SECRET="fake_secret" \
           -Duser.timezone=Australia/Sydney \
           -jar ./bin/sbt-launch.jar clean compile assets scalafmtCheckAll test Universal/packageBin
-      
+
       - name: Test Summary
         uses: test-summary/action@v2
         with:

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -37,7 +37,11 @@ case class RequestLoggerFields(request: RequestHeader, response: Option[Result],
     val guardianSpecificHeaders = allHeadersFields.view.filterKeys(_.toUpperCase.startsWith("X-GU-")).toMap
 
     (allowListedHeaders ++ guardianSpecificHeaders).toList.map { case (headerName, headerValue) =>
-      LogFieldString(s"req.header.$headerName", headerValue)
+      if (headerName == "x-gu-xid") {
+        LogFieldString(s"fastlyRequestId", headerValue)
+      } else {
+        LogFieldString(s"req.header.$headerName", headerValue)
+      }
     }
   }
   private lazy val customFields: List[LogField] = {

--- a/common/app/utils/DotcomponentsLogger.scala
+++ b/common/app/utils/DotcomponentsLogger.scala
@@ -2,7 +2,7 @@ package utils
 
 import common.GuLogging
 import common.LoggingField._
-import model.{ContentPage, ContentType, PageWithStoryPackage}
+import model.ContentType
 import model.liveblog.InteractiveBlockElement
 import play.api.mvc.RequestHeader
 
@@ -18,6 +18,7 @@ case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
           "req.method" -> r.method,
           "req.url" -> r.uri,
           "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString,
+          "fastlyRequestId" -> r.headers.get("x-gu-xid").getOrElse("fastly-id-not-provided"),
         )
       }
       .getOrElse(Nil)
@@ -89,18 +90,6 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends GuLogging
 
   def results(message: String, results: Map[String, String], page: ContentType): Unit = {
     logInfoWithCustomFields(message, customFields ++ fieldsFromResults(results) ++ elementsLogFieldFromPage(page))
-  }
-
-  def info(message: String): Unit = {
-    logInfoWithCustomFields(message, customFields)
-  }
-
-  def warn(message: String, error: Throwable): Unit = {
-    logWarningWithCustomFields(message, error, customFields)
-  }
-
-  def error(message: String, error: Throwable): Unit = {
-    logErrorWithCustomFields(message, error, customFields)
   }
 
 }


### PR DESCRIPTION
## What does this change?
This PR 

**1- Adds fastlyRequestId to all request logs**
extracts the `x-gu-xid` header from the request within the `RequestLogger`. If the header is present, its value is added to the logging context under the `fastlyRequestId` field, ensuring that all request logs include this field.
**2- Adds fastlyRequestId to all DotcomponentsLogger logs**
extracts the `x-gu-xid` header from the request within the `DotcomponentsLogger`. If the header is present, its value is 
added to the logging context under the `fastlyRequestId` field, ensuring that all DotcomponentsLogger logs include this field.
**3- Adds fastlyRequestId to all ApiExceptions logs in common/package.scala**
Since the RequestHeader is an implicit parameter in convertApiExceptionsWithoutEither, the value of `x-gu-xid` is extracted and added as a field `fastlyRequestId` to the error logs
**4- Adds default value for fastlyRequestId**
In all above loggers, if the `x-gu-xid` header is not present, the fastlyRequestId will default to `fastly-id-not-provided`.
**5- Adds x-gu-xid to requests posted to DCR**
extracts the `x-gu-xid` header from the request within the DotcomRenderingService and if it exists adds it as a header to the request sent to DCAR. 

## Why
By doing so, we enable correlation between request logs captured by the frontend and the corresponding logs in DCAR, improving traceability across systems.

The relevant PR in dotcom-rendering: https://github.com/guardian/dotcom-rendering/pull/13207
![image](https://github.com/user-attachments/assets/7f3a6aae-620b-4a44-abef-0a8fc6fc3552)



This image shows the error scenario (Not Found):
![image](https://github.com/user-attachments/assets/a6ecd09a-a2a2-414a-b14b-2d72138ee9cb)

