### PR TITLE
Allow Riff-Raff to update both Applications ASGs during GuCDK migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -25,6 +25,8 @@ deployments:
     template: frontend
   applications:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   archive:
     template: frontend
   article:


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are [dual-stacking](https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md) Applications as we migrate it to GuCDK. This means all infrastructure components (load balancer, autoscaling group, instances etc.) are temporarily duplicated.

Riff-Raff normally expects to find exactly one matching autoscaling group for a set of tags. When deploying it will update the application code for that autoscaling group only. If Riff-Raff finds more than one autoscaling group with the same set of tags the deployment will fail.

This change adds the `asgMigrationInProgress` to allow Riff-Raff to update both Applications autoscaling groups when deploying.

This relies on https://github.com/guardian/platform/pull/1847 being applied first.

## Checklist

[Validated with Riff-Raff](https://riffraff.gutools.co.uk/configuration/validation)

<img width="1156" alt="Screenshot 2025-05-20 at 10 35 16" src="https://github.com/user-attachments/assets/632a0882-4751-4e4b-8c34-d8cedc404409" />
