### PR TITLE
Limit scrollable small to 4 stories

### DIFF
--- a/common/app/layout/slices/Slice.scala
+++ b/common/app/layout/slices/Slice.scala
@@ -1150,7 +1150,7 @@ case object Highlights extends Slice {
 case object ScrollableSmall extends Slice {
   val layout = SliceLayout(
     cssClassName = "scrollable-small",
-    columns = Seq.fill(8)(
+    columns = Seq.fill(4)(
       SingleItem(
         colSpan = 1,
         ItemClasses(

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -336,10 +336,12 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         case "nav/list" => storyCountTotal
         // scrollable feature containers are capped at 3 stories
         case "scrollable/feature" => 3
+        // scrollable small containers are capped at 4 stories
+        case "scrollable/small" => 4
         // scrollable highlights containers are capped at 6 stories
         case "scrollable/highlights" => 6
-        // scrollable small and medium containers are capped at 8 stories
-        case "scrollable/small" | "scrollable/medium" => 8
+        // scrollable medium containers are capped at 8 stories
+        case "scrollable/medium" => 8
         // flexible general containers have max items on each group. In order to know the total max items, we need to sum all of these together.
         case "flexible/general" => {
 


### PR DESCRIPTION
## What does this change?

Updates the pressing logic so that only 4 stories will be shown on scrollable small containers on web. Part of this F&C [ticket](https://trello.com/c/7rvtUFuh/1115-limit-small-and-medium-carousels-to-4-stories)

Corresponding PRs are being raised in the fronts tool and mapi.

## Screenshots

We can see here that the 5th story in the container on the tool doesn't appear on web:

https://github.com/user-attachments/assets/615a33c7-c245-4e74-a8b1-a0d2989596f3

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
