### PR TITLE
Allow Riff-Raff to update both RSS ASGs during GuCDK migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -46,6 +46,8 @@ deployments:
     template: frontend
   rss:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   sport:
     template: frontend
   frontend-static:


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are [dual-stacking](https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md) RSS as we migrate to GuCDK. This means all infrastructure components (load balancer, autoscaling group etc.) are temporarily duplicated.

Riff-Raff normally expects to find exactly one matching autoscaling group for a set of tags. When deploying it will update the application code for that autoscaling group only. If Riff-Raff finds more than one autoscaling group with the same set of tags the deployment will fail.

This change adds the `asgMigrationInProgress` to RSS to allow Riff-Raff to update both autoscaling groups when deploying.

This relies on https://github.com/guardian/platform/pull/1886 being applied first.

## Checklist

[Validated with Riff-Raff](https://riffraff.gutools.co.uk/configuration/validation)

<img width="1151" alt="Screenshot 2025-06-23 at 15 23 09" src="https://github.com/user-attachments/assets/f6d69ff7-6a92-44bb-b694-f8e249c2db49" />
