### PR TITLE
Bump @guardian/libs to 23.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
-		"@guardian/libs": "22.4.0",
+		"@guardian/libs": "23.0.0",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,7 +3899,7 @@ __metadata:
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:6.0.1"
     "@guardian/identity-auth-frontend": "npm:8.1.0"
-    "@guardian/libs": "npm:22.4.0"
+    "@guardian/libs": "npm:23.0.0"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
     "@guardian/source-foundations": "npm:16.0.0"
@@ -4094,6 +4094,19 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/1fff3fa27a4c16108bdd394a728a57c4ebc6c2862777e92d900f94059748d36e622a903c2a564e6101830fd65437d399d5b3a333660a1e7479ef6b6733c625f2
+  languageName: node
+  linkType: hard
+
+"@guardian/libs@npm:23.0.0":
+  version: 23.0.0
+  resolution: "@guardian/libs@npm:23.0.0"
+  peerDependencies:
+    tslib: ^2.6.2
+    typescript: ~5.5.2
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/bfd4990f674fb39fb01aaf8a7780287c1b01369657d1afaddc22af6974a05b49dd7f7b4cc1c89e5921e7b00c7707533d86c5bedbc0628596ca6d23f9c1909139
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?
This PR bumps the version of @guardian/libs to 23.0.0. This update uses Sourcepoint's function to get consent in the US.
## Why?
Sourcepoint recommended we migrate to their getUserConsent function from _gpp as it's more reliable.



Tested in CODE.
[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

