### PR TITLE
Remove the user-benefits api AB test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,7 +14,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeBetaFront,
       DCRCrosswords,
       DarkModeWeb,
-      UseUserBenefitsApi,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -48,13 +47,4 @@ object DarkModeWeb
       owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 4, 30),
       participationGroup = Perc0D,
-    )
-
-object UseUserBenefitsApi
-    extends Experiment(
-      name = "use-user-benefits-api",
-      description = "Enable the switch from members-data-api to the new user-benefits API",
-      owners = Seq(Owner.withGithub("rupertbates")),
-      sellByDate = LocalDate.of(2025, 6, 30),
-      participationGroup = Perc50,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?
This server-side AB test was used to roll out the new user-benefits API. That roll out is now complete so this test is no longer needed.