### PR TITLE
Add ALB support to onward app's 'Ops metrics' functionality

### DIFF
--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -49,7 +49,12 @@ object LoadBalancer extends GuLogging {
       targetGroup = Some("targetgroup/fronte-Targe-LJMDWMGH5FPD/e777dd4276b0bf29"),
     ),
     LoadBalancer("frontend-PROD-commercial-ELB", "Commercial", "frontend-commercial"),
-    LoadBalancer("frontend-PROD-onward-ELB", "Onward", "frontend-onward"),
+    LoadBalancer(
+      "app/fronte-LoadB-NpLaks0rT7va/e5a6b5bea5119952",
+      "Onward",
+      "frontend-onward",
+      targetGroup = Some("targetgroup/fronte-Targe-N0YDVRHJB7IM/99164208e6758b4e"),
+    ),
     LoadBalancer(
       "app/fronte-LoadB-wSjta29AZxoG/32048dda4b467613",
       "Archive",


### PR DESCRIPTION
## What is the value of this and can you measure success?
See [this for context which adds the functionality for discussion](https://github.com/guardian/frontend/pull/27865)
