### PR TITLE
remove the caption title or icon when caption is missing

### DIFF
--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -32,8 +32,11 @@
                 @defining(gallery.item.elements.mainPicture.flatMap(_.images.masterImage)) {
                     case Some(masterImage) => {
                         <figcaption class="caption caption--gallery hide-from-desktop">
-                            Main image:
-                            @masterImage.caption.map(Html(_))
+                            @if(masterImage.caption.isDefined) {
+                                Main image:
+                                @masterImage.caption.map(Html(_))
+                            }
+
                             @if(masterImage.displayCredit && !masterImage.creditEndsWithCaption) {
                                 @masterImage.credit.map(Html(_))
                             }

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -39,13 +39,13 @@
             @defining(page.item.elements.mainPicture.flatMap(_.images.masterImage)) {
                 case Some(masterImage) => {
                     <figcaption class="caption caption--gallery hide-until-desktop">
-                        @if(masterImage.caption.isDefined) {
+                        @if(masterImage.caption.isDefined || (masterImage.displayCredit && !masterImage.creditEndsWithCaption)) {
                             @fragments.inlineSvg("triangle", "icon")
                             @masterImage.caption.map(Html(_))
-                        }
 
-                        @if(masterImage.displayCredit && !masterImage.creditEndsWithCaption) {
-                            @masterImage.credit.map(Html(_))
+                            @if(masterImage.displayCredit && !masterImage.creditEndsWithCaption) {
+                                @masterImage.credit.map(Html(_))
+                            }
                         }
                     </figcaption>
                 }

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -39,8 +39,11 @@
             @defining(page.item.elements.mainPicture.flatMap(_.images.masterImage)) {
                 case Some(masterImage) => {
                     <figcaption class="caption caption--gallery hide-until-desktop">
-                        @fragments.inlineSvg("triangle", "icon")
-                        @masterImage.caption.map(Html(_))
+                        @if(masterImage.caption.isDefined) {
+                            @fragments.inlineSvg("triangle", "icon")
+                            @masterImage.caption.map(Html(_))
+                        }
+
                         @if(masterImage.displayCredit && !masterImage.creditEndsWithCaption) {
                             @masterImage.credit.map(Html(_))
                         }


### PR DESCRIPTION
## What does this change?
A bug was reported that for mobile view when caption is missing, the page is still showing the title `Main image:` while there's no caption or credit appearing for the image. This also happens for desktop viewport but instead of the title a triangle icon is shown. This PR adds a condition where the the title only appears when the caption exists and the icon only appears when either of caption or credit exist. 
## Screenshots

### mobile view
| Before      | After      |
|-------------|------------|
| ![before-mobile][] | ![after-mobile][] |

[before-mobile]: https://github.com/user-attachments/assets/3b943841-f5fb-429b-a08b-8b95b3e590aa
[after-mobile]: https://github.com/user-attachments/assets/d03870ca-cf54-4706-8690-b334f547a816

### desktop view
| Before      | After      |
|-------------|------------|
| ![before-desktop][] | ![after-desktop][] |

[before-desktop]: https://github.com/user-attachments/assets/13053dad-dcdb-4f5a-be19-cf322466e286
[after-desktop]:  https://github.com/user-attachments/assets/5dc30ba4-2d5b-402e-96a7-0d656fead523

