### PR TITLE
Update `admin` to no longer `aggregate` on common

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,6 @@ val diagnostics = application("diagnostics")
 
 val admin = application("admin")
   .dependsOn(commonWithTests)
-  .aggregate(common)
   .settings(
     libraryDependencies ++= Seq(
       paClient,


### PR DESCRIPTION
In SBT, `aggregate` means:

> Aggregation means that running a task on the aggregate project will also run it on the aggregated projects.

This means if a task is run on the `admin` project, it'll also be run on `common`. This isn't necessary as we only need to compile common.

## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
