### PR TITLE
chore: Remove non-existent `diagnostics` project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,15 +106,6 @@ val sport = application("sport")
 
 val discussion = application("discussion").dependsOn(commonWithTests).aggregate(common)
 
-val diagnostics = application("diagnostics")
-  .dependsOn(commonWithTests)
-  .aggregate(common)
-  .settings(
-    libraryDependencies ++= Seq(
-      redisClient,
-    ),
-  )
-
 val admin = application("admin")
   .dependsOn(commonWithTests)
   .aggregate(common)
@@ -174,7 +165,6 @@ val dev = application("dev-build")
     archive,
     sport,
     discussion,
-    diagnostics,
     identity,
     admin,
     commercial,
@@ -209,7 +199,6 @@ val main = root()
     applications,
     sport,
     discussion,
-    diagnostics,
     admin,
     identity,
     commercial,


### PR DESCRIPTION
## What is the value of this and can you measure success?
Removes a redundant project from `build.sbt` as the `diagnostics` app was removed in #24205. This is a no-op and might result in a slight decrease in build speeds.