### PR TITLE
Increase the size of the user-benefits api AB test to 50%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -56,5 +56,5 @@ object UseUserBenefitsApi
       description = "Enable the switch from members-data-api to the new user-benefits API",
       owners = Seq(Owner.withGithub("rupertbates")),
       sellByDate = LocalDate.of(2025, 6, 30),
-      participationGroup = Perc20A,
+      participationGroup = Perc50,
     )


### PR DESCRIPTION
## What does this change?
Follows on from https://github.com/guardian/frontend/pull/27741 and increases the audience size to 50%