### PR TITLE
Crossworddata editions

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -440,9 +440,9 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   }
 
   def getEditionsCrossword(
-                            ws: WSClient,
-                            crosswords: Iterable[CrosswordData],
-                          )(implicit request: RequestHeader): Future[Result] = {
+      ws: WSClient,
+      crosswords: Iterable[CrosswordData],
+  )(implicit request: RequestHeader): Future[Result] = {
     val json = Json.obj("crosswords" -> Json.toJson(crosswords))
     post(ws, json, Configuration.rendering.articleBaseURL + "/EditionsCrossword", CacheTime.Default)
   }

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -1,7 +1,6 @@
 package renderers
 
-import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
-import com.gu.contentapi.client.model.v1.{Block, Blocks, Content, Crossword}
+import com.gu.contentapi.client.model.v1.{Block, Blocks, Content}
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
@@ -10,10 +9,10 @@ import crosswords.CrosswordPageWithContent
 import http.{HttpPreconnections, ResultWithPreconnectPreload}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.dotcomrendering._
-import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
 import model.{
   CacheTime,
   Cached,
+  CrosswordData,
   GalleryPage,
   ImageContentPage,
   InteractivePage,
@@ -25,12 +24,13 @@ import model.{
   RelatedContentItem,
   SimplePage,
 }
-import play.api.libs.json.JsValue
+import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
+import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
-import services.newsletters.model.{NewsletterResponseV2, NewsletterLayout}
+import services.newsletters.model.{NewsletterLayout, NewsletterResponseV2}
 import services.{IndexPage, NewsletterData}
 
 import java.lang.System.currentTimeMillis
@@ -440,10 +440,10 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   }
 
   def getEditionsCrossword(
-      ws: WSClient,
-      crosswords: EditionsCrosswordRenderingDataModel,
-  )(implicit request: RequestHeader): Future[Result] = {
-    val json = EditionsCrosswordRenderingDataModel.toJson(crosswords)
+                            ws: WSClient,
+                            crosswords: Iterable[CrosswordData],
+                          )(implicit request: RequestHeader): Future[Result] = {
+    val json = Json.obj("crosswords" -> Json.toJson(crosswords))
     post(ws, json, Configuration.rendering.articleBaseURL + "/EditionsCrossword", CacheTime.Default)
   }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
