### PR TITLE
Adds the aspectRatio field to the ImageAsset

### DIFF
--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -28,6 +28,7 @@ object Helpers {
       "scriptName" -> asset.typeData.flatMap(_.scriptName),
       "html" -> asset.typeData.flatMap(_.html),
       "embedType" -> asset.typeData.flatMap(_.embedType),
+      "aspectRatio" -> asset.typeData.flatMap(_.aspectRatio),
     ).collect { case (k, Some(v)) => (k, v) }
 
   def audioElementFieldsToMap(audioElementFields: AudioElementFields): Map[String, String] =


### PR DESCRIPTION
## What is the value of this and can you measure success?
Adds the aspectRatio field as this is needed for this work https://github.com/guardian/dotcom-rendering/issues/13341
## What does this change?
Adds the aspectRatio field to the ImageAsset
## Screenshots

<img width="396" alt="image" src="https://github.com/user-attachments/assets/c48de26b-8126-4521-aa2c-4ece2a07b92d" />

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
