### PR TITLE
Add ALB support to archive app's 'Ops metrics' functionality

### DIFF
--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -44,7 +44,12 @@ object LoadBalancer extends GuLogging {
     ),
     LoadBalancer("frontend-PROD-commercial-ELB", "Commercial", "frontend-commercial"),
     LoadBalancer("frontend-PROD-onward-ELB", "Onward", "frontend-onward"),
-    LoadBalancer("frontend-PROD-archive-ELB", "Archive", "frontend-archive"),
+    LoadBalancer(
+      "app/fronte-LoadB-wSjta29AZxoG/32048dda4b467613",
+      "Archive",
+      "frontend-archive",
+      targetGroup = Some("targetgroup/fronte-Targe-CVM11DC1XUEX/5980205ce24de6bf"),
+    ),
     LoadBalancer("frontend-PROD-rss-ELB", "Rss", "frontend-rss"),
   )
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
See [this for context which adds the functionality for discussion](https://github.com/guardian/frontend/pull/27865)
