### PR TITLE
Add Tips link to footer

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -167,6 +167,7 @@ object FooterLinks {
     FooterLink("Guardian Labs", "/guardian-labs", "uk : footer : guardian labs"),
     FooterLink("Search jobs", "https://jobs.theguardian.com", "uk : footer : jobs"),
     FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
+    FooterLink("Tips", "https://www.theguardian.com/tips", "uk : footer : tips"),
   )
 
   val usListThree = List(
@@ -177,6 +178,7 @@ object FooterLinks {
     ),
     FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
     FooterLink("Search jobs", "https://jobs.theguardian.com", "us : footer : jobs"),
+    FooterLink("Tips", "https://www.theguardian.com/tips", "us : footer : tips"),
   )
 
   val auListThree = List(
@@ -187,6 +189,7 @@ object FooterLinks {
       "au : footer : advertise with us",
     ),
     cookiePolicy,
+    FooterLink("Tips", "https://www.theguardian.com/tips", "au : footer : tips"),
   )
 
   val intListThree = List(
@@ -200,6 +203,7 @@ object FooterLinks {
       "https://jobs.theguardian.com",
       "international : footer : uk-jobs",
     ),
+    FooterLink("Tips", "https://www.theguardian.com/tips", "int : footer : tips"),
   )
 
   def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =


### PR DESCRIPTION
## What does this change?
Add Tips link to footer across all editions 
See email from CP https://groups.google.com/a/guardian.co.uk/g/dotcom.platform/c/zuEaliyhJKA

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f2552905-26a9-424e-82e2-52f519990c5a
[after]: https://github.com/user-attachments/assets/720fae88-8df7-4134-a12a-56fa0e6710c9



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
