### PR TITLE
Bump@guardian/libs to 21.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "3.0.0",
 		"@guardian/identity-auth-frontend": "6.0.3",
-		"@guardian/libs": "21.1.0",
+		"@guardian/libs": "21.4.0",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,7 +3758,7 @@ __metadata:
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:3.0.0"
     "@guardian/identity-auth-frontend": "npm:6.0.3"
-    "@guardian/libs": "npm:21.1.0"
+    "@guardian/libs": "npm:21.4.0"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
     "@guardian/source-foundations": "npm:16.0.0"
@@ -3914,16 +3914,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/libs@npm:21.1.0":
-  version: 21.1.0
-  resolution: "@guardian/libs@npm:21.1.0"
+"@guardian/libs@npm:21.4.0":
+  version: 21.4.0
+  resolution: "@guardian/libs@npm:21.4.0"
   peerDependencies:
     tslib: ^2.6.2
     typescript: ~5.5.2
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/f7abc13e554cd103af49dd38311fe59ac4df93c51fa75dba6ae71d4d940e7986a45c7210e9991a7ab72a2c845124b0e7e8a871713f0f2359240fb9f78be23fa3
+  checksum: 10c0/129808382c56daf682f711626733235eb97c71981d7e724e88c14260306822a86f29d033b25401ab836363716557e21ad623e64a9bef3b65bc538fcda914bfcd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?
Update @guardian/libs to latest version.

## Why?
- To include latest improvements for Consent or Pay.
- Resolving issue with Sourcepoint config to send both propertyId and propertyHref
