### PR TITLE
Change `TagIndexesS3` use of S3 `putPublic` to `putPrivate`

### DIFF
--- a/common/app/services/TagIndexesS3.scala
+++ b/common/app/services/TagIndexesS3.scala
@@ -22,7 +22,7 @@ object TagIndexesS3 extends S3 {
     s"${indexRoot(indexType)}/$pageName.json"
 
   private def putJson[A: Writes](key: String, a: A) =
-    putPublic(
+    putPrivate(
       key,
       Json.stringify(Json.toJson(a)),
       "application/json",


### PR DESCRIPTION
## What is the value of this and can you measure success?

Change `TagIndexesS3` use of S3 `putPublic` to `putPrivate`

@cemms1 noticed [error logs](https://logs.gutools.co.uk/s/dotcom/app/r/s/rkvvh) relating to [RebuildIndexJob](https://github.com/guardian/frontend/blob/225788ca9fff4ae065f980d031b197ee88732c1f/admin/app/jobs/RebuildIndexJob.scala) being unable to write to the S3 bucket `aws-frontend-pressed`

This was due to the use of the S3 method [putPublic](https://github.com/guardian/frontend/blob/225788ca9fff4ae065f980d031b197ee88732c1f/common/app/services/S3.scala#L75) which adds a public ACL, however public access to the bucket has been blocked as detailed in the error message:

`
*** is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::aws-frontend-pressed/***" because public access control lists (ACLs) are blocked by the BlockPublicAcls block public access
`

This change updates `TagIndexesS3` used by [RebuildIndexJob](https://github.com/guardian/frontend/blob/225788ca9fff4ae065f980d031b197ee88732c1f/admin/app/jobs/RebuildIndexJob.scala) to use `putPrivate` instead.

| Before     | After   |
|-------------|------------|
| Error Logs | Only Info Logs |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/47e0f9dd-bbe0-4abf-9862-1ee4cc6bb864
[after]: https://github.com/user-attachments/assets/c0a1a8bd-4da0-4b57-a628-757ce0843ff7

Also verified objects were written to S3
