### PR TITLE
Add basic ALB support to admin app's 'Ops metrics' functionality

### DIFF
--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -28,8 +28,8 @@ class MetricsController(
   def renderErrors(): Action[AnyContent] =
     Action.async { implicit request =>
       for {
-        errors4xx <- HttpErrors.global4XX()
-        errors5xx <- HttpErrors.global5XX()
+        errors4xx <- HttpErrors.legacyElb4XXs()
+        errors5xx <- HttpErrors.legacyElb5XXs()
       } yield NoCache(Ok(views.html.lineCharts(Seq(errors4xx, errors5xx))))
     }
 

--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -11,6 +11,8 @@ case class LoadBalancer(
     project: String,
     url: Option[String] = None,
     testPath: Option[String] = None,
+    // Application load balancers (v2) have target groups, classic load balancers (v1) do not
+    targetGroup: Option[String] = None,
 )
 
 object LoadBalancer extends GuLogging {
@@ -27,7 +29,12 @@ object LoadBalancer extends GuLogging {
     ),
     LoadBalancer("frontend-PROD-facia-ELB", "Front", "frontend-facia", testPath = Some("/uk")),
     LoadBalancer("frontend-PROD-applications-ELB", "Applications", "frontend-applications", testPath = Some("/books")),
-    LoadBalancer("frontend-PROD-discussion-ELB", "Discussion", "frontend-discussion"),
+    LoadBalancer(
+      "app/fronte-LoadB-xmdWiUUHyRUS/122c59735e8374bb",
+      "Discussion",
+      "frontend-discussion",
+      targetGroup = Some("targetgroup/fronte-Targe-JGOOGIGPNWQJ/187642c8eda54a4a"),
+    ),
     LoadBalancer("frontend-PROD-identity-ELB", "Identity", "frontend-identity"),
     LoadBalancer("frontend-PROD-sport-ELB", "Sport", "frontend-sport"),
     LoadBalancer("frontend-PROD-commercial-ELB", "Commercial", "frontend-commercial"),

--- a/admin/app/tools/errors.scala
+++ b/admin/app/tools/errors.scala
@@ -35,9 +35,6 @@ object HttpErrors {
       ),
     )
 
-  val v1LoadBalancerNamespace = "AWS/ELB"
-  val v2LoadBalancerNamespace = "AWS/ApplicationELB"
-
   val v1Metric4XX = "HTTPCode_Backend_4XX"
   val v2Metric4XX = "HTTPCode_Target_4XX_Count"
 
@@ -46,7 +43,7 @@ object HttpErrors {
 
   def legacyElb4XXs()(implicit executionContext: ExecutionContext): Future[AwsLineChart] =
     withErrorLogging(
-      euWestClient.getMetricStatisticsFuture(metric("HTTPCode_Backend_4XX", v1LoadBalancerNamespace)),
+      euWestClient.getMetricStatisticsFuture(metric(v1Metric4XX, v1LoadBalancerNamespace)),
     ) map { metric =>
       new AwsLineChart("Legacy ELB 4XXs", Seq("Time", "4xx/min"), ChartFormat.SingleLineBlue, metric)
     }
@@ -54,7 +51,7 @@ object HttpErrors {
   def legacyElb5XXs()(implicit executionContext: ExecutionContext): Future[AwsLineChart] =
     withErrorLogging(
       euWestClient.getMetricStatisticsFuture(
-        metric("HTTPCode_Backend_5XX", v1LoadBalancerNamespace),
+        metric(v2Metric5XX, v1LoadBalancerNamespace),
       ) map { metric =>
         new AwsLineChart("Legacy ELB 5XXs", Seq("Time", "5XX/ min"), ChartFormat.SingleLineRed, metric)
       },

--- a/admin/app/tools/errors.scala
+++ b/admin/app/tools/errors.scala
@@ -51,7 +51,7 @@ object HttpErrors {
   def legacyElb5XXs()(implicit executionContext: ExecutionContext): Future[AwsLineChart] =
     withErrorLogging(
       euWestClient.getMetricStatisticsFuture(
-        metric(v2Metric5XX, v1LoadBalancerNamespace),
+        metric(v1Metric5XX, v1LoadBalancerNamespace),
       ) map { metric =>
         new AwsLineChart("Legacy ELB 5XXs", Seq("Time", "5XX/ min"), ChartFormat.SingleLineRed, metric)
       },


### PR DESCRIPTION
## What is the value of this and can you measure success?

The `admin` app has some 'Ops metrics' functionality which displays CloudWatch metrics for all of the `frontend` applications in this repository ([example](https://frontend.gutools.co.uk/metrics/loadbalancers)). 

Until recently all of the `frontend` applications in this repository used Classic Load Balancers (v1), but now that we are migrating services to GuCDK ([example](https://github.com/guardian/platform/pull/1758)) we have started using Application Load Balancers (v2) too[^1]. The [CloudWatch metrics](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html) for Application Load Balancers are different to the metrics for the [Classic Load Balancer metrics](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-cloudwatch-metrics.html).

Consequently, we need to update the 'Ops metrics' functionality to retain observability coverage of all services (prior to this PR the `discussion` dashboards/visualisations were not working).

## What does this change?

This PR updates most functionality so that it also works with Application Load Balancers.

Note that the 'global error' pages were more complex to update (primarily due to AWS limitations) so for now I have just updated the naming/labelling for these for now instead of updating the metrics that they're showing. I'm not convinced that it's worth continuing to support these global error pages (which also omit errors affecting `*-rendering` services) but it would be useful to hear if reviewers agree with that or not!

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

| Before      | After      |
|-------------|------------|
| ![image](https://github.com/user-attachments/assets/433e7e8f-c522-40c2-b818-70305ca10a96) | ![image](https://github.com/user-attachments/assets/f02d6818-76f2-4244-aa66-3d24f6799175) |
| ![image](https://github.com/user-attachments/assets/effd7a1f-7d67-4963-9cb8-335ef1e33223) | ![image](https://github.com/user-attachments/assets/d79a0b71-48ba-40a5-9809-c6e3a01ec3a0) |
| ![image](https://github.com/user-attachments/assets/c92c3fe1-06bc-45a0-bc29-45e247f766f5) | ![image](https://github.com/user-attachments/assets/08220ab9-c919-43f0-83bb-49219f84d17a) |
| ![image](https://github.com/user-attachments/assets/30bb6e92-448b-4521-b7c8-dfd60113e334) | ![image](https://github.com/user-attachments/assets/cadcb979-18fa-4b6f-a0dd-c10d630d06e4) |

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)

I have not done any accessibility testing as this PR only changes server side code.

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->

[^1]: The `*-rendering` services [also use application load balancers](https://github.com/guardian/dotcom-rendering/blob/e746ce49e9260e661a1a0910b50f089ed2d1d744/dotcom-rendering/cdk/lib/renderingStack.ts#L204-L260), but as far as I can tell they have never been supported by the `admin` app.