### PR TITLE
Remove `DeploysController` from `dev-build`

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -193,7 +193,6 @@ GET            /metrics/errors/5xx                                              
 GET            /metrics/afg                                                                                                      controllers.admin.MetricsController.renderAfg()
 GET            /metrics/webpack-bundle-visualization                                                                             controllers.admin.MetricsController.renderBundleVisualization()
 GET            /metrics/webpack-bundle-analyzer                                                                                  controllers.admin.MetricsController.renderBundleAnalyzer()
-GET            /deploys                                                                                                          controllers.admin.DeploysController.getDeploys(stage: Option[String], pageSize: Option[Int])
 GET            /troubleshoot/football                                                                                            controllers.admin.SportTroubleshooterController.renderFootballTroubleshooter()
 GET            /troubleshoot/cricket                                                                                             controllers.admin.SportTroubleshooterController.renderCricketTroubleshooter()
 GET            /troubleshoot/pages                                                                                               controllers.admin.TroubleshooterController.index()


### PR DESCRIPTION
## What is the value of this and can you measure success?
Remove `DeploysController` from `dev-build` as this has been removed from the `controllers.admin` package in this [pr](https://github.com/guardian/frontend/pull/27782) 
This should fix dev-build


