### PR TITLE
Add commercial switch for the trade desk prebid bidder

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -438,6 +438,17 @@ trait PrebidSwitches {
     highImpact = false,
   )
 
+  val prebidTheTradeDesk: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-the-trade-desk",
+    description = "Include The Trade Desk (ttd) adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
   val sentinelLogger: Switch = Switch(
     group = Commercial,
     name = "sentinel-logger",


### PR DESCRIPTION
## What does this change?
By convention we have a switch for each prebid bidder that runs on the site, we're adding The Trade Desk so we need a switch for them.
