### PR TITLE
Add AB test switch for Prebid v9

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,4 +81,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-prebid-v9",
+    "Test Prebid v9 ahead of full release",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 2, 28)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

We're going to run a 0% client side test for the Prebid upgrade to v9 as there are potentially breaking changes that we are unable to fully test in development

## What does this change?

Adds an AB test switch to turn on the client-side test for Prebid v9

See https://github.com/guardian/commercial/pull/1760