### PR TITLE
Apply default boost levels where available

### DIFF
--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -1,9 +1,10 @@
 package model.facia
 
 import com.gu.commercial.branding.ContainerBranding
-import com.gu.facia.api.{models => fapi}
-import com.gu.facia.api.models.{GroupsConfig}
-import com.gu.facia.api.utils.ContainerBrandingFinder
+import com.gu.facia.api.{FAPI, models => fapi}
+import com.gu.facia.api.models.GroupsConfig
+import com.gu.facia.api.utils.BoostLevel.Boost
+import com.gu.facia.api.utils.{BoostLevel, ContainerBrandingFinder}
 import com.gu.facia.client.models.{Branded, TargetedTerritory}
 import common.Edition
 import model.pressed._
@@ -50,6 +51,20 @@ case class PressedCollection(
     }
 
   def totalSize: Int = curated.size + backfill.size
+
+  lazy val withDefaultBoostLevels = {
+    val (defaultBoostCurated, defaultBoostBackfill) = FAPI
+      .applyDefaultBoostLevels[PressedContent](
+        groupsConfig = config.groupsConfig,
+        collectionType = config.collectionType,
+        contents = curated ++ backfill,
+        getBoostLevel = _.display.boostLevel.getOrElse(BoostLevel.Default),
+        setBoostLevel = (content, level) => content.withBoostLevel(Some(level)),
+      )
+      .splitAt(curated.length)
+
+    copy(curated = defaultBoostCurated, backfill = defaultBoostBackfill)
+  }
 
   def lite(visible: Int): PressedCollection = {
     val liteCurated = curated.take(visible)

--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -54,12 +54,13 @@ case class PressedCollection(
 
   lazy val withDefaultBoostLevels = {
     val (defaultBoostCurated, defaultBoostBackfill) = FAPI
-      .applyDefaultBoostLevels[PressedContent](
+      .applyDefaultBoostLevelsAndGroups[PressedContent](
         groupsConfig = config.groupsConfig,
         collectionType = config.collectionType,
         contents = curated ++ backfill,
         getBoostLevel = _.display.boostLevel.getOrElse(BoostLevel.Default),
         setBoostLevel = (content, level) => content.withBoostLevel(Some(level)),
+        setGroup = (content, group) => content.withCard(content.card.copy(group = group)),
       )
       .splitAt(curated.length)
 

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -1,6 +1,7 @@
 package model.pressed
 
 import com.gu.commercial.branding.Branding
+import com.gu.facia.api.utils.BoostLevel
 import com.gu.facia.api.{models => fapi}
 import common.Edition
 import model.{ContentFormat, Pillar}
@@ -26,6 +27,8 @@ sealed trait PressedContent {
   def withoutTrailText: PressedContent
 
   def withoutCommercial: PressedContent
+
+  def withBoostLevel(level: Option[BoostLevel]): PressedContent
 
   protected def propertiesWithoutCommercial(properties: PressedProperties): PressedProperties =
     properties.copy(
@@ -98,6 +101,10 @@ final case class CuratedContent(
     properties = propertiesWithoutCommercial(properties),
     supportingContent = supportingContent.map(_.withoutCommercial),
   )
+
+  override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
+    display = display.copy(boostLevel = level),
+  )
 }
 
 object CuratedContent {
@@ -128,6 +135,10 @@ final case class SupportingCuratedContent(
   override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
 
   override def withoutCommercial: PressedContent = copy(properties = propertiesWithoutCommercial(properties))
+
+  override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
+    display = display.copy(boostLevel = level),
+  )
 }
 
 object SupportingCuratedContent {
@@ -158,6 +169,10 @@ final case class LinkSnap(
   override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
 
   override def withoutCommercial: PressedContent = copy(properties = propertiesWithoutCommercial(properties))
+
+  override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
+    display = display.copy(boostLevel = level),
+  )
 }
 
 object LinkSnap {
@@ -186,6 +201,10 @@ final case class LatestSnap(
   override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
 
   override def withoutCommercial: PressedContent = copy(properties = propertiesWithoutCommercial(properties))
+
+  override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
+    display = display.copy(boostLevel = level),
+  )
 }
 
 object LatestSnap {

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -30,6 +30,8 @@ sealed trait PressedContent {
 
   def withBoostLevel(level: Option[BoostLevel]): PressedContent
 
+  def withCard(card: PressedCard): PressedContent
+
   protected def propertiesWithoutCommercial(properties: PressedProperties): PressedProperties =
     properties.copy(
       maybeContent = properties.maybeContent.map(storyWithoutCommercial),
@@ -105,6 +107,10 @@ final case class CuratedContent(
   override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
     display = display.copy(boostLevel = level),
   )
+
+  override def withCard(card: PressedCard): PressedContent = copy(
+    card = card,
+  )
 }
 
 object CuratedContent {
@@ -138,6 +144,10 @@ final case class SupportingCuratedContent(
 
   override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
     display = display.copy(boostLevel = level),
+  )
+
+  override def withCard(card: PressedCard): PressedContent = copy(
+    card = card,
   )
 }
 
@@ -173,6 +183,10 @@ final case class LinkSnap(
   override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
     display = display.copy(boostLevel = level),
   )
+
+  override def withCard(card: PressedCard): PressedContent = copy(
+    card = card,
+  )
 }
 
 object LinkSnap {
@@ -204,6 +218,10 @@ final case class LatestSnap(
 
   override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
     display = display.copy(boostLevel = level),
+  )
+
+  override def withCard(card: PressedCard): PressedContent = copy(
+    card = card,
   )
 }
 

--- a/facia-press/app/frontpress/PressedCollectionVisibility.scala
+++ b/facia-press/app/frontpress/PressedCollectionVisibility.scala
@@ -10,10 +10,10 @@ case class PressedCollectionVisibility(pressedCollection: PressedCollection, vis
     copy(pressedCollection = pressedCollection.withoutTrailTextOnTail)
   lazy val pressedCollectionVersions: PressedCollectionVersions = {
     PressedCollectionVersions(
-      pressedCollection.lite(visible),
-      pressedCollection.full(visible),
-      pressedCollection.adFree.lite(visible),
-      pressedCollection.adFree.full(visible),
+      pressedCollection.lite(visible).withDefaultBoostLevels,
+      pressedCollection.full(visible).withDefaultBoostLevels,
+      pressedCollection.adFree.lite(visible).withDefaultBoostLevels,
+      pressedCollection.adFree.full(visible).withDefaultBoostLevels,
     )
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.782"
   val awsSdk2Version = "2.30.38"
   val capiVersion = "34.1.0"
-  val faciaVersion = "18.1.0-PREVIEW.group-based-default-boosts.2025-04-30T1029.90f88dee"
+  val faciaVersion = "18.1.0-PREVIEW.group-based-default-boosts.2025-05-01T1308.2fd5da37"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.782"
   val awsSdk2Version = "2.30.38"
   val capiVersion = "34.1.0"
-  val faciaVersion = "18.1.0-PREVIEW.group-based-default-boosts.2025-05-01T1308.2fd5da37"
+  val faciaVersion = "18.1.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.782"
   val awsSdk2Version = "2.30.38"
   val capiVersion = "34.1.0"
-  val faciaVersion = "18.0.1"
+  val faciaVersion = "18.1.0-PREVIEW.group-based-default-boosts.2025-04-30T1029.90f88dee"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.782"
   val awsSdk2Version = "2.30.38"
   val capiVersion = "34.1.0"
-  val faciaVersion = "18.1.0"
+  val faciaVersion = "18.1.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
This will apply the correct boost level to backfilled content in flexible general containers. It will also ensure that the limits of each group in a flexible general container are respected.

As much of the required logic as is possible is delegated to the facia-scala-client to keep MAPI and Frontend in sync

## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
