### PR TITLE
Update Netty To `4.1.118.Final`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ val common = library("common")
       pekkoSerializationJackson,
       pekkoActorTyped,
       janino,
-    ) ++ jackson ++ netty,
+    ) ++ jackson,
     TestAssets / mappings ~= filterAssets,
   )
 
@@ -205,8 +205,6 @@ val main = root()
     archive,
     preview,
     rss,
-  ).settings(
-    libraryDependencies ++= netty
   )
 val badgeHash = inputKey[Unit]("Generate special badge salts and hashes")
 badgeHash := {

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ val common = library("common")
       awsSqs,
       awsSsm,
       eTagCachingS3,
-      nettyCodecHttp2,
       contentApiClient,
       contentApiModelsJson,
       enumeratumPlayJson,
@@ -72,7 +71,7 @@ val common = library("common")
       pekkoSerializationJackson,
       pekkoActorTyped,
       janino,
-    ) ++ jackson,
+    ) ++ jackson ++ netty,
     TestAssets / mappings ~= filterAssets,
   )
 
@@ -206,6 +205,8 @@ val main = root()
     archive,
     preview,
     rss,
+  ).settings(
+    libraryDependencies ++= netty
   )
 val badgeHash = inputKey[Unit]("Generate special badge salts and hashes")
 badgeHash := {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -100,20 +100,6 @@ object Dependencies {
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.16"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7.4"
 
-  // Forcing a version of this to fix an issue with the dependency.
-  // This is a transitive dependency of the play framework
-  val nettyVersion = "4.1.118.Final"
-  val netty = Seq(
-    "io.netty" % "netty-handler" % nettyVersion,
-    "io.netty" % "netty-codec-http" % nettyVersion,
-    "io.netty" % "netty-buffer" % nettyVersion,
-    "io.netty" % "netty-common" % nettyVersion,
-    "io.netty" % "netty-transport-classes-epoll" % nettyVersion,
-    "io.netty" % "netty-transport-native-unix-common" % nettyVersion,
-    "io.netty" % "netty-transport" % nettyVersion,
-    "io.netty" % "netty-transport-native-epoll" % nettyVersion,
-  )
-
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "5.3.3"
   val jquery = "org.webjars" % "jquery" % "3.7.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "1.12.780"
-  val awsSdk2Version = "2.26.31"
+  val awsSdk2Version = "2.30.37"
   val capiVersion = "34.0.0"
   val faciaVersion = "16.1.0"
   val dispatchVersion = "0.13.1"
@@ -101,8 +101,18 @@ object Dependencies {
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7.4"
 
   // Forcing a version of this to fix an issue with the dependency.
-  // This is a transitive dependency of the AWS SDK used by etag-caching library
-  val nettyCodecHttp2 = "io.netty" % "netty-codec-http2" % "4.1.112.Final"
+  // This is a transitive dependency of the play framework
+  val nettyVersion = "4.1.118.Final"
+  val netty = Seq(
+    "io.netty" % "netty-handler" % nettyVersion,
+    "io.netty" % "netty-codec-http" % nettyVersion,
+    "io.netty" % "netty-buffer" % nettyVersion,
+    "io.netty" % "netty-common" % nettyVersion,
+    "io.netty" % "netty-transport-classes-epoll" % nettyVersion,
+    "io.netty" % "netty-transport-native-unix-common" % nettyVersion,
+    "io.netty" % "netty-transport" % nettyVersion,
+    "io.netty" % "netty-transport-native-epoll" % nettyVersion,
+  )
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "5.3.3"


### PR DESCRIPTION
Netty is a transitive dependency of the AWS SDK, so this has been updated to the latest version. It's also a transitive dependency of Play, but the latest version of Play still depends on `4.1.115.Final`, so this change adds direct dependencies on netty to force an eviction.
