### PR TITLE
Add remote renderer for football live page

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,6 +15,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       LoopVideoTest,
       DCRCrosswords,
       DarkModeWeb,
+      DCRFootballLive,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -57,4 +58,13 @@ object DarkModeWeb
       owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 4, 30),
       participationGroup = Perc0D,
+    )
+
+object DCRFootballLive
+    extends Experiment(
+      name = "dcr-football-live",
+      description = "Render football/live in DCR",
+      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2025, 3, 10),
+      participationGroup = Perc0E,
     )

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -27,6 +27,7 @@ object CacheTime {
   object NotFound extends CacheTime(10) // This will be overwritten by fastly
   object DiscussionDefault extends CacheTime(60)
   object DiscussionClosed extends CacheTime(60, Some(longCacheTime))
+  object Football extends CacheTime(10)
   private def oldArticleCacheTime = if (ShorterSurrogateCacheForOlderArticles.isSwitchedOn) 60 else longCacheTime
   def LastDayUpdated = CacheTime(60, Some(oldArticleCacheTime))
   def NotRecentlyUpdated = CacheTime(60, Some(oldArticleCacheTime))

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -446,6 +446,13 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val json = EditionsCrosswordRenderingDataModel.toJson(crosswords)
     post(ws, json, Configuration.rendering.articleBaseURL + "/EditionsCrossword", CacheTime.Default)
   }
+
+  def getFootballPage(
+      ws: WSClient,
+      json: JsValue,
+  )(implicit request: RequestHeader): Future[Result] = {
+    post(ws, json, Configuration.rendering.tagPageBaseURL + "/FootballDataPage", CacheTime.Football)
+  }
 }
 
 object DotcomRenderingService {

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -451,7 +451,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       ws: WSClient,
       json: JsValue,
   )(implicit request: RequestHeader): Future[Result] = {
-    post(ws, json, Configuration.rendering.tagPageBaseURL + "/FootballDataPage", CacheTime.Football)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/FootballDataPage", CacheTime.Football)
   }
 }
 

--- a/common/app/utils/DotcomponentsLogger.scala
+++ b/common/app/utils/DotcomponentsLogger.scala
@@ -81,15 +81,22 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends GuLogging
   def logRequest(msg: String, results: Map[String, String], page: ContentType)(implicit
       request: RequestHeader,
   ): Unit = {
-    withRequestHeaders(request).results(msg, results, page)
+    withRequestHeaders(request).results(msg, results, Some(page))
+  }
+
+  def logRequestForNonContentPage(msg: String, results: Map[String, String])(implicit
+      request: RequestHeader,
+  ): Unit = {
+    withRequestHeaders(request).results(msg, results, None)
   }
 
   def withRequestHeaders(rh: RequestHeader): DotcomponentsLogger = {
     copy(Some(rh))
   }
 
-  def results(message: String, results: Map[String, String], page: ContentType): Unit = {
-    logInfoWithCustomFields(message, customFields ++ fieldsFromResults(results) ++ elementsLogFieldFromPage(page))
+  def results(message: String, results: Map[String, String], page: Option[ContentType]): Unit = {
+    val elementsLogFieldFromContent = page.map(elementsLogFieldFromPage).getOrElse(List.empty)
+    logInfoWithCustomFields(message, customFields ++ fieldsFromResults(results) ++ elementsLogFieldFromContent)
   }
 
 }

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -5,12 +5,13 @@ import feed.CompetitionsService
 import football.model._
 import model._
 import java.time.LocalDate
-import pa.FootballTeam
+import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 
 class FixturesController(
     val competitionsService: CompetitionsService,
     val controllerComponents: ControllerComponents,
+    val wsClient: WSClient,
 )(implicit context: ApplicationContext)
     extends MatchListController
     with CompetitionFixtureFilters {
@@ -34,7 +35,7 @@ class FixturesController(
     moreFixturesFor(year, month, day)
 
   private def renderAllFixtures(date: LocalDate): Action[AnyContent] =
-    Action { implicit request =>
+    Action.async { implicit request =>
       renderMatchList(page, fixtures(date), filters)
     }
 
@@ -81,7 +82,7 @@ class FixturesController(
   private def renderTagFixtures(date: LocalDate, tag: String): Action[AnyContent] =
     getTagFixtures(date, tag)
       .map(result =>
-        Action { implicit request =>
+        Action.async { implicit request =>
           renderMatchList(
             result._1,
             result._2,

--- a/sport/app/football/controllers/FootballControllers.scala
+++ b/sport/app/football/controllers/FootballControllers.scala
@@ -5,6 +5,7 @@ import conf.FootballClient
 import contentapi.ContentApiClient
 import feed.CompetitionsService
 import model.ApplicationContext
+import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 
 trait FootballControllers {
@@ -12,6 +13,7 @@ trait FootballControllers {
   def footballClient: FootballClient
   def contentApiClient: ContentApiClient
   def controllerComponents: ControllerComponents
+  def wsClient: WSClient
   implicit def appContext: ApplicationContext
   lazy val fixturesController = wire[FixturesController]
   lazy val resultsController = wire[ResultsController]

--- a/sport/app/services/dotcomrendering/FootballPagePicker.scala
+++ b/sport/app/services/dotcomrendering/FootballPagePicker.scala
@@ -1,0 +1,43 @@
+package services.dotcomrendering
+
+import experiments.{ActiveExperiments, DCRFootballLive}
+import football.controllers.FootballPage
+import model.Cors.RichRequestHeader
+import play.api.mvc.RequestHeader
+import utils.DotcomponentsLogger
+
+object FootballPagePicker {
+
+  def isSupportedInDcr(page: FootballPage): Boolean = {
+    page.metadata.id == "football/live"
+  }
+
+  def getTier(
+      footballPage: FootballPage,
+  )(implicit
+      request: RequestHeader,
+  ): RenderType = {
+
+    val dcrCanRender = isSupportedInDcr(footballPage)
+
+    val participatingInTest = ActiveExperiments.isParticipating(DCRFootballLive)
+
+    val tier = {
+      if (request.forceDCROff) LocalRender
+      else if (request.forceDCR) RemoteRender
+      else if (dcrCanRender && participatingInTest) RemoteRender
+      else LocalRender
+    }
+
+    if (tier == RemoteRender) {
+      DotcomponentsLogger.logger.logRequestForNonContentPage(
+        s"path executing in dotcomponents",
+        Map.empty,
+      )
+    } else {
+      DotcomponentsLogger.logger.logRequestForNonContentPage(s"path executing in web (frontend)", Map.empty)
+    }
+
+    tier
+  }
+}

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
   val tag = "premierleague"
 
   lazy val fixturesController =
-    new FixturesController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents())
+    new FixturesController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents(), wsClient)
 
   "can load the all fixtures page" in {
     val result = fixturesController.allFixtures()(TestRequest())

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -25,7 +25,7 @@ import scala.concurrent.Future
     with WithTestWsClient {
 
   val resultsController =
-    new ResultsController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents())
+    new ResultsController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents(), wsClient)
 
   implicit lazy val mat: Materializer = app.materializer
 


### PR DESCRIPTION
## What does this change?
This PR does the following:
- Adding football page picker to decide rendering platform 
  - The picker checks if the query parameter to force dcr exists, or if the experiment header exists and the page is `football/live`
- Adding switch (experiment with 0 percent) to use for picking the rendering platform. for this to work:
   -  we need to enable the switch `dcr-football-live` in the switch board 
   - we need to add the header `X-GU-Experiment-0perc-E` with value `variant` to the request


Tested in code