### PR TITLE
Extend `dcr-crosswords` test expiry date

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -47,7 +47,7 @@ object DCRCrosswords
       name = "dcr-crosswords",
       description = "Render crosswords in DCR",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 2, 26),
+      sellByDate = LocalDate.of(2025, 3, 31),
       participationGroup = Perc10A,
     )
 


### PR DESCRIPTION
## What does this change?

Extends expiry date of `dcr-crosswords` test as it expires tomorrow (26/2/2025).
