### PR TITLE
CI speedup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: 'Build'
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ permissions:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:
@@ -28,6 +28,7 @@ jobs:
         with:
           cache: yarn
           node-version-file: .nvmrc
+
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
@@ -54,7 +55,7 @@ jobs:
       - name: Test Summary
         uses: test-summary/action@v2
         with:
-          paths: "test-results/**/TEST-*.xml"
+          paths: 'test-results/**/TEST-*.xml'
         if: always()
 
       - uses: guardian/actions-riff-raff@v4.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,10 @@ jobs:
           -XX:ReservedCodeCacheSize=128m \
           -Dsbt.log.noformat=true \
           -XX:+UseParallelGC \
+          -DSTAGE=DEV \
           -DAPP_SECRET="fake_secret" \
           -Duser.timezone=Australia/Sydney \
-          -jar ./bin/sbt-launch.jar clean compile assets scalafmtCheckAll test Universal/packageBin
+          -jar ./bin/sbt-launch.jar clean compile assets scalafmtCheckAll test
 
       - name: Test Summary
         uses: test-summary/action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-client:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,16 +29,33 @@ jobs:
           cache: yarn
           node-version-file: .nvmrc
 
+      - run: make install
+      - run: make validate
+      - run: make test
+      - run: make compile
+      # zip compiled output in static/hash and upload so it can be used in the riff-raff deploy
+      - name: zip frontend-client
+        run: |
+          mkdir -p /tmp
+          zip -r /tmp/frontend-client.zip static/hash
+      # upload the zip file using the artifact upload action
+      - name: upload frontend-client
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-client-zip
+          path: /tmp/frontend-client.zip
+          if-no-files-found: error
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
           cache: sbt
           java-version: 11
-
-      - run: make reinstall
-      - run: make validate
-      - run: make test
-      - run: make compile
 
       - name: Test, compile
         # Australia/Sydney  -because it is too easy for devs to forget about timezones
@@ -57,6 +74,45 @@ jobs:
         with:
           paths: 'test-results/**/TEST-*.xml'
         if: always()
+
+  publish:
+    needs: [build-client, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          cache: sbt
+          java-version: 11
+
+      - name: Prepare frontend-client output folder
+        run: |
+          mkdir -p /tmp
+          mkdir -p static/hash
+
+      - name: Download frontend-client
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-client-zip
+          path: /tmp
+
+      - name: Unzip frontend-client
+        run: |
+          unzip -o /tmp/frontend-client.zip -d static/hash
+
+      - name: Package
+        # Australia/Sydney  -because it is too easy for devs to forget about timezones
+        run: |
+          java \
+          -Xmx6144M \
+          -XX:ReservedCodeCacheSize=128m \
+          -Dsbt.log.noformat=true \
+          -XX:+UseParallelGC \
+          -DAPP_SECRET="fake_secret" \
+          -Duser.timezone=Australia/Sydney \
+          -jar ./bin/sbt-launch.jar compile Universal/packageBin
 
       - uses: guardian/actions-riff-raff@v4.1.2
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -206,6 +206,7 @@ val main = root()
     preview,
     rss,
   )
+
 val badgeHash = inputKey[Unit]("Generate special badge salts and hashes")
 badgeHash := {
   import java.math.BigInteger

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -3,7 +3,6 @@ const webpackMerge = require('webpack-merge');
 const BundleAnalyzerPlugin =
 	require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const TerserPlugin = require('terser-webpack-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
 
 const config = require('./webpack.config.js');
 
@@ -12,7 +11,7 @@ module.exports = webpackMerge.smart(config, {
 	output: {
 		filename: `[chunkhash]/graun.[name].js`,
 		chunkFilename: `[chunkhash]/graun.[name].js`,
-        clean: true,
+		clean: true,
 	},
 	devtool: 'source-map',
 	plugins: [


### PR DESCRIPTION
WIP

<!--

## What is the value of this and can you measure success?

Currently the Frontend GHA build takes ~ 9mins and runs the following high-level steps sequentially:

1. Client (validate, test, build)
2. Scala (lint, test, compile, package)
3. Riff-Raff (publish)

```mermaid
flowchart TD
  Client > Scala
  Scala > RiffRaff
```

This change splits the build into separate jobs that can run in parallel and using upload/download artifacts to pass compiled output between jobs:

```mermaid
flowchart TD
  Client > Package
  Scala > Package
  Package > Riff-Raff
```


## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering


-->