### PR TITLE
Also perform internal redirects on interactive content types

### DIFF
--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -83,7 +83,7 @@ object InternalRedirect extends implicits.Requests with GuLogging {
     response.content.map {
       case a if a.isArticle || a.isLiveBlog =>
         internalRedirect("type/article", ItemOrRedirect.canonicalPath(a))
-      case a if a.isVideo || a.isGallery || a.isAudio =>
+      case a if a.isVideo || a.isGallery || a.isAudio || a.isInteractive =>
         internalRedirect("applications", ItemOrRedirect.canonicalPath(a))
       case unsupportedContent =>
         logInfoWithRequestId(s"unsupported content: ${unsupportedContent.id}")


### PR DESCRIPTION
## What does this change?

Quick follow up to #27999 - which is working well for article content types, but interactives are missed from this match statement, so are not sent for internal redirects. So; add it to the list of conditions.

Adding here as a quickfix as the secure messaging/contact the guardian page is falling afoul of this condition
