### PR TITLE
Turn europebetafront on for 10% of users

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -31,7 +31,7 @@ object EuropeBetaFront
         Owner.withEmail("dotcom.platform@theguardian.com"),
       ),
       sellByDate = LocalDate.of(2025, 4, 2),
-      participationGroup = Perc0A,
+      participationGroup = Perc10A,
     )
 
 object LoopVideoTest


### PR DESCRIPTION
## What does this change?
Turns on  the europe beta test, serving it to 10% of users

