### PR TITLE
Extend `dcr-javascript-bundle` experiment expiry date

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -42,7 +42,7 @@ object DCRJavascriptBundle
       name = "dcr-javascript-bundle",
       description = "DCAR JS bundle experiment to test replacing Preact with React",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 6, 30),
+      sellByDate = LocalDate.of(2025, 7, 30),
       participationGroup = Perc0E,
     )
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Extends expiry date of the `dcr-javascript-bundle` experiment by a month.

The purpose of this experiment is to determine the impact of switching from Preact to React on the client. Previous testing revealed some React hydration issues that need resolving before we enable this again for readers. Whilst this isn't being actively worked on at the moment, it's likely to be picked up again in the upcoming health sprint so it seems simplest to keep the experiment in place rather than remove it and the corresponding code in DCAR.
