### PR TITLE
Add a 700px image to  RSS

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -104,7 +104,7 @@ object TrailsToRss {
       val description = makeEntryDescriptionUsing(standfirst, intro, trail.metadata.webUrl)
 
       val mediaModules: Seq[MediaEntryModuleImpl] = for {
-        profile: ImageProfile <- List(Item140, Item460)
+        profile: ImageProfile <- List(Item140, Item460, Item700)
         trailPicture: ImageMedia <- trail.trailPicture
         trailAsset: ImageAsset <- profile.bestFor(trailPicture)
         resizedImage <- profile.bestSrcFor(trailPicture)

--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -11,7 +11,7 @@ import model.liveblog.{Blocks, TextBlockElement}
 import model.pressed.PressedStory
 import org.jsoup.Jsoup
 import play.api.mvc.RequestHeader
-import views.support.{ImageProfile, Item140, Item460}
+import views.support.{ImageProfile, Item140, Item460, Item700}
 
 import java.io.StringWriter
 import java.text.SimpleDateFormat


### PR DESCRIPTION
## What is the value of this and can you measure success?
We supply two image sizes with every RSS item: 140px and 460px wide. _This is not the 1980s any more._ We have received reports this causes bluriness at times. _No way, Sherlock!_ This is how an example RSS item looks now:

```
      <media:content width="140" url="https://i.guim.co.uk/img/media/b070327c2552d027911e918ae9372af5c0b35231/842_0_2658_2126/master/2658.jpg?width=140&amp;quality=85&amp;auto=format&amp;fit=max&amp;s=1891a42ec5e722b6417aa1690ddc8897">
        <media:credit scheme="urn:ebu">Photograph: Andrew Boyers/Reuters</media:credit>
      </media:content>
      <media:content width="460" url="https://i.guim.co.uk/img/media/b070327c2552d027911e918ae9372af5c0b35231/842_0_2658_2126/master/2658.jpg?width=460&amp;quality=85&amp;auto=format&amp;fit=max&amp;s=266ccd4a0616718c7a50e1a13d400ba2">
        <media:credit scheme="urn:ebu">Photograph: Andrew Boyers/Reuters</media:credit>
      </media:content>
```

## What does this change?
I **think/hope** this change will mean we gonna get a third `media:content` item in every RSS after this change with an image 700px wide.

This is not tested in any way, though…

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
