### PR TITLE
Remove Oscars link from News pillar subnavs

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -45,7 +45,6 @@ object NavLinks {
   val retail = NavLink("Retail", "/business/retail")
   val markets = NavLink("Markets", "/business/stock-markets")
   val ukraine = NavLink("Ukraine", "/world/ukraine")
-  val oscars = NavLink("Oscars", "/film/oscars")
   val businessToBusiness = NavLink("B2B", "/business-to-business")
   val diversityEquality = NavLink("Diversity & equality in business", "/business/diversity-and-equality")
   val smallBusiness = NavLink("Small business", "/business/us-small-business")
@@ -285,7 +284,6 @@ object NavLinks {
       climateCrisis,
       middleEast,
       ukraine,
-      oscars,
       football,
       newsletters,
       ukBusiness,
@@ -323,7 +321,6 @@ object NavLinks {
       climateCrisis,
       middleEast,
       ukraine,
-      oscars,
       usSoccer,
       usBusiness,
       usEnvironment,
@@ -341,7 +338,6 @@ object NavLinks {
       climateCrisis,
       middleEast,
       ukraine,
-      oscars,
       ukEnvironment,
       science,
       globalDevelopment,
@@ -357,7 +353,6 @@ object NavLinks {
       ukNews,
       climateCrisis,
       ukraine,
-      oscars,
       ukEnvironment,
       science,
       globalDevelopment,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -176,12 +176,6 @@
 					"classList": []
 				},
 				{
-					"title": "Oscars",
-					"url": "/film/oscars",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -1084,12 +1078,6 @@
 				{
 					"title": "Ukraine",
 					"url": "/world/ukraine",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Oscars",
-					"url": "/film/oscars",
 					"children": [],
 					"classList": []
 				},
@@ -2596,12 +2584,6 @@
 					"classList": []
 				},
 				{
-					"title": "Oscars",
-					"url": "/film/oscars",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "Environment",
 					"url": "/environment",
 					"children": [
@@ -3610,12 +3592,6 @@
 				{
 					"title": "Ukraine",
 					"url": "/world/ukraine",
-					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Oscars",
-					"url": "/film/oscars",
 					"children": [],
 					"classList": []
 				},


### PR DESCRIPTION
## What is the value of this and can you measure success?

The Oscars are over for another year…

![giphy](https://github.com/user-attachments/assets/95c94734-96ae-4293-af97-9042d5a72beb)

## What does this change?

Removes Oscars from subnavs on UK, US, Europe and International fronts for the News pillar
