### PR TITLE
Bump `dfp-axis` and pin transitive `commons-beanutils` dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,8 @@ val admin = application("admin")
       awsSes,
       scalaUri,
     ),
+    // 08.07.2025: pinning commons-beanutils which is a transitive dependency of dfp-axis
+    dependencyOverrides += "commons-beanutils" % "commons-beanutils" % "1.11.0",
     RoutesKeys.routesImport += "bindables._",
     RoutesKeys.routesImport += "org.joda.time.LocalDate",
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "27.1.0"
-  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.8.0"
+  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "5.9.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Keeping on top of dependency updates

## What does this change?

- Bumps `dfp-axis` to latest version (`5.9.0`)
- Pins `commons-beanutils` to `1.11.0`
  - This is needed because it is a transitive dependency of `dfp-axis` but the latest available version of `dfp-axis` (`5.9.0`) has not updated its dependency on `commons-beanutils`

## Testing 

Tested by running [`dependencyBrowseGraph`](https://www.scala-sbt.org/sbt-dependency-graph/tasks/dependencyBrowseGraph.html) in the `admin` project
