### PR TITLE
Ensure fastlyRequestId is correctly extracted from headers

### DIFF
--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -37,7 +37,7 @@ case class RequestLoggerFields(request: RequestHeader, response: Option[Result],
     val guardianSpecificHeaders = allHeadersFields.view.filterKeys(_.toUpperCase.startsWith("X-GU-")).toMap
 
     (allowListedHeaders ++ guardianSpecificHeaders).toList.map { case (headerName, headerValue) =>
-      if (headerName == "x-gu-xid") {
+      if (headerName.toLowerCase == "x-gu-xid") {
         LogFieldString(s"fastlyRequestId", headerValue)
       } else {
         LogFieldString(s"req.header.$headerName", headerValue)


### PR DESCRIPTION
## What is the value of this and can you measure success?
In [PR #27735](https://github.com/guardian/frontend/pull/27735), we added `fastlyRequestId` as a log field. However, after reviewing the logs, I noticed that this field was missing in some entries where it should have been present.

Upon investigation, I found that the condition `headerName == "x-gu-xid"` could fail if the header was received with uppercase letters, preventing the ID from being logged correctly.

There is another ongoing PR ([#27762](https://github.com/guardian/frontend/pull/27762)) aimed at adding the ID when the header is missing. However, before finalizing that change, it’s important to first ensure we are correctly capturing the IDs provided in the header. This will allow for a more accurate analysis of which services are missing the header and why.

This PR fixes the case-sensitivity issue, ensuring fastlyRequestId is consistently extracted and logged.
