### PR TITLE
Create feature switch for observer switch over

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -573,4 +573,15 @@ trait FeatureSwitches {
     exposeClientSide = false,
     highImpact = false,
   )
+
+  val RemoveObserver = Switch(
+    SwitchGroup.Feature,
+    "remove-observer",
+    "If this switch is on, we will remove observer links from the site",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+    highImpact = false,
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -581,7 +581,7 @@ trait FeatureSwitches {
     owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = false,
+    exposeClientSide = true,
     highImpact = false,
   )
 }

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -647,12 +647,12 @@ object NavLinks {
     pictures,
     newsletters,
     todaysPaper,
-    insideTheGuardian
+    insideTheGuardian,
   ) ++ observer ++ List(
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
     crosswords,
     wordiply,
-    corrections
+    corrections,
   )
   val auOtherLinks = List(
     apps,
@@ -684,7 +684,7 @@ object NavLinks {
     pictures,
     newsletters,
     todaysPaper,
-    insideTheGuardian
+    insideTheGuardian,
   ) ++ observer ++ List(
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords,
@@ -698,7 +698,7 @@ object NavLinks {
     pictures,
     newsletters,
     todaysPaper,
-    insideTheGuardian
+    insideTheGuardian,
   ) ++ observer ++ List(
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -2,7 +2,6 @@ package navigation
 
 import play.api.libs.json.{JsValue, Json, OWrites}
 import common.Edition
-import conf.switches.Switches.RemoveObserver
 import play.api.libs.json.Json.toJson
 
 object NavLinks {
@@ -212,24 +211,16 @@ object NavLinks {
     ),
   )
   val insideTheGuardian = NavLink("Inside the Guardian", "https://www.theguardian.com/insidetheguardian")
-
-  val removeObserver = RemoveObserver.isSwitchedOn
-  val observer =
-    if (removeObserver) List.empty[NavLink]
-    else
-      List(
-        NavLink(
-          "The Observer",
-          "/observer",
-          children = List(
-            NavLink("Comment", "/theobserver/news/comment"),
-            NavLink("The New Review", "/theobserver/new-review"),
-            NavLink("Observer Magazine", "/theobserver/magazine"),
-            NavLink("Observer Food Monthly", "/theobserver/foodmonthly"),
-          ),
-        ),
-      )
-
+  val observer = NavLink(
+    "The Observer",
+    "/observer",
+    children = List(
+      NavLink("Comment", "/theobserver/news/comment"),
+      NavLink("The New Review", "/theobserver/new-review"),
+      NavLink("Observer Magazine", "/theobserver/magazine"),
+      NavLink("Observer Food Monthly", "/theobserver/foodmonthly"),
+    ),
+  )
   val weekly = NavLink("Guardian Weekly", "https://www.theguardian.com/weekly")
   val digitalNewspaperArchive = NavLink("Digital Archive", "https://theguardian.newspapers.com")
   val crosswords = NavLink(
@@ -648,7 +639,7 @@ object NavLinks {
     newsletters,
     todaysPaper,
     insideTheGuardian,
-  ) ++ observer ++ List(
+    observer,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
     crosswords,
     wordiply,
@@ -685,7 +676,7 @@ object NavLinks {
     newsletters,
     todaysPaper,
     insideTheGuardian,
-  ) ++ observer ++ List(
+    observer,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords,
     wordiply,
@@ -699,7 +690,7 @@ object NavLinks {
     newsletters,
     todaysPaper,
     insideTheGuardian,
-  ) ++ observer ++ List(
+    observer,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords,
     wordiply,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -2,6 +2,7 @@ package navigation
 
 import play.api.libs.json.{JsValue, Json, OWrites}
 import common.Edition
+import conf.switches.Switches.RemoveObserver
 import play.api.libs.json.Json.toJson
 
 object NavLinks {
@@ -211,16 +212,24 @@ object NavLinks {
     ),
   )
   val insideTheGuardian = NavLink("Inside the Guardian", "https://www.theguardian.com/insidetheguardian")
-  val observer = NavLink(
-    "The Observer",
-    "/observer",
-    children = List(
-      NavLink("Comment", "/theobserver/news/comment"),
-      NavLink("The New Review", "/theobserver/new-review"),
-      NavLink("Observer Magazine", "/theobserver/magazine"),
-      NavLink("Observer Food Monthly", "/theobserver/foodmonthly"),
-    ),
-  )
+
+  val removeObserver = RemoveObserver.isSwitchedOn
+  val observer =
+    if (removeObserver) None
+    else
+      Some(
+        NavLink(
+          "The Observer",
+          "/observer",
+          children = List(
+            NavLink("Comment", "/theobserver/news/comment"),
+            NavLink("The New Review", "/theobserver/new-review"),
+            NavLink("Observer Magazine", "/theobserver/magazine"),
+            NavLink("Observer Food Monthly", "/theobserver/foodmonthly"),
+          ),
+        ),
+      )
+
   val weekly = NavLink("Guardian Weekly", "https://www.theguardian.com/weekly")
   val digitalNewspaperArchive = NavLink("Digital Archive", "https://theguardian.newspapers.com")
   val crosswords = NavLink(

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -215,9 +215,9 @@ object NavLinks {
 
   val removeObserver = RemoveObserver.isSwitchedOn
   val observer =
-    if (removeObserver) None
+    if (removeObserver) List.empty[NavLink]
     else
-      Some(
+      List(
         NavLink(
           "The Observer",
           "/observer",
@@ -647,12 +647,12 @@ object NavLinks {
     pictures,
     newsletters,
     todaysPaper,
-    insideTheGuardian,
-    observer,
+    insideTheGuardian
+  ) ++ observer ++ List(
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
     crosswords,
     wordiply,
-    corrections,
+    corrections
   )
   val auOtherLinks = List(
     apps,
@@ -684,8 +684,8 @@ object NavLinks {
     pictures,
     newsletters,
     todaysPaper,
-    insideTheGuardian,
-    observer,
+    insideTheGuardian
+  ) ++ observer ++ List(
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords,
     wordiply,
@@ -698,8 +698,8 @@ object NavLinks {
     pictures,
     newsletters,
     todaysPaper,
-    insideTheGuardian,
-    observer,
+    insideTheGuardian
+  ) ++ observer ++ List(
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords,
     wordiply,


### PR DESCRIPTION
## What is the value of this and can you measure success?
On the 22nd of April we want to remove observer links and add a footer
Part of https://github.com/guardian/frontend/issues/27911

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
