### PR TITLE
Delete movePermutiveSegmentation test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,16 +48,4 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  Switch(
-    ABTests,
-    "ab-move-permutive-segmentation",
-    "Test the impact of moving the call for the Permutive segmentation script.",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 3, 21)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
 }


### PR DESCRIPTION
## What does this change?
We're removing this test, so we can delete the switch.