### PR TITLE
Add switch for movePermutiveSegmentation test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -92,4 +92,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-move-permutive-segmentation",
+    "Test the impact of moving the call for the Permutive segmentation script.",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 3, 21)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What does this change?
Adds a switch to allow us to test moving the call of `initPermutive()` in the commercial code behind a 0% test.