### PR TITLE
Use CrosswordData for editions

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -350,7 +350,13 @@ class CrosswordEditionsController(
     "crosswords/series/quiptic",
   ).mkString("|")
 
-  private def parseCrosswords(response: SearchResponse): EditionsCrosswordRenderingDataModel =
-    EditionsCrosswordRenderingDataModel(response.results.flatMap(_.crossword))
+  private def parseCrosswords(response: SearchResponse): EditionsCrosswordRenderingDataModel = {
+    val collectedItems = response.results.collect {
+      case content if content.crossword.isDefined =>
+        CrosswordData.fromCrossword(content.crossword.get, content)
+    }
+    val crosswordDataItems: scala.collection.immutable.Seq[CrosswordData] = collectedItems.toList
+    EditionsCrosswordRenderingDataModel(crosswordDataItems)
+  }
 
 }

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -37,6 +37,7 @@ import renderers.DotcomRenderingService
 import services.dotcomrendering.{CrosswordsPicker, RemoteRender}
 import services.{IndexPage, IndexPageItem}
 
+import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -351,12 +352,15 @@ class CrosswordEditionsController(
   ).mkString("|")
 
   private def parseCrosswords(response: SearchResponse): EditionsCrosswordRenderingDataModel = {
+    val originalCapiCrosswords: Seq[Crossword] = response.results.flatMap(_.crossword).toList
     val collectedItems = response.results.collect {
       case content if content.crossword.isDefined =>
         CrosswordData.fromCrossword(content.crossword.get, content)
     }
-    val crosswordDataItems: scala.collection.immutable.Seq[CrosswordData] = collectedItems.toList
-    EditionsCrosswordRenderingDataModel(crosswordDataItems)
+    val crosswordDataItems: immutable.Seq[CrosswordData] = collectedItems.toList
+    EditionsCrosswordRenderingDataModel(
+      crosswords = originalCapiCrosswords,
+      newCrosswords = crosswordDataItems,
+    )
   }
-
 }

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -1,33 +1,15 @@
 package model.dotcomrendering.pageElements
-
-import com.gu.contentapi.client.model.v1.Crossword
-import com.gu.contentapi.json.CirceEncoders._
-import io.circe.syntax._
-import implicits.Dates.CapiRichDateTime
-import model.dotcomrendering.DotcomRenderingUtils
-import play.api.libs.json.{JsObject, Json, JsValue}
+import model.CrosswordData
+import play.api.libs.json.{Json, JsValue}
 
 case class EditionsCrosswordRenderingDataModel(
-    crosswords: Iterable[Crossword],
+    crosswords: Iterable[CrosswordData],
 )
 
 object EditionsCrosswordRenderingDataModel {
-  def apply(crosswords: Iterable[Crossword]): EditionsCrosswordRenderingDataModel =
-    new EditionsCrosswordRenderingDataModel(crosswords.map(crossword => {
-      val shipSolutions =
-        crossword.dateSolutionAvailable
-          .map(_.toJoda.isBeforeNow)
-          .getOrElse(crossword.solutionAvailable)
-
-      if (shipSolutions) {
-        crossword
-      } else {
-        crossword.copy(entries = crossword.entries.map(_.copy(solution = None)))
-      }
-    }))
-
-  def toJson(model: EditionsCrosswordRenderingDataModel): JsValue =
+  def toJson(model: EditionsCrosswordRenderingDataModel): JsValue = {
     Json.obj(
-      "crosswords" -> Json.parse(model.crosswords.asJson.deepDropNullValues.toString()),
+      "crosswords" -> Json.toJson(model.crosswords),
     )
+  }
 }

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -3,6 +3,7 @@ package model.dotcomrendering.pageElements
 import com.gu.contentapi.client.model.v1.Crossword
 import com.gu.contentapi.json.CirceEncoders._
 import io.circe.syntax._
+import model.Cached.CapiRichDateTime
 import model.CrosswordData
 import play.api.libs.json.{JsValue, Json}
 
@@ -12,6 +13,25 @@ case class EditionsCrosswordRenderingDataModel(
 )
 
 object EditionsCrosswordRenderingDataModel {
+  def apply(
+      crosswords: Iterable[Crossword],
+      newCrosswords: Iterable[CrosswordData],
+  ): EditionsCrosswordRenderingDataModel =
+    new EditionsCrosswordRenderingDataModel(
+      crosswords.map(crossword => {
+        val shipSolutions =
+          crossword.dateSolutionAvailable
+            .map(_.toJoda.isBeforeNow)
+            .getOrElse(crossword.solutionAvailable)
+
+        if (shipSolutions) {
+          crossword
+        } else {
+          crossword.copy(entries = crossword.entries.map(_.copy(solution = None)))
+        }
+      }),
+      newCrosswords,
+    )
   def toJson(model: EditionsCrosswordRenderingDataModel): JsValue = {
     Json.obj(
       "crosswords" -> Json.parse(model.crosswords.asJson.deepDropNullValues.toString()),

--- a/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/pageElements/EditionsCrosswordRenderingDataModel.scala
@@ -1,15 +1,21 @@
 package model.dotcomrendering.pageElements
+
+import com.gu.contentapi.client.model.v1.Crossword
+import com.gu.contentapi.json.CirceEncoders._
+import io.circe.syntax._
 import model.CrosswordData
-import play.api.libs.json.{Json, JsValue}
+import play.api.libs.json.{JsValue, Json}
 
 case class EditionsCrosswordRenderingDataModel(
-    crosswords: Iterable[CrosswordData],
+    crosswords: Iterable[Crossword],
+    newCrosswords: Iterable[CrosswordData],
 )
 
 object EditionsCrosswordRenderingDataModel {
   def toJson(model: EditionsCrosswordRenderingDataModel): JsValue = {
     Json.obj(
-      "crosswords" -> Json.toJson(model.crosswords),
+      "crosswords" -> Json.parse(model.crosswords.asJson.deepDropNullValues.toString()),
+      "newCrosswords" -> Json.toJson(model.newCrosswords),
     )
   }
 }

--- a/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
@@ -33,7 +33,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     )
 
     val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword),Nil).crosswords.toSeq
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword), Nil).crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe Some("Mock solution")
     crosswords(0).entries(1).solution shouldBe Some("Mock solution")
@@ -48,7 +48,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     )
 
     val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword),Nil).crosswords.toSeq
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword), Nil).crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe Some("Mock solution")
     crosswords(0).entries(1).solution shouldBe Some("Mock solution")
@@ -63,7 +63,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     )
 
     val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword),Nil).crosswords.toSeq
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword), Nil).crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe None
     crosswords(0).entries(1).solution shouldBe None
@@ -78,7 +78,7 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     )
 
     val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword),Nil).crosswords.toSeq
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword), Nil).crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe None
     crosswords(0).entries(1).solution shouldBe None

--- a/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
@@ -1,134 +1,88 @@
-//package model.dotcomrendering
-//
-//import com.gu.contentapi.client.model.v1.{
-//  CapiDateTime,
-//  Content,
-//  ContentType,
-//  Crossword,
-//  CrosswordDimensions,
-//  CrosswordEntry,
-//  CrosswordType,
-//}
-//import model.CrosswordData
-//import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
-//import org.joda.time.DateTime
-//import org.scalatest.flatspec.AnyFlatSpec
-//import org.scalatest.matchers.should.Matchers
-//import org.scalatestplus.mockito.MockitoSugar
-//
-//class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers with MockitoSugar {
-//
-//  val nowMillis = DateTime.now().getMillis()
-//  val nowCapi = CapiDateTime(nowMillis, "date")
-//
-//  val mockEntry = CrosswordEntry(
-//    id = "mockId-1",
-//    number = Some(1),
-//    humanNumber = Some("1"),
-//    clue = Some("Mock clue"),
-//    direction = Some("across"),
-//    length = Some(4),
-//    group = Some(Seq("mockId-1")),
-//    position = None,
-//    separatorLocations = None,
-//    solution = Some("MOCK"),
-//  )
-//
-//  val baseMockCapiCrossword = Crossword(
-//    name = "Mock name",
-//    `type` = CrosswordType.Quick,
-//    number = 1,
-//    date = nowCapi,
-//    dimensions = CrosswordDimensions(cols = 10, rows = 10),
-//    entries = Seq(mockEntry, mockEntry.copy(id = "mockId-2", solution = Some("SOLN"))),
-//    solutionAvailable = true,
-//    dateSolutionAvailable = None,
-//    hasNumbers = true,
-//    pdf = None,
-//    instructions = None,
-//    creator = None,
-//    randomCluesOrdering = false,
-//  )
-//
-//  def createMockContent(crossword: Crossword): Content = Content(
-//    id = "crosswords/mock/123",
-//    `type` = ContentType.Crossword,
-//    webTitle = "Mock Crossword Content",
-//    webUrl = "http://mock.url/crosswords/mock/123",
-//    apiUrl = "http://mock.api/crosswords/mock/123",
-//    elements = None,
-//    tags = Nil,
-//    references = Nil,
-//    crossword = Some(crossword),
-//    webPublicationDate = Some(nowCapi),
-//  )
-//
-//  def convertToCrosswordData(crossword: Crossword): CrosswordData = {
-//    val content = createMockContent(crossword)
-//    CrosswordData.fromCrossword(crossword, content)
-//  }
-//
-//  "EditionsCrosswordRenderingDataModel" should "contain CrosswordData with solutions when 'dateSolutionAvailable' is in the past" in {
-//    val capiCrossword = baseMockCapiCrossword.copy(
-//      solutionAvailable = true,
-//      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().minusDays(1).getMillis(), "date")),
-//    )
-//    val crosswordData = convertToCrosswordData(capiCrossword)
-//
-//    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
-//    val crosswords = model.crosswords.toSeq
-//
-//    crosswords should have size 2
-//    crosswords.head.entries should have size 2
-//
-//    crosswords(0).entries(0).solution shouldBe Some("MOCK")
-//    crosswords(0).entries(1).solution shouldBe Some("SOLN")
-//    crosswords(1).entries(0).solution shouldBe Some("MOCK")
-//    crosswords(1).entries(1).solution shouldBe Some("SOLN")
-//  }
-//
-//  it should "contain CrosswordData with solutions when 'dateSolutionAvailable' is None and solutionAvailable is true" in {
-//    val capiCrossword = baseMockCapiCrossword.copy(
-//      solutionAvailable = true,
-//      dateSolutionAvailable = None,
-//    )
-//    val crosswordData = convertToCrosswordData(capiCrossword)
-//    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
-//    val crosswords = model.crosswords.toSeq
-//
-//    crosswords(0).entries(0).solution shouldBe Some("MOCK")
-//    crosswords(0).entries(1).solution shouldBe Some("SOLN")
-//    crosswords(1).entries(0).solution shouldBe Some("MOCK")
-//    crosswords(1).entries(1).solution shouldBe Some("SOLN")
-//  }
-//
-//  it should "contain CrosswordData without solutions when 'dateSolutionAvailable' is in the future" in {
-//    val capiCrossword = baseMockCapiCrossword.copy(
-//      solutionAvailable = true,
-//      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().plusDays(1).getMillis(), "date")),
-//    )
-//    val crosswordData = convertToCrosswordData(capiCrossword)
-//    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
-//    val crosswords = model.crosswords.toSeq
-//
-//    crosswords(0).entries(0).solution shouldBe None
-//    crosswords(0).entries(1).solution shouldBe None
-//    crosswords(1).entries(0).solution shouldBe None
-//    crosswords(1).entries(1).solution shouldBe None
-//  }
-//
-//  it should "contain CrosswordData without solutions when 'dateSolutionAvailable' is None and solutionAvailable is false" in {
-//    val capiCrossword = baseMockCapiCrossword.copy(
-//      solutionAvailable = false,
-//      dateSolutionAvailable = None,
-//    )
-//    val crosswordData = convertToCrosswordData(capiCrossword)
-//    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
-//    val crosswords = model.crosswords.toSeq
-//
-//    crosswords(0).entries(0).solution shouldBe None
-//    crosswords(0).entries(1).solution shouldBe None
-//    crosswords(1).entries(0).solution shouldBe None
-//    crosswords(1).entries(1).solution shouldBe None
-//  }
-//}
+package model.dotcomrendering
+
+import com.gu.contentapi.client.model.v1.{CapiDateTime, Crossword, CrosswordType, CrosswordDimensions, CrosswordEntry}
+import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
+import org.mockito.Mockito.when
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import org.joda.time.DateTime
+
+class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers with MockitoSugar {
+  val mockEntry = CrosswordEntry(
+    id = "mockId",
+    solution = Some("Mock solution"),
+  )
+
+  val mockCrossword = Crossword(
+    name = "Mock name",
+    `type` = CrosswordType.Quick,
+    number = 1,
+    date = CapiDateTime(DateTime.now().getMillis(), "date"),
+    dimensions = CrosswordDimensions(1, 1),
+    entries = Seq(mockEntry, mockEntry),
+    solutionAvailable = true,
+    hasNumbers = false,
+    randomCluesOrdering = false,
+  )
+
+  "apply" should "provide solutions when 'dateSolutionAvailable' is in the past" in {
+    val crossword = mockCrossword.copy(
+      solutionAvailable = true,
+      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().minusDays(1).getMillis(), "date")),
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword),Nil).crosswords.toSeq
+
+    crosswords(0).entries(0).solution shouldBe Some("Mock solution")
+    crosswords(0).entries(1).solution shouldBe Some("Mock solution")
+    crosswords(1).entries(0).solution shouldBe Some("Mock solution")
+    crosswords(1).entries(1).solution shouldBe Some("Mock solution")
+  }
+
+  "apply" should "provide solutions when 'dateSolutionAvailable' is 'None' and solutionAvailable is 'true'" in {
+    val crossword = mockCrossword.copy(
+      solutionAvailable = true,
+      dateSolutionAvailable = None,
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword),Nil).crosswords.toSeq
+
+    crosswords(0).entries(0).solution shouldBe Some("Mock solution")
+    crosswords(0).entries(1).solution shouldBe Some("Mock solution")
+    crosswords(1).entries(0).solution shouldBe Some("Mock solution")
+    crosswords(1).entries(1).solution shouldBe Some("Mock solution")
+  }
+
+  "apply" should "not provide solutions when 'dateSolutionAvailable' is in the future" in {
+    val crossword = mockCrossword.copy(
+      solutionAvailable = true,
+      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().plusDays(1).getMillis(), "date")),
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword),Nil).crosswords.toSeq
+
+    crosswords(0).entries(0).solution shouldBe None
+    crosswords(0).entries(1).solution shouldBe None
+    crosswords(1).entries(0).solution shouldBe None
+    crosswords(1).entries(1).solution shouldBe None
+  }
+
+  "apply" should "not provide solutions when 'dateSolutionAvailable' is 'None' and solutionAvailable is 'false'" in {
+    val crossword = mockCrossword.copy(
+      solutionAvailable = false,
+      dateSolutionAvailable = None,
+    )
+
+    val crosswords =
+      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword),Nil).crosswords.toSeq
+
+    crosswords(0).entries(0).solution shouldBe None
+    crosswords(0).entries(1).solution shouldBe None
+    crosswords(1).entries(0).solution shouldBe None
+    crosswords(1).entries(1).solution shouldBe None
+  }
+}

--- a/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
@@ -1,134 +1,134 @@
-package model.dotcomrendering
-
-import com.gu.contentapi.client.model.v1.{
-  CapiDateTime,
-  Content,
-  ContentType,
-  Crossword,
-  CrosswordDimensions,
-  CrosswordEntry,
-  CrosswordType,
-}
-import model.CrosswordData
-import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
-import org.joda.time.DateTime
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar
-
-class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers with MockitoSugar {
-
-  val nowMillis = DateTime.now().getMillis()
-  val nowCapi = CapiDateTime(nowMillis, "date")
-
-  val mockEntry = CrosswordEntry(
-    id = "mockId-1",
-    number = Some(1),
-    humanNumber = Some("1"),
-    clue = Some("Mock clue"),
-    direction = Some("across"),
-    length = Some(4),
-    group = Some(Seq("mockId-1")),
-    position = None,
-    separatorLocations = None,
-    solution = Some("MOCK"),
-  )
-
-  val baseMockCapiCrossword = Crossword(
-    name = "Mock name",
-    `type` = CrosswordType.Quick,
-    number = 1,
-    date = nowCapi,
-    dimensions = CrosswordDimensions(cols = 10, rows = 10),
-    entries = Seq(mockEntry, mockEntry.copy(id = "mockId-2", solution = Some("SOLN"))),
-    solutionAvailable = true,
-    dateSolutionAvailable = None,
-    hasNumbers = true,
-    pdf = None,
-    instructions = None,
-    creator = None,
-    randomCluesOrdering = false,
-  )
-
-  def createMockContent(crossword: Crossword): Content = Content(
-    id = "crosswords/mock/123",
-    `type` = ContentType.Crossword,
-    webTitle = "Mock Crossword Content",
-    webUrl = "http://mock.url/crosswords/mock/123",
-    apiUrl = "http://mock.api/crosswords/mock/123",
-    elements = None,
-    tags = Nil,
-    references = Nil,
-    crossword = Some(crossword),
-    webPublicationDate = Some(nowCapi),
-  )
-
-  def convertToCrosswordData(crossword: Crossword): CrosswordData = {
-    val content = createMockContent(crossword)
-    CrosswordData.fromCrossword(crossword, content)
-  }
-
-  "EditionsCrosswordRenderingDataModel" should "contain CrosswordData with solutions when 'dateSolutionAvailable' is in the past" in {
-    val capiCrossword = baseMockCapiCrossword.copy(
-      solutionAvailable = true,
-      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().minusDays(1).getMillis(), "date")),
-    )
-    val crosswordData = convertToCrosswordData(capiCrossword)
-
-    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
-    val crosswords = model.crosswords.toSeq
-
-    crosswords should have size 2
-    crosswords.head.entries should have size 2
-
-    crosswords(0).entries(0).solution shouldBe Some("MOCK")
-    crosswords(0).entries(1).solution shouldBe Some("SOLN")
-    crosswords(1).entries(0).solution shouldBe Some("MOCK")
-    crosswords(1).entries(1).solution shouldBe Some("SOLN")
-  }
-
-  it should "contain CrosswordData with solutions when 'dateSolutionAvailable' is None and solutionAvailable is true" in {
-    val capiCrossword = baseMockCapiCrossword.copy(
-      solutionAvailable = true,
-      dateSolutionAvailable = None,
-    )
-    val crosswordData = convertToCrosswordData(capiCrossword)
-    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
-    val crosswords = model.crosswords.toSeq
-
-    crosswords(0).entries(0).solution shouldBe Some("MOCK")
-    crosswords(0).entries(1).solution shouldBe Some("SOLN")
-    crosswords(1).entries(0).solution shouldBe Some("MOCK")
-    crosswords(1).entries(1).solution shouldBe Some("SOLN")
-  }
-
-  it should "contain CrosswordData without solutions when 'dateSolutionAvailable' is in the future" in {
-    val capiCrossword = baseMockCapiCrossword.copy(
-      solutionAvailable = true,
-      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().plusDays(1).getMillis(), "date")),
-    )
-    val crosswordData = convertToCrosswordData(capiCrossword)
-    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
-    val crosswords = model.crosswords.toSeq
-
-    crosswords(0).entries(0).solution shouldBe None
-    crosswords(0).entries(1).solution shouldBe None
-    crosswords(1).entries(0).solution shouldBe None
-    crosswords(1).entries(1).solution shouldBe None
-  }
-
-  it should "contain CrosswordData without solutions when 'dateSolutionAvailable' is None and solutionAvailable is false" in {
-    val capiCrossword = baseMockCapiCrossword.copy(
-      solutionAvailable = false,
-      dateSolutionAvailable = None,
-    )
-    val crosswordData = convertToCrosswordData(capiCrossword)
-    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
-    val crosswords = model.crosswords.toSeq
-
-    crosswords(0).entries(0).solution shouldBe None
-    crosswords(0).entries(1).solution shouldBe None
-    crosswords(1).entries(0).solution shouldBe None
-    crosswords(1).entries(1).solution shouldBe None
-  }
-}
+//package model.dotcomrendering
+//
+//import com.gu.contentapi.client.model.v1.{
+//  CapiDateTime,
+//  Content,
+//  ContentType,
+//  Crossword,
+//  CrosswordDimensions,
+//  CrosswordEntry,
+//  CrosswordType,
+//}
+//import model.CrosswordData
+//import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
+//import org.joda.time.DateTime
+//import org.scalatest.flatspec.AnyFlatSpec
+//import org.scalatest.matchers.should.Matchers
+//import org.scalatestplus.mockito.MockitoSugar
+//
+//class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers with MockitoSugar {
+//
+//  val nowMillis = DateTime.now().getMillis()
+//  val nowCapi = CapiDateTime(nowMillis, "date")
+//
+//  val mockEntry = CrosswordEntry(
+//    id = "mockId-1",
+//    number = Some(1),
+//    humanNumber = Some("1"),
+//    clue = Some("Mock clue"),
+//    direction = Some("across"),
+//    length = Some(4),
+//    group = Some(Seq("mockId-1")),
+//    position = None,
+//    separatorLocations = None,
+//    solution = Some("MOCK"),
+//  )
+//
+//  val baseMockCapiCrossword = Crossword(
+//    name = "Mock name",
+//    `type` = CrosswordType.Quick,
+//    number = 1,
+//    date = nowCapi,
+//    dimensions = CrosswordDimensions(cols = 10, rows = 10),
+//    entries = Seq(mockEntry, mockEntry.copy(id = "mockId-2", solution = Some("SOLN"))),
+//    solutionAvailable = true,
+//    dateSolutionAvailable = None,
+//    hasNumbers = true,
+//    pdf = None,
+//    instructions = None,
+//    creator = None,
+//    randomCluesOrdering = false,
+//  )
+//
+//  def createMockContent(crossword: Crossword): Content = Content(
+//    id = "crosswords/mock/123",
+//    `type` = ContentType.Crossword,
+//    webTitle = "Mock Crossword Content",
+//    webUrl = "http://mock.url/crosswords/mock/123",
+//    apiUrl = "http://mock.api/crosswords/mock/123",
+//    elements = None,
+//    tags = Nil,
+//    references = Nil,
+//    crossword = Some(crossword),
+//    webPublicationDate = Some(nowCapi),
+//  )
+//
+//  def convertToCrosswordData(crossword: Crossword): CrosswordData = {
+//    val content = createMockContent(crossword)
+//    CrosswordData.fromCrossword(crossword, content)
+//  }
+//
+//  "EditionsCrosswordRenderingDataModel" should "contain CrosswordData with solutions when 'dateSolutionAvailable' is in the past" in {
+//    val capiCrossword = baseMockCapiCrossword.copy(
+//      solutionAvailable = true,
+//      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().minusDays(1).getMillis(), "date")),
+//    )
+//    val crosswordData = convertToCrosswordData(capiCrossword)
+//
+//    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
+//    val crosswords = model.crosswords.toSeq
+//
+//    crosswords should have size 2
+//    crosswords.head.entries should have size 2
+//
+//    crosswords(0).entries(0).solution shouldBe Some("MOCK")
+//    crosswords(0).entries(1).solution shouldBe Some("SOLN")
+//    crosswords(1).entries(0).solution shouldBe Some("MOCK")
+//    crosswords(1).entries(1).solution shouldBe Some("SOLN")
+//  }
+//
+//  it should "contain CrosswordData with solutions when 'dateSolutionAvailable' is None and solutionAvailable is true" in {
+//    val capiCrossword = baseMockCapiCrossword.copy(
+//      solutionAvailable = true,
+//      dateSolutionAvailable = None,
+//    )
+//    val crosswordData = convertToCrosswordData(capiCrossword)
+//    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
+//    val crosswords = model.crosswords.toSeq
+//
+//    crosswords(0).entries(0).solution shouldBe Some("MOCK")
+//    crosswords(0).entries(1).solution shouldBe Some("SOLN")
+//    crosswords(1).entries(0).solution shouldBe Some("MOCK")
+//    crosswords(1).entries(1).solution shouldBe Some("SOLN")
+//  }
+//
+//  it should "contain CrosswordData without solutions when 'dateSolutionAvailable' is in the future" in {
+//    val capiCrossword = baseMockCapiCrossword.copy(
+//      solutionAvailable = true,
+//      dateSolutionAvailable = Some(CapiDateTime(DateTime.now().plusDays(1).getMillis(), "date")),
+//    )
+//    val crosswordData = convertToCrosswordData(capiCrossword)
+//    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
+//    val crosswords = model.crosswords.toSeq
+//
+//    crosswords(0).entries(0).solution shouldBe None
+//    crosswords(0).entries(1).solution shouldBe None
+//    crosswords(1).entries(0).solution shouldBe None
+//    crosswords(1).entries(1).solution shouldBe None
+//  }
+//
+//  it should "contain CrosswordData without solutions when 'dateSolutionAvailable' is None and solutionAvailable is false" in {
+//    val capiCrossword = baseMockCapiCrossword.copy(
+//      solutionAvailable = false,
+//      dateSolutionAvailable = None,
+//    )
+//    val crosswordData = convertToCrosswordData(capiCrossword)
+//    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
+//    val crosswords = model.crosswords.toSeq
+//
+//    crosswords(0).entries(0).solution shouldBe None
+//    crosswords(0).entries(1).solution shouldBe None
+//    crosswords(1).entries(0).solution shouldBe None
+//    crosswords(1).entries(1).solution shouldBe None
+//  }
+//}

--- a/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/EditionsCrosswordRenderingDataModelTest.scala
@@ -1,69 +1,115 @@
 package model.dotcomrendering
 
-import com.gu.contentapi.client.model.v1.{CapiDateTime, Crossword, CrosswordType, CrosswordDimensions, CrosswordEntry}
+import com.gu.contentapi.client.model.v1.{
+  CapiDateTime,
+  Content,
+  ContentType,
+  Crossword,
+  CrosswordDimensions,
+  CrosswordEntry,
+  CrosswordType,
+}
+import model.CrosswordData
 import model.dotcomrendering.pageElements.EditionsCrosswordRenderingDataModel
-import org.mockito.Mockito.when
+import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import org.joda.time.DateTime
 
 class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers with MockitoSugar {
+
+  val nowMillis = DateTime.now().getMillis()
+  val nowCapi = CapiDateTime(nowMillis, "date")
+
   val mockEntry = CrosswordEntry(
-    id = "mockId",
-    solution = Some("Mock solution"),
+    id = "mockId-1",
+    number = Some(1),
+    humanNumber = Some("1"),
+    clue = Some("Mock clue"),
+    direction = Some("across"),
+    length = Some(4),
+    group = Some(Seq("mockId-1")),
+    position = None,
+    separatorLocations = None,
+    solution = Some("MOCK"),
   )
 
-  val mockCrossword = Crossword(
+  val baseMockCapiCrossword = Crossword(
     name = "Mock name",
     `type` = CrosswordType.Quick,
     number = 1,
-    date = CapiDateTime(DateTime.now().getMillis(), "date"),
-    dimensions = CrosswordDimensions(1, 1),
-    entries = Seq(mockEntry, mockEntry),
+    date = nowCapi,
+    dimensions = CrosswordDimensions(cols = 10, rows = 10),
+    entries = Seq(mockEntry, mockEntry.copy(id = "mockId-2", solution = Some("SOLN"))),
     solutionAvailable = true,
-    hasNumbers = false,
+    dateSolutionAvailable = None,
+    hasNumbers = true,
+    pdf = None,
+    instructions = None,
+    creator = None,
     randomCluesOrdering = false,
   )
 
-  "apply" should "provide solutions when 'dateSolutionAvailable' is in the past" in {
-    val crossword = mockCrossword.copy(
+  def createMockContent(crossword: Crossword): Content = Content(
+    id = "crosswords/mock/123",
+    `type` = ContentType.Crossword,
+    webTitle = "Mock Crossword Content",
+    webUrl = "http://mock.url/crosswords/mock/123",
+    apiUrl = "http://mock.api/crosswords/mock/123",
+    elements = None,
+    tags = Nil,
+    references = Nil,
+    crossword = Some(crossword),
+    webPublicationDate = Some(nowCapi),
+  )
+
+  def convertToCrosswordData(crossword: Crossword): CrosswordData = {
+    val content = createMockContent(crossword)
+    CrosswordData.fromCrossword(crossword, content)
+  }
+
+  "EditionsCrosswordRenderingDataModel" should "contain CrosswordData with solutions when 'dateSolutionAvailable' is in the past" in {
+    val capiCrossword = baseMockCapiCrossword.copy(
       solutionAvailable = true,
       dateSolutionAvailable = Some(CapiDateTime(DateTime.now().minusDays(1).getMillis(), "date")),
     )
+    val crosswordData = convertToCrosswordData(capiCrossword)
 
-    val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword)).crosswords.toSeq
+    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
+    val crosswords = model.crosswords.toSeq
 
-    crosswords(0).entries(0).solution shouldBe Some("Mock solution")
-    crosswords(0).entries(1).solution shouldBe Some("Mock solution")
-    crosswords(1).entries(0).solution shouldBe Some("Mock solution")
-    crosswords(1).entries(1).solution shouldBe Some("Mock solution")
+    crosswords should have size 2
+    crosswords.head.entries should have size 2
+
+    crosswords(0).entries(0).solution shouldBe Some("MOCK")
+    crosswords(0).entries(1).solution shouldBe Some("SOLN")
+    crosswords(1).entries(0).solution shouldBe Some("MOCK")
+    crosswords(1).entries(1).solution shouldBe Some("SOLN")
   }
 
-  "apply" should "provide solutions when 'dateSolutionAvailable' is 'None' and solutionAvailable is 'true'" in {
-    val crossword = mockCrossword.copy(
+  it should "contain CrosswordData with solutions when 'dateSolutionAvailable' is None and solutionAvailable is true" in {
+    val capiCrossword = baseMockCapiCrossword.copy(
       solutionAvailable = true,
       dateSolutionAvailable = None,
     )
+    val crosswordData = convertToCrosswordData(capiCrossword)
+    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
+    val crosswords = model.crosswords.toSeq
 
-    val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword)).crosswords.toSeq
-
-    crosswords(0).entries(0).solution shouldBe Some("Mock solution")
-    crosswords(0).entries(1).solution shouldBe Some("Mock solution")
-    crosswords(1).entries(0).solution shouldBe Some("Mock solution")
-    crosswords(1).entries(1).solution shouldBe Some("Mock solution")
+    crosswords(0).entries(0).solution shouldBe Some("MOCK")
+    crosswords(0).entries(1).solution shouldBe Some("SOLN")
+    crosswords(1).entries(0).solution shouldBe Some("MOCK")
+    crosswords(1).entries(1).solution shouldBe Some("SOLN")
   }
 
-  "apply" should "not provide solutions when 'dateSolutionAvailable' is in the future" in {
-    val crossword = mockCrossword.copy(
+  it should "contain CrosswordData without solutions when 'dateSolutionAvailable' is in the future" in {
+    val capiCrossword = baseMockCapiCrossword.copy(
       solutionAvailable = true,
       dateSolutionAvailable = Some(CapiDateTime(DateTime.now().plusDays(1).getMillis(), "date")),
     )
-
-    val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword)).crosswords.toSeq
+    val crosswordData = convertToCrosswordData(capiCrossword)
+    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
+    val crosswords = model.crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe None
     crosswords(0).entries(1).solution shouldBe None
@@ -71,14 +117,14 @@ class EditionsCrosswordRenderingDataModelTest extends AnyFlatSpec with Matchers 
     crosswords(1).entries(1).solution shouldBe None
   }
 
-  "apply" should "not provide solutions when 'dateSolutionAvailable' is 'None' and solutionAvailable is 'false'" in {
-    val crossword = mockCrossword.copy(
+  it should "contain CrosswordData without solutions when 'dateSolutionAvailable' is None and solutionAvailable is false" in {
+    val capiCrossword = baseMockCapiCrossword.copy(
       solutionAvailable = false,
       dateSolutionAvailable = None,
     )
-
-    val crosswords =
-      EditionsCrosswordRenderingDataModel(Seq(crossword, crossword)).crosswords.toSeq
+    val crosswordData = convertToCrosswordData(capiCrossword)
+    val model = EditionsCrosswordRenderingDataModel(Seq(crosswordData, crosswordData))
+    val crosswords = model.crosswords.toSeq
 
     crosswords(0).entries(0).solution shouldBe None
     crosswords(0).entries(1).solution shouldBe None


### PR DESCRIPTION
## What is the value of this and can you measure success?
The primary value of this change is to create a data model `EditionsCrosswordRenderingDataModel` that directly aligns with the [CAPICrossword type](https://github.com/guardian/csnx/blob/63121f2b74da3db10ee7600053f90bd6f791f6a4/libs/%40guardian/react-crossword/src/%40types/CAPI.ts#L36) expected by the new react-crossword component.
## What does this change?
This refactors the data modelling and parsing logic for Editions crosswords specifically to support the new component.

Related PR in DCR: https://github.com/guardian/dotcom-rendering/pull/13876

Resolves https://github.com/guardian/dotcom-rendering/issues/13864
## Screenshots


| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/455573f4-6ba3-41ab-8639-61fc65d358c5
[after]: https://github.com/user-attachments/assets/191f5d14-95b3-41d5-a99e-955653b111fd



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
