### PR TITLE
reomve defer permutive AB test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -40,17 +40,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-defer-permutive-load",
-    "Test the impact of deferring the Permutive script load",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 4, 18)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-a9-bid-response-winner",
     "The test will enable checking the A9 bid response and determining a winning ad",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
This PR removes the AB test for `defer-permutive` since the AB test has finished and the data has been collected
