### PR TITLE
Automatically update the AMI for onward stack and allow Riff-Raff to update 2 onward ASGs during GuCDK migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -20,6 +20,7 @@ templates:
     - update-ami-for-archive
     - update-ami-for-applications
     - update-ami-for-rss
+    - update-ami-for-onward
 
 deployments:
   admin:
@@ -42,6 +43,8 @@ deployments:
     template: frontend
   onward:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   preview:
     template: frontend
   rss:
@@ -112,5 +115,13 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIRss:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-onward:
+    app: onward
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIOnward:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR allows us to automatically update the AMI for the onward stack and allow Riff-Raff to update 2 onward ASGs during GuCDK migration.
## What does this change?
This allows dotcom:frontend-all deployments (including scheduled deployments) to automatically update the AMI used by the new GuCDK stack (introduced in https://github.com/guardian/platform/pull/1887).

To be deployed after https://github.com/guardian/platform/pull/1891

Part of https://github.com/guardian/platform/issues/1882

The AMI update for the legacy stack (which uses nested stacks) should remain unchanged.


## Checklist

- [x] [Tested on code ](https://riffraff.gutools.co.uk/deployment/view/d0d34856-46b3-4016-ae9e-a5c30996b6bb?verbose=1)

<img width="1121" alt="image" src="https://github.com/user-attachments/assets/df0b4092-3d27-4ab1-b213-870c8a8eb7ad" />

<img width="970" alt="image" src="https://github.com/user-attachments/assets/ca518eff-846f-4b07-a28c-51aca8990cc9" />

