### PR TITLE
define experiments/tests/auxia-sign-in-gate.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { auxiaSignInGate } from './tests/auxia-sign-in-gate';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -9,4 +10,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
+	auxiaSignInGate,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/auxia-sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/auxia-sign-in-gate.js
@@ -1,0 +1,23 @@
+
+export const auxiaSignInGate = {
+	id: 'AuxiaSignInGate',
+	start: '2025-01-23',
+	expiry: '2026-01-30',
+	author: 'Pascal (Growth Team)',
+	description: 'R&D Experiment: using Auxia API to drive the behavior of the SignIn gate',
+	audience: 0,
+	audienceOffset: 0,
+	successMeasure: '',
+	audienceCriteria: '',
+	ophanComponentId: 'auxia_signin_gate',
+	dataLinkNames: 'AuxiaSignInGate',
+	idealOutcome: '',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'auxia-signin-gate',
+			test: () => {},
+		},
+	],
+};


### PR DESCRIPTION
Define the client side experiment for Auxia API integration. 
Follow up of: https://github.com/guardian/frontend/pull/27743
dotcom-rendering companion: https://github.com/guardian/dotcom-rendering/pull/13197