### PR TITLE
Automatically update the AMI for GuCDK stacks

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,11 +10,12 @@ templates:
     type: autoscaling
     parameters:
       bucketSsmKey: /account/services/dotcom-artifact.bucket
-
       warmupGrace: 60
     dependencies:
     - frontend-static
-    - update-ami
+    - update-ami-for-legacy-stacks
+    - update-ami-for-admin
+    - update-ami-for-discussion
 
 deployments:
   admin:
@@ -52,7 +53,7 @@ deployments:
       cacheControl: public, max-age=315360000, immutable
       prefixStack: false
       publicReadAcl: false
-  update-ami:
+  update-ami-for-legacy-stacks:
     type: ami-cloudformation-parameter
     parameters:
       cloudFormationStackByTags: false
@@ -60,5 +61,22 @@ deployments:
       cloudFormationStackName: frontend
       amiParametersToTags:
         AMI:
+          Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  # Riff-Raff identifies the GuCDK stacks using tag-based lookups
+  update-ami-for-admin:
+    app: admin
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIAdmin:
+          Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-discussion:
+    app: discussion
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIDiscussion:
           Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?

This PR allows us to automatically update AMIs for the new `admin` and `discussion` stacks, which helps us to meet our security obligations more easily.

## What does this change?

This allows `dotcom:frontend-all` deployments (including scheduled deployments) to automatically update the AMI used by new GuCDK stacks (introduced in https://github.com/guardian/platform/pull/1701 and https://github.com/guardian/platform/pull/1758).

The AMI update for the legacy stack (which uses nested stacks) should remain unchanged.

## Checklist

Riff-Raff's [validation feature](https://riffraff.gutools.co.uk/configuration/validation) confirms that this change is working as expected:

**Before (`main`)**
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/0345f382-cd76-4bf2-b9c7-ca8b075801b1" />

**After (`jw-automate-cdk-ami-updates`)**
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/fece94ab-58e7-4055-94db-348d6dac2c4c" />

- [x] Tested locally, and on CODE if necessary - **[Tested in `CODE`](https://riffraff.gutools.co.uk/deployment/view/28eadca3-4042-4884-8c88-b1a37e1dfdfc)**

This seems to be working as expected:

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/5d8d1571-3ffa-407f-a187-e938063adc60" />

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/be9b6919-3cd9-4cd6-ac00-94e213fc67b6" />

- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md) - **Not applicable for this change (which affects infrastructure only)**
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
