### PR TITLE
Support all live/results/fixtures football pages in dcr

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,7 +15,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       LoopVideoTest,
       DCRCrosswords,
       DarkModeWeb,
-      DCRFootballLive,
+      DCRFootballMatches,
       FiveFourImages,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
@@ -61,10 +61,10 @@ object DarkModeWeb
       participationGroup = Perc0D,
     )
 
-object DCRFootballLive
+object DCRFootballMatches
     extends Experiment(
-      name = "dcr-football-live",
-      description = "Render football/live in DCR",
+      name = "dcr-football-matches",
+      description = "Render football matches lists in DCR",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 4, 10),
       participationGroup = Perc0E,

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -51,7 +51,7 @@ class ResultsController(
     def allPage = new FootballPage("football/results", "football", "All results")
     def competitionPage =
       (competition: Competition) =>
-        new FootballPage(s"${competition.url}/results", "football", s"${competition.fullName} results")
+        new FootballPage(s"${competition.url.stripPrefix("/")}/results", "football", s"${competition.fullName} results")
     def teamPage =
       (team: FootballTeam) =>
         new FootballPage(s"football/${tag.getOrElse("")}/results", "football", s"${team.name} results")

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -54,7 +54,7 @@ class ResultsController(
         new FootballPage(s"${competition.url}/results", "football", s"${competition.fullName} results")
     def teamPage =
       (team: FootballTeam) =>
-        new FootballPage(s"/football/${tag.getOrElse("")}/results", "football", s"${team.name} results")
+        new FootballPage(s"football/${tag.getOrElse("")}/results", "football", s"${team.name} results")
     byType[FootballPage](allPage)(competitionPage)(teamPage)(tag)
   }
 

--- a/sport/app/services/dotcomrendering/FootballPagePicker.scala
+++ b/sport/app/services/dotcomrendering/FootballPagePicker.scala
@@ -9,7 +9,8 @@ import utils.DotcomponentsLogger
 object FootballPagePicker {
 
   def isSupportedInDcr(page: FootballPage): Boolean = {
-    page.metadata.id == "football/live"
+    val liveMatchPattern = """^football(?:/[^/]+)?/live$""".r
+    liveMatchPattern.matches(page.metadata.id)
   }
 
   def getTier(

--- a/sport/app/services/dotcomrendering/FootballPagePicker.scala
+++ b/sport/app/services/dotcomrendering/FootballPagePicker.scala
@@ -1,6 +1,6 @@
 package services.dotcomrendering
 
-import experiments.{ActiveExperiments, DCRFootballLive}
+import experiments.{ActiveExperiments, DCRFootballMatches}
 import football.controllers.FootballPage
 import model.Cors.RichRequestHeader
 import play.api.mvc.RequestHeader
@@ -9,8 +9,9 @@ import utils.DotcomponentsLogger
 object FootballPagePicker {
 
   def isSupportedInDcr(page: FootballPage): Boolean = {
-    val liveMatchPattern = """^football(?:/[^/]+)?/live$""".r
-    liveMatchPattern.matches(page.metadata.id)
+    val footballMatchesPattern =
+      """^football(?:/[^/]+)?/(live|fixtures|results)(?:/more)?(?:/\d{4}/[A-Za-z]{3}/\d{1,2})?$""".r
+    footballMatchesPattern.matches(page.metadata.id)
   }
 
   def getTier(
@@ -21,7 +22,7 @@ object FootballPagePicker {
 
     val dcrCanRender = isSupportedInDcr(footballPage)
 
-    val participatingInTest = ActiveExperiments.isParticipating(DCRFootballLive)
+    val participatingInTest = ActiveExperiments.isParticipating(DCRFootballMatches)
 
     val tier = {
       if (request.forceDCROff) LocalRender


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR does the following:
- Adds all of the following football pages to the DCR supported pages. 
    - football/fixtures
    - football/results
    - football/\<competition\>/fixtures
    - football/\<competition\>/results
    - football/results/\<year\>/\<month\>/\<day\>
    - football/fixtures/\<year\>/\<month\>/\<day\>
    - football/fixtures/more/\<year\>/\<month\>/\<day\>
    - football/results/more/\<year\>/\<month\>/\<day\>
    - football/\<competition\>/fixtures/\<year\>/\<month\>/\<day\>
    - football/\<competition\>/results/\<year\>/\<month\>/\<day\>
    - football/\<competition\>/fixtures/more/\<year\>/\<month\>/\<day\>
    - football/\<competition\>/results/more/\<year\>/\<month\>/\<day\>
- Fixes a bug where the page id for football competition results had a leading `/`. This bug adds a leading slash to the pageId and as a result the `canonicalUrl` ends up with double slashes 
  - competition results pages e.g. https://www.theguardian.com/football/premierleague/results.json?dcr 
  - Also in team results pages e.g. https://www.theguardian.com/football/newcastleunited/results.json?dcr