### PR TITLE
Handle missing seconds in podcasts

### DIFF
--- a/common/app/model/PressedCard.scala
+++ b/common/app/model/PressedCard.scala
@@ -77,10 +77,10 @@ object PressedCard {
       val seconds: Option[Int] = if (audioDurationSeconds(fc).isDefined) {
         audioDurationSeconds(fc).get.headOption
       } else None
-      if (minutes.isDefined && seconds.isDefined) {
+      if (minutes.isDefined || seconds.isDefined) {
         // adds a leading zero if the values are less than 10
-        val formattedMinutes = f"${minutes.get}%02d"
-        val formattedSeconds = f"${seconds.get}%02d"
+        val formattedMinutes = f"${minutes.getOrElse(0)}%02d"
+        val formattedSeconds = f"${seconds.getOrElse(0)}%02d"
         val duration = s"$formattedMinutes:$formattedSeconds"
         Some(duration)
       } else None


### PR DESCRIPTION
## What is the value of this and can you measure success?

This podcast should show a duration of "31:00"
<img width="222" alt="Screenshot 2025-03-14 at 11 57 41" src="https://github.com/user-attachments/assets/89471896-b804-477e-8bac-b146b17af186" />

Like this one does:
<img width="224" alt="Screenshot 2025-03-14 at 11 57 54" src="https://github.com/user-attachments/assets/0b56795a-3916-4ddc-ab18-847429773253" />

But it doesn't. Hopefully this PR will resolve the issue.

## What does this change?

Podcasts with zero seconds (but non-zero minutes) currently do not render a duration. If seconds are zero they seem to get dropped by Composer. We should probably fix this upstream, but for now let's assuming seconds or minutes are zero if they are missing.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
