### PR TITLE
Update API for suppress image

### DIFF
--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -77,7 +77,6 @@ class ShouldServeFrontTest
         frontsToolSettings = None,
         userVisibility = None,
         targetedTerritory = None,
-        suppressImages = None,
       ),
     ),
   )

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -53,7 +53,7 @@ class LiveFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: Con
   ): Response[List[PressedContent]] =
     FAPI
       .liveCollectionContentWithSnaps(collection, adjustSearchQuery, adjustSnapItemQuery)
-      .map(_.map((item) => PressedContent.make(item, collection.collectionConfig.suppressImages)))
+      .map(_.map((item) => PressedContent.make(item, collection.collectionConfig.displayHints.flatMap(_.suppressImages).getOrElse(false))))
 }
 
 class DraftFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: ContentApiClient)(implicit
@@ -81,7 +81,7 @@ class DraftFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: Co
   ): Response[List[PressedContent]] =
     FAPI
       .draftCollectionContentWithSnaps(collection, adjustSearchQuery, adjustSnapItemQuery)
-      .map(_.map((item) => PressedContent.make(item, collection.collectionConfig.suppressImages)))
+      .map(_.map((item) => PressedContent.make(item, collection.collectionConfig.displayHints.flatMap(_.suppressImages).getOrElse(false))))
 }
 
 // This is the json structure we expect for an embed (know as a snap at render-time).

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -53,7 +53,11 @@ class LiveFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: Con
   ): Response[List[PressedContent]] =
     FAPI
       .liveCollectionContentWithSnaps(collection, adjustSearchQuery, adjustSnapItemQuery)
-      .map(_.map((item) => PressedContent.make(item, collection.collectionConfig.displayHints.flatMap(_.suppressImages).getOrElse(false))))
+      .map(
+        _.map((item) =>
+          PressedContent.make(item, collection.collectionConfig.displayHints.flatMap(_.suppressImages).getOrElse(false)),
+        ),
+      )
 }
 
 class DraftFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: ContentApiClient)(implicit
@@ -81,7 +85,11 @@ class DraftFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: Co
   ): Response[List[PressedContent]] =
     FAPI
       .draftCollectionContentWithSnaps(collection, adjustSearchQuery, adjustSnapItemQuery)
-      .map(_.map((item) => PressedContent.make(item, collection.collectionConfig.displayHints.flatMap(_.suppressImages).getOrElse(false))))
+      .map(
+        _.map((item) =>
+          PressedContent.make(item, collection.collectionConfig.displayHints.flatMap(_.suppressImages).getOrElse(false)),
+        ),
+      )
 }
 
 // This is the json structure we expect for an embed (know as a snap at render-time).

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "1.12.780"
   val awsSdk2Version = "2.26.31"
-  val capiVersion = "33.0.0"
-  val faciaVersion = "14.0.1"
+  val capiVersion = "34.0.0"
+  val faciaVersion = "15.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -33,7 +33,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.16.1"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "26.0.0"
+  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "27.0.0"
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.6.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion


### PR DESCRIPTION
## What does this change?
There has been a change to collections model (https://github.com/guardian/facia-tool/pull/1762 and https://github.com/guardian/facia-scala-client/pull/342) whereby suppressImage value is now kept on the displayHint object rather than on the collection config.

This PR bumps FAPI and CAPI and updates the logic such that suppressImage is retrieved from displayHint.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/9a7f305b-2713-4276-8622-c465128fe5ab
[after]: https://github.com/user-attachments/assets/419cc7ae-5f43-4314-9826-1378ae0a5c05




## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
