### PR TITLE
Update ami stacks and allow Riff-Raff to update 2 sport ASGs during GuCDK migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -86,6 +86,6 @@ deployments:
     type: ami-cloudformation-parameter
     parameters:
       amiParametersToTags:
-        AMIDiscussion:
+        AMISport:
           Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -16,6 +16,7 @@ templates:
     - update-ami-for-legacy-stacks
     - update-ami-for-admin
     - update-ami-for-discussion
+    - update-ami-for-sport
 
 deployments:
   admin:
@@ -44,6 +45,8 @@ deployments:
     template: frontend
   sport:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   frontend-static:
     type: aws-s3
     parameters:
@@ -72,6 +75,14 @@ deployments:
           AmigoStage: PROD
   update-ami-for-discussion:
     app: discussion
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIDiscussion:
+          Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-sport:
+    app: sport
     type: ami-cloudformation-parameter
     parameters:
       amiParametersToTags:


### PR DESCRIPTION
## What is the value of this and can you measure success?
Allow Riff-Raff to update 2 sport ASGs during GuCDK migration. See similar pr https://github.com/guardian/frontend/pull/27850
Automatically update the AMI for GuCDK stacks: See similar pr: https://github.com/guardian/frontend/pull/27856
## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
