### PR TITLE
Rename World Cup 2022 qualifiers to 2026

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -232,9 +232,9 @@ object CompetitionsProvider {
     ),
     Competition(
       "701",
-      "/football/world-cup-2022-qualifiers",
-      "World Cup 2022 qualifying",
-      "World Cup 2022 qual.",
+      "/football/world-cup-2026-qualifiers",
+      "World Cup 2026 qualifying",
+      "World Cup 2026 qual.",
       "Internationals",
     ),
     Competition(


### PR DESCRIPTION
## What does this change?

Change the competition title of World Cup 2022 Qualifying -> World Cup 2026 Qualifying. As the new competition rolls around the ID is reused. See also #27090

## Screenshots


| Before      | After      |
|-------------|------------|
|  ![before][]  | ![after][] |

[before]: https://github.com/user-attachments/assets/d1cd0764-8e94-488c-ba87-513a7f506321
[after]: https://github.com/user-attachments/assets/be382ec8-3da2-4cb6-8c4f-47b243ba72d8



## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
