### PR TITLE
Add AB test for top-above-nav reservation test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -27,6 +27,15 @@ object LoopingVideo
       participationGroup = Perc0A,
     )
 
+object TopAboveNav250Reservation
+    extends Experiment(
+      name = "top-above-nav-250-reservation",
+      description = "Reserve 250px for top-above-nav instead of 90px",
+      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+      sellByDate = LocalDate.of(2025, 8, 29),
+      participationGroup = Perc0B,
+    )
+
 object DarkModeWeb
     extends Experiment(
       name = "dark-mode-web",


### PR DESCRIPTION
## What is the value of this and can you measure success?
This is the first in a series of tests that commercial will be carrying out regarding top-above-nav space reservation and placement.

Firstly, we will be testing reserving 250px instead of 90px for the `top-above-nav` slot as 75% of the time this size of ad displays. This would reduce CLS for those 75% of cases! 

The actual test code will be in DCR.