### PR TITLE
Remove the redirects from /theobserver to /observer

### DIFF
--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -34,15 +34,6 @@ class NewspaperController(
 
     }
 
-  def latestObserverNewspaper(): Action[AnyContent] = {
-    // A request was made by Central Production on the 12th July 2022 to redirect this page to
-    // /observer rather than create a generated page here.
-    // Issue: https://github.com/guardian/frontend/issues/25223
-    Action { implicit request =>
-      Cached(300)(WithoutRevalidationResult(MovedPermanently("/observer")))
-    }
-  }
-
   def newspaperForDate(path: String, day: String, month: String, year: String): Action[AnyContent] =
     Action.async { implicit request =>
       val metadata = path match {

--- a/applications/app/services/NewspaperQuery.scala
+++ b/applications/app/services/NewspaperQuery.scala
@@ -31,11 +31,6 @@ class NewspaperQuery(contentApiClient: ContentApiClient) extends Dates with GuLo
     bookSectionContainers("theguardian/mainsection", getLatestGuardianPageFor(now), "theguardian")
   }
 
-  def fetchLatestObserverNewspaper()(implicit executionContext: ExecutionContext): Future[List[FaciaContainer]] = {
-    val now = DateTime.now(DateTimeZone.UTC)
-    bookSectionContainers("theobserver/news", getPastSundayDateFor(now), "theobserver")
-  }
-
   def fetchNewspaperForDate(path: String, day: String, month: String, year: String)(implicit
       executionContext: ExecutionContext,
   ): Future[List[FaciaContainer]] = {

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -73,7 +73,6 @@ GET        /getprev/$tag<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/*path                
 
 # Newspaper pages
 GET        /theguardian                                                                     controllers.NewspaperController.latestGuardianNewspaper()
-GET        /theobserver                                                                     controllers.NewspaperController.latestObserverNewspaper()
 GET        /$path<theguardian|theobserver>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>        controllers.NewspaperController.newspaperForDate(path, day, month, year)
 GET        /$path<theguardian|theobserver>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/all    controllers.NewspaperController.allOn(path, day, month, year)
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -334,7 +334,6 @@ GET            /tests.json                                                      
 
 # Newspaper pages
 GET            /theguardian                                                                                                      controllers.NewspaperController.latestGuardianNewspaper()
-GET            /theobserver                                                                                                      controllers.NewspaperController.latestObserverNewspaper()
 GET            /$path<theguardian|theobserver>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>                                         controllers.NewspaperController.newspaperForDate(path, day, month, year)
 GET            /$path<theguardian|theobserver>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/all                                     controllers.NewspaperController.allOn(path, day, month, year)
 

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -136,7 +136,6 @@ GET        /container/*id.json                                                  
 
 # Newspaper pages
 GET        /theguardian                                                                        controllers.NewspaperController.latestGuardianNewspaper()
-GET        /theobserver                                                                        controllers.NewspaperController.latestObserverNewspaper()
 GET        /$path<theguardian|theobserver>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>           controllers.NewspaperController.newspaperForDate(path, day, month, year)
 GET        /$path<theguardian|theobserver>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/all       controllers.NewspaperController.allOn(path, day, month, year)
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Due to changes to the Observer, the Observer front is going away. We therefore no longer require a hard redirect from /theobserver to /observer. 

## What does this change?

Remove this hardcoded redirect to /observer. When this is merged, we can set up a [soft redirect](https://frontend.gutools.co.uk/redirects) which will do the business until the front goes away.

Removes the redirect set up in #25224

Tested on CODE, frontend responds with a 404 as expected
