### PR TITLE
Use putPrivate instead of putPublic for switches

### DIFF
--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -19,7 +19,7 @@ trait Store extends GuLogging with Dates {
   def getSwitches: Option[String] = S3.get(switchesKey)
   def getSwitchesWithLastModified: Option[(String, DateTime)] = S3.getWithLastModified(switchesKey)
   def getSwitchesLastModified: Option[DateTime] = S3.getLastModified(switchesKey)
-  def putSwitches(config: String): Unit = { S3.putPublic(switchesKey, config, "text/plain") }
+  def putSwitches(config: String): Unit = { S3.putPrivate(switchesKey, config, "text/plain") }
 
   def getTopStories: Option[String] = S3.get(topStoriesKey)
   def putTopStories(config: String): Unit = { S3.putPublic(topStoriesKey, config, "application/json") }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Fixes problem with saving switches in the frontend admin tool

```
Error
Error saving switches 'User: arn:aws:sts::**********:assumed-role/********** is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::**********/switches.properties" because public access control lists (ACLs) are blocked by the BlockPublicAcls block public access setting'
```

## What does this change?

Swaps `putPublic` for `putPrivate` since we shouldn't be setting ACLs on objects within the bucket since the bucket has the "block public ACLs" setting switched on
