### PR TITLE
Bump Google Ad Manager API version to v202502

### DIFF
--- a/admin/app/dfp/AdUnitAgent.scala
+++ b/admin/app/dfp/AdUnitAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder
 import common.dfp.GuAdUnit
 import conf.Configuration
 import ApiHelper.toSeq

--- a/admin/app/dfp/AdUnitAgent.scala
+++ b/admin/app/dfp/AdUnitAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
 import common.dfp.GuAdUnit
 import conf.Configuration
 import ApiHelper.toSeq

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.v202505._
 import common.GuLogging
 import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
 

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.v202502._
 import common.GuLogging
 import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
 

--- a/admin/app/dfp/CustomFieldAgent.scala
+++ b/admin/app/dfp/CustomFieldAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
-import com.google.api.ads.admanager.axis.v202505.{CustomFieldValue, LineItem, TextValue}
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder
+import com.google.api.ads.admanager.axis.v202502.{CustomFieldValue, LineItem, TextValue}
 import common.dfp.GuCustomField
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/CustomFieldAgent.scala
+++ b/admin/app/dfp/CustomFieldAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder
-import com.google.api.ads.admanager.axis.v202405.{CustomFieldValue, LineItem, TextValue}
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
+import com.google.api.ads.admanager.axis.v202505.{CustomFieldValue, LineItem, TextValue}
 import common.dfp.GuCustomField
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/CustomTargetingAgent.scala
+++ b/admin/app/dfp/CustomTargetingAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder
-import com.google.api.ads.admanager.axis.v202405.{CustomTargetingKey, CustomTargetingValue}
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
+import com.google.api.ads.admanager.axis.v202505.{CustomTargetingKey, CustomTargetingValue}
 import common.GuLogging
 import common.dfp.{GuCustomTargeting, GuCustomTargetingValue}
 import concurrent.BlockingOperations

--- a/admin/app/dfp/CustomTargetingAgent.scala
+++ b/admin/app/dfp/CustomTargetingAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
-import com.google.api.ads.admanager.axis.v202505.{CustomTargetingKey, CustomTargetingValue}
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder
+import com.google.api.ads.admanager.axis.v202502.{CustomTargetingKey, CustomTargetingValue}
 import common.GuLogging
 import common.dfp.{GuCustomTargeting, GuCustomTargetingValue}
 import concurrent.BlockingOperations

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.v202502._
 import common.dfp._
 import dfp.ApiHelper.{isPageSkin, optJavaInt, toJodaTime, toSeq}
 

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.v202505._
 import common.dfp._
 import dfp.ApiHelper.{isPageSkin, optJavaInt, toJodaTime, toSeq}
 

--- a/admin/app/dfp/DataValidation.scala
+++ b/admin/app/dfp/DataValidation.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.v202505._
 import common.dfp._
 import dfp.ApiHelper.toSeq
 

--- a/admin/app/dfp/DataValidation.scala
+++ b/admin/app/dfp/DataValidation.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.v202502._
 import common.dfp._
 import dfp.ApiHelper.toSeq
 

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -2,8 +2,8 @@ package dfp
 
 // StatementBuilder query language is PQL defined here:
 // https://developers.google.com/ad-manager/api/pqlreference
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
+import com.google.api.ads.admanager.axis.v202505._
 import com.madgag.scala.collection.decorators.MapDecorator
 import common.GuLogging
 import common.dfp._

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -2,8 +2,8 @@ package dfp
 
 // StatementBuilder query language is PQL defined here:
 // https://developers.google.com/ad-manager/api/pqlreference
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder
+import com.google.api.ads.admanager.axis.v202502._
 import com.madgag.scala.collection.decorators.MapDecorator
 import common.GuLogging
 import common.dfp._

--- a/admin/app/dfp/PlacementAgent.scala
+++ b/admin/app/dfp/PlacementAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder
 import common.dfp.GuAdUnit
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/PlacementAgent.scala
+++ b/admin/app/dfp/PlacementAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
 import common.dfp.GuAdUnit
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/Reader.scala
+++ b/admin/app/dfp/Reader.scala
@@ -1,8 +1,8 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder.SUGGESTED_PAGE_LIMIT
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder.SUGGESTED_PAGE_LIMIT
+import com.google.api.ads.admanager.axis.v202505._
 
 import scala.annotation.tailrec
 

--- a/admin/app/dfp/Reader.scala
+++ b/admin/app/dfp/Reader.scala
@@ -1,8 +1,8 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder.SUGGESTED_PAGE_LIMIT
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder.SUGGESTED_PAGE_LIMIT
+import com.google.api.ads.admanager.axis.v202502._
 
 import scala.annotation.tailrec
 

--- a/admin/app/dfp/ServicesWrapper.scala
+++ b/admin/app/dfp/ServicesWrapper.scala
@@ -1,7 +1,7 @@
 package dfp
 
 import com.google.api.ads.admanager.axis.factory.AdManagerServices
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.v202505._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 
 private[dfp] class ServicesWrapper(session: AdManagerSession) {

--- a/admin/app/dfp/ServicesWrapper.scala
+++ b/admin/app/dfp/ServicesWrapper.scala
@@ -1,7 +1,7 @@
 package dfp
 
 import com.google.api.ads.admanager.axis.factory.AdManagerServices
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.v202502._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 
 private[dfp] class ServicesWrapper(session: AdManagerSession) {

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder
+import com.google.api.ads.admanager.axis.v202502._
 import common.GuLogging
 
 import scala.util.control.NonFatal

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
+import com.google.api.ads.admanager.axis.v202505._
 import common.GuLogging
 
 import scala.util.control.NonFatal

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -2,8 +2,8 @@ package dfp
 
 import com.google.api.ads.common.lib.auth.OfflineCredentials
 import com.google.api.ads.common.lib.auth.OfflineCredentials.Api
-import com.google.api.ads.admanager.axis.utils.v202405.{ReportDownloader, StatementBuilder}
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.utils.v202505.{ReportDownloader, StatementBuilder}
+import com.google.api.ads.admanager.axis.v202505._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 import com.google.common.io.CharSource
 import common.GuLogging

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -2,8 +2,8 @@ package dfp
 
 import com.google.api.ads.common.lib.auth.OfflineCredentials
 import com.google.api.ads.common.lib.auth.OfflineCredentials.Api
-import com.google.api.ads.admanager.axis.utils.v202505.{ReportDownloader, StatementBuilder}
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.utils.v202502.{ReportDownloader, StatementBuilder}
+import com.google.api.ads.admanager.axis.v202502._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 import com.google.common.io.CharSource
 import common.GuLogging

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -3,10 +3,10 @@ package jobs
 import java.time.{LocalDate, LocalDateTime}
 
 import app.LifecycleComponent
-import com.google.api.ads.admanager.axis.v202505.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
-import com.google.api.ads.admanager.axis.v202505.DateRangeType.CUSTOM_DATE
-import com.google.api.ads.admanager.axis.v202505.Dimension.{CUSTOM_CRITERIA, DATE}
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.v202502.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
+import com.google.api.ads.admanager.axis.v202502.DateRangeType.CUSTOM_DATE
+import com.google.api.ads.admanager.axis.v202502.Dimension.{CUSTOM_CRITERIA, DATE}
+import com.google.api.ads.admanager.axis.v202502._
 import common.{PekkoAsync, Box, JobScheduler, GuLogging}
 import dfp.DfpApi
 import play.api.inject.ApplicationLifecycle

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -3,10 +3,10 @@ package jobs
 import java.time.{LocalDate, LocalDateTime}
 
 import app.LifecycleComponent
-import com.google.api.ads.admanager.axis.v202405.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
-import com.google.api.ads.admanager.axis.v202405.DateRangeType.CUSTOM_DATE
-import com.google.api.ads.admanager.axis.v202405.Dimension.{CUSTOM_CRITERIA, DATE}
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.v202505.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
+import com.google.api.ads.admanager.axis.v202505.DateRangeType.CUSTOM_DATE
+import com.google.api.ads.admanager.axis.v202505.Dimension.{CUSTOM_CRITERIA, DATE}
+import com.google.api.ads.admanager.axis.v202505._
 import common.{PekkoAsync, Box, JobScheduler, GuLogging}
 import dfp.DfpApi
 import play.api.inject.ApplicationLifecycle

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -2,7 +2,7 @@ package dfp
 
 import concurrent.BlockingOperations
 import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
-import com.google.api.ads.admanager.axis.v202405._
+import com.google.api.ads.admanager.axis.v202505._
 import org.joda.time.DateTime
 import org.apache.pekko.actor.ActorSystem
 import org.scalatest.flatspec.AnyFlatSpec

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -2,7 +2,7 @@ package dfp
 
 import concurrent.BlockingOperations
 import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
-import com.google.api.ads.admanager.axis.v202505._
+import com.google.api.ads.admanager.axis.v202502._
 import org.joda.time.DateTime
 import org.apache.pekko.actor.ActorSystem
 import org.scalatest.flatspec.AnyFlatSpec

--- a/admin/test/dfp/ReaderTest.scala
+++ b/admin/test/dfp/ReaderTest.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202502.StatementBuilder
 import dfp.Reader.read
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/admin/test/dfp/ReaderTest.scala
+++ b/admin/test/dfp/ReaderTest.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202405.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202505.StatementBuilder
 import dfp.Reader.read
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "27.1.0"
-  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.6.0"
+  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.8.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 


### PR DESCRIPTION
## What does this change?

Bumps version of Google Ad Manager used in Commercial jobs from `v202405` to `v202502`

## Why

- `v202405` of the Google Ad Manager SOAP API is deprecated
  - https://developers.google.com/ad-manager/api/deprecation
- `v202502` is the latest version available in Maven
  - https://mvnrepository.com/artifact/com.google.api-ads/dfp-axis  