### PR TITLE
Remove `The Observer` from nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -211,16 +211,6 @@ object NavLinks {
     ),
   )
   val insideTheGuardian = NavLink("Inside the Guardian", "https://www.theguardian.com/insidetheguardian")
-  val observer = NavLink(
-    "The Observer",
-    "/observer",
-    children = List(
-      NavLink("Comment", "/theobserver/news/comment"),
-      NavLink("The New Review", "/theobserver/new-review"),
-      NavLink("Observer Magazine", "/theobserver/magazine"),
-      NavLink("Observer Food Monthly", "/theobserver/foodmonthly"),
-    ),
-  )
   val weekly = NavLink("Guardian Weekly", "https://www.theguardian.com/weekly")
   val digitalNewspaperArchive = NavLink("Digital Archive", "https://theguardian.newspapers.com")
   val crosswords = NavLink(
@@ -639,7 +629,6 @@ object NavLinks {
     newsletters,
     todaysPaper,
     insideTheGuardian,
-    observer,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
     crosswords,
     wordiply,
@@ -676,7 +665,6 @@ object NavLinks {
     newsletters,
     todaysPaper,
     insideTheGuardian,
-    observer,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords,
     wordiply,
@@ -690,7 +678,6 @@ object NavLinks {
     newsletters,
     todaysPaper,
     insideTheGuardian,
-    observer,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords,
     wordiply,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -794,37 +794,6 @@
 				"classList": []
 			},
 			{
-				"title": "The Observer",
-				"url": "/observer",
-				"children": [
-					{
-						"title": "Comment",
-						"url": "/theobserver/news/comment",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "The New Review",
-						"url": "/theobserver/new-review",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Magazine",
-						"url": "/theobserver/magazine",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Food Monthly",
-						"url": "/theobserver/foodmonthly",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
 				"title": "Guardian Weekly",
 				"url": "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK",
 				"children": [],
@@ -3160,37 +3129,6 @@
 				"classList": []
 			},
 			{
-				"title": "The Observer",
-				"url": "/observer",
-				"children": [
-					{
-						"title": "Comment",
-						"url": "/theobserver/news/comment",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "The New Review",
-						"url": "/theobserver/new-review",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Magazine",
-						"url": "/theobserver/magazine",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Food Monthly",
-						"url": "/theobserver/foodmonthly",
-						"children": [],
-						"classList": []
-					}
-				],
-				"classList": []
-			},
-			{
 				"title": "Guardian Weekly",
 				"url": "https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int",
 				"children": [],
@@ -4169,37 +4107,6 @@
 				"title": "Inside the Guardian",
 				"url": "https://www.theguardian.com/insidetheguardian",
 				"children": [],
-				"classList": []
-			},
-			{
-				"title": "The Observer",
-				"url": "/observer",
-				"children": [
-					{
-						"title": "Comment",
-						"url": "/theobserver/news/comment",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "The New Review",
-						"url": "/theobserver/new-review",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Magazine",
-						"url": "/theobserver/magazine",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Observer Food Monthly",
-						"url": "/theobserver/foodmonthly",
-						"children": [],
-						"classList": []
-					}
-				],
 				"classList": []
 			},
 			{


### PR DESCRIPTION
## What is the value of this and can you measure success?
On the 22nd of April we want to remove observer links from the nav
Resolves https://github.com/guardian/frontend/issues/27911

