### PR TITLE
Revert "Add AB test switch for Prebid v9"

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,15 +81,4 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  Switch(
-    ABTests,
-    "ab-prebid-v9",
-    "Test Prebid v9 ahead of full release",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 2, 28)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }


### PR DESCRIPTION
Reverts guardian/frontend#27767

Removes AB test switch since we no longer need it