### PR TITLE
Refactor the refreshUserBenefits and isUserLoggedIn into a Promise.

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -29,17 +29,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-ad-block-ask",
-    "Show new ad block ask component in ad slots when we detect ad blocker usage",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 2, 24)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-opt-out-frequency-cap",
     "Test the Opt Out frequency capping feature",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",
 		"@guardian/identity-auth-frontend": "6.0.3",
-		"@guardian/libs": "21.1.0",
+		"@guardian/libs": "21.3.0",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "16.0.0",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -40,14 +40,6 @@ const go = () => {
         bootStandard();
 
         /**
-		 * User Benefits API
-		 *
-		 */
-        await refreshUserBenefits().catch((err) => {
-            reportError(err, { module: 'c-user-benefits' });
-        });
-
-        /**
          * CMP
          *
          */
@@ -129,7 +121,12 @@ const go = () => {
 
         });
 
-        const isUserSignedIn = await isUserLoggedIn();
+        const [refresh, isUserSignedIn] = await Promise.all([
+            refreshUserBenefits().catch((err) => {
+                reportError(err, { module: 'c-user-benefits' });
+            }),
+            isUserLoggedIn(),
+        ]);
         const useNonAdvertisedList = allowRejectAll(isUserSignedIn);
 
         cmp.init({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,7 +3758,7 @@ __metadata:
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"
     "@guardian/identity-auth-frontend": "npm:6.0.3"
-    "@guardian/libs": "npm:21.1.0"
+    "@guardian/libs": "npm:21.3.0"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
     "@guardian/source-foundations": "npm:16.0.0"
@@ -3914,16 +3914,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/libs@npm:21.1.0":
-  version: 21.1.0
-  resolution: "@guardian/libs@npm:21.1.0"
+"@guardian/libs@npm:21.3.0":
+  version: 21.3.0
+  resolution: "@guardian/libs@npm:21.3.0"
   peerDependencies:
     tslib: ^2.6.2
     typescript: ~5.5.2
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/f7abc13e554cd103af49dd38311fe59ac4df93c51fa75dba6ae71d4d940e7986a45c7210e9991a7ab72a2c845124b0e7e8a871713f0f2359240fb9f78be23fa3
+  checksum: 10c0/7837ea32a0a4d2274f9368fe35d2d89f7b9c1b0225a985eb2c81f1615a88b4600454919c3fea46074e030183910d32d6036dcb6dfe8f95037606d07bb4af5d2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
