### PR TITLE
Set HideTrails Experiment to 5%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -28,15 +28,6 @@ object LoopingVideo
       participationGroup = Perc0A,
     )
 
-object HideTrails
-    extends Experiment(
-      name = "hide-trails",
-      description = "Hide trails on UK front on mobile",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 7, 30),
-      participationGroup = Perc0B,
-    )
-
 object DarkModeWeb
     extends Experiment(
       name = "dark-mode-web",
@@ -53,4 +44,13 @@ object DCRJavascriptBundle
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 6, 30),
       participationGroup = Perc0E,
+    )
+
+object HideTrails
+    extends Experiment(
+      name = "hide-trails",
+      description = "Hide trails on UK front on mobile",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 7, 30),
+      participationGroup = Perc5A,
     )


### PR DESCRIPTION
## What does this change?

Sets each participation group to 5%.

Full details of the AB test can be found in the DCR PR: https://github.com/guardian/dotcom-rendering/pull/14108