### PR TITLE
Enable DCR crosswords for 100% of users

### DIFF
--- a/applications/app/services/dotcomrendering/CrosswordsPicker.scala
+++ b/applications/app/services/dotcomrendering/CrosswordsPicker.scala
@@ -1,11 +1,11 @@
 package services.dotcomrendering
 
 import common.GuLogging
+import conf.switches.Switches.DCRCrosswords
 import crosswords.CrosswordPageWithContent
 import model.Cors.RichRequestHeader
 import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
-import conf.switches.Switches.DCRCrosswords
 
 object CrosswordsPicker extends GuLogging {
 

--- a/applications/app/services/dotcomrendering/CrosswordsPicker.scala
+++ b/applications/app/services/dotcomrendering/CrosswordsPicker.scala
@@ -2,10 +2,10 @@ package services.dotcomrendering
 
 import common.GuLogging
 import crosswords.CrosswordPageWithContent
-import experiments.{ActiveExperiments, DCRCrosswords}
 import model.Cors.RichRequestHeader
 import play.api.mvc.RequestHeader
 import utils.DotcomponentsLogger
+import conf.switches.Switches.DCRCrosswords
 
 object CrosswordsPicker extends GuLogging {
 
@@ -15,12 +15,12 @@ object CrosswordsPicker extends GuLogging {
       request: RequestHeader,
   ): RenderType = {
 
-    val participatingInTest = ActiveExperiments.isParticipating(DCRCrosswords)
+    val dcrShouldRender = DCRCrosswords.isSwitchedOn
 
     val tier = {
       if (request.forceDCROff) LocalRender
       else if (request.forceDCR) RemoteRender
-      else if (participatingInTest) RemoteRender
+      else if (dcrShouldRender) RemoteRender
       else LocalRender
     }
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -552,4 +552,14 @@ trait FeatureSwitches {
     highImpact = false,
   )
 
+  val DCRCrosswords = Switch(
+    SwitchGroup.Feature,
+    "dcr-crosswords",
+    "If this switch is on, crosswords will be rendered with DCR",
+    owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com"), Owner.withEmail("devx.e2e@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+    highImpact = false,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,7 +12,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       EuropeBetaFront,
-      DCRCrosswords,
       DarkModeWeb,
       DCRFootballLive,
     )
@@ -30,15 +29,6 @@ object EuropeBetaFront
       ),
       sellByDate = LocalDate.of(2025, 4, 2),
       participationGroup = Perc50,
-    )
-
-object DCRCrosswords
-    extends Experiment(
-      name = "dcr-crosswords",
-      description = "Render crosswords in DCR",
-      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 3, 31),
-      participationGroup = Perc20A,
     )
 
 object DarkModeWeb


### PR DESCRIPTION
## What does this change?

Removes DCR crossword experiment and replaces with a feature switch so we can enable DCR crosswords for all readers.