### PR TITLE
Allow Riff-Raff to update application code for two `admin` ASGs during GuCDK migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -19,6 +19,8 @@ templates:
 deployments:
   admin:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   applications:
     template: frontend
   archive:


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are currently migrating `admin` to GuCDK taking a ['dual-stack' approach](https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md). This means that all infrastructure components (load balancer, autoscaling group, instances etc.) are currently duplicated.

In order to ensure that deployments are deterministic, Riff-Raff normally expects to find exactly one matching autoscaling group for a set of tags. When deploying it will then update the application code for that autoscaling group only. If Riff-Raff finds more than one autoscaling group with the same set of tags it will fail the deployment ([example](https://riffraff.gutools.co.uk/deployment/view/0470503b-8e30-41a7-a3bd-8e8a0dcb9258)).

This change instructs Riff-Raff to update two autoscaling groups for the `admin` deployment while this migration is ongoing. Unfortunately this makes deployments slightly slower but I think this is acceptable as it's a temporary state.

Note that this relies on https://github.com/guardian/platform/pull/1740; this should be applied to the new `admin` CFN stack _before_ this change is deployed.

## Checklist

Riff-Raff's [validation feature](https://riffraff.gutools.co.uk/configuration/validation) confirms that this change updates the admin `autoscaling` deployment as expected:

![image](https://github.com/user-attachments/assets/67edd70b-5faf-474a-b7f3-5a19176cf4db)

![image](https://github.com/user-attachments/assets/a5d252e7-0911-478c-a58b-7e4374bbdf3a)

- [x] Tested locally, and on CODE if necessary - [**Tested in `CODE`**](https://riffraff.gutools.co.uk/deployment/view/85655bc4-9bc1-4752-b569-63662dfb673e)
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md) - **Not applicable for this change (which affects infrastructure only)**
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
