### PR TITLE
Add isImmersive to display settings

### DIFF
--- a/common/app/layout/DisplaySettings.scala
+++ b/common/app/layout/DisplaySettings.scala
@@ -6,6 +6,7 @@ import model.pressed._
 case class DisplaySettings(
     isBoosted: Boolean,
     boostLevel: Option[BoostLevel],
+    isImmersive: Option[Boolean],
     showBoostedHeadline: Boolean,
     showQuotedHeadline: Boolean,
     imageHide: Boolean,
@@ -17,6 +18,7 @@ object DisplaySettings {
     DisplaySettings(
       faciaContent.display.isBoosted,
       faciaContent.display.boostLevel,
+      faciaContent.display.isImmersive,
       faciaContent.display.showBoostedHeadline,
       faciaContent.display.showQuotedHeadline,
       faciaContent.display.imageHide,

--- a/common/app/model/PressedDisplaySettings.scala
+++ b/common/app/model/PressedDisplaySettings.scala
@@ -6,6 +6,7 @@ import com.gu.facia.api.{models => fapi}
 final case class PressedDisplaySettings(
     isBoosted: Boolean,
     boostLevel: Option[BoostLevel],
+    isImmersive: Option[Boolean],
     showBoostedHeadline: Boolean,
     showQuotedHeadline: Boolean,
     imageHide: Boolean,
@@ -20,6 +21,7 @@ object PressedDisplaySettings {
       imageHide = shouldSuppressImages || contentProperties.imageHide,
       isBoosted = FaciaContentUtils.isBoosted(content),
       boostLevel = Some(FaciaContentUtils.boostLevel(content)),
+      isImmersive = Some(FaciaContentUtils.isImmersive(content)),
       showBoostedHeadline = FaciaContentUtils.showBoostedHeadline(content),
       showQuotedHeadline = FaciaContentUtils.showQuotedHeadline(content),
       showLivePlayable = FaciaContentUtils.showLivePlayable(content),

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -1407,6 +1407,7 @@ class TrailsToShowcaseTest extends AnyFlatSpec with Matchers with EitherValues {
     val displaySettings = PressedDisplaySettings(
       isBoosted = false,
       boostLevel = Some(BoostLevel.Default),
+      isImmersive = Some(false),
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       showLivePlayable = false,

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -113,6 +113,7 @@ object FixtureBuilder {
     PressedDisplaySettings(
       isBoosted = false,
       boostLevel = Some(BoostLevel.Default),
+      isImmersive = Some(false),
       showBoostedHeadline = false,
       showQuotedHeadline = false,
       imageHide = false,

--- a/common/test/views/support/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/TrackingCodeBuilderTest.scala
@@ -153,6 +153,7 @@ class TrackingCodeBuilderTest extends AnyFlatSpec with Matchers with BeforeAndAf
         displaySettings = DisplaySettings(
           isBoosted = false,
           boostLevel = Some(BoostLevel.Default),
+          isImmersive = Some(false),
           showBoostedHeadline = false,
           showQuotedHeadline = false,
           imageHide = false,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,6 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.16.1"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-
   val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "27.0.0"
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.6.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.782"
   val awsSdk2Version = "2.30.38"
   val capiVersion = "34.0.0"
-  val faciaVersion = "16.1.2"
+  val faciaVersion = "18.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -33,6 +33,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.16.1"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
+
   val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "27.0.0"
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.6.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion


### PR DESCRIPTION
## What is the value of this and can you measure success?
## What does this change?

Adds the property `isImmersive` to the card's model for display settings. The property has been set as optional in order to be support existing fronts that have not been repressed with this property available. Any future presses will mean the property is available.

`isImmersive` is set in the Fronts tool via a toggle in the card's article meta data. 

It is used by the DCR to decide if a card should render in an "immersive" state, meaning (at time of writing) that it is full width, with a background image, and a content overlay.  

## Screenshots

![Screenshot 2025-04-01 at 09 28 56](https://github.com/user-attachments/assets/c1a39d91-8c25-4b9a-ad78-b2d888f61b34)


## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
