### PR TITLE
Fix liveblog top targeting

### DIFF
--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -76,9 +76,9 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
   def isPlatform(value: String): Boolean = isPositive("p") && values.contains(value)
   def isNotPlatform(value: String): Boolean = isNegative("p") && values.contains(value)
 
-  def matchesLiveBlogTopTargeting: Boolean = {
-    val liveBlogTopSectionTargets = List("culture", "football", "sport", "tv-and-radio")
-    values.intersect(liveBlogTopSectionTargets).nonEmpty
+  val allowedliveBlogTopSectionTargets = Seq("culture", "football", "sport", "tv-and-radio")
+  private def matchesLiveBlogTopTargeting: Boolean = {
+    values.intersect(allowedliveBlogTopSectionTargets).nonEmpty
   }
 
   val isLiveblogTopSlot = isSlot("liveblog-top")
@@ -265,10 +265,8 @@ case class GuLineItem(
       target.name == "ct" && target.values.contains("liveblog")
     }
 
-    val allowedSections = Set("culture", "sport", "football")
-
     val targetsOnlyAllowedSections = matchingLiveblogTargeting.exists { target =>
-      target.name == "s" && target.values.forall(allowedSections.contains)
+      target.name == "s" && target.values.forall(target.allowedliveBlogTopSectionTargets.contains(_))
     }
 
     val isMobileBreakpoint = matchingLiveblogTargeting.exists { target =>

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -266,7 +266,7 @@ case class GuLineItem(
     }
 
     val targetsOnlyAllowedSections = matchingLiveblogTargeting.exists { target =>
-      target.name == "s" && target.values.forall(target.allowedliveBlogTopSectionTargets.contains(_))
+      target.name == "s" && target.values.forall(target.allowedliveBlogTopSectionTargets.contains)
     }
 
     val isMobileBreakpoint = matchingLiveblogTargeting.exists { target =>
@@ -274,10 +274,8 @@ case class GuLineItem(
     }
 
     val isSponsorship = lineItemType == Sponsorship
-
-    val hasEditionTargeting = targeting.editions.nonEmpty
-
-    isLiveblogTopSlot && isLiveblogContentType && targetsOnlyAllowedSections && isMobileBreakpoint && isSponsorship && hasEditionTargeting
+    
+    isLiveblogTopSlot && isLiveblogContentType && targetsOnlyAllowedSections && isMobileBreakpoint && isSponsorship
   }
 
   val targetsSurvey: Boolean = {

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -274,7 +274,7 @@ case class GuLineItem(
     }
 
     val isSponsorship = lineItemType == Sponsorship
-    
+
     isLiveblogTopSlot && isLiveblogContentType && targetsOnlyAllowedSections && isMobileBreakpoint && isSponsorship
   }
 

--- a/common/app/common/dfp/LiveBlogTopSponsorshipAgent.scala
+++ b/common/app/common/dfp/LiveBlogTopSponsorshipAgent.scala
@@ -25,8 +25,8 @@ trait LiveBlogTopSponsorshipAgent {
       // Edition, keywords & adtest are optional matches
       // If specified on the line item, they must match
       sponsorship.matchesEditionTargeting(edition) &&
-        sponsorship.matchesKeywordTargeting(keywords) &&
-         sponsorship.matchesTargetedAdTest(adTest)
+      sponsorship.matchesKeywordTargeting(keywords) &&
+      sponsorship.matchesTargetedAdTest(adTest)
     }
   }
 

--- a/common/app/common/dfp/LiveBlogTopSponsorshipAgent.scala
+++ b/common/app/common/dfp/LiveBlogTopSponsorshipAgent.scala
@@ -20,10 +20,13 @@ trait LiveBlogTopSponsorshipAgent {
       adTest: Option[String],
   ): Seq[LiveBlogTopSponsorship] = {
     liveBlogTopSponsorships.filter { sponsorship =>
-      sponsorship.editions.contains(edition) && sponsorship.sections.contains(
-        sectionId,
-      ) && (keywords exists sponsorship.hasTag) && sponsorship
-        .matchesTargetedAdTest(adTest)
+      // Section must match
+      sponsorship.sections.contains(sectionId) &&
+      // Edition, keywords & adtest are optional matches
+      // If specified on the line item, they must match
+      sponsorship.matchesEditionTargeting(edition) &&
+        sponsorship.matchesKeywordTargeting(keywords) &&
+         sponsorship.matchesTargetedAdTest(adTest)
     }
   }
 
@@ -32,7 +35,7 @@ trait LiveBlogTopSponsorshipAgent {
       val adTest = request.getQueryString("adtest")
       val edition = Edition(request)
 
-      findSponsorships(edition, metadata.sectionId, tags, adTest).nonEmpty
+      findSponsorships(edition, metadata.sectionId, tags.filter(_.isKeyword), adTest).nonEmpty
     } else {
       false
     }

--- a/common/app/common/dfp/LiveblogTopSponsorship.scala
+++ b/common/app/common/dfp/LiveblogTopSponsorship.scala
@@ -13,19 +13,41 @@ case class LiveBlogTopSponsorship(
     adTest: Option[String],
     targetsAdTest: Boolean,
 ) {
-  def matchesTargetedAdTest(adTest: Option[String]): Boolean =
-    if (this.targetsAdTest) { adTest == this.adTest }
-    else { true }
+  def matchesTargetedAdTest(adTest: Option[String]): Boolean = {
+    if (this.targetsAdTest) {
+      // If the sponsorship targets an adtest, check if it matches
+      adTest == this.adTest
+    } else {
+      // If no adtest targeting, return true
+      true
+    }
+  }
 
-  private def hasTagId(tags: Seq[String], tagId: String): Boolean =
+  def matchesEditionTargeting(edition: Edition) = {
+    if (this.editions.nonEmpty) {
+      // If the sponsorship targets an edition, check if it matches
+      this.editions.contains(edition)
+    } else {
+      // If no edition targeting, return true
+      true
+    }
+  }
+
+  def matchesKeywordTargeting(keywordTags: Seq[Tag]) = {
+    if (this.keywords.nonEmpty) {
+      // If the sponsorship targets a keyword, check if it matches
+      keywordTags contains { tag =>
+        matchesTag(this.keywords, tag)
+      }
+    } else {
+      // If no keyword targeting, return true
+      true
+    }
+  }
+
+  private def matchesTag(tags: Seq[String], tagId: String): Boolean =
     tagId.split('/').lastOption exists { endPart =>
       tags contains endPart
-    }
-
-  def hasTag(tag: Tag): Boolean =
-    tag.properties.tagType match {
-      case "Keyword" => hasTagId(keywords, tag.id)
-      case _         => false
     }
 }
 

--- a/common/app/common/dfp/LiveblogTopSponsorship.scala
+++ b/common/app/common/dfp/LiveblogTopSponsorship.scala
@@ -37,7 +37,7 @@ case class LiveBlogTopSponsorship(
     if (this.keywords.nonEmpty) {
       // If the sponsorship targets a keyword, check if it matches
       keywordTags exists { tag: Tag =>
-        matchesTag(this.keywords, tag.id)
+        tag.isKeyword && matchesTag(this.keywords, tag.id)
       }
     } else {
       // If no keyword targeting, return true

--- a/common/app/common/dfp/LiveblogTopSponsorship.scala
+++ b/common/app/common/dfp/LiveblogTopSponsorship.scala
@@ -36,8 +36,8 @@ case class LiveBlogTopSponsorship(
   def matchesKeywordTargeting(keywordTags: Seq[Tag]) = {
     if (this.keywords.nonEmpty) {
       // If the sponsorship targets a keyword, check if it matches
-      keywordTags contains { tag =>
-        matchesTag(this.keywords, tag)
+      keywordTags exists { tag: Tag =>
+        matchesTag(this.keywords, tag.id)
       }
     } else {
       // If no keyword targeting, return true
@@ -46,7 +46,7 @@ case class LiveBlogTopSponsorship(
   }
 
   private def matchesTag(tags: Seq[String], tagId: String): Boolean =
-    tagId.split('/').lastOption exists { endPart =>
+    tagId.split("/").lastOption exists { endPart =>
       tags contains endPart
     }
 }

--- a/common/app/common/dfp/LiveblogTopSponsorship.scala
+++ b/common/app/common/dfp/LiveblogTopSponsorship.scala
@@ -26,7 +26,7 @@ case class LiveBlogTopSponsorship(
   def matchesEditionTargeting(edition: Edition) = {
     if (this.editions.nonEmpty) {
       // If the sponsorship targets an edition, check if it matches
-      this.editions.contains(edition)
+      this.editions.exists(_.id == edition.id)
     } else {
       // If no edition targeting, return true
       true

--- a/common/test/common/dfp/LiveBlogTopSponsorshipTest.scala
+++ b/common/test/common/dfp/LiveBlogTopSponsorshipTest.scala
@@ -49,15 +49,19 @@ class LiveBlogTopSponsorshipTest extends AnyFlatSpec with Matchers {
     )
   }
 
-  "matchesKeywordTargeting" should "be false if there is no keyword targeting on the sponsorship" in {
+  "matchesKeywordTargeting" should "be true if there is no keyword targeting on the sponsorship" in {
     val cricketKeywordTag = mkTag()
     val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(keywords = Seq.empty)
-    liveBlogTopSponsorship.matchesKeywordTargeting(Seq(cricketKeywordTag)) shouldBe false
+    liveBlogTopSponsorship.matchesKeywordTargeting(Seq(cricketKeywordTag)) shouldBe true
   }
 
   it should "be true if sponsorship keyword targeting matches article keyword tags" in {
     val cricketKeywordTag = mkTag()
     val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(keywords = Seq("cricket"))
+
+    println(cricketKeywordTag.id)
+    println(liveBlogTopSponsorship.keywords)
+
     liveBlogTopSponsorship.matchesKeywordTargeting(Seq(cricketKeywordTag)) shouldBe true
   }
 

--- a/common/test/common/dfp/LiveBlogTopSponsorshipTest.scala
+++ b/common/test/common/dfp/LiveBlogTopSponsorshipTest.scala
@@ -1,0 +1,84 @@
+package common.dfp
+
+import common.Edition
+import common.editions.{Uk, Us}
+import model.{Tag, TagProperties}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LiveBlogTopSponsorshipTest extends AnyFlatSpec with Matchers {
+  def mkLiveBlogTopSponsorship(
+      lineItemName: String = "test-sponsorship",
+      lineItemId: Long = 7000726282L,
+      sections: Seq[String] = Seq.empty,
+      editions: Seq[Edition] = Seq.empty,
+      keywords: Seq[String] = Seq.empty,
+      adTest: Option[String] = Some("ad-test-param"),
+      targetsAdTest: Boolean = true,
+  ): LiveBlogTopSponsorship = {
+    LiveBlogTopSponsorship(lineItemName, lineItemId, sections, editions, keywords, adTest, targetsAdTest)
+  }
+
+  def mkTag(
+      tagId: String = "sport/cricket",
+      tagSection: String = "sport",
+      tagType: String = "keyword",
+  ): Tag = {
+    Tag(
+      properties = TagProperties(
+        id = tagId,
+        url = s"https://content.guardianapis.com/$tagId",
+        tagType = tagType,
+        sectionId = tagSection,
+        sectionName = tagSection,
+        webTitle = tagId.split("/").last,
+        webUrl = s"https://www.theguardian.com/$tagId",
+        twitterHandle = None,
+        bio = None,
+        description = None,
+        emailAddress = None,
+        contributorLargeImagePath = None,
+        bylineImageUrl = None,
+        podcast = None,
+        references = Seq.empty,
+        paidContentType = None,
+        commercial = None,
+      ),
+      pagination = None,
+      richLinkId = None,
+    )
+  }
+
+  "matchesKeywordTargeting" should "be false if there is no keyword targeting on the sponsorship" in {
+    val cricketKeywordTag = mkTag()
+    val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(keywords = Seq.empty)
+    liveBlogTopSponsorship.matchesKeywordTargeting(Seq(cricketKeywordTag)) shouldBe false
+  }
+
+  it should "be true if sponsorship keyword targeting matches article keyword tags" in {
+    val cricketKeywordTag = mkTag()
+    val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(keywords = Seq("cricket"))
+    liveBlogTopSponsorship.matchesKeywordTargeting(Seq(cricketKeywordTag)) shouldBe true
+  }
+
+  it should "be false if sponsorship keyword targeting does not match article keyword tags" in {
+    val cricketKeywordTag = mkTag()
+    val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(keywords = Seq("football"))
+    liveBlogTopSponsorship.matchesKeywordTargeting(Seq(cricketKeywordTag)) shouldBe false
+  }
+
+  "matchesEditionTargeting" should "be true if no editions in sponsorship" in {
+    val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(editions = Seq.empty)
+    liveBlogTopSponsorship.matchesEditionTargeting(Uk) shouldBe true
+  }
+
+  it should "be true if edition matches sponsorship" in {
+    val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(editions = Seq(Uk))
+    liveBlogTopSponsorship.matchesEditionTargeting(Uk) shouldBe true
+  }
+
+  it should "be false if edition does not match sponsorship targeted editions" in {
+    val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(editions = Seq(Uk))
+    liveBlogTopSponsorship.matchesEditionTargeting(Us) shouldBe false
+  }
+}

--- a/common/test/common/dfp/LiveBlogTopSponsorshipTest.scala
+++ b/common/test/common/dfp/LiveBlogTopSponsorshipTest.scala
@@ -1,5 +1,6 @@
 package common.dfp
 
+import com.gu.contentapi.client.model.v1.TagType
 import common.Edition
 import common.editions.{Uk, Us}
 import model.{Tag, TagProperties}
@@ -22,7 +23,7 @@ class LiveBlogTopSponsorshipTest extends AnyFlatSpec with Matchers {
   def mkTag(
       tagId: String = "sport/cricket",
       tagSection: String = "sport",
-      tagType: String = "keyword",
+      tagType: String = "Keyword",
   ): Tag = {
     Tag(
       properties = TagProperties(
@@ -58,10 +59,6 @@ class LiveBlogTopSponsorshipTest extends AnyFlatSpec with Matchers {
   it should "be true if sponsorship keyword targeting matches article keyword tags" in {
     val cricketKeywordTag = mkTag()
     val liveBlogTopSponsorship = mkLiveBlogTopSponsorship(keywords = Seq("cricket"))
-
-    println(cricketKeywordTag.id)
-    println(liveBlogTopSponsorship.keywords)
-
     liveBlogTopSponsorship.matchesKeywordTargeting(Seq(cricketKeywordTag)) shouldBe true
   }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Fixes issues in the live blog top slot targeting:

#### DFP scheduled line item fetching process
- When `tv-and-radio` was added to the live blog top targeting (352e9a7d9686e4a25f345c594fb35674afc9d6c1), it was only applied to the _read_ and not the _write_ part of the process

#### Checking incoming requests from the `article` app
- When edition targeting and keyword targeting were included as optional (a802e68df2edf8238e6f11c921560e0d051d03b2), these were actually both still non-optional, causing the ad slot to not appear without this targeting applied

## What does this change?

#### DFP scheduled line item fetching process
- Defines the allowed sections for live blog top targeting in one place and uses this in the two places it is referenced to avoid this error returning

#### Checking incoming requests from the `article` app
- Adds additional methods to `LiveBlogTopSponsorship` to safely check for matching edition or keyword targeting, in a similar way as we do for `adtest` where we only return false if it exists and does not match. If no targeting is applied to the line item, and no ad test parameter is in the request we return true
- Include tests for new `LiveBlogTopSponsorship` methods to verify expected behaviour

## Testing

Tested in CODE by:
- Deploying branch to CODE
- Creating a test line item in GAM with adtest value `charlotte-ad-test`
- Executed `line-item-jobs` state machine in CODE
- Checked sponsorship appeared in CODE admin (admin app path `/commercial/liveblog-top`)
- Opened current live blog in CODE environment which matches targeting
- Checked JSON response for `.config.hasLiveBlogTopAd`

<details>
<summary>Shell snippet to help with testing</summary>

```bash
ARTICLE_PATH="sport/live/2025/may/23/england-v-zimbabwe-mens-cricket-test-day-two-live"
ADTEST="adtest=charlotte-ad-test"
PROD_URL="https://www.theguardian.com/$ARTICLE_PATH.json?dcr=true&$ADTEST"
CODE_URL="https://m.code.dev-theguardian.com/$ARTICLE_PATH.json?dcr=true&$ADTEST"

PROD_RESP=$(curl -s $PROD_URL | jq '.config.hasLiveBlogTopAd')
CODE_RESP=$(curl -s $CODE_URL | jq '.config.hasLiveBlogTopAd')

RESULT="{ "hasLiveBlogTopAd": { "PROD": $PROD_RESP, "CODE": $CODE_RESP } }" 
echo $RESULT
```
</details>