### PR TITLE
Fix pre-push hook node version

### DIFF
--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -42,7 +42,7 @@ const confirmIfMain = execa
 const validate = () => {
     try {
         const nvmrcVersion = fs.readFileSync('.nvmrc', 'utf8').trim();
-        const nodePath = `/.nvm/versions/node/v${nvmrcVersion}/bin/node`;
+        const nodePath = `${process.env.HOME}/.nvm/versions/node/v${nvmrcVersion}/bin/node`;
 
         return execa(
             nodePath, // Use dynamically constructed nodePath

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -39,14 +39,31 @@ const confirmIfMain = execa
         }
     )
     .catch(() => Promise.reject(new Error('Ok, stopping 😉')));
-const validate = () =>
-    execa(
-        './tools/task-runner/runner.mjs',
-        ['validate-head/index.mjs'],
-        {
-            stdio: 'inherit',
-        }
-    );
+const validate = () => {
+    try {
+        const nvmrcVersion = fs.readFileSync('.nvmrc', 'utf8').trim();
+        const nodePath = `/.nvm/versions/node/v${nvmrcVersion}/bin/node`;
+
+        return execa(
+            nodePath, // Use dynamically constructed nodePath
+            ['./tools/task-runner/runner.mjs', 'validate-head/index.mjs'],
+            {
+                stdio: 'inherit',
+            }
+        );
+    } catch (error) {
+        console.error(chalk.red(`Error reading .nvmrc: ${error.message}`));
+        console.error(chalk.red(`Falling back to default node execution, which might fail.`));
+        // If .nvmrc reading fails, we fall back to the original execa call (without explicit node path)
+        return execa(
+            './tools/task-runner/runner.mjs',
+            ['validate-head/index.mjs'],
+            {
+                stdio: 'inherit',
+            }
+        );
+    }
+};
 const checkYarnLock = changed => {
     if (
         changed.some(file => file === 'package.json') &&


### PR DESCRIPTION
## What is the value of this and can you measure success?
This change ensures that the pre-push hook uses the Node.js version specified in `.nvmrc`. This prevents errors related to unsupported JavaScript syntax in older Node.js versions and ensures that the hooks run correctly for all developers, regardless of their system's default Node.js version.
## What does this change?
Modifies the `validate` function within the `.git/hooks/pre-push` script to dynamically determine the Node.js executable path based on the version specified in the `.nvmrc` file.