### PR TITLE
Set React on client test back to 0%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -52,5 +52,5 @@ object DCRJavascriptBundle
       description = "DCAR JS bundle experiment to test replacing Preact with React",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 6, 30),
-      participationGroup = Perc10A,
+      participationGroup = Perc0E,
     )


### PR DESCRIPTION
## What does this change?

Reverts React test back to 0% as we're not planning to enable again just yet and do not want to prevent other teams from running a 10% test. Leaving it at 0% allows us to manually opt in for testing purposes.

We briefly enabled the test for 10% of the audience, but this highlighted a number of hydration errors and warnings from React that we need to investigate and resolve before running the test again. (See https://github.com/guardian/dotcom-rendering/issues/13736)