### PR TITLE
Remove expired tests: server-tracking and europe-beta

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,22 +11,12 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      EuropeBetaFront,
       ServerTracking,
       DarkModeWeb,
       DCRJavascriptBundle,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
-
-object EuropeBetaFront
-    extends Experiment(
-      name = "europe-beta-front",
-      description = "Allows viewing the beta version of the Europe network front",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 5, 28),
-      participationGroup = Perc0A,
-    )
 
 object DarkModeWeb
     extends Experiment(
@@ -42,7 +32,7 @@ object ServerTracking
       name = "server-tracking",
       description = "Test server test tracking",
       owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 5, 28),
+      sellByDate = LocalDate.of(2025, 5, 30),
       participationGroup = Perc1A,
     )
 

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -6,7 +6,7 @@ import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import common.editions.{Uk, Us}
 import common.facia.FixtureBuilder
 import controllers.{Assets, FaciaControllerImpl}
-import experiments.{ActiveExperiments, EuropeBetaFront, ParticipationGroups}
+import experiments.{ActiveExperiments, ParticipationGroups}
 import helpers.FaciaTestData
 import implicits.FakeRequests
 import model.{FrontProperties, PressedPage, SeoData}


### PR DESCRIPTION
## What is the value of this and can you measure success?
Removes expired europe-beta tests and relevant code as this experiment is no longer required. 

Also extends server-tracking which is still required.
