### PR TITLE
read creative templates from s3 with feature switch

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -78,7 +78,8 @@ class CommercialController(
 
   def renderCreativeTemplates: Action[AnyContent] =
     Action { implicit request =>
-      val emptyTemplates = createTemplateAgent.get
+      val emptyTemplates = if (LineItemJobs.isSwitchedOn) { Store.getDfpCreativeTemplates }
+      else { createTemplateAgent.get }
       val creatives = Store.getDfpTemplateCreatives
       val templates = emptyTemplates
         .foldLeft(Seq.empty[GuCreativeTemplate]) { (soFar, template) =>

--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -4,6 +4,7 @@ import app.LifecycleComponent
 import common.dfp.{GuAdUnit, GuCreativeTemplate, GuCustomField, GuCustomTargeting}
 import common._
 import play.api.inject.ApplicationLifecycle
+import conf.switches.Switches.{LineItemJobs}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -79,7 +80,11 @@ class DfpDataCacheLifecycle(
     new Job[Seq[GuCreativeTemplate]] {
       val name: String = "DFP-Creative-Templates-Update"
       val interval: Int = 15
-      def run() = creativeTemplateAgent.refresh()
+      def run(): Future[Seq[GuCreativeTemplate]] = if (LineItemJobs.isSwitchedOff) {
+        creativeTemplateAgent.refresh()
+      } else {
+        Future.successful(Seq.empty)
+      }
     },
     // used for creative templates admin page
     new Job[Unit] {

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -93,6 +93,13 @@ trait Store extends GuLogging with Dates {
     customFields getOrElse Nil
   }
 
+  def getDfpCreativeTemplates: Seq[GuCreativeTemplate] = {
+    val creativeTemplates = for (doc <- S3.get(dfpCreativeTemplatesKey)) yield {
+      Json.parse(doc).as[Seq[GuCreativeTemplate]]
+    }
+    creativeTemplates getOrElse Nil
+  }
+
   def getAbTestFrameUrl: Option[String] = {
     S3.getPresignedUrl(abTestHtmlObjectKey)
   }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -499,6 +499,7 @@ class GuardianConfiguration extends GuLogging {
       else s"$dfpRoot/lineitems-v7.json"
     lazy val dfpSpecialAdUnitsKey = s"$gamRoot/special-ad-units.json"
     lazy val dfpCustomFieldsKey = s"$gamRoot/custom-fields.json"
+    lazy val dfpCreativeTemplatesKey = s"$gamRoot/creative-templates.json"
     lazy val dfpTemplateCreativesKey = s"$dfpRoot/template-creatives.json"
     lazy val dfpCustomTargetingKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/custom-targeting-key-values.json"

--- a/common/app/common/dfp/DfpAgent.scala
+++ b/common/app/common/dfp/DfpAgent.scala
@@ -20,6 +20,7 @@ object DfpAgent extends PageskinAdAgent with LiveBlogTopSponsorshipAgent with Su
   private lazy val nonRefreshableLineItemsAgent = Box[Seq[Long]](Nil)
   private lazy val specialAdUnitsAgent = Box[Seq[(String, String)]](Nil)
   private lazy val customFieldsAgent = Box[Seq[GuCustomField]](Nil)
+  private lazy val creativeTemplatesAgent = Box[Seq[GuCreativeTemplate]](Nil)
 
   protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = pageskinnedAdUnitAgent.get()
   protected def liveBlogTopSponsorships: Seq[LiveBlogTopSponsorship] = liveblogTopSponsorshipAgent.get()
@@ -84,6 +85,13 @@ object DfpAgent extends PageskinAdAgent with LiveBlogTopSponsorshipAgent with Su
         customFields <- Json.parse(jsonString).validate[Seq[GuCustomField]].asOpt
       } yield customFields) getOrElse Nil
     }
+
+    def grabCreativeTemplatesFromStore() = {
+      (for {
+        jsonString <- stringFromS3(dfpCreativeTemplatesKey)
+        creativeTemplates <- Json.parse(jsonString).validate[Seq[GuCreativeTemplate]].asOpt
+      } yield creativeTemplates) getOrElse Nil
+    }
     update(pageskinnedAdUnitAgent)(grabPageSkinSponsorshipsFromStore(dfpPageSkinnedAdUnitsKey))
 
     update(nonRefreshableLineItemsAgent)(grabNonRefreshableLineItemIdsFromStore())
@@ -95,5 +103,7 @@ object DfpAgent extends PageskinAdAgent with LiveBlogTopSponsorshipAgent with Su
     update(specialAdUnitsAgent)(grabSpecialAdUnitsFromStore())
 
     update(customFieldsAgent)(grabCustomFieldsFromStore())
+
+    update(creativeTemplatesAgent)(grabCreativeTemplatesFromStore())
   }
 }


### PR DESCRIPTION
## What does this change?

This PR reads custom-fields.json from S3 instead of reading from directly from DFP/GAM. 
This is part of the Commercial jobs migration to it's own separate repo 'line-item-jobs' to reduce the Commercial code in Frontend and stop allowing Frontend connects with Google AdManager API directly.

The read from S3 relies on the CustomFieldsJobs switch and we will keep it that way for a week or so just to be sure that we are not getting any strange behavior.

Related PR: https://github.com/guardian/line-item-jobs/pull/78
## Screenshots
Test in frontend tools

| https://frontend.local.dev-gutools.co.uk/commercial/templates     |
|-------------|
| <img width="1079" alt="Screenshot 2025-07-09 at 16 44 35" src="https://github.com/user-attachments/assets/ac3b1505-7e9b-427a-872b-d19ff5f1b203" /> |

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
