### PR TITLE
remove pageskins from writing to S3

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -146,8 +146,6 @@ class DfpDataCacheJob(
     if (data.hasValidLineItems && LineItemJobs.isSwitchedOff) {
       val now = printLondonTime(DateTime.now())
 
-      val pageSkinSponsorships = data.pageSkinSponsorships
-      Store.putDfpPageSkinAdUnits(stringify(toJson(PageSkinSponsorshipReport(now, pageSkinSponsorships))))
       Store.putDfpLineItemsReport(stringify(toJson(LineItemReport(now, data.lineItems, data.invalidLineItems))))
     }
   }

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -24,9 +24,6 @@ trait Store extends GuLogging with Dates {
   def getTopStories: Option[String] = S3.get(topStoriesKey)
   def putTopStories(config: String): Unit = { S3.putPublic(topStoriesKey, config, "application/json") }
 
-  def putDfpPageSkinAdUnits(adUnitJson: String): Unit = {
-    S3.putPrivate(dfpPageSkinnedAdUnitsKey, adUnitJson, defaultJsonEncoding)
-  }
   def putDfpLineItemsReport(everything: String): Unit = {
     S3.putPrivate(dfpLineItemsKey, everything, defaultJsonEncoding)
   }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -490,8 +490,7 @@ class GuardianConfiguration extends GuLogging {
 
     private lazy val dfpRoot = s"$commercialRoot/dfp"
     private lazy val gamRoot = s"$commercialRoot/gam"
-    def dfpPageSkinnedAdUnitsKey =
-      if (LineItemJobs.isSwitchedOn) s"$gamRoot/pageskins.json" else s"$dfpRoot/pageskinned-adunits-v9.json"
+    def dfpPageSkinnedAdUnitsKey = s"$gamRoot/pageskins.json"
     lazy val dfpLiveBlogTopSponsorshipDataKey = s"$gamRoot/liveblog-top-sponsorships.json"
     def dfpSurveySponsorshipDataKey = s"$gamRoot/survey-sponsorships.json"
     def dfpNonRefreshableLineItemIdsKey =


### PR DESCRIPTION
## What is the value of this and can you measure success?
Removes code which writes filtered and transformed line items to S3.  
Success can be measured by verifying that no S3 write operations occur during processing, and that all related tests pass.

- S3 storage of line items is no longer required for our workflow, since we are using the `line-item-jobs` app. 
- Related PR's: 
   - https://github.com/guardian/line-item-jobs/pull/40


## What does this change?
- Removes all logic responsible for writing filtered and transformed line items to S3.
- Cleans up related configuration, dependencies, and environment variables.
## Testing
Tested in CODE by:

- Deploying branch to CODE
- Creating a test line item in GAM with `https://frontend.gutools.co.uk/commercial/pageskins`
- VPN into AUS with article `https://m.code.dev-theguardian.com/lifeandstyle/2025/jun/09/the-one-change-that-worked-meditation-cured-my-insomnia-and-transformed-my-relationships.json?adtest=fordv2_mobiletruskin_guardiantest`
- Checked sponsorship appeared in CODE admin (admin app path /commercial/pageskins)
- Opened current pageskins in CODE environment which matches targeting
- Checked JSON response for .config.hasPageSkin


Tested with: https://m.code.dev-theguardian.com/society-professionals.json?&adtest=skintest_kat
`hasPageSkin: true`



