### PR TITLE
Use `putPrivate` instead of `putPublic` for commercial s3 PUT calls

### DIFF
--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -25,28 +25,28 @@ trait Store extends GuLogging with Dates {
   def putTopStories(config: String): Unit = { S3.putPublic(topStoriesKey, config, "application/json") }
 
   def putLiveBlogTopSponsorships(sponsorshipsJson: String): Unit = {
-    S3.putPublic(dfpLiveBlogTopSponsorshipDataKey, sponsorshipsJson, defaultJsonEncoding)
+    S3.putPrivate(dfpLiveBlogTopSponsorshipDataKey, sponsorshipsJson, defaultJsonEncoding)
   }
   def putSurveySponsorships(adUnitJson: String): Unit = {
-    S3.putPublic(dfpSurveySponsorshipDataKey, adUnitJson, defaultJsonEncoding)
+    S3.putPrivate(dfpSurveySponsorshipDataKey, adUnitJson, defaultJsonEncoding)
   }
   def putDfpPageSkinAdUnits(adUnitJson: String): Unit = {
-    S3.putPublic(dfpPageSkinnedAdUnitsKey, adUnitJson, defaultJsonEncoding)
+    S3.putPrivate(dfpPageSkinnedAdUnitsKey, adUnitJson, defaultJsonEncoding)
   }
   def putDfpLineItemsReport(everything: String): Unit = {
-    S3.putPublic(dfpLineItemsKey, everything, defaultJsonEncoding)
+    S3.putPrivate(dfpLineItemsKey, everything, defaultJsonEncoding)
   }
   def putDfpAdUnitList(filename: String, adUnits: String): Unit = {
-    S3.putPublic(filename, adUnits, "text/plain")
+    S3.putPrivate(filename, adUnits, "text/plain")
   }
   def putDfpTemplateCreatives(creatives: String): Unit = {
-    S3.putPublic(dfpTemplateCreativesKey, creatives, defaultJsonEncoding)
+    S3.putPrivate(dfpTemplateCreativesKey, creatives, defaultJsonEncoding)
   }
   def putDfpCustomTargetingKeyValues(keyValues: String): Unit = {
-    S3.putPublic(dfpCustomTargetingKey, keyValues, defaultJsonEncoding)
+    S3.putPrivate(dfpCustomTargetingKey, keyValues, defaultJsonEncoding)
   }
   def putNonRefreshableLineItemIds(lineItemIds: Seq[Long]): Unit = {
-    S3.putPublic(dfpNonRefreshableLineItemIdsKey, Json.stringify(toJson(lineItemIds)), defaultJsonEncoding)
+    S3.putPrivate(dfpNonRefreshableLineItemIdsKey, Json.stringify(toJson(lineItemIds)), defaultJsonEncoding)
   }
 
   val now: String = DateTime.now().toHttpDateTimeString


### PR DESCRIPTION
## What does this change?

As done in https://github.com/guardian/frontend/pull/27909 for `aws-frontend-pressed`, this does the same for `aws-frontend-store` to use `putPrivate` instead of `putPublic` for S3 PUT calls in commercial jobs

Error message:
`
User: ************* is not authorized to perform: s3:PutObject on resource: ************ because public access control lists (ACLs) are blocked by the BlockPublicAcls block public access setting.
`

This is because the `aws-frontend-store` bucket does not allow public access 


Have tested this in `CODE`