### PR TITLE
Remove asgMigrationInProgress

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -45,8 +45,6 @@ deployments:
     template: frontend
   sport:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   frontend-static:
     type: aws-s3
     parameters:


### PR DESCRIPTION
## What is the value of this and can you measure success?
After merging https://github.com/guardian/platform/pull/1814 we need to merge this otherwise deployments to `dotcom:frontend-all` will fail

Part of https://github.com/guardian/platform/issues/1796