### PR TITLE
Add trail picture to dcar model for gallery article

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -23,6 +23,7 @@ import model.{
   GUDateTimeFormatNew,
   GalleryPage,
   ImageContentPage,
+  ImageMedia,
   InteractivePage,
   LiveBlogPage,
   MediaPage,
@@ -90,6 +91,7 @@ case class DotcomRenderingDataModel(
     pageType: PageType,
     starRating: Option[Int],
     audioArticleImage: Option[PageElement],
+    trailPicture: Option[ImageMedia],
     trailText: String,
     nav: Nav,
     showBottomSocialButtons: Boolean,
@@ -168,6 +170,7 @@ object DotcomRenderingDataModel {
         "pageType" -> model.pageType,
         "starRating" -> model.starRating,
         "audioArticleImage" -> model.audioArticleImage,
+        "trailPicture" -> model.trailPicture,
         "trailText" -> model.trailText,
         "nav" -> model.nav,
         "showBottomSocialButtons" -> model.showBottomSocialButtons,
@@ -531,6 +534,13 @@ object DotcomRenderingDataModel {
         None
       }
 
+    val trailPicture: Option[ImageMedia] =
+      if (page.metadata.contentType.contains(DotcomContentType.Gallery)) {
+        page.item.trail.trailPicture
+      } else {
+        None
+      }
+
     def toDCRBlock(isMainBlock: Boolean = false) = { block: APIBlock =>
       Block(
         block = block,
@@ -609,6 +619,7 @@ object DotcomRenderingDataModel {
     DotcomRenderingDataModel(
       affiliateLinksDisclaimer = addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks, shouldAddDisclaimer),
       audioArticleImage = audioImageBlock,
+      trailPicture = trailPicture,
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
       beaconURL = Configuration.debug.beaconUrl,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -543,7 +543,7 @@ object DotcomRenderingDataModel {
         for {
           imageMedia <- page.item.trail.trailPicture
         } yield {
-          getImageBlockElement(imageMedia, Role(Some("immersive")))
+          getImageBlockElement(imageMedia, Role(Some("inline")))
         }
       } else {
         None

--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -75,6 +75,7 @@ object ElementsEnhancer {
       Json.obj("keyEvents" -> enhanceObjectsWithElements(obj.value("keyEvents"))) ++
       Json.obj("pinnedPost" -> enhanceObjectWithElements(obj.value("pinnedPost"))) ++
       Json.obj("promotedNewsletter" -> obj.value("promotedNewsletter")) ++
-      Json.obj("audioArticleImage" -> enhanceElement(obj.value("audioArticleImage")))
+      Json.obj("audioArticleImage" -> enhanceElement(obj.value("audioArticleImage"))) ++
+      Json.obj("trailPicture" -> enhanceElement(obj.value("trailPicture")))
   }
 }


### PR DESCRIPTION
## What does this change?
This PR, adds `trailPicture` to the `DotcomRenderingDataModel`. The field is Optional, therefore it is populated only for the `Gallery` articles. 

The type `ImageBlockElement` to be consistent with `audioArticleImage` field. Using ImageBlockElement also makes it easier in DCAR. 

The DCAR PR that is dependant on this change: https://github.com/guardian/dotcom-rendering/pull/14005