### PR TITLE
Bump facia-scala-client to 18.0.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.782"
   val awsSdk2Version = "2.30.38"
   val capiVersion = "34.0.0"
-  val faciaVersion = "18.0.0"
+  val faciaVersion = "18.0.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
Bumps facia-scala-client to the latest version; v18.0.1