### PR TITLE
Bump facia-scala-client to 16.1.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.780"
   val awsSdk2Version = "2.26.31"
   val capiVersion = "34.0.0"
-  val faciaVersion = "16.1.0"
+  val faciaVersion = "16.1.2"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
Bump facia-scala-client to 16.1.2. This version includes revised sublink limit logic [PR350]( https://github.com/guardian/facia-scala-client/pull/350/files). This results in all cards having a maximum of 4 sublinks except standard non-boosted cards in a flexible container which can have a maximum of 2 sublinks. 

The same change is being applied in MAPI in [PR3561](https://github.com/guardian/frontend/pull/3561)