### PR TITLE
Remove vertical video container

### DIFF
--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -19,8 +19,6 @@ case object NavList extends Container
 case object NavMediaList extends Container
 case object MostPopular extends Container
 case object Video extends Container
-case object VerticalVideo extends Container
-
 object Container extends GuLogging {
 
   /** This is THE top level resolver for containers */
@@ -31,7 +29,6 @@ object Container extends GuLogging {
       ("dynamic/package", Dynamic(DynamicPackage)),
       ("dynamic/slow-mpu", Dynamic(DynamicSlowMPU(adFree = adFree))),
       ("fixed/video", Video),
-      ("fixed/video/vertical", VerticalVideo),
       ("nav/list", NavList),
       ("nav/media-list", NavMediaList),
       ("news/most-popular", MostPopular),

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,6 +1,6 @@
 @import common.commercial.ContainerModel
 @import layout.MetaDataHeader
-@import layout.slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList, Video, VerticalVideo}
+@import layout.slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList, Video}
 @import views.html.fragments.commercial.containers.paidContainer
 @import views.html.fragments.audio.containers.flagshipContainer
 @import views.html.fragments.containers.facia_cards._


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

Remove vertical video from the container resolver. This container is no longer used and can be removed. There are 0 instances of this container type in use in  production.

This is part of the work to deprecate and remove old containers. 

Other relevant PRs for this are

Fronts tool : https://github.com/guardian/facia-tool/pull/1824
DCR : https://github.com/guardian/dotcom-rendering/pull/14037
