### PR TITLE
Increase the Auxia Experiment audience from 0% to 1%

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/auxia-sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/auxia-sign-in-gate.js
@@ -5,7 +5,7 @@ export const auxiaSignInGate = {
 	expiry: '2026-01-30',
 	author: 'Pascal (Growth Team)',
 	description: 'R&D Experiment: using Auxia API to drive the behavior of the SignIn gate',
-	audience: 0,
+	audience: 0.01,
 	audienceOffset: 0,
 	successMeasure: '',
 	audienceCriteria: '',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,8 +8,8 @@ export const signInGateMainVariant = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.9,
-	audienceOffset: 0.0,
+	audience: 0.89,
+	audienceOffset: 0.01,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',


### PR DESCRIPTION
Increase the Auxia Experiment audience from 0% to 1% (reducing the share of SignInGateMainVariant from 0.90 from 0.89)

Sister PR: https://github.com/guardian/dotcom-rendering/pull/13409

```
AuxiaSignInGate (0.01)       SignInGateMainVariant (0.89)      SignInGateMainControl (0.1)
      |                                   |                             |
0.0 ----- 0.01                     0.01 ----- 0.9                 0.9 ----- 1.0
```