### PR TITLE
Remove prebid multibid test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,14 +38,4 @@ trait ABTestSwitches {
     highImpact = false,
   )
 
-  Switch(
-    ABTests,
-    "ab-prebid-multibid",
-    "Test re-enabling the multibid feature in Prebid.js",
-    owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 7, 15)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -37,5 +37,4 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
 }


### PR DESCRIPTION
## What does this change?

This PR removes the prebid `multibid` test as we have enough data for the analysis. 

Related work  https://github.com/guardian/commercial/pull/2066

## Checklist

- [x] Tested locally, and on CODE if necessary
