### PR TITLE
Add trail images to the media atom model

### DIFF
--- a/common/app/model/content/Atom.scala
+++ b/common/app/model/content/Atom.scala
@@ -167,6 +167,7 @@ final case class MediaAtom(
     expired: Option[Boolean],
     activeVersion: Option[Long],
     channelId: Option[String],
+    trailImage: Option[ImageMedia],
 ) extends Atom {
 
   def activeAssets: Seq[MediaAsset] =
@@ -221,6 +222,7 @@ object MediaAtom extends common.GuLogging {
       expired = Some(false),
       activeVersion = mediaAtom.activeVersion,
       channelId = mediaAtom.metadata.flatMap(_.channelId),
+      trailImage = mediaAtom.trailImage.map(imageMediaMake(_, mediaAtom.title)),
     )
   }
 
@@ -241,6 +243,7 @@ object MediaAtom extends common.GuLogging {
       expired = expired,
       activeVersion = mediaAtom.activeVersion,
       channelId = mediaAtom.metadata.flatMap(_.channelId),
+      trailImage = mediaAtom.trailImage.map(imageMediaMake(_, mediaAtom.title)),
     )
   }
 

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -396,9 +396,9 @@ class ContentTest
     val contentNoByline = content("video", Nil).content
     val contentWithByline = content("video", Nil, byline).content
 
-    val mediaAtomWithSource = Some(MediaAtom("", "", Nil, "", None, atomSource, None, None, None, None))
-    val mediaAtomWithNoSource = Some(MediaAtom("", "", Nil, "", None, None, None, None, None, None))
-    val mediaAtomWithEmptySource = Some(MediaAtom("", "", Nil, "", None, emptySource, None, None, None, None))
+    val mediaAtomWithSource = Some(MediaAtom("", "", Nil, "", None, atomSource, None, None, None, None, None))
+    val mediaAtomWithNoSource = Some(MediaAtom("", "", Nil, "", None, None, None, None, None, None, None))
+    val mediaAtomWithEmptySource = Some(MediaAtom("", "", Nil, "", None, emptySource, None, None, None, None, None))
 
     Video(contentNoByline, None, None).bylineWithSource should be(None)
     Video(contentNoByline, videoSource, None).bylineWithSource should be(videoSource.map(s => s"Source: $s"))

--- a/common/test/views/fragments/atoms/YoutubeSpec.scala
+++ b/common/test/views/fragments/atoms/YoutubeSpec.scala
@@ -28,6 +28,7 @@ class YoutubeSpec extends MixedPlaySpec {
         expired = None,
         activeVersion = None,
         channelId = None,
+        trailImage = None,
       )
       val displayCaption = false
       val view = views.html.fragments.atoms

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -45,6 +45,7 @@ class AtomCleanerTest extends AnyFlatSpec with Matchers with WithTestApplication
           expired = None,
           activeVersion = None,
           channelId = None,
+          trailImage = Some(image),
         ),
       ),
       interactives = Nil,


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
Adds the media atom trail images to the media atom model. This allows them to be accessed on DCR.

This is required so that we can show the 5:4 cropped trail image rather than the 16:9 poster image. Its possible we will still use the poster image on the rendering platform so this property has been retained and the trail image property added. 

## Screenshots
![Screenshot 2025-07-03 at 11 51 16](https://github.com/user-attachments/assets/dedc9d66-513c-4fc4-8a02-d16f4eafeeb1)

