### PR TITLE
Run `MostViewedLifecycle` every 60mins on non-prod environments

### DIFF
--- a/facia/app/feed/MostViewedLifecycle.scala
+++ b/facia/app/feed/MostViewedLifecycle.scala
@@ -5,6 +5,7 @@ import agents.MostViewedAgent
 import java.util.concurrent.Executors
 import app.LifecycleComponent
 import common.{JobScheduler, PekkoAsync}
+import conf.Configuration
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
@@ -33,7 +34,10 @@ class MostViewedLifecycle(
 
     descheduleAll()
 
-    jobs.scheduleEveryNMinutes("MostViewedAgentsHighFrequencyRefreshJob", 5) {
+    jobs.scheduleEveryNMinutes(
+      "MostViewedAgentsHighFrequencyRefreshJob",
+      if (Configuration.environment.isProd) 5 else 60,
+    ) {
       mostViewedAgent.refresh()
     }
 


### PR DESCRIPTION
## What does this change?

Run `MostViewedLifecycle` every 60mins on non-prod environments rather than every 5 mins.

We get frequent timeout errors to CAPI in CODE which trigger the circuit breaker to open, which can in turn cause healthchecks to fail and instances to become unhealthy.

Facia's MostViewedAgent is one of the largest requests to CAPI. Reducing the frequency of the agent should help reduce the load to CAPI and timeouts.