### PR TITLE
Reassign `europe-beta-front` experiment owners

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -21,11 +21,7 @@ object EuropeBetaFront
     extends Experiment(
       name = "europe-beta-front",
       description = "Allows viewing the beta version of the Europe network front",
-      owners = Seq(
-        Owner.withGithub("cemms1"),
-        Owner.withEmail("project.fairground@theguardian.com"),
-        Owner.withEmail("dotcom.platform@theguardian.com"),
-      ),
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
       sellByDate = LocalDate.of(2025, 4, 2),
       participationGroup = Perc50,
     )


### PR DESCRIPTION
## What does this change?

Reassigns the _owners_ of the Europe beta experiment to more accurately represent who is responsible for this switch (cc @guardian/fronts-and-curation) 

> [!NOTE]
> This experiment expires soon!