### PR TITLE
Automatically update AMI for GuCDK Applications stack

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -18,6 +18,7 @@ templates:
     - update-ami-for-discussion
     - update-ami-for-sport
     - update-ami-for-archive
+    - update-ami-for-applications
 
 deployments:
   admin:
@@ -92,6 +93,14 @@ deployments:
           AmigoStage: PROD
   update-ami-for-archive:
     app: archive
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIArchive:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-applications:
+    app: applications
     type: ami-cloudformation-parameter
     parameters:
       amiParametersToTags:


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows us to automatically update the AMI for the new GuCDK Applications stack

## What does this change?

This allows `dotcom:frontend-all` deployments (including scheduled deployments) to automatically update the AMI

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)
