### PR TITLE
add a9 bid response winner feature switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -53,7 +53,7 @@ trait ABTestSwitches {
     ABTests,
     "ab-a9-bid-response-winner",
     "The test will enable checking the A9 bid response and determining a winning ad",
-    owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
     safeState = Off,
     sellByDate = Some(LocalDate.of(2025, 4, 30)),
     exposeClientSide = true,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,4 +48,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-a9-bid-response-winner",
+    "The test will enable checking the A9 bid response and determin a winning ad",
+    owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 4, 30)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -52,7 +52,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-a9-bid-response-winner",
-    "The test will enable checking the A9 bid response and determin a winning ad",
+    "The test will enable checking the A9 bid response and determining a winning ad",
     owners = Seq(Owner.withGithub("commercial.dev@theguardian.com")),
     safeState = Off,
     sellByDate = Some(LocalDate.of(2025, 4, 30)),


### PR DESCRIPTION
## What is the value of this and can you measure success?

This PR creates a AB test switch to enable the client side AB test in commercial. Related PR: https://github.com/guardian/commercial/pull/1898

