### PR TITLE
chore(admin): Remove unused configuration

### DIFF
--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -85,13 +85,4 @@ object AdminConfiguration {
       userName <- configuration.getStringProperty("admin.omniture.username")
       secret <- configuration.getStringProperty("admin.omniture.secret")
     } yield OmnitureCredentials(userName, secret)
-
-  object db {
-    object default {
-      lazy val driver = configuration.getStringProperty("default.driver")
-      lazy val url = configuration.getStringProperty("default.url")
-      lazy val user = configuration.getStringProperty("default.user")
-      lazy val password = configuration.getStringProperty("default.password")
-    }
-  }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?
Originally added in https://github.com/guardian/frontend/pull/5917, this configuration allowed `admin` to talk to a Postgres database. In https://github.com/guardian/frontend/pull/10383 the functionality was removed. This change removes some unused code.

## Checklist
- [x] Tested locally, and on [CODE](https://riffraff.gutools.co.uk/deployment/view/0116f5e0-1a22-4f68-923e-8fb312e280c4) if necessary
- [x] Will not break dotcom-rendering