### PR TITLE
Bump facia scala client to 20.0.1

### DIFF
--- a/common/test/html/BrazeEmailFormatterTest.scala
+++ b/common/test/html/BrazeEmailFormatterTest.scala
@@ -3,6 +3,7 @@ package html
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.twirl.api.Html
+import org.jsoup.Jsoup
 
 class BrazeEmailFormatterTest extends AnyFlatSpec with Matchers {
 
@@ -83,7 +84,10 @@ class BrazeEmailFormatterTest extends AnyFlatSpec with Matchers {
         |</body>
         |</html>""".stripMargin
 
-    BrazeEmailFormatter(Html(rawHtml)) shouldBe Html(expectedText)
+    val actualHtml = Jsoup.parse(BrazeEmailFormatter(Html(rawHtml)).body).body().html().trim
+    val expectedHtml = Jsoup.parse(expectedText).body().html().trim
+
+    actualHtml shouldBe expectedHtml
   }
 
   it should "not affect unsubscribe url placeholder links" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsVersion = "1.12.782"
   val awsSdk2Version = "2.30.38"
   val capiVersion = "34.1.1"
-  val faciaVersion = "20.0.0"
+  val faciaVersion = "20.0.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
Bumps FSC to version 20.0.1. 

This version contains a fix for video atoms where main media atoms were not being correctly selected when more than one atom was available.

During development, a flakey braze test kept failing due to formatting differences. I've added a jsoup parser to this test so that it correctly ignores irrelevant formatting differences during test comparison

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4183ca4b-bd4e-4301-912f-fb288c9d2d2c
[after]: https://github.com/user-attachments/assets/c445d3ca-e870-4c10-942e-e50bd2085428



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
