### PR TITLE
Remove `asgMigrationInProgress` from RSS deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -49,8 +49,6 @@ deployments:
     template: frontend
   rss:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   sport:
     template: frontend
   frontend-static:


### PR DESCRIPTION
## What is the value of this and can you measure success?

This should be merged following removal of the legacy RSS infrastructure (https://github.com/guardian/platform/pull/1894) so we don't break `dotcom:frontend-all` deployments.
