### PR TITLE
Update the AMI for archive stack

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -87,3 +87,11 @@ deployments:
         AMISport:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD
+  update-ami-for-archive:
+    app: archive
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIArchive:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -17,6 +17,7 @@ templates:
     - update-ami-for-admin
     - update-ami-for-discussion
     - update-ami-for-sport
+    - update-ami-for-archive
 
 deployments:
   admin:


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR allows us to automatically update the AMI for the new archive stack.
## What does this change?
This allows `dotcom:frontend-all` deployments (including scheduled deployments) to automatically update the AMI
## Screenshots



 https://github.com/user-attachments/assets/25e1120c-6bb1-49c9-ad93-5890e29d49d0



## Checklist

- [x] Tested locally, and on CODE if necessary [Tested on code ](https://github.com/guardian/frontend/commit/e0c936494b1d91980d85615e02618c81300d58f2)
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
