### PR TITLE
Update the max total number of cards in a flexible general

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -344,8 +344,10 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         case "flexible/general" => {
 
           collection.collectionConfig.groupsConfig
-            .flatMap(_.config)
-            .map(_.maxItems).flatten // Removes None values as maxItems is optional
+            .map(_.config)
+            .getOrElse(Nil)
+            .map(_.maxItems)
+            .flatten // Removes None values as maxItems is optional
             .sum
 
         }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -340,13 +340,15 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         case "scrollable/highlights" => 6
         // scrollable small and medium containers are capped at 8 stories
         case "scrollable/small" | "scrollable/medium" => 8
-        // flexible general containers are capped at the maxItemsToDisplay value (set in the config tool)
-        // In the event the field isn't populated, the fallback cap is 9 stories
-        case "flexible/general" =>
-          collection.collectionConfig.displayHints match {
-            case Some(displayHints) => displayHints.maxItemsToDisplay.getOrElse(9)
-            case None               => 9
-          }
+        // flexible general containers have max items on each group. In order to know the total max items, we need to sum all of these together.
+        case "flexible/general" => {
+
+          collection.collectionConfig.groupsConfig
+            .flatMap(_.config)
+            .map(_.maxItems).flatten // Removes None values as maxItems is optional
+            .sum
+
+        }
         // other container types should be capped at a maximum number of stories set in the app config
         case _ => Math.min(Configuration.facia.collectionCap, storyCountTotal)
       }


### PR DESCRIPTION
## What is the value of this and can you measure success?
## What does this change?
Previously we took the maximum number of cards that could be shown in a flexible general from the display hints. Now we want to make sure that this is the sum total of the max items of all groups. 


NB this pr only adjusts the maximum number of cards, it doesnt ensure that those limits are per group ie if the total limit was 4, max 1 for splash, max 1 for very big, max 1 for big and max 1 for standard, a user *could* put 4 cards in standard. 

This edgecase will be addressed in this ticket https://trello.com/c/SugwQ3xV/1032-set-card-limits-from-groups
## Screenshots

5 cards in the container in the fronts tools (exceeding limit of 4)
![Screenshot 2025-03-10 at 15 25 07](https://github.com/user-attachments/assets/8268a74c-2c64-4382-9b9e-cfa1fe957be4)

Pressed json shows only 4 cards in the content which matches the total limits set
![Screenshot 2025-03-10 at 15 26 10](https://github.com/user-attachments/assets/d08233f3-1b23-4ba1-8028-c38d1a6b6027)


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
