### PR TITLE
Add experiment for client-side React rendering

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,6 +14,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeBetaFront,
       EuropeBetaFrontTest2,
       DarkModeWeb,
+      ReactBundle,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -42,5 +43,14 @@ object DarkModeWeb
       description = "Enable dark mode on web",
       owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 7, 30),
+      participationGroup = Perc0D,
+    )
+
+object ReactBundle
+    extends Experiment(
+      name = "react-bundle",
+      description = "Use React for client-side rendering instead of Preact",
+      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2025, 4, 30),
       participationGroup = Perc0D,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,7 +14,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       EuropeBetaFront,
       EuropeBetaFrontTest2,
       DarkModeWeb,
-      ReactBundle,
+      DCRJavascriptBundle,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -46,11 +46,11 @@ object DarkModeWeb
       participationGroup = Perc0D,
     )
 
-object ReactBundle
+object DCRJavascriptBundle
     extends Experiment(
-      name = "react-bundle",
-      description = "Use React for client-side rendering instead of Preact",
+      name = "dcr-javascript-bundle",
+      description = "DCAR JS bundle experiment to test replacing Preact with React",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 4, 30),
-      participationGroup = Perc0D,
+      participationGroup = Perc0A,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -52,5 +52,5 @@ object DCRJavascriptBundle
       description = "DCAR JS bundle experiment to test replacing Preact with React",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 4, 30),
-      participationGroup = Perc0A,
+      participationGroup = Perc0E,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -51,6 +51,6 @@ object DCRJavascriptBundle
       name = "dcr-javascript-bundle",
       description = "DCAR JS bundle experiment to test replacing Preact with React",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 4, 30),
+      sellByDate = LocalDate.of(2025, 6, 30),
       participationGroup = Perc0E,
     )


### PR DESCRIPTION
## What does this change?

Adds server-side A/B test to switch DCAR to a client-side bundle that includes React instead of Preact.

See https://github.com/guardian/dotcom-rendering/pull/13774 for the corresponding DCAR changes.
