### PR TITLE
Add women euro 2025 atoms to euro specific live scores and tables

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -606,4 +606,15 @@ trait FeatureSwitches {
     exposeClientSide = false,
     highImpact = false,
   )
+
+  val WomensEuro2025Atom = Switch(
+    SwitchGroup.Feature,
+    "womens-euro-2025-atom",
+    "If this switch is on, the atom will be rendered on several football data pages",
+    owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+    highImpact = false,
+  )
 }

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -1,6 +1,7 @@
 package football.controllers
 
 import common.Edition
+import contentapi.ContentApiClient
 import feed.CompetitionsService
 import football.model._
 import model._
@@ -11,6 +12,7 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents}
 class FixturesController(
     val competitionsService: CompetitionsService,
     val controllerComponents: ControllerComponents,
+    val contentApiClient: ContentApiClient,
     val wsClient: WSClient,
 )(implicit context: ApplicationContext)
     extends MatchListController
@@ -77,10 +79,18 @@ class FixturesController(
     getTagFixtures(date, tag)
       .map(result =>
         Action.async { implicit request =>
-          renderMatchList(
-            result._1,
-            result._2,
-            filters,
+          val futureAtom = FootballWomensEuro2025Atom.getAtom(
+            tag,
+            contentApiClient,
+            "/atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-live-scores",
+          )
+          futureAtom.flatMap(maybeAtom =>
+            renderMatchList(
+              result._1,
+              result._2,
+              filters,
+              maybeAtom,
+            ),
           )
         },
       )

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -7,13 +7,12 @@ import model._
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import model.content.InteractiveAtom
 import contentapi.ContentApiClient
-import football.model.DotcomRenderingFootballTablesDataModel
+import football.model.{DotcomRenderingFootballTablesDataModel, FootballWomensEuro2025Atom}
 import implicits.{HtmlFormat, JsonFormat}
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import services.dotcomrendering.{FootballTablesPagePicker, RemoteRender}
 
-import scala.concurrent.Future
 import scala.concurrent.Future.successful
 
 case class TablesPage(
@@ -160,14 +159,11 @@ class LeagueTableController(
             s"${table.competition.fullName} table",
           )
 
-          val futureAtom = if (competition == "women-s-euro-2025") {
-            val id = "/atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-tables"
-            val edition = Edition(request)
-            contentApiClient
-              .getResponse(contentApiClient.item(id, edition))
-              .map(_.interactive.map(InteractiveAtom.make(_)))
-              .recover { case _ => None }
-          } else Future.successful(None)
+          val futureAtom = FootballWomensEuro2025Atom.getAtom(
+            competition,
+            contentApiClient,
+            "/atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-tables",
+          )
 
           val smallTableGroup =
             table.copy(groups = table.groups.map { group => group.copy(entries = group.entries.take(10)) }).groups(0)

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -8,7 +8,6 @@ import model._
 import football.model._
 import common.{Edition, ImplicitControllerExecutionContext, JsonComponent}
 import contentapi.ContentApiClient
-import model.content.InteractiveAtom
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.Future
@@ -59,14 +58,11 @@ class MatchDayController(
           val page = new FootballPage(s"football/$competitionTag/live", "football", webTitle)
           val matches = CompetitionMatchDayList(competitionsService.competitions, competition.id, date)
 
-          val futureAtom = if (competition.url.endsWith("women-s-euro-2025")) {
-            val id = "/atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-live-scores"
-            val edition = Edition(request)
-            contentApiClient
-              .getResponse(contentApiClient.item(id, edition))
-              .map(_.interactive.map(InteractiveAtom.make(_)))
-              .recover { case _ => None }
-          } else Future.successful(None)
+          val futureAtom = FootballWomensEuro2025Atom.getAtom(
+            competitionTag,
+            contentApiClient,
+            "atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-live-scores",
+          )
 
           futureAtom.flatMap(maybeAtom => renderMatchList(page, matches, filters, maybeAtom))
         }

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -47,6 +47,7 @@ trait MatchListController extends BaseController with Requests with ImplicitCont
           page = page,
           matchesList = matchesList,
           filters = filters,
+          atom,
         )
         successful(Cached(CacheTime.Football)(JsonComponent.fromWritable(model)))
       case JsonFormat =>
@@ -63,6 +64,7 @@ trait MatchListController extends BaseController with Requests with ImplicitCont
           page = page,
           matchesList = matchesList,
           filters = filters,
+          atom,
         )
         remoteRenderer.getFootballPage(wsClient, DotcomRenderingFootballMatchListDataModel.toJson(model))
       case _ =>

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -1,6 +1,7 @@
 package football.controllers
 
 import common.Edition
+import contentapi.ContentApiClient
 import feed.CompetitionsService
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import java.time.LocalDate
@@ -16,6 +17,7 @@ import scala.concurrent.Future
 class ResultsController(
     val competitionsService: CompetitionsService,
     val controllerComponents: ControllerComponents,
+    val contentApiClient: ContentApiClient,
     val wsClient: WSClient,
 )(implicit context: ApplicationContext)
     extends MatchListController
@@ -65,24 +67,34 @@ class ResultsController(
           Map[String, Seq[CompetitionFilter]],
           Option[InteractiveAtom],
       ) => Future[Result],
-  )(date: LocalDate, tag: Option[String] = None): Future[Result] = {
+  )(date: LocalDate, tag: Option[String] = None, maybeAtom: Option[InteractiveAtom]): Future[Result] = {
     val result = for {
       p <- page(tag)
       r <- results(date, tag)
     } yield {
-      renderFunction(p, r, filters, None)
+      renderFunction(p, r, filters, maybeAtom)
     }
     result.getOrElse(Future.successful(NotFound("No results")))
   }
 
   private def renderForDate(date: LocalDate, tag: Option[String] = None): Action[AnyContent] =
     Action.async { implicit request =>
-      renderWithAsync(renderMatchList)(date, tag)
+      tag match {
+        case Some(t) =>
+          val futureAtom = FootballWomensEuro2025Atom.getAtom(
+            t,
+            contentApiClient,
+            "/atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-tables",
+          )
+          futureAtom.flatMap(maybeAtom => renderWithAsync(renderMatchList)(date, tag, maybeAtom))
+
+        case None => renderWithAsync(renderMatchList)(date, tag, None)
+      }
     }
 
   private def renderMoreForDate(date: LocalDate, tag: Option[String] = None): Action[AnyContent] =
     Action.async { implicit request =>
-      renderWithAsync(renderMoreMatches)(date, tag)
+      renderWithAsync(renderMoreMatches)(date, tag, None)
     }
 
   /* Public methods */
@@ -97,8 +109,10 @@ class ResultsController(
   def moreResultsForJson(year: String, month: String, day: String): Action[AnyContent] =
     renderMoreForDate(createDate(year, month, day))
 
-  def tagResults(tag: String): Action[AnyContent] =
+  def tagResults(tag: String): Action[AnyContent] = {
     renderForDate(LocalDate.now(Edition.defaultEdition.timezoneId), Some(tag))
+  }
+
   def tagResultsJson(tag: String): Action[AnyContent] = tagResults(tag)
 
   def tagResultsFor(year: String, month: String, day: String, tag: String): Action[AnyContent] =

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -57,8 +57,8 @@ class WallchartController(
               Future.successful(NotFound)
             case _ =>
               val nextMatch = WallchartController.nextMatch(competition.matches, ZonedDateTime.now())
-              val futureAtom = if (competitionTag == "euro-2024") {
-                val id = "/atom/interactive/interactives/2023/01/euros-2024/tables-euros-2024-header"
+              val futureAtom = if (competitionTag == "women-s-euro-2025") {
+                val id = "/atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-tables"
                 val edition = Edition(request)
                 contentApiClient
                   .getResponse(contentApiClient.item(id, edition))

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -5,18 +5,21 @@ import model.Cached.RevalidatableResult
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import common.{GuLogging, ImplicitControllerExecutionContext, JsonComponent}
 import model.{ApplicationContext, Cached}
-import football.model.{CompetitionStage, DotcomRenderingWallchartDataModel, Groups, KnockoutSpider}
+import football.model.{
+  CompetitionStage,
+  DotcomRenderingWallchartDataModel,
+  FootballWomensEuro2025Atom,
+  Groups,
+  KnockoutSpider,
+}
 import pa.FootballMatch
 
 import java.time.ZonedDateTime
 import scala.concurrent.Future
 import contentapi.ContentApiClient
-import conf.switches.Switches
-import common.Edition
 import football.model.DotcomRenderingWallchartDataModel.toJson
 import implicits.JsonFormat
 import model.Cors.RichRequestHeader
-import model.content.InteractiveAtom
 
 class WallchartController(
     competitionsService: CompetitionsService,
@@ -57,14 +60,12 @@ class WallchartController(
               Future.successful(NotFound)
             case _ =>
               val nextMatch = WallchartController.nextMatch(competition.matches, ZonedDateTime.now())
-              val futureAtom = if (competitionTag == "women-s-euro-2025") {
-                val id = "/atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-tables"
-                val edition = Edition(request)
-                contentApiClient
-                  .getResponse(contentApiClient.item(id, edition))
-                  .map(_.interactive.map(InteractiveAtom.make(_)))
-                  .recover { case _ => None }
-              } else Future.successful(None)
+
+              val futureAtom = FootballWomensEuro2025Atom.getAtom(
+                competitionTag,
+                contentApiClient,
+                "/atom/interactive/interactives/2025/06/2025-women-euro/2025-women-euro-tables",
+              )
 
               futureAtom.map { maybeAtom =>
                 Cached(60) {

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -4,6 +4,7 @@ import common.{CanonicalLink, Edition}
 import conf.Configuration
 import experiments.ActiveExperiments
 import football.controllers.{CompetitionFilter, FootballPage, MatchDataAnswer, MatchPage}
+import model.content.InteractiveAtom
 import model.dotcomrendering.DotcomRenderingUtils.{assetURL, withoutDeepNull, withoutNull}
 import model.dotcomrendering.{Config, PageFooter, PageType, Trail}
 import model.{ApplicationContext, Competition, CompetitionSummary, Group, StandalonePage, Table, TeamUrl}
@@ -95,6 +96,8 @@ private object DotcomRenderingFootballDataModelImplicits {
   implicit val leagueTeamWrites: Writes[LeagueTeam] = Json.writes[LeagueTeam]
   implicit val leagueTableEntryWrites: Writes[LeagueTableEntry] = Json.writes[LeagueTableEntry]
 
+  implicit val atomFormat: Writes[InteractiveAtom] = Json.writes[InteractiveAtom]
+
   private implicit val matchDayTeamFormat: Writes[MatchDayTeam] = Json.writes[MatchDayTeam]
 
   // Writes for Fixture with a type discriminator
@@ -155,6 +158,7 @@ case class DotcomRenderingFootballMatchListDataModel(
     contributionsServiceUrl: String,
     canonicalUrl: String,
     pageId: String,
+    atom: Option[InteractiveAtom],
 ) extends DotcomRenderingFootballDataModel
 
 object DotcomRenderingFootballMatchListDataModel {
@@ -162,6 +166,7 @@ object DotcomRenderingFootballMatchListDataModel {
       page: FootballPage,
       matchesList: MatchesList,
       filters: Map[String, Seq[CompetitionFilter]],
+      atom: Option[InteractiveAtom] = None,
   )(implicit
       request: RequestHeader,
       context: ApplicationContext,
@@ -188,6 +193,7 @@ object DotcomRenderingFootballMatchListDataModel {
       contributionsServiceUrl = Configuration.contributionsService.url,
       canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
       pageId = page.metadata.id,
+      atom = atom,
     )
   }
 
@@ -230,6 +236,7 @@ case class DotcomRenderingFootballTablesDataModel(
     contributionsServiceUrl: String,
     canonicalUrl: String,
     pageId: String,
+    atom: Option[InteractiveAtom],
 ) extends DotcomRenderingFootballDataModel
 
 object DotcomRenderingFootballTablesDataModel {
@@ -237,6 +244,7 @@ object DotcomRenderingFootballTablesDataModel {
       page: FootballPage,
       tables: Seq[Table],
       filters: Map[String, Seq[CompetitionFilter]],
+      atom: Option[InteractiveAtom] = None,
   )(implicit
       request: RequestHeader,
       context: ApplicationContext,
@@ -257,6 +265,7 @@ object DotcomRenderingFootballTablesDataModel {
       contributionsServiceUrl = Configuration.contributionsService.url,
       canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
       pageId = page.metadata.id,
+      atom = atom,
     )
   }
 

--- a/sport/app/football/model/FootballWomensEuro2025Atom.scala
+++ b/sport/app/football/model/FootballWomensEuro2025Atom.scala
@@ -1,0 +1,24 @@
+package football.model
+
+import common.Edition
+import conf.switches.Switches.WomensEuro2025Atom
+import contentapi.ContentApiClient
+import model.content.InteractiveAtom
+import play.api.mvc.{AnyContent, Request}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object FootballWomensEuro2025Atom {
+  def getAtom(competition: String, contentApiClient: ContentApiClient, atomId: String)(implicit
+      request: Request[AnyContent],
+      executionContext: ExecutionContext,
+  ) = {
+    if (WomensEuro2025Atom.isSwitchedOn && competition == "women-s-euro-2025") {
+      val edition = Edition(request)
+      contentApiClient
+        .getResponse(contentApiClient.item(atomId, edition))
+        .map(_.interactive.map(InteractiveAtom.make(_)))
+        .recover { case _ => None }
+    } else Future.successful(None)
+  }
+}

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -17,6 +17,7 @@ import org.scalatest.matchers.should.Matchers
     with WithMaterializer
     with BeforeAndAfterAll
     with WithTestApplicationContext
+    with WithTestContentApiClient
     with WithTestWsClient {
 
   val fixturesUrl = "/football/fixtures"
@@ -24,7 +25,12 @@ import org.scalatest.matchers.should.Matchers
   val tag = "premierleague"
 
   lazy val fixturesController =
-    new FixturesController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents(), wsClient)
+    new FixturesController(
+      testCompetitionsService,
+      play.api.test.Helpers.stubControllerComponents(),
+      testContentApiClient,
+      wsClient,
+    )
 
   "can load the all fixtures page" in {
     val result = fixturesController.allFixtures()(TestRequest())

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -22,10 +22,16 @@ import scala.concurrent.Future
     with BeforeAndAfterAll
     with WithTestApplicationContext
     with WithTestExecutionContext
+    with WithTestContentApiClient
     with WithTestWsClient {
 
   val resultsController =
-    new ResultsController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents(), wsClient)
+    new ResultsController(
+      testCompetitionsService,
+      play.api.test.Helpers.stubControllerComponents(),
+      testContentApiClient,
+      wsClient,
+    )
 
   implicit lazy val mat: Materializer = app.materializer
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR does the following:

- Adds `Women's Euro 2025` live score atom to these pages:
   -  `football/women-s-euro-2025/live`
   -   `football/women-s-euro-2025/fixtures`
- Adds `Women's Euro 2025` tables atom to these pages:
   -  `football/women-s-euro-2025/table`
   - `football/women-s-euro-2025/overview`
   - `football/women-s-euro-2025/results`

## Why
This was requested by editorial for the duration of the Women's Euro 2025 competition


This PR is part of https://github.com/guardian/dotcom-rendering/issues/14152