### PR TITLE
Add women's euros 2025 competition

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -137,14 +137,13 @@ object CompetitionsProvider {
     ),
     Competition(
       "423",
-      "/football/women-s-euro-2022",
-      "Women's Euro 2022",
-      "Women's Euro 2022",
+      "/football/women-s-euro-2025",
+      "Women's Euro 2025",
+      "Women's Euro 2025",
       "Internationals",
       showInTeamsList = true,
       tableDividers = List(2),
-      startDate = Some(LocalDate.of(2022, 7, 1)),
-      finalMatchSVG = Some("womens_euros_2022_badge"),
+      startDate = Some(LocalDate.of(2025, 7, 2)),
     ),
     Competition(
       "870",

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -257,22 +257,22 @@ object KnockoutSpider {
       //   ━┛             ┗━
       ZonedDateTime.of(2024, 7, 14, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Match 51
     ),
-    // Womens Euro 2022
+    // Womens Euro 2025
     "423" -> List(
       // Group A Winner & Group B Runner Up
-      ZonedDateTime.of(2022, 7, 20, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 1  // 4287725
+      ZonedDateTime.of(2025, 7, 16, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 1  // 4287725
       // Group C Winner & Group D Runner up
-      ZonedDateTime.of(2022, 7, 22, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 3  // 4287727
+      ZonedDateTime.of(2025, 7, 18, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 3  // 4287727
       // Group B Winner & Group A Runner Up
-      ZonedDateTime.of(2022, 7, 21, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 2  // 4287726
+      ZonedDateTime.of(2025, 7, 17, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 2  // 4287726
       // Group D Winner & Group C Runner up
-      ZonedDateTime.of(2022, 7, 23, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 4  // 4287728
+      ZonedDateTime.of(2025, 7, 19, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 4  // 4287728
       // QF Winners 3 & 1
-      ZonedDateTime.of(2022, 7, 26, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final 1     // 4287730
+      ZonedDateTime.of(2025, 7, 22, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final 1     // 4287730
       // QF Winners 4 & 2
-      ZonedDateTime.of(2022, 7, 27, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final 2     // 4287731
+      ZonedDateTime.of(2025, 7, 23, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final 2     // 4287731
       // SM Winners 1 & 2
-      ZonedDateTime.of(2022, 7, 31, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final            // 4287732
+      ZonedDateTime.of(2025, 7, 27, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final            // 4287732
     ),
   )
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
Part of https://github.com/guardian/dotcom-rendering/issues/14079
## What does this change?
The women's euro championship retains the same competition id from the 2022 championship. I have updated the competition title and dates for the competition and the spider
## Screenshots

<img width="962" alt="image" src="https://github.com/user-attachments/assets/c72fabab-0328-4bd8-ad84-9e9bb5bcdb90" />

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
