### PR TITLE
Enable React on the client for 10% of readers

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -52,5 +52,5 @@ object DCRJavascriptBundle
       description = "DCAR JS bundle experiment to test replacing Preact with React",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 6, 30),
-      participationGroup = Perc0E,
+      participationGroup = Perc10A,
     )


### PR DESCRIPTION
## What does this change?

Enable React on the client for 10% of readers. This will be disabled again after a couple of days, once we have enough data to analyse the impact on performance.