### PR TITLE
Remove asgMigrationInProgress paramater for archive

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,8 +26,6 @@ deployments:
     template: frontend
   archive:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   article:
     template: frontend
   commercial:


### PR DESCRIPTION
## What is the value of this and can you measure success?
When https://github.com/guardian/platform/pull/1848 is merged we will need to merge this immediately after in order to not break deployments.

Part of https://github.com/guardian/platform/issues/1824
