### PR TITLE
New Play Framework release 3.0.8 and others

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
-  val playJsonVersion = "3.0.4"
+  val playJsonVersion = "3.0.5"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.16.0"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ logLevel := Level.Warn
 // Dependencies used by the VersionInfo plugin
 libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.12.7",
-  "org.joda" % "joda-convert" % "2.2.3",
+  "org.joda" % "joda-convert" % "2.2.4",
 )
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.7")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.8")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 
 addDependencyTreePlugin
 


### PR DESCRIPTION
Copy of https://github.com/guardian/frontend/pull/28063 thanks @mkurz

See https://github.com/playframework/playframework/releases/tag/3.0.8

Also updated some other dependencies along the way.

Deployed to code: https://riffraff.gutools.co.uk/deployment/view/31d8efd8-8966-4b53-8ba3-e344c798541b