### PR TITLE
remove gpid prebid switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,17 +51,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-gpid-prebid-ad-units",
-    "Test new GPID prebid ad units",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 1, 31)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-prebid-keywords",
     "Test impact of adding keywords to Prebid config",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),


### PR DESCRIPTION
## What does this change?
This removes the Switch to enable the test for `ab-gpid-prebid-ad-units`

The [related PR ](https://github.com/guardian/commercial/pull/1772)removes the test from commercial code.

## Screenshots

| Switch removal      | After      |
|-------------|------------|
| <img width="859" alt="Screenshot 2025-01-30 at 09 18 16" src="https://github.com/user-attachments/assets/3c102318-34e4-4b41-98a5-b74ef6310ab4" /> | <img width="476" alt="Screenshot 2025-01-30 at 09 19 56" src="https://github.com/user-attachments/assets/da800e97-d2a0-4542-8b21-c429aacbc89e" /> |


<!-- Please use the following table template to make image comparison easier to parse:




[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
