### PR TITLE
Remove switch notifications

### DIFF
--- a/admin/app/controllers/admin/SwitchboardController.scala
+++ b/admin/app/controllers/admin/SwitchboardController.scala
@@ -6,7 +6,6 @@ import conf.switches.Switches
 import http.GuardianAuthWithExemptions
 import model.{ApplicationContext, NoCache}
 import play.api.mvc._
-import services.SwitchNotification
 import tools.Store
 
 import scala.concurrent.Future
@@ -87,7 +86,6 @@ class SwitchboardController(
       log.info("switches successfully updated")
 
       val changes = updates filterNot { current contains _ }
-      SwitchNotification.onSwitchChanges(pekkoAsync)(requester, Configuration.environment.stage, changes)
       changes foreach { change =>
         log.info(s"Switch change by $requester: $change")
       }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -645,7 +645,6 @@ class GuardianConfiguration extends GuLogging {
     lazy val frontendStoreBucket = configuration.getMandatoryStringProperty("aws.bucket")
     lazy val topMentionsStoreBucket =
       configuration.getStringProperty("aws.topMentions.bucket")
-    lazy val notificationSns: String = configuration.getMandatoryStringProperty("sns.notification.topic.arn")
     lazy val videoEncodingsSns: String =
       configuration.getMandatoryStringProperty("sns.missing_video_encodings.topic.arn")
     lazy val frontPressSns: Option[String] = configuration.getStringProperty("frontpress.sns.topic")

--- a/common/app/services/Notification.scala
+++ b/common/app/services/Notification.scala
@@ -60,25 +60,6 @@ trait Notification extends GuLogging {
     }
 }
 
-object SwitchNotification extends Notification {
-  lazy val topic: String = Configuration.aws.notificationSns
-
-  def onSwitchChanges(
-      pekkoAsync: PekkoAsync,
-  )(requester: String, stage: String, changes: Seq[String])(implicit executionContext: ExecutionContext): Unit = {
-    val subject = s"${stage.toUpperCase}: Switch changes by $requester"
-    val message =
-      s"""
-          |The following updates have been made to the ${stage.toUpperCase} switches by $requester.
-          |
-          |${changes mkString "\n"}
-          |
-        """.stripMargin
-
-    send(pekkoAsync)(subject, message)
-  }
-}
-
 object FrontPressNotification extends Notification {
   lazy val topic: String = Configuration.aws.frontPressSns.getOrElse("")
 }


### PR DESCRIPTION
These notifications are sent to an SNS topic whenever a switch's state changes. However, they haven't been useful for a long time, so we're removing the code that sends them.
