### PR TITLE
Automatically update AMI for GuCDK RSS stack

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -19,6 +19,7 @@ templates:
     - update-ami-for-sport
     - update-ami-for-archive
     - update-ami-for-applications
+    - update-ami-for-rss
 
 deployments:
   admin:
@@ -103,5 +104,13 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIApplications:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-rss:
+    app: rss
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIRss:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows us to automatically update the AMI for the GuCDK RSS stack

## What does this change?

This allows `dotcom:frontend-all` deployments (including scheduled deployments) to automatically update the AMI
