### PR TITLE
Delete old commercial code to fix dev build

### DIFF
--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -1,4 +1,3 @@
-import _root_.commercial.CommercialLifecycle
 import _root_.commercial.controllers.CommercialControllers
 import _root_.commercial.targeting.TargetingLifecycle
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
@@ -88,7 +87,6 @@ trait AppComponents
     List(
       wire[AdminLifecycle],
       wire[OnwardJourneyLifecycle],
-      wire[CommercialLifecycle],
       wire[DfpDataCacheLifecycle],
       wire[FaciaDfpAgentLifecycle],
       wire[ConfigAgentLifecycle],

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -2,8 +2,6 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET            /commercial/test-page                                                                                             commercial.controllers.CreativeTestPage.allComponents(k: List[String])
-
 GET            /email-newsletters.json                                                                                           controllers.SignupPageController.renderNewsletters()
 GET            /email-newsletters                                                                                                controllers.SignupPageController.renderNewsletters()
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
Removes CommercialLifecycle route as in https://github.com/guardian/frontend/pull/27755 and the test pages route as in here https://github.com/guardian/frontend/pull/27726 for dev-build app as has been done in the commercial app

Presumably we could delete this file now also https://github.com/guardian/frontend/blob/09d382fd6531117c0c5910e5cf5267a54d707471/commercial/app/controllers/CreativeTestPage.scala 

## What does this change?
Fix dev-build
