### PR TITLE
Increase the size of the user-benefits api AB test to 1%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -56,5 +56,5 @@ object UseUserBenefitsApi
       description = "Enable the switch from members-data-api to the new user-benefits API",
       owners = Seq(Owner.withGithub("rupertbates")),
       sellByDate = LocalDate.of(2025, 6, 30),
-      participationGroup = Perc0B,
+      participationGroup = Perc1A,
     )


### PR DESCRIPTION
## What does this change?
We have a server side AB test to allow us to introduce a new API to dotcom in a controlled way. This was set to 0% to allow testing in PROD, and as that testing has been successful we now want to increase the audience to 1%. This PR does that.