### PR TITLE
Remove Play Plugin From `root` Project

### DIFF
--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -93,11 +93,7 @@ object ProjectSettings {
 
   def root(): Project =
     Project("root", base = file("."))
-      .enablePlugins(PlayScala, PlayNettyServer)
-      .disablePlugins(PlayPekkoHttpServer)
-      .settings(frontendCompilationSettings)
       .settings(frontendRootSettings)
-      .settings(libraryDependencies ++= jackson)
 
   def application(applicationName: String): Project = {
     Project(applicationName, file(applicationName))


### PR DESCRIPTION
The root project is used to aggregate the other projects for compilation and testing. It's not run as an application in its own right, and therefore does not need to include the Play plugin directly. Removing it also removes the need for the root project to have its own dependency tree.

See also https://github.com/guardian/frontend/pull/27834#discussion_r1991170554
