### PR TITLE
Reduce sports jobs frequency in preview

### DIFF
--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -75,7 +75,7 @@ class FootballLifecycle(
       competitionsService.refreshCompetitionData()
     }
 
-    // if preview "Every hour at 40 minutes" otherwise "Every minute"
+    // if preview "Every hour at 40 minutes" otherwise "Every 10 minutes"
     jobs.schedule("TeamMapRefreshJob", if (context.isPreview) "0 40 * * * ?" else "0 0/10 * * * ?") {
       TeamMap.refresh()(contentApiClient, ec)
     }

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -4,7 +4,7 @@ import app.LifecycleComponent
 import common._
 import contentapi.ContentApiClient
 import feed.CompetitionsService
-import model.TeamMap
+import model.{ApplicationContext, TeamMap}
 import pa.{Http, PaClient, PaClientErrorsException}
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.ws.WSClient
@@ -18,7 +18,7 @@ class FootballLifecycle(
     pekkoAsync: PekkoAsync,
     competitionsService: CompetitionsService,
     contentApiClient: ContentApiClient,
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, context: ApplicationContext)
     extends LifecycleComponent {
 
   val defaultClock = Clock.systemDefaultZone()
@@ -31,10 +31,19 @@ class FootballLifecycle(
 
   private def scheduleJobs(): Unit = {
     competitionsService.competitionIds.zipWithIndex foreach { case (id, index) =>
-      // stagger fixtures and results refreshes to avoid timeouts
-      val seconds = index * 5 % 60
-      val minutes = index * 5 / 60 % 5
-      val cron = s"$seconds $minutes/5 * * * ?"
+      val cron = if (context.isPreview) {
+        // In preview mode, stagger jobs more slowly (once per hour, spaced out by minute based on index)
+        val minute = index % 60 // Distribute jobs over the 60 minutes of the hour
+        s"0 $minute * * * ?"
+      } else {
+        // Normal mode: Stagger jobs once per 5 minutes spaced out by seconds based on index
+        // stagger fixtures and results refreshes to avoid timeouts
+        val seconds = index * 5 % 60
+        val minutes = index * 5 / 60 % 5
+        s"$seconds $minutes/5 * * * ?"
+      }
+
+      println(s"cron: ${cron}")
 
       jobs.schedule(s"CompetitionAgentRefreshJob_$id", cron) {
         competitionsService.refreshCompetitionAgent(id, defaultClock)
@@ -46,19 +55,24 @@ class FootballLifecycle(
     Ideally, we should combine the logic of these two jobs so we only call once. This is tricky to achieve with the current code.
     We intend to move to a stream model so we can achieve this.
      */
-    jobs.schedule("MatchDayAgentRefreshJob", "0 0/5 * * * ?") {
+    // if preview "Every hour at 40 minutes" otherwise "Every 5 minutes"
+    // 40 minute was chosen for preview to run these jobs after the 35 CompetitionAgentRefreshJobs are finished
+    jobs.schedule("MatchDayAgentRefreshJob", if (context.isPreview) "0 40 * * * ?" else "0 0/5 * * * ?") {
       competitionsService.refreshMatchDay(defaultClock)
     }
 
-    jobs.schedule("MaybeMatchDayAgentRefreshJob", "0 0/1 * * * ?") {
+    // if preview "Every hour at 40 minutes" otherwise "Every minute"
+    jobs.schedule("MaybeMatchDayAgentRefreshJob", if (context.isPreview) "0 40 * * * ?" else "0 0/1 * * * ?") {
       competitionsService.maybeRefreshLiveMatches(defaultClock)
     }
 
-    jobs.schedule("CompetitionRefreshJob", "0 0/10 * * * ?") {
+    // if preview "Every hour at 40 minutes" otherwise "Every 10 minutes"
+    jobs.schedule("CompetitionRefreshJob", if (context.isPreview) "0 40 * * * ?" else "0 0/10 * * * ?") {
       competitionsService.refreshCompetitionData()
     }
 
-    jobs.schedule("TeamMapRefreshJob", "0 0/10 * * * ?") {
+    // if preview "Every hour at 40 minutes" otherwise "Every minute"
+    jobs.schedule("TeamMapRefreshJob", if (context.isPreview) "0 40 * * * ?" else "0 0/10 * * * ?") {
       TeamMap.refresh()(contentApiClient, ec)
     }
   }

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -66,17 +66,17 @@ class FootballLifecycle(
     }
 
     // if preview "Every hour at 40 minutes" otherwise "Every minute"
-    jobs.schedule("MaybeMatchDayAgentRefreshJob", if (context.isPreview) "0 40 * * * ?" else "0 0/1 * * * ?") {
+    jobs.schedule("MaybeMatchDayAgentRefreshJob", if (context.isPreview) "0 41 * * * ?" else "0 0/1 * * * ?") {
       competitionsService.maybeRefreshLiveMatches(defaultClock)
     }
 
     // if preview "Every hour at 40 minutes" otherwise "Every 10 minutes"
-    jobs.schedule("CompetitionRefreshJob", if (context.isPreview) "0 40 * * * ?" else "0 0/10 * * * ?") {
+    jobs.schedule("CompetitionRefreshJob", if (context.isPreview) "0 42 * * * ?" else "0 0/10 * * * ?") {
       competitionsService.refreshCompetitionData()
     }
 
     // if preview "Every hour at 40 minutes" otherwise "Every 10 minutes"
-    jobs.schedule("TeamMapRefreshJob", if (context.isPreview) "0 40 * * * ?" else "0 0/10 * * * ?") {
+    jobs.schedule("TeamMapRefreshJob", if (context.isPreview) "0 43 * * * ?" else "0 0/10 * * * ?") {
       TeamMap.refresh()(contentApiClient, ec)
     }
   }

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -1,7 +1,8 @@
 package rugby.conf
 
 import app.LifecycleComponent
-import common.{PekkoAsync, JobScheduler}
+import common.{JobScheduler, PekkoAsync}
+import model.ApplicationContext
 import play.api.inject.ApplicationLifecycle
 import rugby.feed.CapiFeed
 import rugby.jobs.RugbyStatsJob
@@ -15,7 +16,7 @@ class RugbyLifecycle(
     pekkoAsync: PekkoAsync,
     rugbyStatsJob: RugbyStatsJob,
     capiFeed: CapiFeed,
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, context: ApplicationContext)
     extends LifecycleComponent {
 
   protected val initializationTimeout: FiniteDuration = 10.seconds
@@ -24,12 +25,16 @@ class RugbyLifecycle(
     rugbyStatsJob.fetchFixturesAndResults()
 
     jobs.deschedule("FixturesAndResults")
-    jobs.schedule("FixturesAndResults", "30 * * * * ?") {
+    // if preview "Every hour at 50 minutes" (e.g., 1:50, 2:50, 3:50)
+    // otherwise "At 30 seconds past the minute, every minute" (e.g., 00:30, 01:30, 02:30, etc.)
+    jobs.schedule("FixturesAndResults", if (context.isPreview) "0 50 * * * ?" else "30 * * * * ?") {
       rugbyStatsJob.fetchFixturesAndResults()
     }
 
     jobs.deschedule("MatchNavArticles")
-    jobs.schedule("MatchNavArticles", "35 0/30 * * * ?") {
+    // if preview "Every hour at 55 minutes" (e.g., 1:55, 2:55, 3:55)
+    // otherwise "At 35 seconds past the minute, every 30 minutes" (e.g., 00:35, 00:05, 01:35, 01:05, etc.)
+    jobs.schedule("MatchNavArticles", if (context.isPreview) "0 55 * * * ?" else "35 0/30 * * * ?") {
       val refreshedNavContent = capiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
       rugbyStatsJob.sendMatchArticles(refreshedNavContent)
     }


### PR DESCRIPTION
## What does this change?
This PR is reducing the frequency of all the sports jobs (football, cricket & rugby) for `preview` app. The jobs are all now running once every hour, but at different minutes to reduce the chance of making several calls to PA at the same time. 

The issue related to this: [#28059](https://github.com/guardian/frontend/issues/28059)
