### PR TITLE
also remove the download step from the dev compile tasks

### DIFF
--- a/tools/__tasks__/compile/data/index.dev.mjs
+++ b/tools/__tasks__/compile/data/index.dev.mjs
@@ -1,5 +1,4 @@
 import clean from './clean.mjs';
-import download from './download.mjs';
 import amp from './amp.mjs';
 
 /** @type {import('listr2').ListrTask} */
@@ -10,7 +9,6 @@ const task = {
 			[
 				// prettier: multi-line
 				clean,
-				download,
 				amp,
 			],
 			{ concurrent: false },


### PR DESCRIPTION


## What does this change?

this download.mjs module was removed and removed from other tasks in #27724, but this usage was overlooked, meaning that this script cannot run, including `make compile-dev`

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
