### PR TITLE
remove non-refreshable-line-items from writing to S3

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -29,7 +29,6 @@ class DfpDataCacheJob(
       val duration = System.currentTimeMillis - start
       log.info(s"Loading DFP data took $duration ms")
       write(data)
-      if (LineItemJobs.isSwitchedOff) Store.putNonRefreshableLineItemIds(sponsorshipLineItemIds)
     }
 
   /*

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -33,9 +33,6 @@ trait Store extends GuLogging with Dates {
   def putDfpCustomTargetingKeyValues(keyValues: String): Unit = {
     S3.putPrivate(dfpCustomTargetingKey, keyValues, defaultJsonEncoding)
   }
-  def putNonRefreshableLineItemIds(lineItemIds: Seq[Long]): Unit = {
-    S3.putPrivate(dfpNonRefreshableLineItemIdsKey, Json.stringify(toJson(lineItemIds)), defaultJsonEncoding)
-  }
 
   val now: String = DateTime.now().toHttpDateTimeString
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -493,9 +493,7 @@ class GuardianConfiguration extends GuLogging {
     def dfpPageSkinnedAdUnitsKey = s"$gamRoot/pageskins.json"
     lazy val dfpLiveBlogTopSponsorshipDataKey = s"$gamRoot/liveblog-top-sponsorships.json"
     def dfpSurveySponsorshipDataKey = s"$gamRoot/survey-sponsorships.json"
-    def dfpNonRefreshableLineItemIdsKey =
-      if (LineItemJobs.isSwitchedOn) s"$gamRoot/non-refreshable-line-items.json"
-      else s"$dfpRoot/non-refreshable-lineitem-ids-v1.json"
+    def dfpNonRefreshableLineItemIdsKey = s"$gamRoot/non-refreshable-line-items.json"
     def dfpLineItemsKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/line-items.json"
       else s"$dfpRoot/lineitems-v7.json"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Removes code which writes filtered and transformed line items to S3.  
Success can be measured by verifying that no S3 write operations occur during processing, and that all related tests pass.

- S3 storage of line items is no longer required for our workflow, since we are using the `line-item-jobs` app. 
- Related PR's: 
   - https://github.com/guardian/line-item-jobs/pull/11


## What does this change?
- Removes all logic responsible for writing filtered and transformed line items to S3.
- Cleans up related configuration, dependencies, and environment variables.
## Testing
Tested in CODE by:

- Deploying branch to CODE
- Creating a test line item in GAM with adtest value `liveblog-top-test`
- Executed line-item-jobs state machine in CODE 
- Compared the non-refreshable-line-items in CODE vs PROD


test :compare  `https://www.theguardian.com/commercial/non-refreshable-line-items.json` vs `https://m.code.dev-theguardian.com/commercial/non-refreshable-line-items.json`



