### PR TITLE
Avoid null value in tables json response

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -242,6 +242,18 @@ object DotcomRenderingUtils {
     }
   }
 
+  def withoutDeepNull(json: JsValue): JsValue = {
+    json match {
+      case JsObject(fields) =>
+        JsObject(fields.collect {
+          case (key, value) if value != JsNull => key -> withoutDeepNull(value)
+        })
+      case JsArray(values) =>
+        JsArray(values.map(withoutDeepNull))
+      case other => other
+    }
+  }
+
   def shouldAddAffiliateLinks(content: ContentType): Boolean = {
     val contentHtml = Jsoup.parse(content.fields.body)
     val bodyElements = contentHtml.select("body").first().children()

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -249,7 +249,9 @@ object DotcomRenderingUtils {
           case (key, value) if value != JsNull => key -> withoutDeepNull(value)
         })
       case JsArray(values) =>
-        JsArray(values.map(withoutDeepNull))
+        JsArray(values.collect {
+          case value if value != JsNull => withoutDeepNull(value)
+        })
       case other => other
     }
   }

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -4,7 +4,7 @@ import common.{CanonicalLink, Edition}
 import conf.Configuration
 import experiments.ActiveExperiments
 import football.controllers.{CompetitionFilter, FootballPage}
-import model.dotcomrendering.DotcomRenderingUtils.{assetURL, withoutNull}
+import model.dotcomrendering.DotcomRenderingUtils.{assetURL, withoutDeepNull, withoutNull}
 import model.dotcomrendering.{Config, PageFooter, PageType, Trail}
 import model.{ApplicationContext, Competition, CompetitionSummary, Group, Table, TeamUrl}
 import navigation.{FooterLinks, Nav}
@@ -285,15 +285,17 @@ object DotcomRenderingFootballTablesDataModel {
   private implicit val groupFormat: Writes[Group] = Json.writes[Group]
 
   private implicit val tableWrites: Writes[Table] = (table: Table) =>
-    Json.obj(
-      "competition" -> Json.toJson(table.competition: CompetitionSummary),
-      "groups" -> table.groups.map { group =>
-        Json.obj(
-          "round" -> group.round,
-          "entries" -> getEntries(table.competition, group),
-        )
-      },
-      "hasGroups" -> table.hasGroups,
+    withoutDeepNull(
+      Json.obj(
+        "competition" -> Json.toJson(table.competition: CompetitionSummary),
+        "groups" -> table.groups.map { group =>
+          Json.obj(
+            "round" -> group.round,
+            "entries" -> getEntries(table.competition, group),
+          )
+        },
+        "hasGroups" -> table.hasGroups,
+      ),
     )
 
   implicit def dotcomRenderingFootballTablesDataModel: Writes[DotcomRenderingFootballTablesDataModel] =


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR ensures that for tables json response None values in Scala are completely omitted from the JSON output instead of being serialized as null.

We already have withoutNull, which removes null fields but only at the top level and nested null values are still present in the JSON.

To address this, the new withoutDeepNull method ensures that all null values, including those in nested structures, are removed from the JSON output.