### PR TITLE
Split out some Ipsos sections for more granularity in reporting

### DIFF
--- a/common/app/model/IpsosTags.scala
+++ b/common/app/model/IpsosTags.scala
@@ -30,7 +30,7 @@ object IpsosTags {
     "au/environment" -> "environment",
     "fashion" -> "fashion",
     "au/lifeandstyle/fashion" -> "fashion",
-    "fashion/beauty" -> "fashion",
+    "fashion/beauty" -> "beauty",
     "uk/film" -> "film", /* There is no US film tag - should these map to film? */
     "film" -> "film",
     "au/film" -> "film",
@@ -52,7 +52,7 @@ object IpsosTags {
     "lifeandstyle/love-and-sex" -> "lifeandstyle",
     "lifeandstyle/women" -> "lifeandstyle",
     "lifeandstyle/men" -> "lifeandstyle",
-    "lifeandstyle/home-and-garden" -> "lifeandstyle",
+    "lifeandstyle/home-and-garden" -> "homeandgarden",
     "us/lifeandstyle" -> "lifeandstyle",
     "lifeandstyle/home-and-garden" -> "lifeandstyle",
     "au/media" -> "media",
@@ -97,7 +97,8 @@ object IpsosTags {
     "teacher-network" -> "teachernetwork",
     "uk/technology" -> "technology", /* There is no US technology tag - should these map to technology? */
     "au/technology" -> "technology",
-    "technology" -> "technology", /* Default for technology (including motoring) articles */
+    "technology" -> "technology", /* Default for technology articles */
+    "technology/motoring" -> "cars",
     "thefilter" -> "thefilter",
     "uk/thefilter" -> "thefilter",
     "the-guardian-foundation" -> "foundation",

--- a/common/app/model/IpsosTags.scala
+++ b/common/app/model/IpsosTags.scala
@@ -54,7 +54,6 @@ object IpsosTags {
     "lifeandstyle/men" -> "lifeandstyle",
     "lifeandstyle/home-and-garden" -> "homeandgarden",
     "us/lifeandstyle" -> "lifeandstyle",
-    "lifeandstyle/home-and-garden" -> "lifeandstyle",
     "au/media" -> "media",
     "uk/media" -> "media", /* There is no US media tag - should these map to media? */
     "membership" -> "membership",


### PR DESCRIPTION
## What does this change?
Updates a few of the Ipsos tags to provide more granularity in reporting

- `fashion/beauty` is now reported as **beauty** instead of being grouped with **fashion**
- `lifeandstyle/home-and-garden` is now reported as **homeandgarden** instead of being grouped with **lifeandstyle**
- `technology/motoring` is now reported as **cars** instead of being grouped with **technology**