### PR TITLE
remove survey-sponsorships from writing to S3

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -30,7 +30,6 @@ class DfpDataCacheJob(
       log.info(s"Loading DFP data took $duration ms")
       write(data)
       if (LineItemJobs.isSwitchedOff) Store.putNonRefreshableLineItemIds(sponsorshipLineItemIds)
-      writeSurveySponsorships(currentLineItems)
     }
 
   /*
@@ -150,17 +149,6 @@ class DfpDataCacheJob(
       val pageSkinSponsorships = data.pageSkinSponsorships
       Store.putDfpPageSkinAdUnits(stringify(toJson(PageSkinSponsorshipReport(now, pageSkinSponsorships))))
       Store.putDfpLineItemsReport(stringify(toJson(LineItemReport(now, data.lineItems, data.invalidLineItems))))
-    }
-  }
-
-  private def writeSurveySponsorships(data: DfpDataExtractor): Unit = {
-    if (data.hasValidLineItems && LineItemJobs.isSwitchedOff) {
-      val now = printLondonTime(DateTime.now())
-
-      val sponsorships = data.surveySponsorships
-      Store.putSurveySponsorships(
-        stringify(toJson(SurveySponsorshipReport(Some(now), sponsorships))),
-      )
     }
   }
 

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -24,9 +24,6 @@ trait Store extends GuLogging with Dates {
   def getTopStories: Option[String] = S3.get(topStoriesKey)
   def putTopStories(config: String): Unit = { S3.putPublic(topStoriesKey, config, "application/json") }
 
-  def putSurveySponsorships(adUnitJson: String): Unit = {
-    S3.putPrivate(dfpSurveySponsorshipDataKey, adUnitJson, defaultJsonEncoding)
-  }
   def putDfpPageSkinAdUnits(adUnitJson: String): Unit = {
     S3.putPrivate(dfpPageSkinnedAdUnitsKey, adUnitJson, defaultJsonEncoding)
   }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -493,8 +493,7 @@ class GuardianConfiguration extends GuLogging {
     def dfpPageSkinnedAdUnitsKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/pageskins.json" else s"$dfpRoot/pageskinned-adunits-v9.json"
     lazy val dfpLiveBlogTopSponsorshipDataKey = s"$gamRoot/liveblog-top-sponsorships.json"
-    def dfpSurveySponsorshipDataKey =
-      if (LineItemJobs.isSwitchedOn) s"$gamRoot/survey-sponsorships.json" else s"$dfpRoot/survey-sponsorships.json"
+    def dfpSurveySponsorshipDataKey = s"$gamRoot/survey-sponsorships.json"
     def dfpNonRefreshableLineItemIdsKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/non-refreshable-line-items.json"
       else s"$dfpRoot/non-refreshable-lineitem-ids-v1.json"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Removes code which writes filtered and transformed line items to S3.  
Success can be measured by verifying that no S3 write operations occur during processing, and that all related tests pass.

- S3 storage of line items is no longer required for our workflow, since we are using the `line-item-jobs` app. 
- Related PR's: 
   - https://github.com/guardian/line-item-jobs/pull/44 
   - https://github.com/guardian/line-item-jobs/pull/37


## What does this change?
- Removes all logic responsible for writing filtered and transformed line items to S3.
- Cleans up related configuration, dependencies, and environment variables.
## Testing
Tested in CODE by:

- Deploying branch to CODE
- Creating a test line item in GAM with adtest value `fordv2_mobiletruskin_guardiantest`
- VPN into AUS with article `https://m.code.dev-theguardian.com/lifeandstyle/2025/jun/09/the-one-change-that-worked-meditation-cured-my-insomnia-and-transformed-my-relationships.json?adtest=fordv2_mobiletruskin_guardiantest`
- Checked sponsorship appeared in CODE admin (admin app path /commercial/survey-sponsorships)
- Opened current survey blog in CODE environment which matches targeting
- Checked JSON response for .config.hasSurveyAd

`hasSurveyAd: true`



