### PR TITLE
Remove expired ab-ad-block-ask switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -27,16 +27,6 @@ trait ABTestSwitches {
     highImpact = false,
   )
 
-  Switch(
-    ABTests,
-    "ab-ad-block-ask",
-    "Show new ad block ask component in ad slots when we detect ad blocker usage",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 2, 24)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
 
   Switch(
     ABTests,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -27,7 +27,6 @@ trait ABTestSwitches {
     highImpact = false,
   )
 
-
   Switch(
     ABTests,
     "ab-opt-out-frequency-cap",


### PR DESCRIPTION
## What does this change?
Removes the expired switch for `ab-ad-block-ask` as this is no longer required by commercial. 
@Amouzle 
