### PR TITLE
Remove asgMigrationInProgress from Onward deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -43,8 +43,6 @@ deployments:
     template: frontend
   onward:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   preview:
     template: frontend
   rss:


### PR DESCRIPTION
## What is the value of this and can you measure success?
This should be merged following removal of the legacy Onward infrastructure (https://github.com/guardian/platform/pull/1898) so we don't break dotcom:frontend-all deployments.
