### PR TITLE
Remove Europe Beta 2 test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,7 +12,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       EuropeBetaFront,
-      EuropeBetaFrontTest2,
       DarkModeWeb,
       DCRJavascriptBundle,
     )
@@ -26,15 +25,6 @@ object EuropeBetaFront
       owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
       sellByDate = LocalDate.of(2025, 5, 28),
       participationGroup = Perc0A,
-    )
-
-object EuropeBetaFrontTest2
-    extends Experiment(
-      name = "europe-beta-front-test-2",
-      description = "Allows viewing the beta version of the Europe network front",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 5, 28),
-      participationGroup = Perc0B,
     )
 
 object DarkModeWeb

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -6,7 +6,7 @@ import common._
 import conf.Configuration
 import conf.switches.Switches.InlineEmailStyles
 import controllers.front._
-import experiments.{ActiveExperiments, EuropeBetaFront, EuropeBetaFrontTest2}
+import experiments.{ActiveExperiments, EuropeBetaFront}
 import http.HttpPreconnections
 import implicits.GUHeaders
 import layout.slices._
@@ -228,8 +228,8 @@ trait FaciaController
       */
     val futureFaciaPageWithEuropeBetaTest: Future[Option[(PressedPage, Boolean)]] = {
       if (
-        path == "europe" && (ActiveExperiments
-          .isParticipating(EuropeBetaFront) || ActiveExperiments.isParticipating(EuropeBetaFrontTest2))
+        path == "europe" && ActiveExperiments
+          .isParticipating(EuropeBetaFront)
       ) {
         val futureEuropeBetaPage = getFaciaPage("europe-beta")
         for {

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -6,7 +6,7 @@ import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import common.editions.{Uk, Us}
 import common.facia.FixtureBuilder
 import controllers.{Assets, FaciaControllerImpl}
-import experiments.{ActiveExperiments, EuropeBetaFront, EuropeBetaFrontTest2, ParticipationGroups}
+import experiments.{ActiveExperiments, EuropeBetaFront, ParticipationGroups}
 import helpers.FaciaTestData
 import implicits.FakeRequests
 import model.{FrontProperties, PressedPage, SeoData}


### PR DESCRIPTION
## What is the value of this and can you measure success?
Europe beta 2 test was added in https://github.com/guardian/frontend/pull/27920 with the following goals

- more easily distinguish between this test and the prior test
- have an immediate switch to 50% rather than a pr rollout

The test is now complete and we no longer require this test set up.

## What does this change?
Removes the Europe beta 2 test from the list of experiments.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
