### PR TITLE
Add switch and AB test for looping video test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,6 +12,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       EuropeBetaFront,
+      LoopVideoTest,
       DCRCrosswords,
       DarkModeWeb,
     )
@@ -29,6 +30,15 @@ object EuropeBetaFront
       ),
       sellByDate = LocalDate.of(2025, 4, 2),
       participationGroup = Perc0A,
+    )
+
+object LoopVideoTest
+    extends Experiment(
+      name = "loop-video-test",
+      description = "Test looping videos effect on Core Web Vitals",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 5, 28),
+      participationGroup = Perc0B,
     )
 
 object DCRCrosswords


### PR DESCRIPTION
## What does this change?

Fronts & Curation would like to test the effect of looping videos on a front has on Core Web Vitals in a simple test. We will add custom code in DCR to add looping videos to a front, and hide it behind this switch, so that real users are not affected.