### PR TITLE
Remove sbt JVM setting `java.awt.headless=true`

### DIFF
--- a/sbt
+++ b/sbt
@@ -34,7 +34,7 @@ jvm_mem="-Xmx$((physical_mem / 2 / 1024))m"
 
 
 if [ -z $FRONTEND_JVM_ARGS ]; then
-    FRONTEND_JVM_ARGS="$jvm_mem -XX:ReservedCodeCacheSize=128m -Djava.awt.headless=true -XX:NewRatio=4"
+    FRONTEND_JVM_ARGS="$jvm_mem -XX:ReservedCodeCacheSize=128m -XX:NewRatio=4"
 fi
 
 echo ''


### PR DESCRIPTION
### Background on `java.awt.headless`

Setting `java.awt.headless=true` allows a Java process that's _not_ running in a Graphical User Interface (eg, running on a server) to still perform various graphical operations, perhaps for capturing a screenshot of a generated image:

* https://stackoverflow.com/a/59883645/438886
* https://www.oracle.com/technical-resources/articles/javase/headless.html

### Problem with setting `java.awt.headless=true`

Frontend's [`sbt`](https://github.com/guardian/frontend/blob/main/sbt) script is only used by developers (it's not used by CI or in live-environment EC2 instances), who tend to run in a graphical environment, and setting `java.awt.headless=true` _stops_ useful commands like [`sbt dependencyBrowseTree`](https://www.scala-sbt.org/sbt-dependency-graph/tasks/dependencyBrowseTree.html) from automatically opening a browser window to show their results:

```
[error] java.awt.HeadlessException
[error] 	at java.desktop/java.awt.Desktop.getDesktop(Desktop.java:301)
[error] 	at sbt.plugins.DependencyTreeSettings$.$anonfun$openBrowser$1(DependencyTreeSettings.scala:248)
```

### Why was `java.awt.headless=true` set on `frontend`?

The setting was added to Frontend's `sbt` script a looong time ago, in May 2013 with commit e5eb892f991f010a37f89b647ef5aca5d9e5543c - the commit doesn't really explain _why_ it was added, and it seems unassociated with the CORS issue.

I think the setting is probably _not_ useful for us, and causes some problems, so this change removes it.