### PR TITLE
Remove limit on flexible general container

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -340,17 +340,6 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         case "scrollable/small" | "scrollable/medium" => 4
         // scrollable highlights containers are capped at 6 stories
         case "scrollable/highlights" => 6
-        // flexible general containers have max items on each group. In order to know the total max items, we need to sum all of these together.
-        case "flexible/general" => {
-
-          collection.collectionConfig.groupsConfig
-            .map(_.config)
-            .getOrElse(Nil)
-            .map(_.maxItems)
-            .flatten // Removes None values as maxItems is optional
-            .sum
-
-        }
         // other container types should be capped at a maximum number of stories set in the app config
         case _ => Math.min(Configuration.facia.collectionCap, storyCountTotal)
       }


### PR DESCRIPTION
## What is the value of this and can you measure success?

The expected number of items should now be included in flexible/general containers with group limits.

## What does this change?

Remove limit on flexible/general container that was applied before deduplication. We are now applying a group level limit for flexible general AFTER deduplication via the fapi method `applyDefaultBoostLevelsAndGroups`.

Applying a limit before deduplication introduces the real possibility that we won't have the appropriate amount of cards available after deduplication

