### PR TITLE
Improve loggings with requestId

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -9,7 +9,7 @@ import _root_.dfp.DfpDataCacheLifecycle
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import concurrent.BlockingOperations
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
-import http.{AdminHttpErrorHandler, CommonGzipFilter, Filters}
+import http.{AdminHttpErrorHandler, CommonGzipFilter, Filters, RequestIdFilter}
 import dev.DevAssetsController
 import jobs._
 import model.{AdminLifecycle, ApplicationIdentity}
@@ -99,7 +99,7 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
   def pekkoActorSystem: PekkoActorSystem
 
   override lazy val httpFilters: Seq[EssentialFilter] =
-    auth.filter :: Filters.common(frontend.admin.BuildInfo) ++ wire[CommonGzipFilter].filters
+    auth.filter :: new RequestIdFilter :: Filters.common(frontend.admin.BuildInfo) ++ wire[CommonGzipFilter].filters
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[AdminHttpErrorHandler]
 }

--- a/admin/app/controllers/admin/commercial/AdsDotTextEditController.scala
+++ b/admin/app/controllers/admin/commercial/AdsDotTextEditController.scala
@@ -50,7 +50,7 @@ class AdsDotTextEditController(val controllerComponents: ControllerComponents)(i
           },
           adsTextSellers => {
             S3.putPrivate(s3DotTextKey, adsTextSellers.sellers, "text/plain")
-            log.info(s"Wrote new $name file to $s3DotTextKey")
+            logInfoWithRequestId(s"Wrote new $name file to $s3DotTextKey")
             NoCache(Redirect(postSave))
           },
         )

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -280,7 +280,7 @@ class FrontsController(
       val embedContent = (previewResponse.json \ "html").as[String]
       Cached(60)(RevalidatableResult.Ok(views.html.football.fronts.viewEmbed(Html(embedContent), snapFields)))
     }).recover { case e =>
-      log.error(s"Failed to preview snap content from ${snapFields.uri}", e)
+      logErrorWithRequestId(s"Failed to preview snap content from ${snapFields.uri}", e)
       NoCache(Ok(views.html.football.fronts.failedEmbed(Html(e.getMessage), snapFields)))
     }
     result

--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -172,9 +172,9 @@ class AllIndexController(
 
     result.failed.foreach {
       case ContentApiError(404, _, _) =>
-        log.warn(s"Cannot fetch content for request '${request.uri}'")
+        logWarnWithRequestId(s"Cannot fetch content for request '${request.uri}'")
       case e: Exception =>
-        log.error(e.getMessage, e)
+        logErrorWithRequestId(e.getMessage, e)
     }
 
     result
@@ -196,9 +196,9 @@ class AllIndexController(
 
     result.failed.foreach {
       case ContentApiError(404, _, _) =>
-        log.warn(s"Cannot fetch content for request '${request.uri}'")
+        logWarnWithRequestId(s"Cannot fetch content for request '${request.uri}'")
       case e: Exception =>
-        log.error(e.getMessage, e)
+        logErrorWithRequestId(e.getMessage, e)
     }
 
     result

--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -72,7 +72,7 @@ class AtomPageController(
         .bindFromRequest()
         .fold(
           formWithErrors => {
-            log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+            logInfoWithRequestId(s"Form has been submitted with errors: ${formWithErrors.errors}")
             Future.successful(Cors(NoCache(BadRequest("Invalid email"))))
           },
           form => {
@@ -83,12 +83,12 @@ class AtomPageController(
                   Cors(NoCache(Created("Subscribed")))
 
                 case status =>
-                  log.error(s"Error posting to ExactTarget: HTTP $status")
+                  logErrorWithRequestId(s"Error posting to ExactTarget: HTTP $status")
                   Cors(NoCache(InternalServerError("Internal error")))
 
               })
               .recover { case e: Exception =>
-                log.error(s"Error posting to ExactTarget: ${e.getMessage}")
+                logErrorWithRequestId(s"Error posting to ExactTarget: ${e.getMessage}")
                 Cors(NoCache(InternalServerError("Internal error")))
               }
           },

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -65,7 +65,7 @@ trait CrosswordController extends BaseController with GuLogging with ImplicitCon
       } yield f(crossword, content)
       maybeCrossword getOrElse Future.successful(noResults())
     } recover { case t: Throwable =>
-      log.error(s"Error retrieving $crosswordType crossword id $id from API", t)
+      logErrorWithRequestId(s"Error retrieving $crosswordType crossword id $id from API", t)
       noResults()
     }
   }

--- a/applications/app/controllers/EmbedController.scala
+++ b/applications/app/controllers/EmbedController.scala
@@ -25,7 +25,7 @@ class EmbedController(contentApiClient: ContentApiClient, val controllerComponen
   private def lookup(path: String)(implicit request: RequestHeader): Future[Either[Result, Video]] = {
     val edition = Edition(request)
 
-    log.info(s"Fetching video: $path for edition $edition")
+    logInfoWithRequestId(s"Fetching video: $path for edition $edition")
 
     val response: Future[ItemResponse] = contentApiClient.getResponse(
       contentApiClient

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -83,7 +83,8 @@ class GalleryController(
       request: RequestHeader,
   ): Future[Either[Result, (GalleryPage, Blocks)]] = {
     val edition = Edition(request)
-    log.info(s"Fetching gallery: $path for edition $edition")
+    logInfoWithRequestId(s"Fetching gallery: $path for edition $edition")
+
     contentApiClient
       .getResponse(
         contentApiClient

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -100,7 +100,7 @@ class LatestIndexController(contentApiClient: ContentApiClient, val controllerCo
       }
 
     result recover { case e: Exception =>
-      log.error(e.getMessage, e)
+      logErrorWithRequestId(e.getMessage, e)
       None
     }
   }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -9,7 +9,7 @@ import implicits.{AppsFormat, JsonFormat}
 import model._
 import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import pages.ContentHtmlPage
-import play.api.libs.json.{Format, JsObject, Json, JsValue}
+import play.api.libs.json.{Format, JsObject, JsValue, Json}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import renderers.DotcomRenderingService
@@ -58,7 +58,8 @@ class MediaController(
   private def lookup(path: String)(implicit request: RequestHeader): Future[Either[Result, (MediaPage, Blocks)]] = {
     val edition = Edition(request)
 
-    log.info(s"Fetching media: $path for edition $edition")
+    logInfoWithRequestId(s"Fetching media: $path for edition $edition")
+
     val response: Future[ItemResponse] = contentApiClient.getResponse(
       contentApiClient
         .item(path, edition)

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -55,7 +55,7 @@ class QuizController(
           hasErrors = errors => {
             val errorMessages = errors.errors.flatMap(_.messages.mkString(", ")).mkString(". ")
             val serverError = s"Problem with quiz form request: $errorMessages"
-            log.error(serverError)
+            logErrorWithRequestId(serverError)
             Future.successful(InternalServerError(serverError))
           },
           success = form => renderQuiz(quizId, path, form),
@@ -67,7 +67,7 @@ class QuizController(
   ): Future[Result] = {
     val edition = Edition(request)
 
-    log.info(s"Fetching quiz atom: $quizId from content id: $path")
+    logInfoWithRequestId(s"Fetching quiz atom: $quizId from content id: $path")
     val capiQuery = contentApiClient.item(path, edition).showAtoms("all")
     val result = contentApiClient.getResponse(capiQuery) map { itemResponse =>
       val maybePage: Option[QuizAnswersPage] = itemResponse.content.flatMap { content =>

--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -50,7 +50,7 @@ class SignupPageController(
           ),
         )
       case Left(e) =>
-        log.error(s"API call to get newsletters failed: $e")
+        logErrorWithRequestId(s"API call to get newsletters failed: $e")
         Future(NoCache(InternalServerError))
     }
   }
@@ -72,7 +72,7 @@ class SignupPageController(
           page = StaticPages.dcrSimpleNewsletterPage(request.path),
         )
       case Left(e) =>
-        log.error(s"API call to get newsletters failed: $e")
+        logErrorWithRequestId(s"API call to get newsletters failed: $e")
         Future(NoCache(InternalServerError))
     }
   }
@@ -93,7 +93,7 @@ class SignupPageController(
         Future.successful(common.renderJson(dataJson, page).as("application/json"))
       }
       case Left(e) =>
-        log.error(s"API call to get newsletters failed: $e")
+        logErrorWithRequestId(s"API call to get newsletters failed: $e")
         throw new RuntimeException()
     }
   }

--- a/applications/app/controllers/TagIndexController.scala
+++ b/applications/app/controllers/TagIndexController.scala
@@ -18,11 +18,11 @@ class TagIndexController(val controllerComponents: ControllerComponents)(implici
     Action { implicit request =>
       TagIndexesS3.getIndex(keywordType, page) match {
         case Left(TagIndexNotFound) =>
-          log.error(s"404 error serving tag index page for $keywordType $page")
+          logErrorWithRequestId(s"404 error serving tag index page for $keywordType $page")
           NotFound
 
         case Left(TagIndexReadError(error)) =>
-          log.error(s"JSON parse error serving tag index page for $keywordType $page: $error")
+          logErrorWithRequestId(s"JSON parse error serving tag index page for $keywordType $page: $error")
           InternalServerError
 
         case Right(tagIndex) =>

--- a/applications/app/controllers/YoutubeController.scala
+++ b/applications/app/controllers/YoutubeController.scala
@@ -29,7 +29,7 @@ class YoutubeController(
       response.transform {
         case result @ Success(_) => result
         case Failure(error) =>
-          log.error(s"Failed to get atom ID for youtube ID $youtubeId", error)
+          logErrorWithRequestId(s"Failed to get atom ID for youtube ID $youtubeId", error)
           Failure(error)
       }
     }

--- a/applications/app/services/ImageQuery.scala
+++ b/applications/app/services/ImageQuery.scala
@@ -16,7 +16,7 @@ trait ImageQuery extends ConciergeRepository {
       request: RequestHeader,
       context: ApplicationContext,
   ): Future[Either[PlayResult, (ImageContentPage, Option[Block])]] = {
-    log.info(s"Fetching image content: $path for edition ${edition.id}")
+    logInfoWithRequestId(s"Fetching image content: $path for edition ${edition.id}")
     val response = contentApiClient.getResponse(
       contentApiClient
         .item(path, edition)

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -126,18 +126,8 @@ class ArchiveController(redirects: RedirectService, val controllerComponents: Co
     val endOfPath = if (pathSuffixes.isEmpty) "" else s"/${pathSuffixes.mkString("/")}"
     val redirect = LinkTo(path) + endOfPath
 
-    log.info(s"""Archive $redirectHttpStatus, redirect to $redirect""")
+    logInfoWithRequestId(s"""Archive $redirectHttpStatus, redirect to $redirect""")
     Cached(CacheTime.ArchiveRedirect)(WithoutRevalidationResult(Redirect(redirect, redirectHttpStatus)))
-  }
-
-  private def log404(request: Request[AnyContent]) = {
-    log.warn(s"Archive returned 404 for path: ${request.path}")
-
-    val GoogleBot = """.*(Googlebot).*""".r
-    request.headers.get("User-Agent").getOrElse("no user agent") match {
-      case GoogleBot(_) => GoogleBotMetric.Googlebot404Count.increment()
-      case _            =>
-    }
   }
 
   private def lookupPath(path: String)(implicit request: RequestHeader): Future[Option[CacheableResult]] =

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -67,7 +67,7 @@ class ArticleController(
         headline
           .map(s => Cached(CacheTime.Default)(RevalidatableResult.Ok(s)))
           .getOrElse {
-            log.warn(s"headline not found for $path")
+            logWarnWithRequestId(s"headline not found for $path")
             Cached(10)(WithoutRevalidationResult(NotFound))
           }
       }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -395,12 +395,12 @@ class LiveBlogController(
           */
         val hasBlocks = nonLiveBlogArticle.fields.blocks.nonEmpty;
         val hasMinuteByMinuteTag = nonLiveBlogArticle.tags.isLiveBlog;
-        log.error(
+        logErrorWithRequestId(
           s"Requested non-liveblog article as liveblog: ${nonLiveBlogArticle.metadata.id}: { hasBlocks: ${hasBlocks}, hasMinuteByMinuteTag: ${hasMinuteByMinuteTag} }",
         )
         Left(InternalServerError)
       case unknown =>
-        log.error(s"Requested non-liveblog: ${unknown.metadata.id}")
+        logErrorWithRequestId(s"Requested non-liveblog: ${unknown.metadata.id}")
         Left(InternalServerError)
     }
 

--- a/commercial/app/controllers/ContentApiOffersController.scala
+++ b/commercial/app/controllers/ContentApiOffersController.scala
@@ -37,13 +37,13 @@ class ContentApiOffersController(
       .getOrElse(Future.successful(Nil))
 
     latestContent.failed.foreach { case NonFatal(e) =>
-      log.error(s"Looking up content by keyword failed: ${e.getMessage}")
+      logErrorWithRequestId(s"Looking up content by keyword failed: ${e.getMessage}")
     }
 
     val specificContent: Future[Seq[model.ContentType]] = capiAgent.contentByShortUrls(specificIds)
 
     specificContent.failed.foreach { case NonFatal(e) =>
-      log.error(s"Looking up content by short URL failed: ${e.getMessage}")
+      logErrorWithRequestId(s"Looking up content by short URL failed: ${e.getMessage}")
     }
 
     val futureContents = for {

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -5,6 +5,8 @@ import play.api.Logger
 import org.apache.commons.lang.exception.ExceptionUtils
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers._
+import play.api.mvc.RequestHeader
+
 import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
@@ -16,6 +18,43 @@ trait GuLogging {
 
   protected def logException(e: Exception): Unit = {
     log.error(ExceptionUtils.getStackTrace(e))
+  }
+
+  def logInfoWithRequestId(message: String)(implicit request: RequestHeader): Unit = {
+    log.logger.info(
+      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
+      message,
+    )
+  }
+
+  def logWarnWithRequestId(message: String)(implicit request: RequestHeader): Unit = {
+    log.logger.warn(
+      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
+      message,
+    )
+  }
+
+  def logWarnWithRequestId(message: String, error: Throwable)(implicit request: RequestHeader): Unit = {
+    log.logger.warn(
+      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
+      message,
+      error,
+    )
+  }
+
+  def logErrorWithRequestId(message: String)(implicit request: RequestHeader): Unit = {
+    log.logger.error(
+      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
+      message,
+    )
+  }
+
+  def logErrorWithRequestId(message: String, error: Throwable)(implicit request: RequestHeader): Unit = {
+    log.logger.error(
+      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
+      message,
+      error,
+    )
   }
 
   def logInfoWithCustomFields(message: String, customFields: List[LogField]): Unit = {

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -21,40 +21,23 @@ trait GuLogging {
   }
 
   def logInfoWithRequestId(message: String)(implicit request: RequestHeader): Unit = {
-    log.logger.info(
-      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
-      message,
-    )
+    log.logger.info(getRequestIdField, message)
   }
 
   def logWarnWithRequestId(message: String)(implicit request: RequestHeader): Unit = {
-    log.logger.warn(
-      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
-      message,
-    )
+    log.logger.warn(getRequestIdField, message)
   }
 
   def logWarnWithRequestId(message: String, error: Throwable)(implicit request: RequestHeader): Unit = {
-    log.logger.warn(
-      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
-      message,
-      error,
-    )
+    log.logger.warn(getRequestIdField, message, error)
   }
 
   def logErrorWithRequestId(message: String)(implicit request: RequestHeader): Unit = {
-    log.logger.error(
-      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
-      message,
-    )
+    log.logger.error(getRequestIdField, message)
   }
 
   def logErrorWithRequestId(message: String, error: Throwable)(implicit request: RequestHeader): Unit = {
-    log.logger.error(
-      customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"))),
-      message,
-      error,
-    )
+    log.logger.error(getRequestIdField, message, error)
   }
 
   def logInfoWithCustomFields(message: String, customFields: List[LogField]): Unit = {
@@ -80,6 +63,10 @@ trait GuLogging {
       case Success(result) => result
       case Failure(e)      => log.error(message, e); throw e
     }
+  }
+
+  private def getRequestIdField(implicit request: RequestHeader) = {
+    customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided")))
   }
 }
 

--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -84,7 +84,7 @@ object InternalRedirect extends implicits.Requests with GuLogging {
       case g if g.isGallery                 => internalRedirect("applications", g.id)
       case a if a.isAudio                   => internalRedirect("applications", a.id)
       case unsupportedContent =>
-        log.info(s"unsupported content: ${unsupportedContent.id}")
+        logInfoWithRequestId(s"unsupported content: ${unsupportedContent.id}")
         NotFound
 
     }

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -270,12 +270,12 @@ class EmailSignupController(
       }
     }
 
-  def logApiError(error: String): Unit = {
-    log.error(s"API call to get newsletters failed: $error")
+  def logApiError(error: String)(implicit request: RequestHeader): Unit = {
+    logErrorWithRequestId(s"API call to get newsletters failed: $error")
   }
 
-  def logNewsletterNotFoundError(newsletterName: String): Unit = {
-    log.error(s"Newsletter not found: Couldn't find $newsletterName")
+  def logNewsletterNotFoundError(newsletterName: String)(implicit request: RequestHeader): Unit = {
+    logErrorWithRequestId(s"Newsletter not found: Couldn't find $newsletterName")
   }
 
   def renderFormFromNameWithParentComponent(
@@ -370,12 +370,12 @@ class EmailSignupController(
         .bindFromRequest()
         .fold(
           formWithErrors => {
-            log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+            logInfoWithRequestId(s"Form has been submitted with errors: ${formWithErrors.errors}")
             EmailFormError.increment()
             Future.successful(respondFooter(InvalidEmail))
           },
           form => {
-            log.info(
+            logInfoWithRequestId(
               s"Post request received to /email/ - " +
                 s"ref: ${form.ref}, " +
                 s"refViewId: ${form.refViewId}, " +
@@ -428,7 +428,7 @@ class EmailSignupController(
           respondFooter(Subscribed)
 
         case status =>
-          log.error(s"Error posting to Identity API: HTTP $status")
+          logErrorWithRequestId(s"Error posting to Identity API: HTTP $status")
           APIHTTPError.increment()
           respondFooter(OtherError)
 
@@ -436,7 +436,7 @@ class EmailSignupController(
       case _: IllegalAccessException =>
         respondFooter(Subscribed)
       case e: Exception =>
-        log.error(s"Error posting to Identity API: ${e.getMessage}")
+        logErrorWithRequestId(s"Error posting to Identity API: ${e.getMessage}")
         APINetworkError.increment()
         respondFooter(OtherError)
     }
@@ -482,12 +482,12 @@ class EmailSignupController(
         .bindFromRequest()
         .fold(
           formWithErrors => {
-            log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+            logInfoWithRequestId(s"Form has been submitted with errors: ${formWithErrors.errors}")
             EmailFormError.increment()
             Future.successful(respond(InvalidEmail))
           },
           form => {
-            log.info(
+            logInfoWithRequestId(
               s"Post request received to /email/ - " +
                 s"ref: ${form.ref}, " +
                 s"refViewId: ${form.refViewId}, " +
@@ -516,12 +516,12 @@ class EmailSignupController(
         .bindFromRequest()
         .fold(
           formWithErrors => {
-            log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+            logInfoWithRequestId(s"Form has been submitted with errors: ${formWithErrors.errors}")
             EmailFormError.increment()
             Future.successful(respond(InvalidEmail))
           },
           form => {
-            log.info(
+            logInfoWithRequestId(
               s"Post request received to /email/many/ - " +
                 s"listNames.size: ${form.listNames.size.toString()}, " +
                 s"ref: ${form.ref}, " +
@@ -552,7 +552,7 @@ class EmailSignupController(
         respond(Subscribed, listName)
 
       case status =>
-        log.error(s"Error posting to Identity API: HTTP $status")
+        logErrorWithRequestId(s"Error posting to Identity API: HTTP $status")
         APIHTTPError.increment()
         respond(OtherError)
 
@@ -560,7 +560,7 @@ class EmailSignupController(
       case _: IllegalAccessException =>
         respond(Subscribed)
       case e: Exception =>
-        log.error(s"Error posting to Identity API: ${e.getMessage}")
+        logErrorWithRequestId(s"Error posting to Identity API: ${e.getMessage}")
         APINetworkError.increment()
         respond(OtherError)
     }

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -37,7 +37,7 @@ trait IndexControllerCommon
 
   private def logGoogleBot(request: RequestHeader) = {
     request.headers.get("User-Agent").filter(_.contains("Googlebot")).foreach { _ =>
-      log.info(s"GoogleBot => ${request.uri}")
+      logInfoWithRequestId(s"GoogleBot => ${request.uri}")(request)
     }
   }
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -251,8 +251,7 @@ trait FaciaController
             && !request.isJson =>
         val pageType = PageType(faciaPage, request, context)
 
-        log.logger.info(
-          customLogFieldMarker,
+        logInfoWithRequestId(
           s"Front Geo Request (212): ${Edition(request).id} ${request.headers.toSimpleMap.getOrElse("X-GU-GeoLocation", "country:row")}",
         )
         withVaryHeader(
@@ -276,8 +275,7 @@ trait FaciaController
         )
       case Some((faciaPage: PressedPage, targetedTerritories)) if request.isJson =>
         val result = if (request.forceDCR) {
-          log.logger.info(
-            customLogFieldMarker,
+          logInfoWithRequestId(
             s"Front Geo Request (237): ${Edition(request).id} ${request.headers.toSimpleMap.getOrElse("X-GU-GeoLocation", "country:row")}",
           )
           JsonComponent.fromWritable(
@@ -304,7 +302,7 @@ trait FaciaController
       }
     }
 
-    futureResult.failed.foreach { t: Throwable => log.error(s"Failed rendering $path with $t", t) }
+    futureResult.failed.foreach { t: Throwable => logErrorWithRequestId(s"Failed rendering $path with $t", t) }
     futureResult
   }
 

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -42,7 +42,7 @@ class MediaInSectionController(
       request: RequestHeader,
   ): Future[Option[Seq[RelatedContentItem]]] = {
     val currentShortUrl = request.getQueryString("shortUrl")
-    log.info(s"Fetching $mediaType content in section: $sectionId")
+    logInfoWithRequestId(s"Fetching $mediaType content in section: $sectionId")
 
     val excludeTags: Seq[String] = (request.queryString.getOrElse("exclude-tag", Nil) ++ seriesId).map(t => s"-$t")
     val tags = (s"type/$mediaType" +: excludeTags).mkString(",")
@@ -71,7 +71,7 @@ class MediaInSectionController(
       }
 
     promiseOrResponse recover { case ContentApiError(404, message, _) =>
-      log.info(s"Got a 404 calling content api: $message")
+      logInfoWithRequestId(s"Got a 404 calling content api: $message")
       None
     }
   }

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -260,7 +260,8 @@ class MostPopularController(
     mostPopularAgent.mostSingleCardsBox.get().mapV(ContentCard.fromApiContent)
 
   private def lookup(edition: Edition, path: String)(implicit request: RequestHeader): Future[Option[MostPopular]] = {
-    log.info(s"Fetching most popular: $path for edition $edition")
+    logInfoWithRequestId(s"Fetching most popular: $path for edition $edition")
+
     val capiItem = contentApiClient
       .item(path, edition)
       .tag(None)

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -88,7 +88,7 @@ class SeriesController(
       }
     }
     seriesResponse.recover { case ContentApiError(404, message, _) =>
-      log.info(s"Got a 404 calling content api: $message")
+      logInfoWithRequestId(s"Got a 404 calling content api: $message")
       None
     }
   }

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -55,7 +55,7 @@ class TaggedContentController(
   )
 
   private def lookup(tag: String)(implicit request: RequestHeader): Future[List[ContentType]] = {
-    log.info(s"Fetching tagged stories")
+    logInfoWithRequestId(s"Fetching tagged stories")
     contentApiClient
       .getResponse(
         contentApiClient
@@ -66,7 +66,7 @@ class TaggedContentController(
       .map { response =>
         response.results.toList map { Content(_) }
       } recover { case ContentApiError(404, message, _) =>
-      log.info(s"Got a 404 while calling content api: $message")
+      logInfoWithRequestId(s"Got a 404 while calling content api: $message")
       Nil
     }
   }

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -40,7 +40,7 @@ class TopStoriesController(
     }
 
   private def lookup(edition: Edition)(implicit request: RequestHeader): Future[Option[RelatedContent]] = {
-    log.info(s"Fetching top stories for edition ${edition.id}")
+    logInfoWithRequestId(s"Fetching top stories for edition ${edition.id}")
     contentApiClient
       .getResponse(
         contentApiClient
@@ -55,7 +55,7 @@ class TopStoriesController(
           case picks => Some(RelatedContent(picks))
         }
       } recover { case ContentApiError(404, message, _) =>
-      log.info(s"Got a 404 while calling content api: $message")
+      logInfoWithRequestId(s"Got a 404 while calling content api: $message")
       None
     }
   }

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -29,7 +29,7 @@ class FaciaDraftController(
   private val indexController = new IndexController(contentApiClient, sectionsLookUp, controllerComponents, ws)
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
-    log.info(s"Serving Path: $path")
+    logInfoWithRequestId(s"Serving Path: $path")
     if (!ConfigAgent.getPathIds.contains(path))
       indexController.renderItem(path)
     else

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -309,7 +309,7 @@ class MoreOnMatchController(
       val maybeResponse: Option[Future[RevalidatableResult]] = maybeMatch map { theMatch =>
         loadMoreOn(request, theMatch) map {
           case Nil =>
-            log.info(s"Cannot load more for match id: ${theMatch.id}")
+            logInfoWithRequestId(s"Cannot load more for match id: ${theMatch.id}")
             JsonNotFound()
           case related =>
             JsonComponent(


### PR DESCRIPTION
## What does this change?
This PR adds `RequestIdFilter` to the filters of the `admin` application. This filter ensures that the `x-gu-xid` header is added to incoming requests.

Additionally, I introduced new functions in GuLogging that take an implicit request parameter. These functions attempt to retrieve the `x-gu-xid` from request headers and include it as the requestId field in logs.

Using these new functions, I updated nearly all logs generated during the request journey. I say "nearly all" because, in the frontend, many logs are produced via agents or background jobs, which are outside the request flow. I’ve done my best to capture all logs within the request journey, but I may have missed some.
