### PR TITLE
Increase editions crosswords from 25 to 75

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -336,7 +336,7 @@ class CrosswordEditionsController(
       .contentType("crossword")
       .tag(crosswordTags)
       .useDate("newspaper-edition")
-      .pageSize(25)
+      .pageSize(75)
 
   private lazy val crosswordTags = Seq(
     "crosswords/series/quick",


### PR DESCRIPTION
## What is the value of this and can you measure success?
Resolves: https://github.com/guardian/dotcom-rendering/issues/13287

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a390dd8c-7bbf-4bc6-bb29-592c160cd3e2
[after]: https://github.com/user-attachments/assets/53308016-d464-49bc-8167-8b7a76a3b64d
