### PR TITLE
Add AB test for prebid `multibid`

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,4 +48,16 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-prebid-multibid",
+    "Test multibid feature with useBicCache to allows configured bidders to pass more than one bid per AdUnit through to the ad server.",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 5, 12)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
 }


### PR DESCRIPTION
## What does this change?

This PR adds an AB test for `multibid` a feature in prebid config to use when `useBidCache` switch is on.
`multibid` allows configured bidders to pass more than one bid per AdUnit through to the ad server.

We want to test if adding `multibid` will result in revenue uplift with prebid bid caching. 

Commercial related PR https://github.com/guardian/commercial/pull/1947

## Checklist

- [x] Tested locally, and on CODE if necessary
