### PR TITLE
try again to route interactives after odd evolved urls

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -118,6 +118,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)+>/$file<interactive(-service)?-worker.js> 
 # Interactive paths
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    controllers.InteractiveController.renderInteractiveJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>         controllers.InteractiveController.renderInteractive(path)
+GET        /interactive/$path<[\w\d-]+(/[\w\d-]*)*>                             controllers.InteractiveController.renderInteractive(path)
 
 # Interactive test (removing ng-interactive in the url)
 GET        /$path<info/2017/jul/26/interactive-test>                            controllers.InteractiveController.renderInteractive(path)

--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -83,7 +83,9 @@ object InternalRedirect extends implicits.Requests with GuLogging {
     response.content.map {
       case a if a.isArticle || a.isLiveBlog =>
         internalRedirect("type/article", ItemOrRedirect.canonicalPath(a))
-      case a if a.isVideo || a.isGallery || a.isAudio || a.isInteractive =>
+      case a if a.isInteractive =>
+        internalRedirect("applications/interactive", ItemOrRedirect.canonicalPath(a))
+      case a if a.isVideo || a.isGallery || a.isAudio =>
         internalRedirect("applications", ItemOrRedirect.canonicalPath(a))
       case unsupportedContent =>
         logInfoWithRequestId(s"unsupported content: ${unsupportedContent.id}")

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -62,6 +62,8 @@ trait Requests {
 
     lazy val isEmailJson: Boolean = r.path.endsWith(EMAIL_JSON_SUFFIX)
 
+    lazy val isInteractiveRedirect: Boolean = r.path.startsWith("/interactive/")
+
     lazy val isEmailTxt: Boolean = r.path.endsWith(EMAIL_TXT_SUFFIX)
 
     lazy val isLazyLoad: Boolean =
@@ -86,6 +88,7 @@ trait Requests {
 
     lazy val pathWithoutModifiers: String =
       if (isEmail) r.path.stripSuffix(EMAIL_SUFFIX)
+      else if (isInteractiveRedirect) r.path.stripPrefix("/interactive")
       else r.path.stripSuffix("/all")
 
     lazy val hasParameters: Boolean = r.queryString.nonEmpty


### PR DESCRIPTION
## What does this change?

Followup to #27999 and #28005 - which should finally properly fix the internal redirect problem for interactives.

While #27999 fixed immediately for article content, neither of those prior PRs provided a sufficient fix for interactive content, which is important for the upcoming revamped "How to contact us securely" page, which is an _interactive_.

After #28005, the router would have seen a url like `/tips`, and sent it to `applications` which would have treated it as a tag page. But there is no tag page `/tips`, so it would have been sent as an internal redirect to the app which handles interactives. But unlike articles, which have their own app, interactives are handled by `applications`. And since the url given to `applications` is `/tips`.... we start a redirect cycle 🤦 

We have to break the loop by redirecting to something that is noticeably different to `/tips`, and will be handled as an interactive. The only routes in `applications` which deal with interactives expect `ng-interactive` or `interactive` to be part of the path, but since we're trying to support an interactive on a path that doesn't contain those keywords, we'll need a new handler.

I don't know if it's a great pattern, but I've opted for `/interactive/<remaining path>` - it's clear about what it does, and it doesn't conflict with any other paths I can see (nor with any tag pages; there are no tags with `interactive` in the path except for `interactive` the type tag, and there remains no conflict as the route matcher requires a second segment of at least one character in length.

We must then treat this leading `/interactive/` as a "modifier", similar to the trailing `/all` which disambiguates a tag page from a curated front with the same path. (Without doing so, the requested path does not match the path fetched from CAPI, and so the request is treated as if for an alias path for the content, and is redirected; again to `/tips`, which sends us into a _different_ redirect loop!)

Altogether, this is now working, and has been double checked on CODE. I suspect that audio, video, gallery and picture content pages will be subject to similar or identical problems; if we're happy with this approach then it could be rolled out to these remaining content types too; though as they do not have any currently inaccessible pages, I'd prefer to do them in a followup.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
