### PR TITLE
git ignore deleted `cmp_vendorlist.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ static/riffraff
 
 static/src/stylesheets/icons/*
 
+# Generated CMP data
+cmp_vendorlist.json
+
 # emacs temp #
 **~
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

git ignore deleted `cmp_vendorlist.json` for which the overall feature was removed in https://github.com/guardian/frontend/pull/27724

If you already have the generated file in your Frontend repo it will appear in the git changes, which is a little confusing.

