### PR TITLE
Allow 5:4 aspect ratio images to be sent to DCAR

### DIFF
--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -24,23 +24,23 @@ object Trail {
       .orElse(elements.videos.headOption.map(_.images))
       .orElse(elements.thumbnail.map(_.images))
 
-    // Try to take the master 5:3 image. At render-time, the image resizing service will size the image according to card width.
+    // Try to take the master image (5:4 or 5:3). At render-time, the image resizing service will size the image according to card width.
     // Filtering the list images here means that facia-press does not need to slim down the Trail object.
     trailImageMedia.flatMap { imageMedia =>
       val filteredTrailImages = imageMedia.allImages.filter { image =>
-        IsRatio(5, 3, image.width, image.height)
+        IsRatio(5, 4, image.width, image.height) || IsRatio(5, 3, image.width, image.height)
       }
 
       val masterTrailImage = filteredTrailImages.find(_.isMaster).map { master =>
         ImageMedia.make(List(master))
       }
 
-      // If there isn't a 5:3 image, no ImageMedia object will be created.
+      // If there isn't a 5:4 or 5:3 image, no ImageMedia object will be created.
       lazy val largestTrailImage = filteredTrailImages.sortBy(-_.width).headOption.map { bestImage =>
         ImageMedia.make(List(bestImage))
       }
 
-      // Choose the master 5:3 image, or the largest 5:3 image.
+      // Choose the master image (5:4 or 5:3), or the largest image (5:4 or 5:3).
       masterTrailImage.orElse(largestTrailImage)
     }
   }


### PR DESCRIPTION
## What is the value of this and can you measure success?

DCAR currently supports using 5:4 and 5:3 trail images in cards on fronts, tag pages and onwards containers. DCR autocrops the image when necessary, depending on the container in which the card appears. 

This change ensures frontend pages trail image data to DCAR when the trail image has an aspect ratio of 5:4 or 5:3.

## What does this change?

- Frontend may pass 5:4 trail images to DCAR

## Screenshots

### Tag page

| Before      | After      |
|-------------|------------|
| ![before-tag][] | ![after-tag][] |

[before-tag]: https://github.com/user-attachments/assets/5cf83cb2-8149-4ba2-99d3-eb66fd082bcf
[after-tag]: https://github.com/user-attachments/assets/f3cf3b7b-337d-4040-8ded-b7c330e9e465

### Related content

| Before      | After      |
|-------------|------------|
| ![before-related][] | ![after-related][] |

[before-related]: https://github.com/user-attachments/assets/6ba9f254-3c6a-4a38-a9f9-4965d8c33b78
[after-related]: https://github.com/user-attachments/assets/2b9afdc2-7595-4a12-b95d-b8411bb5eb7d

### Fronts (new container – 5:4)

 ![after-new][] 

[after-new]: https://github.com/user-attachments/assets/3a1c4606-3b3a-495d-bad1-74a1c1dc457f

### Fronts (old container – 5:3 autocropped)

 ![after-old][] 

[after-old]: https://github.com/user-attachments/assets/286dad40-37d4-4e3f-b51a-890398b24a6b

### Not tested:

- More on this story
- Rich links

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
