### PR TITLE
Revert "Allow Riff-Raff to update 2 discussion ASGs during GuCDK migration"

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -30,8 +30,6 @@ deployments:
     template: frontend
   discussion:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   facia:
     template: frontend
   facia-press:


### PR DESCRIPTION
When https://github.com/guardian/platform/pull/1782 is merged we should also revert guardian/frontend#27850 so that deployments do not break.