### PR TITLE
Temporarily extend Trade Desk Switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -55,7 +55,7 @@ trait ABTestSwitches {
     "Test the impact of disabling the trade desk for some of our users",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 3, 28)),
+    sellByDate = Some(LocalDate.of(2025, 4, 1)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

The build will fail until this switch is deleted or extended

## What does this change?

Extend the switch until we've made a decision about what to do with it

