### PR TITLE
Remove expired Commerical AB test switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -40,28 +40,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-a9-bid-response-winner",
-    "The test will enable checking the A9 bid response and determining a winning ad",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 5, 30)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
-    "ab-prebid-id5",
-    "Test enabling the ID5 module in prebid.js",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 5, 30)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-prebid-multibid",
     "Test re-enabling the multibid feature in Prebid.js",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),


### PR DESCRIPTION
## What does this change?

Removes the expired AB test switches:
- `ab-a9-bid-response-winner` (AB test definition already removed in Commercial in https://github.com/guardian/commercial/pull/1993)
- `ab-prebid-id5` ([link to Commercial AB test definition for `ab-prebid-id5`](https://github.com/guardian/commercial/blob/3ee6eae350d4354d5833714ea606ff12834cf7e8/src/experiments/tests/prebid-id5.ts))

## Why

These have expired