### PR TITLE
set ab-test switch for the auxia signin gate experiment

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,4 +81,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-auxia-sign-in-gate",
+    "Experimental use of Auxia to drive the client-side SignIn gate",
+    owners = Seq(Owner.withEmail("growth@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2026, 1, 30)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
The Growth team is going to experiment with using an external API to drive the behaviour of the client side sign-in gate. We set up the switch that is going to allow the definition of the client side ab test.