### PR TITLE
Add pageId to dcr sports models

### DIFF
--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -23,6 +23,7 @@ case class DotcomRenderingCricketDataModel(
     isAdFreeUser: Boolean,
     contributionsServiceUrl: String,
     canonicalUrl: String,
+    pageId: String,
 )
 
 object DotcomRenderingCricketDataModel {
@@ -68,6 +69,7 @@ object DotcomRenderingCricketDataModel {
       isAdFreeUser = views.support.Commercial.isAdFree(request),
       contributionsServiceUrl = Configuration.contributionsService.url,
       canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
+      pageId = page.metadata.id,
     )
   }
 

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -46,6 +46,7 @@ trait DotcomRenderingFootballDataModel {
   def isAdFreeUser: Boolean
   def contributionsServiceUrl: String
   def canonicalUrl: String
+  def pageId: String
 }
 
 private object DotcomRenderingFootballDataModel {
@@ -119,6 +120,7 @@ case class DotcomRenderingFootballMatchListDataModel(
     isAdFreeUser: Boolean,
     contributionsServiceUrl: String,
     canonicalUrl: String,
+    pageId: String,
 ) extends DotcomRenderingFootballDataModel
 
 object DotcomRenderingFootballMatchListDataModel {
@@ -150,6 +152,7 @@ object DotcomRenderingFootballMatchListDataModel {
       isAdFreeUser = views.support.Commercial.isAdFree(request),
       contributionsServiceUrl = Configuration.contributionsService.url,
       canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
+      pageId = page.metadata.id,
     )
   }
 
@@ -226,6 +229,7 @@ case class DotcomRenderingFootballTablesDataModel(
     isAdFreeUser: Boolean,
     contributionsServiceUrl: String,
     canonicalUrl: String,
+    pageId: String,
 ) extends DotcomRenderingFootballDataModel
 
 object DotcomRenderingFootballTablesDataModel {
@@ -252,6 +256,7 @@ object DotcomRenderingFootballTablesDataModel {
       isAdFreeUser = views.support.Commercial.isAdFree(request),
       contributionsServiceUrl = Configuration.contributionsService.url,
       canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
+      pageId = page.metadata.id,
     )
   }
 
@@ -316,6 +321,7 @@ case class DotcomRenderingFootballMatchSummaryDataModel(
     isAdFreeUser: Boolean,
     contributionsServiceUrl: String,
     canonicalUrl: String,
+    pageId: String,
 ) extends DotcomRenderingFootballDataModel
 
 object DotcomRenderingFootballMatchSummaryDataModel {
@@ -339,6 +345,7 @@ object DotcomRenderingFootballMatchSummaryDataModel {
       isAdFreeUser = views.support.Commercial.isAdFree(request),
       contributionsServiceUrl = Configuration.contributionsService.url,
       canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
+      pageId = page.metadata.id,
     )
   }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
Adding `pageId` to the sports DCAR models (football matches list, tables, matches summary & cricket)


## Why
In DCAR the `logging-middleware` checks if pageId exists and uses that as one of the generic log fields.  https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/server/lib/logging-middleware.ts#L6 

We could also instead of making this change, update the logic in DCAR to also check the config since pageId exists in the config too. But since all the other frontend DCAR jsons include the pageId at the root, it might be more performant to just include it for the sports jsons as well. 

The relevant frontend PR for this is https://github.com/guardian/dotcom-rendering/pull/13855