### PR TITLE
reads custom fields from s3 with feature switch

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -11,7 +11,6 @@ import play.api.mvc._
 import tools._
 import conf.switches.Switches.{LineItemJobs}
 
-import conf.switches.Switches.{LineItemJobs}
 import scala.concurrent.duration._
 import scala.util.Try
 

--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -11,6 +11,7 @@ import play.api.mvc._
 import tools._
 import conf.switches.Switches.{LineItemJobs}
 
+import conf.switches.Switches.{LineItemJobs}
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -90,9 +91,9 @@ class CommercialController(
 
   def renderCustomFields: Action[AnyContent] =
     Action { implicit request =>
-      val fields: Seq[GuCustomField] = customFieldAgent.get.data.values.toSeq
+      val fields: Seq[GuCustomField] = if (LineItemJobs.isSwitchedOn) { Store.getDfpCustomFields }
+      else { customFieldAgent.get.data.values.toSeq }
       NoCache(Ok(views.html.commercial.customFields(fields)))
-
     }
 
   def renderAdTests: Action[AnyContent] =

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -86,6 +86,13 @@ trait Store extends GuLogging with Dates {
     targeting getOrElse Nil
   }
 
+  def getDfpCustomFields: Seq[GuCustomField] = {
+    val specialAdUnits = for (doc <- S3.get(dfpCustomFieldsKey)) yield {
+      Json.parse(doc).as[Seq[GuCustomField]]
+    }
+    specialAdUnits getOrElse Nil
+  }
+
   def getAbTestFrameUrl: Option[String] = {
     S3.getPresignedUrl(abTestHtmlObjectKey)
   }

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -87,10 +87,10 @@ trait Store extends GuLogging with Dates {
   }
 
   def getDfpCustomFields: Seq[GuCustomField] = {
-    val specialAdUnits = for (doc <- S3.get(dfpCustomFieldsKey)) yield {
+    val customFields = for (doc <- S3.get(dfpCustomFieldsKey)) yield {
       Json.parse(doc).as[Seq[GuCustomField]]
     }
-    specialAdUnits getOrElse Nil
+    customFields getOrElse Nil
   }
 
   def getAbTestFrameUrl: Option[String] = {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -498,6 +498,7 @@ class GuardianConfiguration extends GuLogging {
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/line-items.json"
       else s"$dfpRoot/lineitems-v7.json"
     lazy val dfpSpecialAdUnitsKey = s"$gamRoot/special-ad-units.json"
+    lazy val dfpCustomFieldsKey = s"$gamRoot/custom-fields.json"
     lazy val dfpTemplateCreativesKey = s"$dfpRoot/template-creatives.json"
     lazy val dfpCustomTargetingKey = s"$dfpRoot/custom-targeting-key-values.json"
     lazy val adsTextObjectKey = s"$commercialRoot/ads.txt"

--- a/common/app/common/dfp/DfpAgent.scala
+++ b/common/app/common/dfp/DfpAgent.scala
@@ -19,6 +19,7 @@ object DfpAgent extends PageskinAdAgent with LiveBlogTopSponsorshipAgent with Su
   private lazy val pageskinnedAdUnitAgent = Box[Seq[PageSkinSponsorship]](Nil)
   private lazy val nonRefreshableLineItemsAgent = Box[Seq[Long]](Nil)
   private lazy val specialAdUnitsAgent = Box[Seq[(String, String)]](Nil)
+  private lazy val customFieldsAgent = Box[Seq[GuCustomField]](Nil)
 
   protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = pageskinnedAdUnitAgent.get()
   protected def liveBlogTopSponsorships: Seq[LiveBlogTopSponsorship] = liveblogTopSponsorshipAgent.get()
@@ -77,6 +78,12 @@ object DfpAgent extends PageskinAdAgent with LiveBlogTopSponsorshipAgent with Su
       } yield report) getOrElse Nil
     }
 
+    def grabCustomFieldsFromStore() = {
+      (for {
+        jsonString <- stringFromS3(dfpCustomFieldsKey)
+        customFields <- Json.parse(jsonString).validate[Seq[GuCustomField]].asOpt
+      } yield customFields) getOrElse Nil
+    }
     update(pageskinnedAdUnitAgent)(grabPageSkinSponsorshipsFromStore(dfpPageSkinnedAdUnitsKey))
 
     update(nonRefreshableLineItemsAgent)(grabNonRefreshableLineItemIdsFromStore())
@@ -87,5 +94,6 @@ object DfpAgent extends PageskinAdAgent with LiveBlogTopSponsorshipAgent with Su
 
     update(specialAdUnitsAgent)(grabSpecialAdUnitsFromStore())
 
+    update(customFieldsAgent)(grabCustomFieldsFromStore())
   }
 }


### PR DESCRIPTION

## What does this change?

This PR reads custom-fields.json from S3 instead of reading from directly from DFP/GAM. 
This is part of the Commercial jobs migration to it's own separate repo 'line-item-jobs' to reduce the Commercial code in Frontend and stop allowing Frontend connects with Google AdManager API directly.

The read from S3 relies on the CustomFieldsJobs switch and we will keep it that way for a week or so just to be sure that we are not getting any strange behavior.

Related PR: https://github.com/guardian/line-item-jobs/pull/70

## Screenshots
<img width="1462" alt="Screenshot 2025-07-01 at 18 01 21" src="https://github.com/user-attachments/assets/e6f0f307-2de3-4e28-8c84-26788b3e6a66" />

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary (using DEV env for S3 retrieval)
