### PR TITLE
Adds a 50% europe beta test bucket

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,6 +12,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       EuropeBetaFront,
+      EuropeBetaFrontTest2,
       DarkModeWeb,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
@@ -24,6 +25,15 @@ object EuropeBetaFront
       owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
       sellByDate = LocalDate.of(2025, 5, 28),
       participationGroup = Perc0A,
+    )
+
+object EuropeBetaFrontTest2
+    extends Experiment(
+      name = "europe-beta-front-test-2",
+      description = "Allows viewing the beta version of the Europe network front",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 5, 28),
+      participationGroup = Perc50,
     )
 
 object DarkModeWeb

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -6,7 +6,7 @@ import common._
 import conf.Configuration
 import conf.switches.Switches.InlineEmailStyles
 import controllers.front._
-import experiments.{ActiveExperiments, EuropeBetaFront}
+import experiments.{ActiveExperiments, EuropeBetaFront, EuropeBetaFrontTest2}
 import http.HttpPreconnections
 import implicits.GUHeaders
 import layout.slices._
@@ -227,7 +227,10 @@ trait FaciaController
       * for users participating in the test
       */
     val futureFaciaPageWithEuropeBetaTest: Future[Option[(PressedPage, Boolean)]] = {
-      if (path == "europe" && ActiveExperiments.isParticipating(EuropeBetaFront)) {
+      if (
+        path == "europe" && (ActiveExperiments
+          .isParticipating(EuropeBetaFront) || ActiveExperiments.isParticipating(EuropeBetaFrontTest2))
+      ) {
         val futureEuropeBetaPage = getFaciaPage("europe-beta")
         for {
           europePage <- futureFaciaPage

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -6,7 +6,7 @@ import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import common.editions.{Uk, Us}
 import common.facia.FixtureBuilder
 import controllers.{Assets, FaciaControllerImpl}
-import experiments.{ActiveExperiments, EuropeBetaFront, ParticipationGroups}
+import experiments.{ActiveExperiments, EuropeBetaFront, EuropeBetaFrontTest2, ParticipationGroups}
 import helpers.FaciaTestData
 import implicits.FakeRequests
 import model.{FrontProperties, PressedPage, SeoData}


### PR DESCRIPTION
The naming convention copies that of the native apps so that the tests can be more easily married up by Data and Insight.

This is so that we can

    1. more easily distinguish between this test and the prior test
    2. have an immediate switch to 50% rather than a pr rollout

The test will start on 22nd April.

The corresponding DCR PR is https://github.com/guardian/dotcom-rendering/pull/13809
