### PR TITLE
Add a 0% looping video tests for DCR

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,9 +14,19 @@ object ActiveExperiments extends ExperimentsDefinition {
       DarkModeWeb,
       DCRJavascriptBundle,
       StackedCarousels,
+      LoopingVideo,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
+
+object LoopingVideo
+    extends Experiment(
+      name = "looping-video",
+      description = "Enable looping videos on DCR",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 9, 30),
+      participationGroup = Perc0A,
+    )
 
 object DarkModeWeb
     extends Experiment(


### PR DESCRIPTION
Add a 0% looping video tests for DCR. This will allow editorial and engineers to opt in to see looping videos on fronts.