### PR TITLE
Add dcr cricket json

### DIFF
--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -4,6 +4,7 @@ import common._
 import conf.Configuration
 import cricketModel.Match
 import conf.cricketPa.{CricketTeam, CricketTeams}
+import football.model.DotcomRenderingCricketDataModel
 import jobs.CricketStatsJob
 import model.Cached.RevalidatableResult
 import model._
@@ -34,11 +35,15 @@ class CricketMatchController(cricketStatsJob: CricketStatsJob, val controllerCom
           cricketStatsJob.findMatch(team, date).map { matchData =>
             val page = CricketMatchPage(matchData, date, team)
             Cached(60) {
-              if (request.isJson && request.forceDCR)
-                JsonComponent(
-                  "match" -> Json.toJson(page.theMatch),
-                  "scorecardUrl" -> (Configuration.site.host + page.metadata.id),
-                )
+              if (request.isJson && request.forceDCR) {
+                val model = DotcomRenderingCricketDataModel(page)
+
+                JsonComponent.fromWritable(model)
+              }
+//                JsonComponent(
+//                  "match" -> Json.toJson(page.theMatch),
+//                  "scorecardUrl" -> (Configuration.site.host + page.metadata.id),
+//                )
               else if (request.isJson)
                 JsonComponent(
                   "summary" -> cricket.views.html.fragments

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -39,12 +39,7 @@ class CricketMatchController(cricketStatsJob: CricketStatsJob, val controllerCom
                 val model = DotcomRenderingCricketDataModel(page)
 
                 JsonComponent.fromWritable(model)
-              }
-//                JsonComponent(
-//                  "match" -> Json.toJson(page.theMatch),
-//                  "scorecardUrl" -> (Configuration.site.host + page.metadata.id),
-//                )
-              else if (request.isJson)
+              } else if (request.isJson)
                 JsonComponent(
                   "summary" -> cricket.views.html.fragments
                     .cricketMatchSummary(page.theMatch, page.metadata.id)

--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -1,0 +1,83 @@
+package football.model
+
+import common.{CanonicalLink, Edition}
+import conf.Configuration
+import cricket.controllers.CricketMatchPage
+import cricketModel.{Innings, InningsBatter, InningsBowler, InningsWicket, Match, Team}
+import experiments.ActiveExperiments
+import model.ApplicationContext
+import model.dotcomrendering.DotcomRenderingUtils.assetURL
+import model.dotcomrendering.{Config, PageFooter, PageType}
+import navigation.{FooterLinks, Nav}
+import play.api.libs.json.{JsObject, JsValue, Json, Writes}
+import play.api.mvc.RequestHeader
+import views.support.{CamelCase, JavaScriptPage}
+
+case class DotcomRenderingCricketDataModel(
+    cricketMatch: Match,
+    nav: Nav,
+    editionId: String,
+    guardianBaseURL: String,
+    config: JsObject,
+    pageFooter: PageFooter,
+    isAdFreeUser: Boolean,
+    contributionsServiceUrl: String,
+    canonicalUrl: String,
+)
+
+object DotcomRenderingCricketDataModel {
+  def apply(
+      page: CricketMatchPage,
+  )(implicit
+      request: RequestHeader,
+      context: ApplicationContext,
+  ): DotcomRenderingCricketDataModel = {
+    val edition = Edition(request)
+    val nav = Nav(page, edition)
+
+    val pageType: PageType = PageType(page, request, context)
+
+    val switches: Map[String, Boolean] = conf.switches.Switches.all
+      .filter(_.exposeClientSide)
+      .foldLeft(Map.empty[String, Boolean])((acc, switch) => {
+        acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
+      })
+
+    val config = Config(
+      switches = switches,
+      abTests = ActiveExperiments.getJsMap(request),
+      ampIframeUrl = assetURL("data/vendor/amp-iframe.html"),
+      googletagUrl = Configuration.googletag.jsLocation,
+      stage = common.Environment.stage,
+      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
+    )
+
+    val combinedConfig: JsObject = {
+      val jsPageConfig: Map[String, JsValue] =
+        JavaScriptPage.getMap(page, Edition(request), pageType.isPreview, request)
+      Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
+    }
+
+    DotcomRenderingCricketDataModel(
+      page.theMatch,
+      nav = nav,
+      editionId = edition.id,
+      guardianBaseURL = Configuration.site.host,
+      config = combinedConfig,
+      pageFooter = PageFooter(FooterLinks.getFooterByEdition(edition)),
+      isAdFreeUser = views.support.Commercial.isAdFree(request),
+      contributionsServiceUrl = Configuration.contributionsService.url,
+      canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
+    )
+  }
+
+  implicit val inningsWicketFormat: Writes[InningsWicket] = Json.writes[InningsWicket]
+  implicit val inningsBowlerFormat: Writes[InningsBowler] = Json.writes[InningsBowler]
+  implicit val inningsBatterFormat: Writes[InningsBatter] = Json.writes[InningsBatter]
+  implicit val inningsFormat: Writes[Innings] = Json.writes[Innings]
+  implicit val teamFormat: Writes[Team] = Json.writes[Team]
+  implicit val matchFormat: Writes[Match] = Json.writes[Match]
+
+  implicit val dotcomRenderingCricketDataModelFormat: Writes[DotcomRenderingCricketDataModel] =
+    Json.writes[DotcomRenderingCricketDataModel]
+}

--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -71,13 +71,6 @@ object DotcomRenderingCricketDataModel {
     )
   }
 
-  implicit val inningsWicketFormat: Writes[InningsWicket] = Json.writes[InningsWicket]
-  implicit val inningsBowlerFormat: Writes[InningsBowler] = Json.writes[InningsBowler]
-  implicit val inningsBatterFormat: Writes[InningsBatter] = Json.writes[InningsBatter]
-  implicit val inningsFormat: Writes[Innings] = Json.writes[Innings]
-  implicit val teamFormat: Writes[Team] = Json.writes[Team]
-  implicit val matchFormat: Writes[Match] = Json.writes[Match]
-
   implicit val dotcomRenderingCricketDataModelFormat: Writes[DotcomRenderingCricketDataModel] =
     Json.writes[DotcomRenderingCricketDataModel]
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR adds the full DCR response for the `/sport/cricket/match/:matchDate/:teamId.json` endpoint. Previously this endpoint was returning the response for rendering the cricket scoreboard component at the top of the cricket match reports. But now it is returning the json response for rendering the cricket scorecard page. 

The cricket scoreboard is now using another endpoint to get its json which was implemented as part of this PR https://github.com/guardian/frontend/pull/27889 

**This PR can only be merged after** https://github.com/guardian/frontend/pull/27889 

Paired with: @andrewHEguardian & @JamieB-gu 

