### PR TITLE
Extend Europe beta front test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -22,7 +22,7 @@ object EuropeBetaFront
       name = "europe-beta-front",
       description = "Allows viewing the beta version of the Europe network front",
       owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 4, 2),
+      sellByDate = LocalDate.of(2025, 5, 28),
       participationGroup = Perc50,
     )
 


### PR DESCRIPTION
## What does this change?

Extend the Europe beta front test, which is due to expire in a few days. 

## Why?

An experiment that has an expired date will cause a [test](https://github.com/guardian/frontend/blob/main/common/test/conf/switches/SwitchesTest.scala#L89) to fail, which will fail the build. When we want this test to end, we should turn off the switch on the switchboard, then create a PR to delete the test.