### PR TITLE
Fix football fixture json for dcr

### DIFF
--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -40,7 +40,7 @@ class FixturesController(
     }
 
   private def renderMoreFixtures(fixtures: Fixtures): Action[AnyContent] =
-    Action { implicit request =>
+    Action.async { implicit request =>
       renderMoreMatches(page, fixtures, filters)
     }
 

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -58,18 +58,6 @@ class ResultsController(
     byType[FootballPage](allPage)(competitionPage)(teamPage)(tag)
   }
 
-  private def renderWith(
-      renderFunction: (FootballPage, Results, Map[String, Seq[CompetitionFilter]], Option[InteractiveAtom]) => Result,
-  )(date: LocalDate, tag: Option[String] = None): Result = {
-    val result = for {
-      p <- page(tag)
-      r <- results(date, tag)
-    } yield {
-      renderFunction(p, r, filters, None)
-    }
-    result.getOrElse(NotFound("No results"))
-  }
-
   private def renderWithAsync(
       renderFunction: (
           FootballPage,
@@ -93,8 +81,8 @@ class ResultsController(
     }
 
   private def renderMoreForDate(date: LocalDate, tag: Option[String] = None): Action[AnyContent] =
-    Action { implicit request =>
-      renderWith(renderMoreMatches)(date, tag)
+    Action.async { implicit request =>
+      renderWithAsync(renderMoreMatches)(date, tag)
     }
 
   /* Public methods */

--- a/sport/app/football/implicits/Football.scala
+++ b/sport/app/football/implicits/Football.scala
@@ -44,8 +44,7 @@ trait Football {
       m.awayTeam.score,
     )
 
-    def isOn(date: LocalDate): Boolean =
-      m.date.toLocalDate.isAfter(date) && m.date.toLocalDate.isBefore(date.plusDays(1))
+    def isOn(date: LocalDate): Boolean = m.date.toLocalDate == date
 
     // results and fixtures do not actually have a status field in the API
     lazy val matchStatus = m match {

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -3,7 +3,7 @@ package football.model
 import common.{CanonicalLink, Edition}
 import conf.Configuration
 import experiments.ActiveExperiments
-import football.controllers.FootballPage
+import football.controllers.{CompetitionFilter, FootballPage}
 import model.dotcomrendering.DotcomRenderingUtils.{assetURL, withoutNull}
 import model.dotcomrendering.{Config, PageFooter, PageType, Trail}
 import model.{ApplicationContext, Competition, CompetitionSummary}
@@ -37,6 +37,7 @@ case class MatchesByDateAndCompetition(date: LocalDate, competitionMatches: List
 case class DotcomRenderingFootballDataModel(
     matchesList: Seq[MatchesByDateAndCompetition],
     nextPage: Option[String],
+    filters: Map[String, Seq[CompetitionFilter]],
     previousPage: Option[String],
     nav: Nav,
     editionId: String,
@@ -52,6 +53,7 @@ object DotcomRenderingFootballDataModel {
   def apply(
       page: FootballPage,
       matchesList: MatchesList,
+      filters: Map[String, Seq[CompetitionFilter]],
   )(implicit request: RequestHeader, context: ApplicationContext): DotcomRenderingFootballDataModel = {
     val pageType: PageType = PageType(page, request, context)
     val edition = Edition.edition(request)
@@ -83,6 +85,7 @@ object DotcomRenderingFootballDataModel {
 
     DotcomRenderingFootballDataModel(
       matchesList = matches,
+      filters = filters,
       nextPage = matchesList.nextPage,
       previousPage = matchesList.previousPage,
       nav = nav,
@@ -173,6 +176,8 @@ object DotcomRenderingFootballDataModelImplicits {
   implicit val competitionMatchesFormat: Writes[CompetitionMatches] = Json.writes[CompetitionMatches]
   implicit val dateCompetitionMatchesFormat: Writes[MatchesByDateAndCompetition] =
     Json.writes[MatchesByDateAndCompetition]
+
+  implicit val competitionFilterFormat: Writes[CompetitionFilter] = Json.writes[CompetitionFilter]
 
   implicit val SportsFormat: Writes[DotcomRenderingFootballDataModel] = Json.writes[DotcomRenderingFootballDataModel]
 }

--- a/sport/test/football/implicits/FootballTest.scala
+++ b/sport/test/football/implicits/FootballTest.scala
@@ -1,0 +1,48 @@
+package football.implicits
+
+import test.FootballTestData.{fixture, liveMatch, result}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.GivenWhenThen
+import java.time.{ZoneId, ZonedDateTime}
+
+class FootballTest extends AnyFeatureSpec with GivenWhenThen with Matchers with implicits.Football {
+  private val zone = ZoneId.of("Europe/London")
+  private val today = ZonedDateTime.now().withZoneSameInstant(zone)
+
+  Feature("FootballMatch") {
+
+    Scenario("isOn returns false if match date is before the given date") {
+
+      Given("a match which happened yesterday")
+      val yesterdayMatch =
+        result("Aston Villa", "Cardiff", 1, 0, today.minusDays(1), None)
+
+      Then("calling isOn with today's date should return false")
+      val isMatchOnToday = yesterdayMatch.isOn(today.toLocalDate)
+      isMatchOnToday shouldBe (false)
+    }
+
+    Scenario("isOn returns false if match date is after the given date") {
+
+      Given("a match which will happen tomorrow")
+      val tomorrowMatch =
+        fixture("Aston Villa", "Cardiff", today.plusDays(1))
+
+      Then("calling isOn with today's date should return false")
+      val isMatchOnToday = tomorrowMatch.isOn(today.toLocalDate)
+      isMatchOnToday shouldBe (false)
+    }
+
+    Scenario("isOn returns true if match date is same as the given date") {
+
+      Given("a match which happens today")
+      val todayMatch =
+        liveMatch("Aston Villa", "Cardiff", 1, 0, today, isLive = true)
+
+      Then("calling isOn with today's date should return true")
+      val isMatchOnToday = todayMatch.isOn(today.toLocalDate)
+      isMatchOnToday shouldBe (true)
+    }
+  }
+}


### PR DESCRIPTION
## What is the value of this and can you measure success?

- Reviewed all `/football/fixtures` endpoints to assess what needed updating to support DCR JSON responses.
- Most endpoints were already compatible, but `/football/fixtures/more/` required an update, which has now been implemented.
- Updated `DotcomRenderingFootballDataModel` to include filters—these filters represent a list of relevant competitions for the league selector, determined based on match type and date.
- Fixed a bug in the `isOn` function, which was previously always returning false for any input.

### Note:
The fix for isOn will now enable the league selector on the /football/live page, which was previously missing.
