### PR TITLE
Filter out extra fields from the trail picture in dcar model

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -543,7 +543,14 @@ object DotcomRenderingDataModel {
         for {
           imageMedia <- page.item.trail.trailPicture
         } yield {
-          getImageBlockElement(imageMedia, Role(Some("inline")))
+          // DCAR only relies on 'height', 'width', and 'isMaster' fields,
+          // so we remove all other properties to reduce unnecessary data.
+          val filteredImageMedia = ImageMedia(imageMedia.allImages.map { image =>
+            image.copy(fields = image.fields.filter(f => {
+              f._1 == "height" || f._1 == "width" || f._1 == "isMaster"
+            }))
+          })
+          getImageBlockElement(filteredImageMedia, Role(Some("inline")))
         }
       } else {
         None


### PR DESCRIPTION
## What does this change?
In a previous PR https://github.com/guardian/frontend/pull/27992 we added the `trailPicture` to the `DotcomRenderingDataModel` which is a `ImageBlockElement`. The mdeia field in the ImageBlockElement contains a list of assets, and each asset has a field named `fields` which is a Map[String, String]. 

This map could contain several fields that are not at all used in DCAR. And to avoid updating the DCAR type and adding the fields that are not even used, we decided to filter those fields out, and only allow for 'height', 'width', and 'isMaster' fields. 
