### PR TITLE
Set cookie to false when opting out of experiment

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -25,7 +25,8 @@ class OptInController(val controllerComponents: ControllerComponents) extends Ba
       case "delete" => optDelete(feature)
     }
   def optIn(cookieName: String): Result = SeeOther("/").withCookies(Cookie(cookieName, "true", maxAge = Some(lifetime)))
-  def optOut(cookieName: String): Result = SeeOther("/").discardingCookies(DiscardingCookie(cookieName))
+  def optOut(cookieName: String): Result =
+    SeeOther("/").withCookies(Cookie(cookieName, "false", maxAge = Some(lifetime)))
   def optDelete(cookieName: String): Result = SeeOther("/").discardingCookies(DiscardingCookie(cookieName))
 
   def reset(): Action[AnyContent] =


### PR DESCRIPTION
## What does this change?

When opting out of an experiment using the [opt-out link](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#forcing-yourself-into-the-test), this sets the cookie to false instead of removing the cookie.

## Why?

Removing the cookie means that a users participation in a test is decided by their MVT value, which may or may not result in them being included in the variant of the test. By setting the cookie to false, we ensure that the user will not be included within the variant of the test.