### PR TITLE
Update survey slots to require desktop breakpoint targeting

### DIFF
--- a/admin/app/views/commercial/surveySponsorships.scala.html
+++ b/admin/app/views/commercial/surveySponsorships.scala.html
@@ -22,7 +22,6 @@
 
     <p>Pages can show a survey slot if you set up a line item in GAM with the following parameters:</p>
     <ol>
-        <li>Is a Sponsorship</li>
         <li>Targets the <pre>survey</pre> slot</li>
         <li>Targets the <pre>desktop</pre> breakpoint</li>
     </ol>

--- a/admin/app/views/commercial/surveySponsorships.scala.html
+++ b/admin/app/views/commercial/surveySponsorships.scala.html
@@ -20,18 +20,22 @@
 
     <p>Last updated: @if(report.updatedTimeStamp) { @{report.updatedTimeStamp} } else { never }</p>
 
-    <p>Pages will show a survey slot if you set up a line item in GAM with the following parameters:</p>
+    <p>Pages can show a survey slot if you set up a line item in GAM with the following parameters:</p>
     <ol>
         <li>Is a Sponsorship</li>
         <li>Targets the <pre>survey</pre> slot</li>
-        <li>Targets the <pre>theguardian.com</pre> except <pre>front</pre> adUnit</li>
-        <li>Targets the <pre>theguardian.com</pre> except <pre>front</pre> content type</li>
         <li>Targets the <pre>desktop</pre> breakpoint</li>
-        <li>Targets the <pre>connected TV</pre> device category in GAM</li>
     </ol>
 
     <strong>ANY OTHER TARGETING WILL CAUSE THE SLOT TO APPEAR UNINTENTIONALLY</strong>
     <p>If you are unsure please contact the <a href="mailto:commercial.dev@@theguardian.com">commercial dev team</a> first.</p>
+
+    <h3>Limitations</h3>
+    <p>Regardless of the targeting applied to the line item, survey slots:</p>
+    <ul>
+        <li>Will not appear on front pages, tag pages or the all newsletters page</li>
+        <li>Will only appear on desktop breakpoints and above</li>
+    </ul>
 
     <h2>Sponsorships</h2>
     <p>Line items that match the above targeting:</p>

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -286,14 +286,18 @@ case class GuLineItem(
     val matchingSurveyTargeting = for {
       targetSet <- targeting.customTargetSets
       target <- targetSet.targets
-      if target.name == "slot" || target.values.contains("survey")
+      if target.name == "slot" || target.name == "bp"
     } yield target
 
-    val isSurveySlot = matchingSurveyTargeting.exists { target =>
+    val targetsSurveySlot = matchingSurveyTargeting.exists { target =>
       target.name == "slot" && target.values.contains("survey")
     }
 
-    isSurveySlot
+    val targetsDesktopBreakpoint = matchingSurveyTargeting.exists { target =>
+      target.name == "bp" && target.values.contains("desktop")
+    }
+
+    targetsSurveySlot && targetsDesktopBreakpoint
   }
 
   lazy val targetsNetworkOrSectionFrontDirectly: Boolean = {


### PR DESCRIPTION
## What does this change?

- Updates the survey sponsorship logic to include the requirement that breakpoint targeting must include desktop (line-item-jobs sister PR: https://github.com/guardian/line-item-jobs/pull/54)
- Updates the commercial admin page for survey sponsorships to make it clear what we expect from GAM targeting and what can/can't happen due to restraints in the rendering CODE

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/08141af7-1bda-4b3f-8bd8-5866a1a59440
[after]: https://github.com/user-attachments/assets/89427604-03d9-441e-a015-7d5c1977d603
