### PR TITLE
Update Editions Crossword Data Model and Controller Parsing

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -1,11 +1,25 @@
 package controllers
 
 import com.gu.contentapi.client.model.SearchQuery
-import com.gu.contentapi.client.model.v1.{Crossword, ItemResponse, SearchResponse, Content => ApiContent, Section => ApiSection}
+import com.gu.contentapi.client.model.v1.{
+  Crossword,
+  ItemResponse,
+  SearchResponse,
+  Content => ApiContent,
+  Section => ApiSection,
+}
 import common.{Edition, GuLogging, ImplicitControllerExecutionContext}
 import conf.Static
 import contentapi.ContentApiClient
-import crosswords.{AccessibleCrosswordPage, AccessibleCrosswordRows, CrosswordPageWithContent, CrosswordPageWithSvg, CrosswordSearchPageNoResult, CrosswordSearchPageWithResults, CrosswordSvg}
+import crosswords.{
+  AccessibleCrosswordPage,
+  AccessibleCrosswordRows,
+  CrosswordPageWithContent,
+  CrosswordPageWithSvg,
+  CrosswordSearchPageNoResult,
+  CrosswordSearchPageWithResults,
+  CrosswordSvg,
+}
 import html.HtmlPageHelpers.ContentCSSFile
 import model.Cached.{CapiRichDateTime, RevalidatableResult, WithoutRevalidationResult}
 import model._
@@ -42,7 +56,7 @@ trait CrosswordController extends BaseController with GuLogging with ImplicitCon
   }
 
   def withCrossword(crosswordType: String, id: Int)(
-    f: (Crossword, ApiContent) => Future[Result],
+      f: (Crossword, ApiContent) => Future[Result],
   )(implicit request: RequestHeader): Future[Result] = {
     getCrossword(crosswordType, id).flatMap { response =>
       val maybeCrossword = for {
@@ -57,8 +71,8 @@ trait CrosswordController extends BaseController with GuLogging with ImplicitCon
   }
 
   def renderCrosswordPage(crosswordType: String, id: Int)(implicit
-                                                          request: RequestHeader,
-                                                          context: ApplicationContext,
+      request: RequestHeader,
+      context: ApplicationContext,
   ): Future[Result] = {
     withCrossword(crosswordType, id) { (crossword, content) =>
       val page = CrosswordPageWithSvg(
@@ -81,12 +95,12 @@ trait CrosswordController extends BaseController with GuLogging with ImplicitCon
 }
 
 class CrosswordPageController(
-                               val contentApiClient: ContentApiClient,
-                               val controllerComponents: ControllerComponents,
-                               val wsClient: WSClient,
-                             )(implicit
-                               context: ApplicationContext,
-                             ) extends CrosswordController {
+    val contentApiClient: ContentApiClient,
+    val controllerComponents: ControllerComponents,
+    val wsClient: WSClient,
+)(implicit
+    context: ApplicationContext,
+) extends CrosswordController {
 
   def noResults()(implicit request: RequestHeader): Result =
     Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))
@@ -110,7 +124,7 @@ class CrosswordPageController(
     }
   }
   private def getDCRJson(crosswordPage: CrosswordPageWithContent, pageType: PageType)(implicit
-                                                                                      request: RequestHeader,
+      request: RequestHeader,
   ): JsValue =
     DotcomRenderingDataModel.toJson(
       DotcomRenderingDataModel.forCrossword(crosswordPage, request, pageType),
@@ -187,11 +201,11 @@ class CrosswordPageController(
 }
 
 class CrosswordSearchController(
-                                 val contentApiClient: ContentApiClient,
-                                 val controllerComponents: ControllerComponents,
-                                 val wsClient: WSClient,
-                               )(implicit context: ApplicationContext)
-  extends CrosswordController {
+    val contentApiClient: ContentApiClient,
+    val controllerComponents: ControllerComponents,
+    val wsClient: WSClient,
+)(implicit context: ApplicationContext)
+    extends CrosswordController {
   val searchForm = Form(
     mapping(
       "crossword_type" -> nonEmptyText,
@@ -287,13 +301,13 @@ class CrosswordSearchController(
 }
 
 class CrosswordEditionsController(
-                                   val contentApiClient: ContentApiClient,
-                                   val controllerComponents: ControllerComponents,
-                                   val remoteRenderer: DotcomRenderingService = DotcomRenderingService(),
-                                   val wsClient: WSClient,
-                                 ) extends BaseController
-  with GuLogging
-  with ImplicitControllerExecutionContext {
+    val contentApiClient: ContentApiClient,
+    val controllerComponents: ControllerComponents,
+    val remoteRenderer: DotcomRenderingService = DotcomRenderingService(),
+    val wsClient: WSClient,
+) extends BaseController
+    with GuLogging
+    with ImplicitControllerExecutionContext {
 
   def digitalEdition: Action[AnyContent] = Action.async { implicit request =>
     getCrosswords
@@ -319,8 +333,8 @@ class CrosswordEditionsController(
     contentApiClient.getResponse(crosswordsQuery)
 
   /** Search for playable crosswords sorted by print publication date. This will exclude older, originally print-only
-   * crosswords that happen to have been re-published in a digital format recently.
-   */
+    * crosswords that happen to have been re-published in a digital format recently.
+    */
   private lazy val crosswordsQuery =
     SearchQuery()
       .contentType("crossword")
@@ -342,7 +356,6 @@ class CrosswordEditionsController(
 
   private def parseCrosswords(response: SearchResponse): Seq[EditionsCrosswordRenderingDataModel] = {
     response.results.flatMap(_.crossword).map { crossword =>
-
       EditionsCrosswordRenderingDataModel(
         id = s"crosswords/${crossword.`type`.name}/${crossword.number}",
         number = crossword.number,
@@ -350,13 +363,14 @@ class CrosswordEditionsController(
         creator = crossword.creator,
         date = crossword.date.toJoda.getMillis,
         webPublicationDate = crossword.date.toJoda.getMillis,
-        entries = crossword.entries.map(entry => EditionsCrosswordEntry.fromCrosswordEntry(entry, crossword.solutionAvailable)),
+        entries =
+          crossword.entries.map(entry => EditionsCrosswordEntry.fromCrosswordEntry(entry, crossword.solutionAvailable)),
         solutionAvailable = crossword.solutionAvailable,
         dateSolutionAvailable = crossword.dateSolutionAvailable.map(_.toJoda.getMillis).getOrElse(0L),
         dimensions = crossword.dimensions,
         crosswordType = CamelCase.toHyphenated(crossword.`type`.name),
         pdf = crossword.pdf,
-        instructions = crossword.instructions
+        instructions = crossword.instructions,
       )
     }
   }.toList

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -12,17 +12,17 @@ object CrosswordPosition {
 }
 
 case class EditionsCrosswordEntry(
-                                   id: String,
-                                   number: Int,
-                                   humanNumber: String,
-                                   clue: String,
-                                   direction: String,
-                                   length: Int,
-                                   group: Seq[String],
-                                   position: CrosswordPosition,
-                                   separatorLocations: Option[Map[String, Seq[Int]]],
-                                   solution: Option[String],
-                                 )
+    id: String,
+    number: Int,
+    humanNumber: String,
+    clue: String,
+    direction: String,
+    length: Int,
+    group: Seq[String],
+    position: CrosswordPosition,
+    separatorLocations: Option[Map[String, Seq[Int]]],
+    solution: Option[String],
+)
 
 object EditionsCrosswordEntry {
   implicit val jsonWrites: OWrites[EditionsCrosswordEntry] = Json.writes[EditionsCrosswordEntry]
@@ -44,25 +44,26 @@ object EditionsCrosswordEntry {
 }
 
 case class EditionsCrosswordRenderingDataModel(
-                                                id: String,
-                                                number: Int,
-                                                name: String,
-                                                creator: Option[CrosswordCreator],
-                                                date: Long,
-                                                webPublicationDate: Long,
-                                                entries: Seq[EditionsCrosswordEntry],
-                                                solutionAvailable: Boolean,
-                                                dateSolutionAvailable: Long,
-                                                dimensions: CrosswordDimensions,
-                                                crosswordType: String,
-                                                pdf: Option[String],
-                                                instructions: Option[String],
-                                              )
+    id: String,
+    number: Int,
+    name: String,
+    creator: Option[CrosswordCreator],
+    date: Long,
+    webPublicationDate: Long,
+    entries: Seq[EditionsCrosswordEntry],
+    solutionAvailable: Boolean,
+    dateSolutionAvailable: Long,
+    dimensions: CrosswordDimensions,
+    crosswordType: String,
+    pdf: Option[String],
+    instructions: Option[String],
+)
 
 object EditionsCrosswordRenderingDataModel {
   implicit val crosswordCreatorWrites: OWrites[CrosswordCreator] = Json.writes[CrosswordCreator]
   implicit val crosswordDimensionsWrites: OWrites[CrosswordDimensions] = Json.writes[CrosswordDimensions]
-  implicit val jsonWrites: OWrites[EditionsCrosswordRenderingDataModel] = Json.writes[EditionsCrosswordRenderingDataModel]
+  implicit val jsonWrites: OWrites[EditionsCrosswordRenderingDataModel] =
+    Json.writes[EditionsCrosswordRenderingDataModel]
 
   def toJson(model: EditionsCrosswordRenderingDataModel): JsValue = {
     Json.toJson(model)

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -1,33 +1,70 @@
 package model.dotcomrendering.pageElements
 
-import com.gu.contentapi.client.model.v1.Crossword
-import com.gu.contentapi.json.CirceEncoders._
-import io.circe.syntax._
-import implicits.Dates.CapiRichDateTime
-import model.dotcomrendering.DotcomRenderingUtils
-import play.api.libs.json.{JsObject, Json, JsValue}
+import com.gu.contentapi.client.model.v1.{CrosswordCreator, CrosswordDimensions, CrosswordEntry}
+import play.api.libs.json._
+
+import scala.collection.Seq
+
+case class CrosswordPosition(x: Int, y: Int)
+
+object CrosswordPosition {
+  implicit val jsonWrites: OWrites[CrosswordPosition] = Json.writes[CrosswordPosition]
+}
+
+case class EditionsCrosswordEntry(
+                                   id: String,
+                                   number: Int,
+                                   humanNumber: String,
+                                   clue: String,
+                                   direction: String,
+                                   length: Int,
+                                   group: Seq[String],
+                                   position: CrosswordPosition,
+                                   separatorLocations: Option[Map[String, Seq[Int]]],
+                                   solution: Option[String],
+                                 )
+
+object EditionsCrosswordEntry {
+  implicit val jsonWrites: OWrites[EditionsCrosswordEntry] = Json.writes[EditionsCrosswordEntry]
+
+  def fromCrosswordEntry(entry: CrosswordEntry, shipSolutions: Boolean): EditionsCrosswordEntry = {
+    EditionsCrosswordEntry(
+      id = entry.id,
+      number = entry.number.getOrElse(0),
+      humanNumber = entry.humanNumber.getOrElse(""),
+      clue = entry.clue.getOrElse(""),
+      direction = entry.direction.getOrElse(""),
+      length = entry.length.getOrElse(0),
+      group = entry.group.getOrElse(Seq.empty),
+      position = CrosswordPosition(entry.position.map(_.x).getOrElse(0), entry.position.map(_.y).getOrElse(0)),
+      separatorLocations = entry.separatorLocations.map(_.toMap.view.mapValues(_.toSeq).toMap),
+      solution = if (shipSolutions) entry.solution else None,
+    )
+  }
+}
 
 case class EditionsCrosswordRenderingDataModel(
-    crosswords: Iterable[Crossword],
-)
+                                                id: String,
+                                                number: Int,
+                                                name: String,
+                                                creator: Option[CrosswordCreator],
+                                                date: Long,
+                                                webPublicationDate: Long,
+                                                entries: Seq[EditionsCrosswordEntry],
+                                                solutionAvailable: Boolean,
+                                                dateSolutionAvailable: Long,
+                                                dimensions: CrosswordDimensions,
+                                                crosswordType: String,
+                                                pdf: Option[String],
+                                                instructions: Option[String],
+                                              )
 
 object EditionsCrosswordRenderingDataModel {
-  def apply(crosswords: Iterable[Crossword]): EditionsCrosswordRenderingDataModel =
-    new EditionsCrosswordRenderingDataModel(crosswords.map(crossword => {
-      val shipSolutions =
-        crossword.dateSolutionAvailable
-          .map(_.toJoda.isBeforeNow)
-          .getOrElse(crossword.solutionAvailable)
+  implicit val crosswordCreatorWrites: OWrites[CrosswordCreator] = Json.writes[CrosswordCreator]
+  implicit val crosswordDimensionsWrites: OWrites[CrosswordDimensions] = Json.writes[CrosswordDimensions]
+  implicit val jsonWrites: OWrites[EditionsCrosswordRenderingDataModel] = Json.writes[EditionsCrosswordRenderingDataModel]
 
-      if (shipSolutions) {
-        crossword
-      } else {
-        crossword.copy(entries = crossword.entries.map(_.copy(solution = None)))
-      }
-    }))
-
-  def toJson(model: EditionsCrosswordRenderingDataModel): JsValue =
-    Json.obj(
-      "crosswords" -> Json.parse(model.crosswords.asJson.deepDropNullValues.toString()),
-    )
+  def toJson(model: EditionsCrosswordRenderingDataModel): JsValue = {
+    Json.toJson(model)
+  }
 }

--- a/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
@@ -1,7 +1,8 @@
 package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.{CrosswordEntry, CrosswordPosition => CapiCrosswordPosition}
-import model.dotcomrendering.pageElements.{CrosswordPosition, EditionsCrosswordEntry}
+import model.dotcomrendering.pageElements.CrosswordPosition
+import model.dotcomrendering.pageElements.EditionsCrosswordEntry
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -39,7 +40,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     resultEntry.solution shouldBe Some("ANSWER") // Solution included
   }
 
-  "EditionsCrosswordEntry.fromCrosswordEntry" should "correctly map all fields when solution is NOT provided (input has None)" in {
+  it should "correctly map all fields when solution is NOT provided (input has None)" in {
     val shipSolutions = true
     val resultEntry = EditionsCrosswordEntry.fromCrosswordEntry(mockCapiEntryWithoutSolution, shipSolutions)
 
@@ -50,9 +51,13 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     resultEntry.solution shouldBe None
   }
 
-  "EditionsCrosswordEntry.fromCrosswordEntry" should "correctly map fields and explicitly exclude solution when shipSolutions is false" in {
+  it should "correctly map fields and explicitly exclude solution when shipSolutions is false" in {
     val shipSolutions = false
-    val resultEntry = EditionsCrosswordEntry.fromCrosswordEntry(mockCapiEntryWithSolution, shipSolutions) // Use entry *with* solution
+    val resultEntry =
+      EditionsCrosswordEntry.fromCrosswordEntry(
+        mockCapiEntryWithSolution,
+        shipSolutions,
+      ) // Use entry *with* solution
 
     resultEntry.id shouldBe "seven-down"
     resultEntry.number shouldBe 7
@@ -61,7 +66,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     resultEntry.solution shouldBe None
   }
 
-  "EditionsCrosswordEntry.fromCrosswordEntry" should "handle missing optional CAPI fields gracefully" in {
+  it should "handle missing optional CAPI fields gracefully" in {
     val minimalCapiEntry = CrosswordEntry(id = "one-across")
     val shipSolutions = true
     val resultEntry = EditionsCrosswordEntry.fromCrosswordEntry(minimalCapiEntry, shipSolutions)
@@ -76,4 +81,5 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     resultEntry.position shouldBe CrosswordPosition(x = 0, y = 0)
     resultEntry.separatorLocations shouldBe None
     resultEntry.solution shouldBe None
-  }}
+  }
+}


### PR DESCRIPTION
## What is the value of this and can you measure success?
The primary value of this change is to create a data model `EditionsCrosswordRenderingDataModel` that directly aligns with the [CAPICrossword type](https://github.com/guardian/csnx/blob/63121f2b74da3db10ee7600053f90bd6f791f6a4/libs/%40guardian/react-crossword/src/%40types/CAPI.ts#L36) expected by the new react-crossword component.
## What does this change?
This refactors the data modelling and parsing logic for Editions crosswords specifically to support the new component.

Related PR in DCR: https://github.com/guardian/dotcom-rendering/pull/13876

Resolves https://github.com/guardian/dotcom-rendering/issues/13864
## Screenshots


| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/455573f4-6ba3-41ab-8639-61fc65d358c5
[after]: https://github.com/user-attachments/assets/191f5d14-95b3-41d5-a99e-955653b111fd



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
