### PR TITLE
Start Stacked Carousels AB test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -18,15 +18,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
 
-object StackedCarousels
-    extends Experiment(
-      name = "stacked-carousels",
-      description = "Show stacked cards instead of medium carousels on UK front",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 7, 30),
-      participationGroup = Perc0A,
-    )
-
 object DarkModeWeb
     extends Experiment(
       name = "dark-mode-web",
@@ -43,4 +34,13 @@ object DCRJavascriptBundle
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 6, 30),
       participationGroup = Perc0E,
+    )
+
+object StackedCarousels
+    extends Experiment(
+      name = "stacked-carousels",
+      description = "Show stacked cards instead of carousels on UK front on mobile",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 7, 30),
+      participationGroup = Perc5A,
     )


### PR DESCRIPTION
## What does this change?

Sets each participation group to 5%.

Full details of the AB test can be found in the DCR PR: https://github.com/guardian/dotcom-rendering/pull/14027
