### PR TITLE
Add a 700px image to RSS fronts feeds

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -211,7 +211,7 @@ object TrailsToRss {
       val description = makeEntryDescriptionUsing(standfirst, intro, webUrl)
 
       val mediaModules: Seq[MediaEntryModuleImpl] = for {
-        profile: ImageProfile <- List(Item140, Item460)
+        profile: ImageProfile <- List(Item140, Item460, Item700)
         trailPicture: ImageMedia <- faciaContent.trail.trailPicture
         trailAsset: ImageAsset <- profile.bestFor(trailPicture)
         resizedImage <- profile.bestSrcFor(trailPicture)


### PR DESCRIPTION
## What is the value of this and can you measure success?
This adds a 700px image format to RSS feeds for fronts. Similar to https://github.com/guardian/frontend/pull/28032

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/02637645-d77e-4070-847c-ace59f34ce2b
[after]: https://github.com/user-attachments/assets/def9b09e-d12a-437d-bb10-a24c71997f09


## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
