### PR TITLE
Trim data used for cricket scoreboard in dcar

### DIFF
--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -4,7 +4,7 @@ import common._
 import conf.Configuration
 import cricketModel.Match
 import conf.cricketPa.{CricketTeam, CricketTeams}
-import football.model.DotcomRenderingCricketDataModel
+import football.model.{CricketScoreBoardDataModel, DotcomRenderingCricketDataModel}
 import implicits.{HtmlFormat, JsonFormat}
 import jobs.CricketStatsJob
 import model.Cached.RevalidatableResult
@@ -48,7 +48,7 @@ class CricketMatchController(
             val page = CricketMatchPage(matchData, date, team)
             Cached(60) {
               JsonComponent(
-                "match" -> Json.toJson(page.theMatch),
+                "match" -> CricketScoreBoardDataModel.toJson(page.theMatch),
                 "scorecardUrl" -> (Configuration.site.host + page.metadata.id),
               )
             }

--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -81,3 +81,46 @@ object DotcomRenderingCricketDataModel {
     withoutNull(jsValue)
   }
 }
+
+object CricketScoreBoardDataModel {
+  private def getTeam(team: Team) = {
+    Json.obj(
+      "name" -> team.name,
+      "home" -> team.home,
+    )
+  }
+
+  private def getFallOfWicket(inningsWicket: InningsWicket) = {
+    Json.obj(
+      "order" -> inningsWicket.order,
+    )
+  }
+
+  private def getInnings(innings: Innings) = {
+    Json.obj(
+      "order" -> innings.order,
+      "battingTeam" -> innings.battingTeam,
+      "runsScored" -> innings.runsScored,
+      "declared" -> innings.declared,
+      "forfeited" -> innings.forfeited,
+      "fallOfWicket" -> innings.fallOfWicket.map(getFallOfWicket),
+      "overs" -> innings.overs,
+    )
+  }
+
+  def getMatch(theMatch: Match): JsObject = {
+    Json.obj(
+      "matchId" -> theMatch.matchId,
+      "competitionName" -> theMatch.competitionName,
+      "venueName" -> theMatch.venueName,
+      "teams" -> theMatch.teams.map(getTeam),
+      "innings" -> theMatch.innings.map(getInnings),
+      "gameDate" -> theMatch.gameDate,
+    )
+  }
+
+  def toJson(theMatch: Match): JsValue = {
+    val jsValue = Json.toJson(getMatch(theMatch))
+    withoutNull(jsValue)
+  }
+}


### PR DESCRIPTION
## What is the value of this and can you measure success?
DCAR cricket live blogs include a client-side cricket scoreboard component that fetches data from the `/sport/cricket/match-scoreboard/:matchDate/:teamId.json` frontend endpoint.

Previously, this endpoint returned a large payload containing data that DCAR doesn't use. This PR reduces the response size by trimming unnecessary fields, aligning the returned data with the actual requirements of the DCAR model.