### PR TITLE
Make Archive's gallery redirects temporary

### DIFF
--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -80,7 +80,7 @@ import services.RedirectService.{ArchiveRedirect, PermanentRedirect}
 
   it should "redirect old style galleries" in {
     val result = archiveController.lookup("/arts/gallery/0,")(TestRequest())
-    status(result) should be(301)
+    status(result) should be(307)
     location(result) should be(s"${Configuration.site.host}/arts/pictures/0,")
   }
 


### PR DESCRIPTION


## What is the value of this and can you measure success?

## What does this change?

Like all content, if someone accidentally attempts to open a Gallery before it's been published, we'll get a 404 from CAPI in the usual rendering path, which will internally redirect the request to Archive in case the content is in the archive instead. However Archive rewrites requests for `.../gallery/...` to `.../pictures/...` using a *permanent* redirect. The redirected request will 404 since the content's not in the archive, which is expected, but since the redirect was permanent, the reader will now always be sent to this `pictures` URL, *even when the content has been published* on its intended `/gallery/` URL, and it seems almost impossible to remove a permanent redirect once it's been established in a browser.

Instead, use a temporary redirect. This might incur some slightly increased requests for archived galleries which would otherwise have been redirected by browsers but that feels pretty uncommon, and is a worthwhile tradeoff for preventing readers accidentally locking themselves out of content.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
