### PR TITLE
Change log level from error to warn for non-critical PA errors

### DIFF
--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -111,15 +111,15 @@ class FootballClient(wsClient: WSClient)(implicit executionContext: ExecutionCon
 
   lazy val apiKey = SportConfiguration.pa.footballKey
 
-  val noneCriticalErrors: List[String] = List(
+  val nonCriticalErrors: List[String] = List(
     "Access to season is denied by client configuration.",
     "No data available",
   )
   def logErrorsWithMessage[T](message: String): PartialFunction[Throwable, T] = { case e: PaClientErrorsException =>
-    if (noneCriticalErrors.contains(e.getMessage)) {
-      log.warn(s"Football Client errors: $message (${e.getMessage})")
+    if (nonCriticalErrors.contains(e.getMessage)) {
+      log.warn(s"$message (${e.getMessage})")
     } else {
-      log.error(s"Football Client errors: $message (${e.getMessage})")
+      log.error(s"$message (${e.getMessage})")
     }
     throw e
   }

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -111,9 +111,16 @@ class FootballClient(wsClient: WSClient)(implicit executionContext: ExecutionCon
 
   lazy val apiKey = SportConfiguration.pa.footballKey
 
+  val noneCriticalErrors: List[String] = List(
+    "Access to season is denied by client configuration.",
+    "No data available",
+  )
   def logErrorsWithMessage[T](message: String): PartialFunction[Throwable, T] = { case e: PaClientErrorsException =>
-    log.error(s"Football Client errors: $message (${e.getMessage})")
+    if (noneCriticalErrors.contains(e.getMessage)) {
+      log.warn(s"Football Client errors: $message (${e.getMessage})")
+    } else {
+      log.error(s"Football Client errors: $message (${e.getMessage})")
+    }
     throw e
   }
-
 }


### PR DESCRIPTION
## What does this change?
This PR changes the log level for PA errors where the error is either of the followings:
- `Access to season is denied by client configuration.`
- `No data available`

These errors happen due to the season data is not available. 


Part of the fix for [#28059](https://github.com/guardian/frontend/issues/28059)