### PR TITLE
Revert "Add switch and AB test for looping video test"

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,7 +12,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       EuropeBetaFront,
-      LoopVideoTest,
       DCRCrosswords,
       DarkModeWeb,
     )
@@ -30,15 +29,6 @@ object EuropeBetaFront
       ),
       sellByDate = LocalDate.of(2025, 4, 2),
       participationGroup = Perc0A,
-    )
-
-object LoopVideoTest
-    extends Experiment(
-      name = "loop-video-test",
-      description = "Test looping videos effect on Core Web Vitals",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 5, 28),
-      participationGroup = Perc0B,
     )
 
 object DCRCrosswords


### PR DESCRIPTION
Reverts guardian/frontend#27768

We have finished testing looping videos and can now remove this switch