### PR TITLE
Update `CircuitBreakerRegistry.scala` logging to include `callTimeout` and `resetTimeout`

### DIFF
--- a/common/app/concurrent/CircuitBreakerRegistry.scala
+++ b/common/app/concurrent/CircuitBreakerRegistry.scala
@@ -25,7 +25,9 @@ object CircuitBreakerRegistry extends GuLogging {
     )
 
     cb.onOpen(
-      log.error(s"Circuit breaker ($name) OPEN (exceeded $maxFailures failures)"),
+      log.error(
+        s"Circuit breaker ($name) OPEN (exceeded $maxFailures failures) with $callTimeout (${callTimeout}) and resetTimeout (${resetTimeout}).",
+      ),
     )
 
     cb.onHalfOpen(


### PR DESCRIPTION
## What does this change?

Update CircuitBreakerRegistry.scala logs to include `callTimeout` and `resetTimeout` to aid investigation into when the circuit breaker opens.