### PR TITLE
Limit scrollable medium to 4 stories

### DIFF
--- a/common/app/layout/slices/Slice.scala
+++ b/common/app/layout/slices/Slice.scala
@@ -1165,7 +1165,7 @@ case object ScrollableSmall extends Slice {
 case object ScrollableMedium extends Slice {
   val layout = SliceLayout(
     cssClassName = "scrollable-medium",
-    columns = Seq.fill(6)(
+    columns = Seq.fill(4)(
       SingleItem(
         colSpan = 1,
         ItemClasses(

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -336,12 +336,10 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         case "nav/list" => storyCountTotal
         // scrollable feature containers are capped at 3 stories
         case "scrollable/feature" => 3
-        // scrollable small containers are capped at 4 stories
-        case "scrollable/small" => 4
+        // scrollable small and medium containers are capped at 4 stories
+        case "scrollable/small" | "scrollable/medium" => 4
         // scrollable highlights containers are capped at 6 stories
         case "scrollable/highlights" => 6
-        // scrollable medium containers are capped at 8 stories
-        case "scrollable/medium" => 8
         // flexible general containers have max items on each group. In order to know the total max items, we need to sum all of these together.
         case "flexible/general" => {
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Resolves [this ticket](https://trello.com/c/7rvtUFuh/1115-limit-small-and-medium-carousels-to-4-stories). This was missed in the corresponding scrollable small PR.

## Screenshots

In a container with 5 stories in the fronts tool: 
<img width="681" alt="image" src="https://github.com/user-attachments/assets/9e858fb5-28f7-4260-827e-494c7b36e931" />


https://github.com/user-attachments/assets/e4e5aad8-ec18-4d9d-be03-db65191bbc3c



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
