### PR TITLE
update content-api-client to 34.1.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "1.12.782"
   val awsSdk2Version = "2.30.38"
-  val capiVersion = "34.1.0"
+  val capiVersion = "34.1.1"
   val faciaVersion = "18.1.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
The gallery articles were incorrectly given immersive display in the client. This upgrade fixes that. 

The PR in content-api-client: https://github.com/guardian/content-api-scala-client/pull/441

Tested locally and in code