### PR TITLE
Read `special-ad-units` from S3 

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -9,6 +9,7 @@ import services.ophan.SurgingContentAgent
 import play.api.libs.json.{JsString, Json}
 import play.api.mvc._
 import tools._
+import conf.switches.Switches.{LineItemJobs}
 
 import scala.concurrent.duration._
 import scala.util.Try
@@ -44,7 +45,9 @@ class CommercialController(
 
   def renderSpecialAdUnits: Action[AnyContent] =
     Action { implicit request =>
-      val specialAdUnits = dfpApi.readSpecialAdUnits(Configuration.commercial.dfpAdUnitGuRoot)
+      val specialAdUnits =
+        if (LineItemJobs.isSwitchedOn) { Store.getDfpSpecialAdUnits }
+        else { dfpApi.readSpecialAdUnits(Configuration.commercial.dfpAdUnitGuRoot) }
       Ok(views.html.commercial.specialAdUnits(specialAdUnits))
     }
 

--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -48,7 +48,7 @@ class CommercialController(
       val specialAdUnits =
         if (LineItemJobs.isSwitchedOn) { Store.getDfpSpecialAdUnits }
         else { dfpApi.readSpecialAdUnits(Configuration.commercial.dfpAdUnitGuRoot) }
-      Ok(views.html.commercial.specialAdUnits(specialAdUnits))
+      NoCache(Ok(views.html.commercial.specialAdUnits(specialAdUnits)))
     }
 
   def renderPageskins: Action[AnyContent] =

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -89,6 +89,13 @@ trait Store extends GuLogging with Dates {
   def getAbTestFrameUrl: Option[String] = {
     S3.getPresignedUrl(abTestHtmlObjectKey)
   }
+
+  def getDfpSpecialAdUnits: Seq[(String, String)] = {
+    val specialAdUnits = for (doc <- S3.get(dfpSpecialAdUnitsKey)) yield {
+      Json.parse(doc).as[Seq[(String, String)]]
+    }
+    specialAdUnits getOrElse Nil
+  }
 }
 
 object Store extends Store

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -497,6 +497,7 @@ class GuardianConfiguration extends GuLogging {
     def dfpLineItemsKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/line-items.json"
       else s"$dfpRoot/lineitems-v7.json"
+    lazy val dfpSpecialAdUnitsKey = s"$gamRoot/special-ad-units.json"
     lazy val dfpTemplateCreativesKey = s"$dfpRoot/template-creatives.json"
     lazy val dfpCustomTargetingKey = s"$dfpRoot/custom-targeting-key-values.json"
     lazy val adsTextObjectKey = s"$commercialRoot/ads.txt"


### PR DESCRIPTION
## What does this change?

This PR reads `special-ad-units.json` from S3 instead of reading from memory. This is part of the Commercial jobs migration to it's own separate repo 'line-item-jobs' to reduce the Commercial code in Frontend and stop allowing Frontend connects with Google AdManager API directly. 

The read from S3 relies on the `LineItemJobs` switch and we will keep it that way for a week or so just to be sure that we are not getting any strange behavior. 

Related PR https://github.com/guardian/line-item-jobs/pull/68

## Checklist

- [x] Tested locally, and on CODE if necessary
