### PR TITLE
increase max-age for crossword local renderer

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -84,7 +84,7 @@ trait CrosswordController extends BaseController with GuLogging with ImplicitCon
         remoteRenderer.getCrossword(wsClient, page, PageType(page, request, context))
       else
         Future.successful(
-          Cached(60.seconds)(
+          Cached(CacheTime.Crosswords)(
             RevalidatableResult.Ok(
               CrosswordHtmlPage.html(page),
             ),

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -22,6 +22,7 @@ object CacheTime {
   def RecentlyUpdated = CacheTime(60, if (ShorterSurrogateCacheForRecentArticles.isSwitchedOn) Some(30) else None)
   // There is lambda which invalidates the cache on press events, so the facia cache time can be high.
   object Facia extends CacheTime(60, Some(900))
+  object Crosswords extends CacheTime(60, Some(900))
   object ArchiveRedirect extends CacheTime(60, Some(300))
   object ShareCount extends CacheTime(60, Some(600))
   object NotFound extends CacheTime(10) // This will be overwritten by fastly

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -436,7 +436,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomRenderingDataModel.forCrossword(crosswordPage, request, pageType)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Crosswords)
   }
 
   def getEditionsCrossword(


### PR DESCRIPTION
## What does this change?
This PR updates the `max-age` for the `Surrogate-Control` response header for Crosswords local rendering. For remote renderer we were already using 900 seconds but this lower max-age for local rendering in frontend responses could impact the caching of DCAR responses as well. 
