### PR TITLE
feat(admin): Add `/_tags` endpoint

### DIFF
--- a/admin/app/controllers/HealthCheck.scala
+++ b/admin/app/controllers/HealthCheck.scala
@@ -1,6 +1,8 @@
 package controllers
 
+import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import scala.io.Source
 
 class HealthCheck(val controllerComponents: ControllerComponents) extends BaseController {
 
@@ -9,4 +11,20 @@ class HealthCheck(val controllerComponents: ControllerComponents) extends BaseCo
       Ok("OK")
     }
 
+  def tags: Action[AnyContent] = Action {
+    /*
+    This file is created by https://github.com/guardian/instance-tag-discovery,
+    which is part of the `cdk-base` AMIgo role.
+     */
+    val filename = "/etc/config/tags.json"
+    try {
+      val content = Source.fromFile(filename)
+      val tagsJson =
+        try content.mkString
+        finally content.close()
+      Ok(Json.parse(tagsJson))
+    } catch {
+      case e: Exception => InternalServerError(e.getMessage)
+    }
+  }
 }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -4,6 +4,7 @@
 
 
 GET         /_healthcheck                                                                           controllers.HealthCheck.healthCheck()
+GET         /_tags                                                                                  controllers.HealthCheck.tags()
 
 # authentication endpoints
 GET         /oauthCallback                                                                          http.GuardianAuthWithExemptions.oauthCallback


### PR DESCRIPTION
## What is the value of this and can you measure success?
The instance tags are useful to understand things for debugging. For example, we're about to start dual-stacking `admin`, with this endpoint we can identify which load balancer handled a request.

The implementation is inspired by https://github.com/guardian/cdk-playground/pull/512.

![image](https://github.com/user-attachments/assets/d016c4e1-d5fd-451d-a0d5-9009eaa60a16)

## Checklist

- [x] Tested locally, and [on CODE](https://riffraff.gutools.co.uk/deployment/view/63b17ecb-2593-4aeb-9202-056c911176e1) if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
