### PR TITLE
Revert "Allow Riff-Raff to update application code for two `admin` ASGs during GuCDK migration"

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -19,8 +19,6 @@ templates:
 deployments:
   admin:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   applications:
     template: frontend
   archive:


### PR DESCRIPTION
When https://github.com/guardian/platform/pull/1753 is merged we should also revert guardian/frontend#27813 so that Riff-Raff deployments do not break.