### PR TITLE
Remove `asgMigrationInProgress` param from Applications deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -25,8 +25,6 @@ deployments:
     template: frontend
   applications:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   archive:
     template: frontend
   article:


### PR DESCRIPTION
## What is the value of this and can you measure success?

This should be merged following removal of the legacy Applications infrastructure (https://github.com/guardian/platform/pull/1869) so we don't break `dotcom:frontend-all` deployments.
