### PR TITLE
Identity | Add instructions on developing with okta/sign in local dev

### DIFF
--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -283,7 +283,7 @@ Recommended VSCode extensions are listed in `.vscode/extensions.json` and VSCode
 If you are working on Identity or Discussion, Nginx must be installed and
 configured to correctly serve the application, please refer to
 [`/nginx/README.md`](https://github.com/guardian/frontend/blob/main/nginx/README.md) in this project.
-This will allow you to access frontend via `https://m.thegulocal.com`
+This will allow you to access frontend via `https://m.thegulocal.com` and test signed in behaviour.
 
 ### Optional steps
 

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -28,3 +28,15 @@ You need to install:
 ## Access the Site
 
 Visit https://m.thegulocal.com/.
+
+## Testing signed in behaviour
+
+1. Sign in to https://profile.code.dev-theguardian.com/ on a separate tab/window
+
+    - Third party cookies must be enabled in your browser for this to work
+
+2. Back on `frontend` under https://m.thegulocal.com set a cookie with the name `GU_U` with any value on the `m.thegulocal.com` domain and refresh the page
+3. You should now be signed in!
+
+    - You should see the header change to show `My Account` instead of `Sign in`
+    - In local storage you should see a key `gu.access_token` and `gu.id_token` with the values of the tokens you are signed in with


### PR DESCRIPTION
## What does this change?

For Frontend local development we want to be able to use Okta/OAuth tokens locally during development to test and develop against signed in features.

This is currently very difficult as Frontend developments happens on localhost, which cannot share cookies with Identity/Okta, which runs on https on the `profile` subdomain.

However Fronend can be run on `https://m.thegulocal.com` by following [these instructions](https://github.com/guardian/frontend/blob/main/nginx/README.md#frontend-nginx-dev-config). Since that does run locally using https, and on the `thegulocal.com` domain, it makes it possible to share cookies with Okta.

This PR updates those instructions with updated ones showing exactly the steps needed to be taken in order to enable this. It also updates `@guardian/identity-auth-frontend` which enables the use of this domain in local development (see the CSNX and Identity Platform PRs below).

## Related PRs

Identity Platform: https://github.com/guardian/identity-platform/pull/802
Dotcom Rendering: https://github.com/guardian/dotcom-rendering/pull/13426
CSNX: https://github.com/guardian/csnx/pull/1964
Frontend (This PR): https://github.com/guardian/frontend/pull/27791

## Tested

- [ ] Local DEV
