### PR TITLE
Upgrading Braze SDK from web-sdk-core@3.5.1 to web-sdk@5.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@babel/preset-typescript": "^7.26.0",
 		"@babel/register": "^7.25.9",
 		"@babel/runtime": "^7.26.0",
-		"@braze/web-sdk-core": "3.5.1",
+		"@braze/web-sdk": "5.8.1",
 		"@emotion/cache": "^11.13.1",
 		"@emotion/core": "^10.0.27",
 		"@emotion/react": "11.11.1",

--- a/static/src/javascripts/projects/common/modules/commercial/braze/buildBrazeMessaging.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/buildBrazeMessaging.ts
@@ -34,12 +34,12 @@ const maybeWipeUserData = async (
 
 	if (userHasLoggedOut || userHasRemovedConsent) {
 		try {
-			const { default: importedAppboy } = await import(
-				/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core'
+			const { default: importedBraze } = await import(
+				/* webpackChunkName: "braze-web-sdk" */ '@braze/web-sdk'
 			);
 			if (apiKey) {
-				importedAppboy.initialize(apiKey, SDK_OPTIONS);
-				importedAppboy.wipeData();
+				importedBraze.initialize(apiKey, SDK_OPTIONS);
+				importedBraze.wipeData();
 			}
 
 			clearLocalMessageCache();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3193,10 +3193,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@braze/web-sdk-core@npm:3.5.1":
-  version: 3.5.1
-  resolution: "@braze/web-sdk-core@npm:3.5.1"
-  checksum: 10c0/fdaaa0174419d030207081bf68d852697856191744c4c9a5de9bbbd65b5eb7345c20688cb302a126eb0839f54d49575d32396e79dee80907ef7ff4f9288201db
+"@braze/web-sdk@npm:5.8.1":
+  version: 5.8.1
+  resolution: "@braze/web-sdk@npm:5.8.1"
+  checksum: 10c0/33d124228cb3f1561a938e2eac11bf0c28bc44730a778be4235f347524a1024844c78473a650a58244050e0f4f45c14bfc85027d5822d3e12b72d39e5dfb1f5f
   languageName: node
   linkType: hard
 
@@ -3747,7 +3747,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.26.0"
     "@babel/register": "npm:^7.25.9"
     "@babel/runtime": "npm:^7.26.0"
-    "@braze/web-sdk-core": "npm:3.5.1"
+    "@braze/web-sdk": "npm:5.8.1"
     "@emotion/cache": "npm:^11.13.1"
     "@emotion/core": "npm:^10.0.27"
     "@emotion/react": "npm:11.11.1"


### PR DESCRIPTION
## What does this change?
This PR upgrades our Braze SDK from the older `@braze/web-sdk-core@3.5.1` to the newer `@braze/web-sdk@5.8.1`. The PR updates package.json, yarn.lock, and modifies the imports in our Braze messaging module to use the new package name.

## What is the value of this and can you measure success?
This upgrade provides access to the latest Braze features and security updates, ensuring we maintain a secure and supported implementation. Success can be measured by:
- Successful initialization of the Braze SDK
- Proper functioning of the user data wiping feature
- No increase in JavaScript errors related to Braze

## Screenshots
N/A - This is a dependency upgrade with no visual changes.