### PR TITLE
Add DfpAgentLifecycle back into facia app loader

### DIFF
--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -58,6 +58,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
     wire[CachedHealthCheckLifeCycle],
     wire[MostViewedLifecycle],
     wire[DeeplyReadLifecycle],
+    wire[DfpAgentLifecycle],
   )
 
   lazy val router: Router = wire[Routes]

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -3,6 +3,7 @@ import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
+import common.dfp.DfpAgentLifecycle
 import concurrent.BlockingOperations
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle


### PR DESCRIPTION
## What does this change?
Add DfpAgentLifecycle back into facia app loader

Removed in #27965, the lack of it is preventing fronts access `hasPageskin` breaking pageskins. 
