### PR TITLE
Add a link to allow a user to enable ad-lite for a short period

### DIFF
--- a/commercial/app/controllers/CommercialControllers.scala
+++ b/commercial/app/controllers/CommercialControllers.scala
@@ -18,4 +18,5 @@ trait CommercialControllers {
   lazy val passbackController = wire[PassbackController]
   lazy val ampIframeHtmlController = wire[AmpIframeHtmlController]
   lazy val nonRefreshableLineItemsController = wire[nonRefreshableLineItemsController]
+  lazy val TemporaryAdLiteController = wire[TemporaryAdLiteController]
 }

--- a/commercial/app/controllers/TemporaryAdLiteController.scala
+++ b/commercial/app/controllers/TemporaryAdLiteController.scala
@@ -1,0 +1,34 @@
+package commercial.controllers
+
+import play.api.mvc._
+
+import scala.concurrent.duration._
+import model.Cached
+import model.Cached.WithoutRevalidationResult
+
+/*
+ * Temporarily enable ad-lite for a user by setting a short lived cookie, used for demoing ad-lite to advertisers
+ */
+
+class TemporaryAdLiteController(val controllerComponents: ControllerComponents) extends BaseController {
+
+  private val lifetime: Int = 1.hours.toSeconds.toInt
+
+  def enable(): Action[AnyContent] = Action { implicit request =>
+    Cached(60)(
+      WithoutRevalidationResult(
+        SeeOther("/").withCookies(
+          Cookie("gu_allow_reject_all", lifetime.toString(), maxAge = Some(lifetime), httpOnly = false),
+        ),
+      ),
+    )
+  }
+
+  def disable(): Action[AnyContent] = Action { implicit request =>
+    Cached(60)(
+      WithoutRevalidationResult(
+        SeeOther("/").discardingCookies(DiscardingCookie("gu_allow_reject_all")),
+      ),
+    )
+  }
+}

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -33,3 +33,7 @@ GET         /commercial/amp-iframe.html                                     comm
 
 # DFP Non refreshable line items
 GET         /commercial/non-refreshable-line-items.json                     commercial.controllers.nonRefreshableLineItemsController.getIds
+
+# Ad-Lite opt in
+GET         /commercial/ad-lite/enable                                      commercial.controllers.TemporaryAdLiteController.enable()
+GET         /commercial/ad-lite/disable                                     commercial.controllers.TemporaryAdLiteController.disable()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -257,6 +257,9 @@ GET            /ads.txt                                                         
 GET            /app-ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderAppTextFile()
 GET            /commercial/ias-passback/:size                                                                                    commercial.controllers.PassbackController.renderIasPassback(size)
 
+# Ad-Lite opt in
+GET         /commercial/ad-lite/enable                                                                                           commercial.controllers.TemporaryAdLiteController.enable()
+GET         /commercial/ad-lite/disable                                                                                          commercial.controllers.TemporaryAdLiteController.disable()
 # Commercial Admin
 GET         /commercial                                                                                                          controllers.admin.CommercialController.renderCommercialMenu()
 GET         /commercial/specialadunits                                                                                           controllers.admin.CommercialController.renderSpecialAdUnits()


### PR DESCRIPTION
## What does this change?
Add an opt in link for ad-lite so that we can demo ad-lite to potential advertisers

It will temporarily allow the user to use ad-lite for 1 hour, or they can visit the disable link.