### PR TITLE
Make sure internal redirects for content redirect to the correct URL

### DIFF
--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -77,16 +77,18 @@ object InternalRedirect extends implicits.Requests with GuLogging {
       .orElse(response.tag.map(t => internalRedirect("facia", t.id)))
       .orElse(response.section.map(s => internalRedirect("facia", s.id)))
 
+  private def pathFromWebUrl(webUrl: String): String =
+    webUrl.replaceFirst("^https?://www.theguardian.com/", "")
+
   def contentTypes(response: ItemResponse)(implicit request: RequestHeader): Option[Result] = {
     response.content.map {
-      case a if a.isArticle || a.isLiveBlog => internalRedirect("type/article", a.id)
-      case v if v.isVideo                   => internalRedirect("applications", v.id)
-      case g if g.isGallery                 => internalRedirect("applications", g.id)
-      case a if a.isAudio                   => internalRedirect("applications", a.id)
+      case a if a.isArticle || a.isLiveBlog =>
+        internalRedirect("type/article", pathFromWebUrl(a.webUrl))
+      case a if a.isVideo || a.isGallery || a.isAudio =>
+        internalRedirect("applications", pathFromWebUrl(a.webUrl))
       case unsupportedContent =>
         logInfoWithRequestId(s"unsupported content: ${unsupportedContent.id}")
         NotFound
-
     }
   }
 

--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -1,8 +1,9 @@
 package common
 
-import com.gu.contentapi.client.model.v1.{Section => ApiSection, ItemResponse}
+import com.gu.contentapi.client.model.v1
+import com.gu.contentapi.client.model.v1.{ItemResponse, Section => ApiSection}
 import contentapi.Paths
-import play.api.mvc.{Result, RequestHeader, Results}
+import play.api.mvc.{RequestHeader, Result, Results}
 import model._
 import implicits.ItemResponses
 import java.net.URI
@@ -57,6 +58,7 @@ private object ItemOrRedirect extends ItemResponses with GuLogging {
   private def paramString(r: RequestHeader) = if (r.rawQueryString.isEmpty) "" else s"?${r.rawQueryString}"
 
   private def canonicalPath(response: ItemResponse) = response.webUrl.map(new URI(_)).map(_.getPath)
+  def canonicalPath(content: v1.Content): String = new URI(content.webUrl).getPath
 
   private def pathWithoutEdition(section: ApiSection) =
     section.editions
@@ -77,15 +79,12 @@ object InternalRedirect extends implicits.Requests with GuLogging {
       .orElse(response.tag.map(t => internalRedirect("facia", t.id)))
       .orElse(response.section.map(s => internalRedirect("facia", s.id)))
 
-  private def pathFromWebUrl(webUrl: String): String =
-    webUrl.replaceFirst("^https?://www.(?:code.dev-)?theguardian.com/", "")
-
   def contentTypes(response: ItemResponse)(implicit request: RequestHeader): Option[Result] = {
     response.content.map {
       case a if a.isArticle || a.isLiveBlog =>
-        internalRedirect("type/article", pathFromWebUrl(a.webUrl))
+        internalRedirect("type/article", ItemOrRedirect.canonicalPath(a))
       case a if a.isVideo || a.isGallery || a.isAudio =>
-        internalRedirect("applications", pathFromWebUrl(a.webUrl))
+        internalRedirect("applications", ItemOrRedirect.canonicalPath(a))
       case unsupportedContent =>
         logInfoWithRequestId(s"unsupported content: ${unsupportedContent.id}")
         NotFound
@@ -98,10 +97,12 @@ object InternalRedirect extends implicits.Requests with GuLogging {
   def internalRedirect(base: String, id: String, queryString: Option[String])(implicit
       request: RequestHeader,
   ): Result = {
+    // remove any leading `/` from the ID before using in the redirect
+    val path = id.stripPrefix("/")
     val qs: String = queryString.getOrElse("")
     request.path match {
-      case ShortUrl(_) => Found(s"/$id$qs")
-      case _           => Ok.withHeaders("X-Accel-Redirect" -> s"/$base/$id$qs")
+      case ShortUrl(_) => Found(s"/$path$qs")
+      case _           => Ok.withHeaders("X-Accel-Redirect" -> s"/$base/$path$qs")
     }
   }
 

--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -78,7 +78,7 @@ object InternalRedirect extends implicits.Requests with GuLogging {
       .orElse(response.section.map(s => internalRedirect("facia", s.id)))
 
   private def pathFromWebUrl(webUrl: String): String =
-    webUrl.replaceFirst("^https?://www.theguardian.com/", "")
+    webUrl.replaceFirst("^https?://www.(?:code.dev-)?theguardian.com/", "")
 
   def contentTypes(response: ItemResponse)(implicit request: RequestHeader): Option[Result] = {
     response.content.map {

--- a/common/test/common/ModelOrResultTest.scala
+++ b/common/test/common/ModelOrResultTest.scala
@@ -28,8 +28,8 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
     sectionName = None,
     webPublicationDate = Some(offsetDate.toCapiDateTime),
     webTitle = "the title",
-    webUrl = "http://www.guardian.co.uk/canonical",
-    apiUrl = "http://foo.bar",
+    webUrl = "https://www.theguardian.com/the/id",
+    apiUrl = "https://foo.bar",
     elements = None,
   )
 
@@ -46,6 +46,7 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
   val audioTag = articleTag.copy(id = "type/audio")
 
   val testArticle = testContent.copy(tags = List(articleTag))
+  val testEvolvedArticle = testArticle.copy(webUrl = "https://www.theguardian.com/the-new-url")
   val testGallery = testContent.copy(tags = List(galleryTag))
   val testVideo = testContent.copy(tags = List(videoTag))
   val testAudio = testContent.copy(tags = List(audioTag))
@@ -100,6 +101,18 @@ class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecution
 
     status(notFound) should be(200)
     headers(notFound).apply("X-Accel-Redirect") should be("/type/article/the/id")
+  }
+
+  it should "internal redirect to an article with evolved url if it has shown up at the wrong server" in {
+    val notFound = Future {
+      ModelOrResult(
+        item = None,
+        response = stubResponse.copy(content = Some(testEvolvedArticle)),
+      ).left.value
+    }
+
+    status(notFound) should be(200)
+    headers(notFound).apply("X-Accel-Redirect") should be("/type/article/the-new-url")
   }
 
   it should "internal redirect to a video if it has shown up at the wrong server" in {


### PR DESCRIPTION
## What does this change?

Since the evolving URLs feature (where a piece of content's URL may change over time), it is possible to create a redirect loop.

A piece can be launched with a "normal" URL, (which looks like `/section/year/month/day/slug`), then evolved to an odder (but still very much legitimate) URL, like `/slug`. This looks indistinguishable from a fronts URL, so requests will be routed initially to facia, but once it is discovered that it is _not_ a front but instead a piece of content, it will be internally redirected. Currently this internal redirect sends the request by using the content ID, but crucially the content ID is not updated with the evolving URLs feature. So when a request comes through with the content's ID, it is considered to be a request for the outdated URL, and an external redirect is issued, sending the requester to the new URL.

But this new URL is the exact same that the initial request was for, meaning that for the reader's browser a request for `/slug` redirects to `/slug`, meaning we immediately enter an indefinite redirect loop.

If we instead perform the internal redirect using the `webUrl` property, we should redirect to the article service using the latest current URL and avoid any need for further redirections.

## What is the value of this and can you measure success?

We can evolve content to non-standard URLs and not cause redirect loops.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
