### PR TITLE
Add next page link to dcr football matches data to support no js

### DIFF
--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -110,6 +110,7 @@ private object DotcomRenderingFootballDataModelImplicits {
 case class DotcomRenderingFootballMatchListDataModel(
     matchesList: Seq[MatchesByDateAndCompetition],
     nextPage: Option[String],
+    nextPageNoJs: Option[String],
     filters: Map[String, Seq[CompetitionFilter]],
     previousPage: Option[String],
     nav: Nav,
@@ -142,6 +143,7 @@ object DotcomRenderingFootballMatchListDataModel {
     DotcomRenderingFootballMatchListDataModel(
       matchesList = matches,
       nextPage = matchesList.nextPage,
+      nextPageNoJs = matchesList.nextPageNoJs,
       filters = filters,
       previousPage = matchesList.previousPage,
       nav = nav,

--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -82,6 +82,10 @@ trait MatchesList extends Football with RichList {
     val nextMatchDate = matchDates.dropWhile(dateComesFirstInList(_, date)).drop(daysToDisplay).headOption
     nextMatchDate.map(s"$baseUrl/more/" + _.format(DateTimeFormatter.ofPattern("yyyy/MMM/dd")))
   }
+  lazy val nextPageNoJs: Option[String] = {
+    val nextMatchDate = matchDates.dropWhile(dateComesFirstInList(_, date)).drop(daysToDisplay).headOption
+    nextMatchDate.map(s"$baseUrl/" + _.format(DateTimeFormatter.ofPattern("yyyy/MMM/dd")))
+  }
   lazy val previousPage: Option[String] = {
     val nextMatchDate = matchDates.takeWhile(dateComesFirstInList(_, date)).lastOption
     nextMatchDate.map(s"$baseUrl/" + _.format(DateTimeFormatter.ofPattern("yyyy/MMM/dd")))


### PR DESCRIPTION
## What does this change?
This PR adds a new `nextPageNoJs` field to the DCAR matches list data. This field provides a link to the next page of football matches without the `/more/` segment in the URL path, unlike the existing `nextPage` field.

This new field is specifically intended for use by the **More** button on football match list pages when JavaScript is disabled. It enables DCAR to fall back to a regular anchor link that works in no-JS environments, improving accessibility and resilience.

## Why is this needed?
Historically, frontend pagination in football match pages used a `/more/` route pattern (e.g. /football/fixtures/more/:year/:month/:day) to fetch additional matches via JSON when JS is enabled or link to HTML version (non-json route) when JS is disabled. 

However, the HTML versions of these /more/ routes are identical to the standard routes without /more/ (e.g. /football/fixtures/:year/:month/:day). Maintaining both versions adds unnecessary complexity. 

As a result, we're planning to remove the /more/ HTML routes in https://github.com/guardian/frontend/pull/27939. For no-JS support, instead of linking to the soon-to-be-deprecated /more/ routes, we want the More button to fall back to the canonical route without /more/. The nextPageNoJs field provides that path.

This is the DCAR pull request that will need to get merged after this change in frontend. https://github.com/guardian/dotcom-rendering/pull/13903