### PR TITLE
Add a cricket match-scoreboard endpoint

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -54,7 +54,7 @@ object DotcomRenderingUtils {
       case (Some(date), Some(team)) =>
         Some(
           DotcomRenderingMatchData(
-            s"${Configuration.ajax.url}/sport/cricket/match/$date/${team}.json?dcr=true",
+            s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
             CricketMatchType,
           ),
         )

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -109,6 +109,7 @@ GET            /embed/contentcard/*path                                         
 # Sport
 GET            /sport/cricket/match/:matchDate/:teamId.json                                                                      cricket.controllers.CricketMatchController.renderMatchIdJson(matchDate, teamId)
 GET            /sport/cricket/match/:matchDate/:teamId                                                                           cricket.controllers.CricketMatchController.renderMatchId(matchDate, teamId)
+GET            /sport/cricket/match-scoreboard/:matchDate/:teamId.json                                                           cricket.controllers.CricketMatchController.renderMatchScoreboardJson(matchDate, teamId)
 
 GET            /football/fixtures/more/:year/:month/:day.json                                                                    football.controllers.FixturesController.moreFixturesForJson(year, month, day)
 GET            /football/fixtures/more/:year/:month/:day                                                                         football.controllers.FixturesController.moreFixturesFor(year, month, day)

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -12,6 +12,7 @@ GET        /football/wallchart/:competitionTag                                  
 
 GET        /sport/cricket/match/:matchDate/:teamId.json                                        cricket.controllers.CricketMatchController.renderMatchIdJson(matchDate, teamId)
 GET        /sport/cricket/match/:matchDate/:teamId                                             cricket.controllers.CricketMatchController.renderMatchId(matchDate, teamId)
+GET        /sport/cricket/match-scoreboard/:matchDate/:teamId.json                             cricket.controllers.CricketMatchController.renderMatchScoreboardJson(matchDate, teamId)
 
 GET        /football/fixtures/more/:year/:month/:day.json                                      football.controllers.FixturesController.moreFixturesForJson(year, month, day)
 GET        /football/fixtures/more/:year/:month/:day                                           football.controllers.FixturesController.moreFixturesFor(year, month, day)


### PR DESCRIPTION
## What does this change?
Create a new endpoint to be used in DCAR cricket live blogs for rendering a scoreboard

## What is the value of this and can you measure success?
We need to move this use case off of (`sport/cricket/match/:matchDate/:teamId`), the endpoint used for the entire match's scorecard page, so that we can render that page in DCAR using the same endpoint but with `.json?dcr=true`

This also follows a convention that we have companion `.json` endpoints on full pages - whereas the scoreboard was not an entire page

## Screenshots

The scoreboard component (remains unchanged)

<img width="985" alt="image" src="https://github.com/user-attachments/assets/420ddb8e-bfe6-4160-be52-c7d13d5dfcbb" />


<!-- Please use the following table template to make image comparison easier to parse:

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->


Paired with: @marjisound 