### PR TITLE
Remove switch for regional prebid test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -62,17 +62,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-region-specific-prebid",
-    "Test impact of splitting the Prebid bundle by region",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 1, 24)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-prebid-keywords",
     "Test impact of adding keywords to Prebid config",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),


### PR DESCRIPTION
## What does this change?
Removes the switch for the region specific prebid test as the test has finished and the switch has now expired.