### PR TITLE
Add competition overview json route for DCAR

### DIFF
--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -53,6 +53,8 @@ class WallchartController(
             case JsonFormat if request.forceDCR =>
               val model = toJson(DotcomRenderingWallchartDataModel(page, competitionStages, competition))
               Future.successful(Cached(60) { RevalidatableResult.Ok(model) })
+            case JsonFormat =>
+              Future.successful(NotFound)
             case _ =>
               val nextMatch = WallchartController.nextMatch(competition.matches, ZonedDateTime.now())
               val futureAtom = if (competitionTag == "euro-2024") {

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -50,7 +50,7 @@ class WallchartController(
             .stagesFromCompetition(competition, KnockoutSpider.orderings)
 
           request.getRequestFormat match {
-            case JsonFormat =>
+            case JsonFormat if request.forceDCR =>
               val model = toJson(DotcomRenderingWallchartDataModel(page, competitionStages, competition))
               Future.successful(Cached(60) { RevalidatableResult.Ok(model) })
             case _ =>

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -5,14 +5,17 @@ import model.Cached.RevalidatableResult
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import common.{GuLogging, ImplicitControllerExecutionContext, JsonComponent}
 import model.{ApplicationContext, Cached}
-import football.model.{CompetitionStage, Groups, KnockoutSpider}
-import pa.{FootballMatch}
+import football.model.{CompetitionStage, DotcomRenderingWallchartDataModel, Groups, KnockoutSpider}
+import pa.FootballMatch
 
 import java.time.ZonedDateTime
 import scala.concurrent.Future
 import contentapi.ContentApiClient
 import conf.switches.Switches
 import common.Edition
+import football.model.DotcomRenderingWallchartDataModel.toJson
+import implicits.JsonFormat
+import model.Cors.RichRequestHeader
 import model.content.InteractiveAtom
 
 class WallchartController(
@@ -45,29 +48,35 @@ class WallchartController(
           )
           val competitionStages = new CompetitionStage(competitionsService.competitions)
             .stagesFromCompetition(competition, KnockoutSpider.orderings)
-          val nextMatch = WallchartController.nextMatch(competition.matches, ZonedDateTime.now())
-          val futureAtom = if (competitionTag == "euro-2024") {
-            val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
-            val edition = Edition(request)
-            contentApiClient
-              .getResponse(contentApiClient.item(id, edition))
-              .map(_.interactive.map(InteractiveAtom.make(_)))
-              .recover { case _ => None }
-          } else Future.successful(None)
 
-          futureAtom.map { maybeAtom =>
-            Cached(60) {
-              if (embed)
-                RevalidatableResult.Ok(
-                  football.views.html.wallchart.embed(page, competition, competitionStages, nextMatch),
-                )
-              else
-                RevalidatableResult.Ok(
-                  football.views.html.wallchart.page(page, competition, competitionStages, nextMatch, maybeAtom),
-                )
-            }
+          request.getRequestFormat match {
+            case JsonFormat =>
+              val model = toJson(DotcomRenderingWallchartDataModel(page, competitionStages, competition))
+              Future.successful(Cached(60) { RevalidatableResult.Ok(model) })
+            case _ =>
+              val nextMatch = WallchartController.nextMatch(competition.matches, ZonedDateTime.now())
+              val futureAtom = if (competitionTag == "euro-2024") {
+                val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
+                val edition = Edition(request)
+                contentApiClient
+                  .getResponse(contentApiClient.item(id, edition))
+                  .map(_.interactive.map(InteractiveAtom.make(_)))
+                  .recover { case _ => None }
+              } else Future.successful(None)
+
+              futureAtom.map { maybeAtom =>
+                Cached(60) {
+                  if (embed)
+                    RevalidatableResult.Ok(
+                      football.views.html.wallchart.embed(page, competition, competitionStages, nextMatch),
+                    )
+                  else
+                    RevalidatableResult.Ok(
+                      football.views.html.wallchart.page(page, competition, competitionStages, nextMatch, maybeAtom),
+                    )
+                }
+              }
           }
-
         }
         .getOrElse(Future.successful(NotFound))
     }

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -49,7 +49,7 @@ trait DotcomRenderingFootballDataModel {
   def pageId: String
 }
 
-private object DotcomRenderingFootballDataModel {
+object DotcomRenderingFootballDataModel {
   def getConfig(page: StandalonePage)(implicit
       request: RequestHeader,
       context: ApplicationContext,
@@ -95,6 +95,35 @@ private object DotcomRenderingFootballDataModelImplicits {
   implicit val leagueTeamWrites: Writes[LeagueTeam] = Json.writes[LeagueTeam]
   implicit val leagueTableEntryWrites: Writes[LeagueTableEntry] = Json.writes[LeagueTableEntry]
 
+  private implicit val matchDayTeamFormat: Writes[MatchDayTeam] = Json.writes[MatchDayTeam]
+
+  // Writes for Fixture with a type discriminator
+  private implicit val fixtureWrites: Writes[Fixture] = Writes { fixture =>
+    Json.writes[Fixture].writes(fixture).as[JsObject] + ("type" -> JsString("Fixture"))
+  }
+
+  // Writes for MatchDay with a type discriminator
+  private implicit val matchDayWrites: Writes[MatchDay] = Writes { matchDay =>
+    Json.writes[MatchDay].writes(matchDay).as[JsObject] + ("type" -> JsString("MatchDay"))
+  }
+
+  // Writes for Result with a type discriminator
+  private implicit val resultWrites: Writes[Result] = Writes { result =>
+    Json.writes[Result].writes(result).as[JsObject] + ("type" -> JsString("Result"))
+  }
+
+  // Writes for LiveMatch with a type discriminator
+  private implicit val liveMatchWrites: Writes[LiveMatch] = Writes { liveMatch =>
+    Json.writes[LiveMatch].writes(liveMatch).as[JsObject] + ("type" -> JsString("LiveMatch"))
+  }
+
+  implicit val footballMatchWrites: Writes[FootballMatch] = Writes {
+    case f: Fixture   => Json.toJson(f)(fixtureWrites)
+    case m: MatchDay  => Json.toJson(m)(matchDayWrites)
+    case r: Result    => Json.toJson(r)(resultWrites)
+    case l: LiveMatch => Json.toJson(l)(liveMatchWrites)
+  }
+
   implicit val competitionFormat: Writes[CompetitionSummary] = (competition: CompetitionSummary) =>
     Json.obj(
       "id" -> competition.id,
@@ -103,6 +132,10 @@ private object DotcomRenderingFootballDataModelImplicits {
       "nation" -> competition.nation,
       "tableDividers" -> competition.tableDividers,
     )
+
+  private implicit val competitionMatchesFormat: Writes[CompetitionMatches] = Json.writes[CompetitionMatches]
+  implicit val dateCompetitionMatchesFormat: Writes[MatchesByDateAndCompetition] =
+    Json.writes[MatchesByDateAndCompetition]
 
   implicit val competitionFilterFormat: Writes[CompetitionFilter] = Json.writes[CompetitionFilter]
 }
@@ -159,41 +192,6 @@ object DotcomRenderingFootballMatchListDataModel {
   }
 
   import football.model.DotcomRenderingFootballDataModelImplicits._
-
-  private implicit val matchDayTeamFormat: Writes[MatchDayTeam] = Json.writes[MatchDayTeam]
-
-  // Writes for Fixture with a type discriminator
-  private implicit val fixtureWrites: Writes[Fixture] = Writes { fixture =>
-    Json.writes[Fixture].writes(fixture).as[JsObject] + ("type" -> JsString("Fixture"))
-  }
-
-  // Writes for MatchDay with a type discriminator
-  private implicit val matchDayWrites: Writes[MatchDay] = Writes { matchDay =>
-    Json.writes[MatchDay].writes(matchDay).as[JsObject] + ("type" -> JsString("MatchDay"))
-  }
-
-  // Writes for Result with a type discriminator
-  private implicit val resultWrites: Writes[Result] = Writes { result =>
-    Json.writes[Result].writes(result).as[JsObject] + ("type" -> JsString("Result"))
-  }
-
-  // Writes for LiveMatch with a type discriminator
-  private implicit val liveMatchWrites: Writes[LiveMatch] = Writes { liveMatch =>
-    Json.writes[LiveMatch].writes(liveMatch).as[JsObject] + ("type" -> JsString("LiveMatch"))
-  }
-
-  private implicit val footballMatchWrites: Writes[FootballMatch] = Writes { matchInstance =>
-    matchInstance match {
-      case f: Fixture   => Json.toJson(f)(fixtureWrites)
-      case m: MatchDay  => Json.toJson(m)(matchDayWrites)
-      case r: Result    => Json.toJson(r)(resultWrites)
-      case l: LiveMatch => Json.toJson(l)(liveMatchWrites)
-    }
-  }
-
-  private implicit val competitionMatchesFormat: Writes[CompetitionMatches] = Json.writes[CompetitionMatches]
-  private implicit val dateCompetitionMatchesFormat: Writes[MatchesByDateAndCompetition] =
-    Json.writes[MatchesByDateAndCompetition]
 
   implicit def dotcomRenderingFootballMatchListDataModel: Writes[DotcomRenderingFootballMatchListDataModel] =
     Json.writes[DotcomRenderingFootballMatchListDataModel]

--- a/sport/app/football/model/DotcomRenderingWallchartDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingWallchartDataModel.scala
@@ -1,0 +1,154 @@
+package football.model
+
+import common.{CanonicalLink, Edition}
+import conf.Configuration
+import football.controllers.FootballPage
+import football.model.DotcomRenderingFootballDataModelImplicits._
+import model.{ApplicationContext, Competition, CompetitionSummary}
+import model.dotcomrendering.DotcomRenderingUtils.withoutNull
+import model.dotcomrendering.PageFooter
+import navigation.{FooterLinks, Nav}
+import pa.{FootballMatch, Round}
+import play.api.libs.json.{JsObject, JsString, JsValue, Json, Writes}
+import play.api.mvc.RequestHeader
+
+import java.time.LocalDate
+
+case class MatchesByDate(date: LocalDate, matches: List[FootballMatch])
+
+case class DotcomRenderingWallchartDataModel(
+    competitionStages: List[CompetitionStageLike],
+    competition: Competition,
+    nav: Nav,
+    editionId: String,
+    guardianBaseURL: String,
+    config: JsObject,
+    pageFooter: PageFooter,
+    isAdFreeUser: Boolean,
+    contributionsServiceUrl: String,
+    canonicalUrl: String,
+    pageId: String,
+) extends DotcomRenderingFootballDataModel
+
+object DotcomRenderingWallchartDataModel {
+  def apply(
+      page: FootballPage,
+      competitionStages: List[CompetitionStageLike],
+      competition: Competition,
+  )(implicit
+      request: RequestHeader,
+      context: ApplicationContext,
+  ): DotcomRenderingWallchartDataModel = {
+    val edition = Edition(request)
+    val nav = Nav(page, edition)
+    val combinedConfig: JsObject = DotcomRenderingFootballDataModel.getConfig(page)
+    DotcomRenderingWallchartDataModel(
+      competitionStages = competitionStages,
+      competition = competition,
+      nav = nav,
+      editionId = edition.id,
+      guardianBaseURL = Configuration.site.host,
+      config = combinedConfig,
+      pageFooter = PageFooter(FooterLinks.getFooterByEdition(edition)),
+      isAdFreeUser = views.support.Commercial.isAdFree(request),
+      contributionsServiceUrl = Configuration.contributionsService.url,
+      canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
+      pageId = page.metadata.id,
+    )
+  }
+
+  implicit val matchesByDateWrites: Writes[MatchesByDate] =
+    Json.writes[MatchesByDate]
+
+  def toJson(model: DotcomRenderingWallchartDataModel)(implicit
+      request: RequestHeader,
+  ): JsValue = {
+    val competitionStagesJson = model.competitionStages.map {
+      case spider: KnockoutSpider =>
+        getKnockoutSpider(spider, model.competition).+("type" -> JsString("knockoutSpider"))
+
+      case groups: Groups =>
+        getGroups(groups, model.competition).+("type" -> JsString("groups"))
+
+      case league: League =>
+        getLeague(league).+("type" -> JsString("League"))
+
+      case knockoutList: KnockoutList =>
+        getKnockoutList(knockoutList, model.competition).+("type" -> JsString("knockoutList"))
+
+    }
+
+    val json = Json.obj(
+      "competition" -> Json.toJson(model.competition: CompetitionSummary),
+      "competitionStages" -> competitionStagesJson,
+    )
+    withoutNull(json)
+  }
+
+  private def getKnockoutSpider(spider: KnockoutSpider, competition: Competition)(implicit
+      request: RequestHeader,
+  ) = {
+    Json.obj(
+      "rounds" -> spider.rounds.map(round => spiderRoundWithMatches(round, spider, competition)),
+    )
+  }
+
+  private def getGroups(groups: Groups, competition: Competition)(implicit
+      request: RequestHeader,
+  ) = {
+    val groupTables = groups.groupTables
+    Json.obj(
+      "groupTables" -> groupTables.map { table =>
+        Json.obj(
+          "round" -> table._1,
+          "entries" -> table._2,
+          "matches" -> getMatchesList(groups.matchesList(competition, table._1).matchesGroupedByDateAndCompetition),
+        )
+      },
+    )
+  }
+
+  private def getLeague(league: League) = {
+    Json.obj(
+      "leagueTable" -> league.leagueTable,
+    )
+  }
+
+  private def getKnockoutList(knockoutList: KnockoutList, competition: Competition)(implicit
+      request: RequestHeader,
+  ) = {
+    Json.obj(
+      "rounds" -> knockoutList.rounds.map(round =>
+        Json.obj(
+          "matchesByDate" -> getMatchesList(
+            knockoutList.matchesList(competition, round).matchesGroupedByDateAndCompetition,
+          ),
+        ),
+      ),
+    )
+  }
+
+  private def spiderRoundWithMatches(round: Round, spider: KnockoutSpider, competition: Competition)(implicit
+      request: RequestHeader,
+  ): JsObject = Json.obj(
+    "roundNumber" -> round.roundNumber,
+    "name" -> round.name,
+    "matches" -> spider.roundMatches(round),
+    "matchesByDate" ->
+      getMatchesList(spider.matchesList(competition, round).matchesGroupedByDateAndCompetition),
+    "isActiveRound" -> spider.isActiveRound(round),
+  )
+
+  private def getMatchesList(
+      matches: Seq[(LocalDate, List[(Competition, List[FootballMatch])])],
+  ): Seq[MatchesByDate] = {
+    matches.map { case (date, competitionMatches) =>
+      MatchesByDate(
+        date = date,
+        matches = competitionMatches.flatMap { case (_, matches) =>
+          matches
+        },
+      )
+    }
+  }
+}

--- a/sport/app/football/model/DotcomRenderingWallchartDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingWallchartDataModel.scala
@@ -71,7 +71,7 @@ object DotcomRenderingWallchartDataModel {
         getGroups(groups, model.competition).+("type" -> JsString("groups"))
 
       case league: League =>
-        getLeague(league).+("type" -> JsString("League"))
+        getLeague(league).+("type" -> JsString("league"))
 
       case knockoutList: KnockoutList =>
         getKnockoutList(knockoutList, model.competition).+("type" -> JsString("knockoutList"))
@@ -81,6 +81,15 @@ object DotcomRenderingWallchartDataModel {
     val json = Json.obj(
       "competition" -> Json.toJson(model.competition: CompetitionSummary),
       "competitionStages" -> competitionStagesJson,
+      "nav" -> Json.toJson(model.nav),
+      "editionId" -> model.editionId,
+      "guardianBaseURL" -> model.guardianBaseURL,
+      "config" -> model.config,
+      "pageFooter" -> Json.toJson(model.pageFooter),
+      "isAdFreeUser" -> model.isAdFreeUser,
+      "contributionsServiceUrl" -> model.contributionsServiceUrl,
+      "canonicalUrl" -> model.canonicalUrl,
+      "pageId" -> model.pageId,
     )
     withoutNull(json)
   }

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -65,6 +65,7 @@ GET        /football/:competitionTag/groups/individual/embed/:groupIds        fo
 GET        /football/:competitionTag/spider/embed                             football.controllers.WallchartController.renderSpiderEmbed(competitionTag)
 GET        /football/:competitionTag/spider/:roundId/embed                   football.controllers.WallchartController.renderSpiderEmbedForRound(competitionTag, roundId)
 GET        /football/:competitionTag/overview                                 football.controllers.WallchartController.renderWallchart(competitionTag)
+GET        /football/:competitionTag/overview.json                            football.controllers.WallchartController.renderWallchart(competitionTag)
 GET        /football/:competitionTag/wallchart.json                           football.controllers.WallchartController.renderWallchartJson(competitionTag)
 
 GET        /football/api/match-nav/:year/:month/:day/:home/:away.json         football.controllers.MoreOnMatchController.matchNavJson(year, month, day, home, away)


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR adds a json route for `/football/:competitionTag/overview`. This route will be used in DCR dev server to render the overview pages e.g. https://www.theguardian.com/football/euro-2024/overview

This PR fixes the issue [#13879](https://github.com/guardian/dotcom-rendering/issues/13879)