### PR TITLE
Read liveBlogtopSponsorships from S3 generated by line-item-jobs lambdas

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -155,7 +155,7 @@ class DfpDataCacheJob(
   }
 
   private def writeLiveBlogTopSponsorships(data: DfpDataExtractor): Unit = {
-    if (data.hasValidLineItems) {
+    if (data.hasValidLineItems && LineItemJobs.isSwitchedOff) {
       val now = printLondonTime(DateTime.now())
 
       val sponsorships = data.liveBlogTopSponsorships

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -492,7 +492,9 @@ class GuardianConfiguration extends GuLogging {
     private lazy val gamRoot = s"$commercialRoot/gam"
     def dfpPageSkinnedAdUnitsKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/pageskins.json" else s"$dfpRoot/pageskinned-adunits-v9.json"
-    lazy val dfpLiveBlogTopSponsorshipDataKey = s"$dfpRoot/liveblog-top-sponsorships-v3.json"
+    lazy val dfpLiveBlogTopSponsorshipDataKey =
+      if (LineItemJobs.isSwitchedOn) s"$gamRoot/liveblog-top-sponsorships.json"
+      else s"$dfpRoot/liveblog-top-sponsorships-v3.json"
     def dfpSurveySponsorshipDataKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/survey-sponsorships.json" else s"$dfpRoot/survey-sponsorships.json"
     def dfpNonRefreshableLineItemIdsKey =


### PR DESCRIPTION
## What does this change?
This PR allows Frontend to read from the S3 for liveblog-top-sponsorships.json generated by the Step Functions from `line-item-jobs`  and stop writing it to the Frontend S3 prefix /dfp.
Set up for these processes here [PR](https://github.com/guardian/line-item-jobs/pull/48)

The conditional code relies on the LineItemJobs switch along with other commercial jobs e.g. line-items.json.
## Screenshots
| **Before**                | **After**                 |
|---------------------------|---------------------------|
 | No relevant Line item in GAM: no liveblog-top slot   | With adtest line item in CODE: with liveblog-top slot    |
| <img width="548" alt="Screenshot 2025-05-21 at 15 42 46" src="https://github.com/user-attachments/assets/76ff5038-cc90-4352-8598-4bbd854ed521" /> | <img width="592" alt="Screenshot 2025-05-21 at 15 41 55" src="https://github.com/user-attachments/assets/1c8dd09b-7c71-4cd5-ba5b-d4e96c5bd9d1" /> |


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary


#### To test that the frontend is now writing to `commercial/gam` S3 bucket:
- Deploy frontend to CODE
- Manually trigger the step functions execution
- Check that the liveblog-top-sponsorships.json in the commercial/gam S3 bucket has a new timestamp.
<img width="950" alt="Screenshot 2025-05-21 at 15 16 24" src="https://github.com/user-attachments/assets/1b215d9f-4c9b-4782-b30b-38bf4d227ae5" />
- Confirm that the commercial/dfp bucket still has the old timestamp for the same file
- .**note: that CODE requires manual triggering, unlike PROD.
 


#### Testing with a live adtest line item

1. **Use a current line-item**  
   Example: `liveblog-top-sponsorship-arsenal-takeover`
2. **Deploy the frontend to CODE**
3. **Manually execute the Lambda step functions**  
   This ensures the edited line item is picked up.
4. **Test with a specific article**  
   Visit:  
   `https://m.code.dev-theguardian.com/football/live/2025/may/21/tottenham-manchester-united-europa-league-final-bilbao-buildup-live?adtest=liveblog-top-test`  
   This applies the test line item to the article.
5. **Check the article’s JSON output**  
   - Confirm that the field `"hasLiveBlogTopAd": true` appears in the JSON.

**Tip:**  
To check the JSON, open the article in your browser with `.json` appended, or use browser dev tools to inspect the page config.  
Search for `"hasLiveBlogTopAd": true` in the JSON response.

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
