### PR TITLE
updates the admin description for liveblog top sponsorship

### DIFF
--- a/admin/app/views/commercial/liveBlogTopSponsorships.scala.html
+++ b/admin/app/views/commercial/liveBlogTopSponsorships.scala.html
@@ -24,11 +24,11 @@
     <ol>
         <li>Is a Sponsorship</li>
         <li>Targets the <pre>liveblog-top</pre> slot</li>
-        <li>Targets the <pre>culture</pre>, <pre>tv-and-radio</pre>, <pre>sport</pre> or <pre>football</pre> section</li>
+        <li>Targets the <pre>culture</pre>, <pre>sport</pre> or <pre>football</pre> section</li>
         <li>Targets the <pre>liveblog</pre> content type</li>
         <li>Targets the <pre>mobile</pre> breakpoint</li>
-        <li>[Optional] Targets an edition</li>
-        <li>[Optional] Targets a keyword</li>
+        <li>Targets an edition</li>
+        <li>Targets a keyword</li>
     </ol>
 
     <strong>ANY OTHER TARGETING WILL CAUSE THE SLOT TO APPEAR UNINTENTIONALLY</strong>


### PR DESCRIPTION
## What does this change?
A simple PR to amend the description for a `LiveBlog Top Sponsorships` article to determine whether to show a live blog top slot if you set up a line item in GAM with the following parameters.


## Screenshots
| Before      | After      |
|-------------|------------|
| <img width="700" alt="Screenshot 2025-05-21 at 15 51 03" src="https://github.com/user-attachments/assets/cd1ebc10-347c-4e37-8d04-3d916fdc7c06" /> | <img width="738" alt="Screenshot 2025-05-21 at 16 54 07" src="https://github.com/user-attachments/assets/62a8c0f1-a5b4-42a0-9dea-faccb08edc93" /> |

<!-- Please use the following table template to make image comparison easier to parse:


[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
