### PR TITLE
Remove crossword specific ads logic

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -46,11 +46,6 @@
                     <div class="content__secondary-column hide-until-wide" aria-hidden="true">
                         @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map())
                     </div>
-                    @if(crosswordPage.item.trail.isCommentable) {
-                        <div class="crossword-banner hide-until-tablet hide-from-wide" aria-hidden="true">
-                            @fragments.commercial.standardAd("crossword-banner", Seq("crossword-banner"), Map())
-                        </div>
-                    }
                 }
             </div>
         </div>

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -807,13 +807,11 @@ class Crossword extends Component {
 						{anagramHelper}
 					</div>
 				</div>
-				<div class="crossword__container__above-controls"></div>
 				<Controls
 					hasSolutions={this.hasSolutions()}
 					clueInFocus={focused}
 					crossword={this}
 				/>
-				<div class="crossword__container__below-controls"></div>
 				<Clues
 					clues={this.cluesData()}
 					focussed={focused}

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -741,11 +741,6 @@ class Crossword extends Component {
 				this.grid = grid;
 			},
 		};
-		// Trigger the custom event when component has loaded for ad slot in commercial
-		useEffect(() => {
-			const customEvent = new CustomEvent('crossword-loaded');
-			window.dispatchEvent(customEvent);
-		});
 
 		return (
 			<div

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -167,12 +167,6 @@ $garnett-medium-button-icon: 16px;
 $garnett-large-button-icon: 20px;
 $garnett-x-large-button-icon: 24px;
 
-
-// Crosswords mobile banner advert
-// =============================================================================
-$crosswords-advert-width: 320px;
-$crosswords-advert-height: 74px;
-
 // MPU
 // =============================================================================
 $mpu-original-width: 300px;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -104,22 +104,6 @@
     margin: 0 auto;
 }
 
-
-.ad-slot-container .ad-slot--crossword-banner-mobile {
-    width: $crosswords-advert-width;
-    height: $crosswords-advert-height;
-    background-color: #ffffff;
-}
-
-.ad-slot-container--centre-slot.crossword-mobile-banner-ad {
-    display: flex;
-    margin: 8px auto;
-
-    @include mq($from: phablet) {
-        display: none;
-    }
-}
-
 .ad-slot-container .ad-slot--mobile {
     margin-left: auto;
     margin-right: auto;
@@ -136,7 +120,6 @@
     }
 }
 
-.ad-slot--crossword-banner,
 .ad-slot--top-banner-ad-desktop {
     margin: 0 auto;
     min-height: 90px;

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -64,24 +64,6 @@
     }
 }
 
-.crossword-banner {
-    clear: both;
-    margin-top: $gs-baseline;
-    // 90px is the height of a leaderboard
-    min-height: 90px + $mpu-ad-label-height + $gs-row-height * 0.5;
-    display: flex;
-    justify-content: center;
-
-    & .ad-slot-container {
-        width: fit-content;
-    }
-
-    @include mq($until: desktop) {
-        margin-left: -$gs-gutter;
-        margin-right: -$gs-gutter;
-    }
-}
-
 .crossword__controls {
     margin-top: $gs-baseline;
     float: left;


### PR DESCRIPTION
## What does this change?
Now that DCR crosswords are at 100%, removes logic from frontend associated with ads so that we can simplify our commercial code.

- Removes the tablet crossword-banner ad, as this ad is not rendered in DCR, so we can stop supporting it in the commercial code now
- Removes the divs used to insert the mobile crossword banner ad (eg "crossword__container__above-controls"), so that we can deprecate the client side logic for this slot since DCR handles it server side
- Removes the custom event fired when the crossword loads that commercial looks for before inserting the mobile banner
- Removes variables and styles associated with the slots