### PR TITLE
Add x-gu-xid header to preview requests

### DIFF
--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -38,7 +38,7 @@ case class RequestLoggerFields(request: RequestHeader, response: Option[Result],
 
     (allowListedHeaders ++ guardianSpecificHeaders).toList.map { case (headerName, headerValue) =>
       if (headerName.toLowerCase == "x-gu-xid") {
-        LogFieldString(s"fastlyRequestId", headerValue)
+        LogFieldString(s"requestId", headerValue)
       } else {
         LogFieldString(s"req.header.$headerName", headerValue)
       }

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -43,9 +43,9 @@ object `package`
       context: ApplicationContext,
       log: Logger,
   ): PartialFunction[Throwable, Result] = {
-    val fastlyRequestId = request.headers.get("x-gu-xid").getOrElse("fastly-id-not-provided")
+    val requestId = request.headers.get("x-gu-xid").getOrElse("request-id-not-provided")
     val customFieldMarker: LogstashMarker = {
-      append("fastlyRequestId", fastlyRequestId)
+      append("requestId", requestId)
     }
     {
       case _: CircuitBreakerOpenException =>

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -123,6 +123,7 @@ object Filters {
       executionContext: ExecutionContext,
   ): List[EssentialFilter] =
     List(
+      new RequestIdFilter(),
       new RequestLoggingFilter,
       new PanicSheddingFilter,
       new JsonVaryHeadersFilter,

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -123,7 +123,6 @@ object Filters {
       executionContext: ExecutionContext,
   ): List[EssentialFilter] =
     List(
-      new RequestIdFilter(),
       new RequestLoggingFilter,
       new PanicSheddingFilter,
       new JsonVaryHeadersFilter,

--- a/common/app/http/RequestIdFilter.scala
+++ b/common/app/http/RequestIdFilter.scala
@@ -13,6 +13,7 @@ class RequestIdFilter(implicit val mat: Materializer, executionContext: Executio
 
   override def apply(next: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
     val headerKey = "x-gu-xid"
+    // Play Framework's Headers.get(key) does a case-insensitive lookup
     val updatedRequest =
       if (rh.headers.get(headerKey).isEmpty) {
         rh.withHeaders(rh.headers.add(headerKey -> UUID.randomUUID().toString))

--- a/common/app/http/RequestIdFilter.scala
+++ b/common/app/http/RequestIdFilter.scala
@@ -1,0 +1,24 @@
+package http
+
+import common.{GuLogging}
+import org.apache.pekko.stream.Materializer
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
+
+class RequestIdFilter(implicit val mat: Materializer, executionContext: ExecutionContext)
+    extends Filter
+    with GuLogging {
+
+  override def apply(next: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
+    val headerKey = "x-gu-xid"
+    val updatedRequest =
+      if (rh.headers.get(headerKey).isEmpty) {
+        rh.withHeaders(rh.headers.add(headerKey -> UUID.randomUUID().toString))
+      } else {
+        rh
+      }
+    next(updatedRequest)
+  }
+}

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -59,7 +59,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       ws: WSClient,
       payload: JsValue,
       endpoint: String,
-      fastlyRequestId: Option[String],
+      requestId: Option[String],
       timeout: Duration = Configuration.rendering.timeout,
   )(implicit request: RequestHeader): Future[WSResponse] = {
 
@@ -70,7 +70,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       .withRequestTimeout(timeout)
       .addHttpHeaders("Content-Type" -> "application/json")
 
-    val resp = fastlyRequestId match {
+    val resp = requestId match {
       case Some(id) => request.addHttpHeaders("x-gu-xid" -> id).post(payload)
       case None     => request.post(payload)
     }
@@ -104,7 +104,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       cacheTime: CacheTime,
       timeout: Duration = Configuration.rendering.timeout,
   )(implicit request: RequestHeader): Future[Result] = {
-    val fastlyRequestId = request.headers.get("x-gu-xid")
+    val requestId = request.headers.get("x-gu-xid")
     def handler(response: WSResponse): Result = {
       response.status match {
         case 200 =>
@@ -140,10 +140,10 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     if (CircuitBreakerDcrSwitch.isSwitchedOn) {
       circuitBreaker
-        .withCircuitBreaker(postWithoutHandler(ws, payload, endpoint, fastlyRequestId, timeout))
+        .withCircuitBreaker(postWithoutHandler(ws, payload, endpoint, requestId, timeout))
         .map(handler)
     } else {
-      postWithoutHandler(ws, payload, endpoint, fastlyRequestId, timeout).map(handler)
+      postWithoutHandler(ws, payload, endpoint, requestId, timeout).map(handler)
     }
   }
 
@@ -232,9 +232,9 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[String] = {
     val dataModel = DotcomBlocksRenderingDataModel(page, request, blocks)
     val json = DotcomBlocksRenderingDataModel.toJson(dataModel)
-    val fastlyRequestId = request.headers.get("x-gu-xid")
+    val requestId = request.headers.get("x-gu-xid")
 
-    postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/Blocks", fastlyRequestId)
+    postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/Blocks", requestId)
       .flatMap(response => {
         if (response.status == 200)
           Future.successful(response.body)
@@ -254,9 +254,9 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[String] = {
     val dataModel = DotcomBlocksRenderingDataModel(page, request, blocks)
     val json = DotcomBlocksRenderingDataModel.toJson(dataModel)
-    val fastlyRequestId = request.headers.get("x-gu-xid")
+    val requestId = request.headers.get("x-gu-xid")
 
-    postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/AppsBlocks", fastlyRequestId)
+    postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/AppsBlocks", requestId)
       .flatMap(response => {
         if (response.status == 200)
           Future.successful(response.body)

--- a/common/app/services/dotcomrendering/DotcomFrontsLogger.scala
+++ b/common/app/services/dotcomrendering/DotcomFrontsLogger.scala
@@ -14,6 +14,7 @@ case class DotcomFrontsLogger() extends GuLogging {
       "req.method" -> request.method,
       "req.url" -> request.uri,
       "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString,
+      "requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"),
     )
   }
 

--- a/common/app/utils/DotcomponentsLogger.scala
+++ b/common/app/utils/DotcomponentsLogger.scala
@@ -18,7 +18,7 @@ case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
           "req.method" -> r.method,
           "req.url" -> r.uri,
           "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString,
-          "fastlyRequestId" -> r.headers.get("x-gu-xid").getOrElse("fastly-id-not-provided"),
+          "requestId" -> r.headers.get("x-gu-xid").getOrElse("request-id-not-provided"),
         )
       }
       .getOrElse(Nil)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -238,8 +238,7 @@ trait FaciaController
       }
     }
 
-    val headers = request.headers.toSimpleMap
-    val customLogFieldMarker = append("requestId", headers.getOrElse("x-gu-xid", "request-id-not-provided"))
+    val customLogFieldMarker = append("requestId", request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))
 
     val networkFrontEdition = Edition.allEditions.find(_.networkFrontId == path)
     val deeplyRead = networkFrontEdition.map(deeplyReadAgent.getTrails)
@@ -254,7 +253,7 @@ trait FaciaController
 
         log.logger.info(
           customLogFieldMarker,
-          s"Front Geo Request (212): ${Edition(request).id} ${headers.getOrElse("X-GU-GeoLocation", "country:row")}",
+          s"Front Geo Request (212): ${Edition(request).id} ${request.headers.toSimpleMap.getOrElse("X-GU-GeoLocation", "country:row")}",
         )
         withVaryHeader(
           remoteRenderer.getFront(
@@ -279,7 +278,7 @@ trait FaciaController
         val result = if (request.forceDCR) {
           log.logger.info(
             customLogFieldMarker,
-            s"Front Geo Request (237): ${Edition(request).id} ${headers.getOrElse("X-GU-GeoLocation", "country:row")}",
+            s"Front Geo Request (237): ${Edition(request).id} ${request.headers.toSimpleMap.getOrElse("X-GU-GeoLocation", "country:row")}",
           )
           JsonComponent.fromWritable(
             DotcomFrontsRenderingDataModel(

--- a/onward/app/controllers/OnwardContentCardController.scala
+++ b/onward/app/controllers/OnwardContentCardController.scala
@@ -1,10 +1,11 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.ItemResponse
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, GuLogging}
+import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent}
 import contentapi.ContentApiClient
 import implicits.Requests
 import model.{ApplicationContext, Cached, NoCache}
+import net.logstash.logback.marker.Markers.append
 import play.api.mvc._
 import play.twirl.api.HtmlFormat
 
@@ -26,7 +27,11 @@ abstract class OnwardContentCardController(
 
   protected def lookup(path: String, fields: String)(implicit request: RequestHeader): Future[ItemResponse] = {
     val edition = Edition(request)
-    log.info(s"Fetching article: $path for edition: ${edition.id}:")
+
+    val requestId = request.headers.get("x-gu-xid").getOrElse("request-id-not-provided")
+    val customFieldMarker = append("requestId", requestId)
+
+    log.logger.info(customFieldMarker, s"Fetching article: $path for edition: ${edition.id}:")
 
     contentApiClient.getResponse(
       contentApiClient

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -17,7 +17,14 @@ import cricket.controllers.CricketControllers
 import dev.DevAssetsController
 import feed.OnwardJourneyLifecycle
 import football.controllers.FootballControllers
-import http.{Filters, GuardianAuthWithExemptions, PreviewContentSecurityPolicyFilter, PreviewNoCacheFilter, routes}
+import http.{
+  Filters,
+  GuardianAuthWithExemptions,
+  PreviewContentSecurityPolicyFilter,
+  PreviewNoCacheFilter,
+  RequestIdFilter,
+  routes,
+}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.http.HttpErrorHandler
@@ -134,7 +141,7 @@ trait AppComponents
     standaloneLifecycleComponents :+ wire[CachedHealthCheckLifeCycle]
 
   override lazy val httpFilters: Seq[EssentialFilter] =
-    new PreviewNoCacheFilter :: new PreviewContentSecurityPolicyFilter :: Filters.common(
+    new PreviewNoCacheFilter :: new PreviewContentSecurityPolicyFilter :: new RequestIdFilter :: Filters.common(
       frontend.preview.BuildInfo,
     )
 

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -17,14 +17,7 @@ import cricket.controllers.CricketControllers
 import dev.DevAssetsController
 import feed.OnwardJourneyLifecycle
 import football.controllers.FootballControllers
-import http.{
-  Filters,
-  GuardianAuthWithExemptions,
-  PreviewContentSecurityPolicyFilter,
-  PreviewNoCacheFilter,
-  RequestIdFilter,
-  routes,
-}
+import http.{Filters, GuardianAuthWithExemptions, PreviewContentSecurityPolicyFilter, PreviewNoCacheFilter, routes}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.http.HttpErrorHandler
@@ -141,7 +134,7 @@ trait AppComponents
     standaloneLifecycleComponents :+ wire[CachedHealthCheckLifeCycle]
 
   override lazy val httpFilters: Seq[EssentialFilter] =
-    new PreviewNoCacheFilter :: new PreviewContentSecurityPolicyFilter :: new RequestIdFilter :: Filters.common(
+    new PreviewNoCacheFilter :: new PreviewContentSecurityPolicyFilter :: Filters.common(
       frontend.preview.BuildInfo,
     )
 

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -141,9 +141,10 @@ trait AppComponents
     standaloneLifecycleComponents :+ wire[CachedHealthCheckLifeCycle]
 
   override lazy val httpFilters: Seq[EssentialFilter] =
-    new PreviewNoCacheFilter :: new PreviewContentSecurityPolicyFilter :: new RequestIdFilter :: Filters.common(
-      frontend.preview.BuildInfo,
-    )
+    auth.filter :: new PreviewNoCacheFilter :: new PreviewContentSecurityPolicyFilter :: new RequestIdFilter :: Filters
+      .common(
+        frontend.preview.BuildInfo,
+      )
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[PreviewErrorHandler]
 }

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -17,7 +17,14 @@ import cricket.controllers.CricketControllers
 import dev.DevAssetsController
 import feed.OnwardJourneyLifecycle
 import football.controllers.FootballControllers
-import http.{Filters, GuardianAuthWithExemptions, PreviewContentSecurityPolicyFilter, PreviewNoCacheFilter, routes}
+import http.{
+  Filters,
+  GuardianAuthWithExemptions,
+  PreviewContentSecurityPolicyFilter,
+  PreviewNoCacheFilter,
+  RequestIdFilter,
+  routes,
+}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.http.HttpErrorHandler
@@ -134,7 +141,7 @@ trait AppComponents
     standaloneLifecycleComponents :+ wire[CachedHealthCheckLifeCycle]
 
   override lazy val httpFilters: Seq[EssentialFilter] =
-    auth.filter :: new PreviewNoCacheFilter :: new PreviewContentSecurityPolicyFilter :: Filters.common(
+    new PreviewNoCacheFilter :: new PreviewContentSecurityPolicyFilter :: new RequestIdFilter :: Filters.common(
       frontend.preview.BuildInfo,
     )
 


### PR DESCRIPTION
## What does this change?
This PR adds a new Filter (middleware) to the the preview filters. This filter is adding `x-gu-xid` header to the request if it's missing. It also renames the log field the log field `fastlyRequestId` to `requestId` to keep the field more generic.
It also adds the requestId field to the logs in facia controller & DotcomFrontsLogger. 

Context: As part of this PR https://github.com/guardian/frontend/pull/27735 the value of `x-gu-xid` is retrieved and added as a log field `fastlyRequestId` to the request logs. We then realised that there are still quite a lot of logs that are ending up no fastly request id.  

Digging more, we found our that some of the requests are coming from fastly with no id. These were fixed by:
- https://github.com/guardian/fastly-edge-cache/pull/1077
- Adding vcl snippet for embed.theguardian.com and crossword fastly services directly in fastly (because these services don't have custom VCL setup in fastly-edge-cache repo)

Looking more at the logs, it seems that `preview` requests also don't have the `x-gu-xid` header. So this filter is explicitly adding the header in order to better associate the logs.

**Note:** After this PR, the logs will be more analysed to see if there are still other requests that are coming with no xid or if we need to add the requestId to more logs throughout the code base. 

The DCR PR that is relevant to this PR: https://github.com/guardian/dotcom-rendering/pull/13266
