### PR TITLE
Re-create commercial Prebid ID5 AB test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -40,6 +40,17 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-prebid-id5",
+    "Test enabling the ID5 module in prebid.js",
+    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 6, 24)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
+  Switch(
+    ABTests,
     "ab-prebid-multibid",
     "Test re-enabling the multibid feature in Prebid.js",
     owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),


### PR DESCRIPTION
## What is the value of this and can you measure success?

We need to gather more data for analysis so need to restart the commercial ID5 AB test

## What does this change?

Adds back the Prebid ID5 AB test switch