### PR TITLE
Add switch for ID5 prebid integration test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -60,4 +60,15 @@ trait ABTestSwitches {
     highImpact = false,
   )
 
+  Switch(
+    ABTests,
+    "ab-prebid-id5",
+    "Test enabling the ID5 module in prebid.js",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 5, 30)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
 }


### PR DESCRIPTION
## What does this change?
Add switch for the test introduced in this PR https://github.com/guardian/commercial/pull/1970