### PR TITLE
Update incorrect AMI name for Applications

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -104,6 +104,6 @@ deployments:
     type: ami-cloudformation-parameter
     parameters:
       amiParametersToTags:
-        AMIArchive:
+        AMIApplications:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?

Update AMI name for Applications to use correct name in Riff-Raff config