### PR TITLE
Speedup CI: Split up client build into parallel tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  client-validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,18 +29,63 @@ jobs:
         with:
           cache: yarn
           node-version-file: .nvmrc
+
+      - run: make install
+      - run: make validate
+      - run: make test
+
+  client-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version-file: .nvmrc
+
+      - run: make install
+      - run: make compile
+
+      - name: upload frontend-client
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-client
+          path: |
+            static/hash
+            static/target
+            common/conf/assets
+          if-no-files-found: error
+
+  build:
+    needs: [client-validate, client-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version-file: .nvmrc
+
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
           cache: sbt
           java-version: 11
 
-      - run: make reinstall
-      - run: make validate
-      - run: make test
-      - run: make compile
+      # Scala tests rely on client build assets
+      - name: Download frontend-client
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-client
+          path: .
 
-      - name: Test, compile
+      - name: Test, Compile, Package
         # Australia/Sydney  -because it is too easy for devs to forget about timezones
         run: |
           java \
@@ -50,7 +95,7 @@ jobs:
           -XX:+UseParallelGC \
           -DAPP_SECRET="fake_secret" \
           -Duser.timezone=Australia/Sydney \
-          -jar ./bin/sbt-launch.jar clean compile assets scalafmtCheckAll test Universal/packageBin
+          -jar ./bin/sbt-launch.jar compile assets scalafmtCheckAll test Universal/packageBin
 
       - name: Test Summary
         uses: test-summary/action@v2


### PR DESCRIPTION
## What does this change?

Speedup CI:

- split up client build into parallel tasks:
    - client validate (lint and tests)
    - client compile
- uploads client build artifacts as required by
    - the Scala tests :(
    - the packaging step
    
Build times can vary, but from initial observations this change reduces the time taken by ~30-60s.

Not a huge amount but this is a precursor to further work to parallelise the build.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/cd35d428-f1aa-4a67-803f-c209d2984fc9
[after]: https://github.com/user-attachments/assets/d7f70a4a-a7ba-464f-a144-e53ac021eb70

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering

