### PR TITLE
Update AMIgo Recipe To Ubuntu Jammy Base Image

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -60,7 +60,7 @@ deployments:
       cloudFormationStackName: frontend
       amiParametersToTags:
         AMI:
-          Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD
   # Riff-Raff identifies the GuCDK stacks using tag-based lookups
   update-ami-for-admin:
@@ -69,7 +69,7 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIAdmin:
-          Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD
   update-ami-for-discussion:
     app: discussion
@@ -77,7 +77,7 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIDiscussion:
-          Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD
   update-ami-for-sport:
     app: sport
@@ -85,5 +85,5 @@ deployments:
     parameters:
       amiParametersToTags:
         AMISport:
-          Recipe: ubuntu-focal-frontend-base-ARM-java11-cdk-base
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?
Update AMIgo Recipe To [Ubuntu Jammy Base Image ](https://amigo.gutools.co.uk/recipes/ubuntu-jammy-frontend-base-ARM-java11-cdk-base)

Tested on code https://riffraff.gutools.co.uk/deployment/view/2ae0746e-9ea9-48c5-b2f4-9d786c1f9d4e

Resolves https://github.com/guardian/platform/issues/1755
