### PR TITLE
Add tips link to subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -257,6 +257,7 @@ object NavLinks {
     "https://recruiters.theguardian.com/?utm_source=gdnwb&utm_medium=navbar&utm_campaign=Guardian_Navbar_Recruiters&CMP_TU=trdmkt&CMP_BUNIT=jobs",
   )
   val aboutUs = NavLink("About Us", "/about")
+  val tips = NavLink("Tips", "https://www.theguardian.com/tips")
 
   // News Pillar
   val ukNewsPillar = NavLink(
@@ -629,6 +630,7 @@ object NavLinks {
     crosswords,
     wordiply,
     corrections,
+    tips,
   )
   val auOtherLinks = List(
     apps,
@@ -641,6 +643,7 @@ object NavLinks {
     crosswords,
     wordiply,
     corrections,
+    tips,
   )
   val usOtherLinks = List(
     apps,
@@ -652,6 +655,7 @@ object NavLinks {
     crosswords,
     wordiply,
     corrections,
+    tips,
   )
   val intOtherLinks = List(
     apps,
@@ -665,6 +669,7 @@ object NavLinks {
     crosswords,
     wordiply,
     corrections,
+    tips,
   )
   val eurOtherLinks = List(
     apps,
@@ -678,6 +683,7 @@ object NavLinks {
     crosswords,
     wordiply,
     corrections,
+    tips,
   )
 
   val ukBrandExtensions = List(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -877,6 +877,12 @@
 				"url": "/theguardian/series/corrections-and-clarifications",
 				"children": [],
 				"classList": []
+			},
+			{
+				"title": "Tips",
+				"url": "https://www.theguardian.com/tips",
+				"children": [],
+				"classList": []
 			}
 		],
 		"brandExtensions": [
@@ -1624,6 +1630,12 @@
 				"url": "/theguardian/series/corrections-and-clarifications",
 				"children": [],
 				"classList": []
+			},
+			{
+				"title": "Tips",
+				"url": "https://www.theguardian.com/tips",
+				"children": [],
+				"classList": []
 			}
 		],
 		"brandExtensions": [
@@ -2309,6 +2321,12 @@
 			{
 				"title": "Corrections",
 				"url": "/theguardian/series/corrections-and-clarifications",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Tips",
+				"url": "https://www.theguardian.com/tips",
 				"children": [],
 				"classList": []
 			}
@@ -3168,6 +3186,12 @@
 			{
 				"title": "Corrections",
 				"url": "/theguardian/series/corrections-and-clarifications",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Tips",
+				"url": "https://www.theguardian.com/tips",
 				"children": [],
 				"classList": []
 			}
@@ -4135,6 +4159,12 @@
 			{
 				"title": "Corrections",
 				"url": "/theguardian/series/corrections-and-clarifications",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Tips",
+				"url": "https://www.theguardian.com/tips",
 				"children": [],
 				"classList": []
 			}


### PR DESCRIPTION
## What does this change?
Add Tips link to subnav across all editions
See email from CP https://groups.google.com/a/guardian.co.uk/g/dotcom.platform/c/zuEaliyhJKA
## Screenshots
| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/47d7dc14-8a4e-4eb9-b2cb-42984f662e93
[after]: https://github.com/user-attachments/assets/cbe5c3b0-91b0-4880-afb4-16d29df9473d



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
