### PR TITLE
Add hide trails experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,6 +13,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     Set(
       DarkModeWeb,
       DCRJavascriptBundle,
+      HideTrails,
       LoopingVideo,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
@@ -25,6 +26,15 @@ object LoopingVideo
       owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
       sellByDate = LocalDate.of(2025, 9, 30),
       participationGroup = Perc0A,
+    )
+
+object HideTrails
+    extends Experiment(
+      name = "hide-trails",
+      description = "Hide trails on UK front on mobile",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 7, 30),
+      participationGroup = Perc0B,
     )
 
 object DarkModeWeb


### PR DESCRIPTION
## What does this change?

Creates an Experiment for hiding trails. This will be used in a server-side AB test which will involve hiding trail text from the UK front on mobile web.

Currently set to 0%. This will be a 5% test when it is started.