### PR TITLE
Revert "Read `surveySponsorships` from S3 generated by step functions"

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -166,7 +166,7 @@ class DfpDataCacheJob(
   }
 
   private def writeSurveySponsorships(data: DfpDataExtractor): Unit = {
-    if (data.hasValidLineItems && LineItemJobs.isSwitchedOff) {
+    if (data.hasValidLineItems) {
       val now = printLondonTime(DateTime.now())
 
       val sponsorships = data.surveySponsorships

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -497,8 +497,7 @@ class GuardianConfiguration extends GuLogging {
     def dfpPageSkinnedAdUnitsKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/pageskins.json" else s"$dfpRoot/pageskinned-adunits-v9.json"
     lazy val dfpLiveBlogTopSponsorshipDataKey = s"$dfpRoot/liveblog-top-sponsorships-v3.json"
-    def dfpSurveySponsorshipDataKey =
-      if (LineItemJobs.isSwitchedOn) s"$gamRoot/survey-sponsorships.json" else s"$dfpRoot/survey-sponsorships.json"
+    lazy val dfpSurveySponsorshipDataKey = s"$dfpRoot/survey-sponsorships.json"
     def dfpNonRefreshableLineItemIdsKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/non-refreshable-line-items.json"
       else s"$dfpRoot/non-refreshable-lineitem-ids-v1.json"


### PR DESCRIPTION
Reverts guardian/frontend#27962 as we have some errors in the dfp api by the EOB so it's better to revert and check what's the cause of that the following day.