### PR TITLE
Add Oscars link to news pillar subnavs

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -45,6 +45,7 @@ object NavLinks {
   val retail = NavLink("Retail", "/business/retail")
   val markets = NavLink("Markets", "/business/stock-markets")
   val ukraine = NavLink("Ukraine", "/world/ukraine")
+  val oscars = NavLink("Oscars", "/film/oscars")
   val businessToBusiness = NavLink("B2B", "/business-to-business")
   val diversityEquality = NavLink("Diversity & equality in business", "/business/diversity-and-equality")
   val smallBusiness = NavLink("Small business", "/business/us-small-business")
@@ -284,12 +285,12 @@ object NavLinks {
       climateCrisis,
       middleEast,
       ukraine,
+      oscars,
       football,
       newsletters,
       ukBusiness,
       ukEnvironment,
       politics,
-      society,
       science,
       tech,
       globalDevelopment,
@@ -322,6 +323,7 @@ object NavLinks {
       climateCrisis,
       middleEast,
       ukraine,
+      oscars,
       usSoccer,
       usBusiness,
       usEnvironment,
@@ -339,6 +341,7 @@ object NavLinks {
       climateCrisis,
       middleEast,
       ukraine,
+      oscars,
       ukEnvironment,
       science,
       globalDevelopment,
@@ -354,6 +357,7 @@ object NavLinks {
       ukNews,
       climateCrisis,
       ukraine,
+      oscars,
       ukEnvironment,
       science,
       globalDevelopment,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -176,6 +176,12 @@
 					"classList": []
 				},
 				{
+					"title": "Oscars",
+					"url": "/film/oscars",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -344,12 +350,6 @@
 				{
 					"title": "UK politics",
 					"url": "/politics",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Society",
-					"url": "/society",
 					"children": [],
 					"classList": []
 				},
@@ -1084,6 +1084,12 @@
 				{
 					"title": "Ukraine",
 					"url": "/world/ukraine",
+					"children": [],
+					"classList": []
+				},
+				{
+					"title": "Oscars",
+					"url": "/film/oscars",
 					"children": [],
 					"classList": []
 				},
@@ -2590,6 +2596,12 @@
 					"classList": []
 				},
 				{
+					"title": "Oscars",
+					"url": "/film/oscars",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Environment",
 					"url": "/environment",
 					"children": [
@@ -3598,6 +3610,12 @@
 				{
 					"title": "Ukraine",
 					"url": "/world/ukraine",
+					"children": [],
+					"classList": []
+				},
+				{
+					"title": "Oscars",
+					"url": "/film/oscars",
 					"children": [],
 					"classList": []
 				},


### PR DESCRIPTION
## What is the value of this and can you measure success?

It's nearly the Oscars!

![giphy (1)](https://github.com/user-attachments/assets/d5214446-5748-4e71-8b6e-db4e25a1b36c)


## What does this change?

- Add Oscars to the subnavs on UK, US, Europe and International fronts for the News pillar
- Remove Society from subnav on the UK front for the News pillar
