### PR TITLE
Add rel=sponsored to affiliate links

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -17,7 +17,7 @@ object TextCleaner {
       val links = AffiliateLinksCleaner.getAffiliateableLinks(doc)
       links.foreach(el => {
         val id = affiliateLinksConfig.skimlinksId
-        el.attr("href", AffiliateLinksCleaner.linkToSkimLink(el.attr("href"), pageUrl, id))
+        el.attr("href", AffiliateLinksCleaner.linkToSkimLink(el.attr("href"), pageUrl, id)).attr("rel", "sponsored")
       })
 
       if (links.nonEmpty) {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -895,14 +895,18 @@ object AffiliateLinksCleaner {
       skimlinksId: String,
   ): Document = {
     val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(html)
-    linksToReplace.foreach { el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId)) }
+    linksToReplace.foreach { el =>
+      el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId)).attr("rel", "sponsored")
+    }
     html
   }
 
   def replaceLinksInElement(html: String, pageUrl: String): TextBlockElement = {
     val doc = Jsoup.parseBodyFragment(html)
     val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(doc)
-    linksToReplace.foreach { el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId)) }
+    linksToReplace.foreach { el =>
+      el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId)).attr("rel", "sponsored")
+    }
 
     if (linksToReplace.nonEmpty) {
       TextBlockElement(doc.body().html())

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -103,6 +103,7 @@ trait AppComponents
       wire[StocksDataLifecycle],
       wire[NewsletterSignupLifecycle],
       wire[MostViewedLifecycle],
+      wire[SkimLinksCacheLifeCycle],
     )
 
   override lazy val httpFilters = wire[DevFilters].filters


### PR DESCRIPTION
## What does this change?
Affiliate links need to be [appropriately marked](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links) in order to comply with their [policy](https://developers.google.com/search/blog/2024/11/site-reputation-abuse?ck_subscriber_id=3021330475&utm_source=convertkit&utm_medium=email&utm_campaign=%F0%9F%94%AE%20Latest%20SEO%20News%2C%20Google%20Update%2C%20&%20More%20-%20SEOFOMO%2C%20Dec%208%2C%202024%20-%2015912713#affiliate-content) or could be considered by them to be abuse.

I've also added the skimlinks lifecycle to the dev app so that affiliate links work when running `dev-build` locally!

Have tested on CODE and this works as expected.