### PR TITLE
Add AB test switch for multibid commercial test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -60,4 +60,14 @@ trait ABTestSwitches {
     highImpact = false,
   )
 
+  Switch(
+    ABTests,
+    "ab-prebid-multibid",
+    "Test re-enabling the multibid feature in Prebid.js",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 6, 17)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Adding an AB test switch to control whether the `multibid` config in Prebid runs or not

We're running this as a 0% test initially and then increasing it once we are more confident

Previous PRs:
- https://github.com/guardian/frontend/pull/27930
- https://github.com/guardian/frontend/pull/27956