### PR TITLE
extend expiry date of permutive switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,7 +44,7 @@ trait ABTestSwitches {
     "Test the impact of deferring the Permutive script load",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 3, 28)),
+    sellByDate = Some(LocalDate.of(2025, 4, 18)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
This PR extends the expiry for the `ab-defer-permutive-load` feature switch, to ensure we get desired user volumes.
