### PR TITLE
Roll out football pages behind a feature swicth

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -562,4 +562,15 @@ trait FeatureSwitches {
     exposeClientSide = false,
     highImpact = false,
   )
+
+  val DCRFootballPages = Switch(
+    SwitchGroup.Feature,
+    "dcr-football-pages",
+    "If this switch is on, live, fixtures and results football pages will be rendered with DCR",
+    owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+    highImpact = false,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,7 +13,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     Set(
       EuropeBetaFront,
       DarkModeWeb,
-      DCRFootballMatches,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -38,13 +37,4 @@ object DarkModeWeb
       owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 4, 30),
       participationGroup = Perc0D,
-    )
-
-object DCRFootballMatches
-    extends Experiment(
-      name = "dcr-football-matches",
-      description = "Render football matches lists in DCR",
-      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 4, 10),
-      participationGroup = Perc10A,
     )

--- a/sport/app/services/dotcomrendering/FootballPagePicker.scala
+++ b/sport/app/services/dotcomrendering/FootballPagePicker.scala
@@ -1,6 +1,6 @@
 package services.dotcomrendering
 
-import experiments.{ActiveExperiments, DCRFootballMatches}
+import conf.switches.Switches.DCRFootballPages
 import football.controllers.FootballPage
 import model.Cors.RichRequestHeader
 import play.api.mvc.RequestHeader
@@ -21,13 +21,12 @@ object FootballPagePicker {
   ): RenderType = {
 
     val dcrCanRender = isSupportedInDcr(footballPage)
-
-    val participatingInTest = ActiveExperiments.isParticipating(DCRFootballMatches)
+    val dcrShouldRender = DCRFootballPages.isSwitchedOn
 
     val tier = {
       if (request.forceDCROff) LocalRender
       else if (request.forceDCR) RemoteRender
-      else if (dcrCanRender && participatingInTest) RemoteRender
+      else if (dcrCanRender && dcrShouldRender) RemoteRender
       else LocalRender
     }
 


### PR DESCRIPTION
This change removes the AB test for DCR football pages and adds a feature switch instead. The swicth currently only works on live, fixtures and results football pages.
