### PR TITLE
Turn 50% test into 0% test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -76,5 +76,5 @@ object FiveFourImages
       description = "Compare 5:4 vs 5:3 aspect ratio in article images",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 3, 20),
-      participationGroup = Perc50,
+      participationGroup = Perc0C,
     )


### PR DESCRIPTION
## What does this change?
Moves the  FiveFourImages test thats set to 50% to a 0% bucket. This test is no longer active and there is [another test](https://github.com/guardian/frontend/pull/27832) that is due to use the 50% participation group later on today.

