### PR TITLE
Log "info" when newsletter not found

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -275,7 +275,9 @@ class EmailSignupController(
   }
 
   def logNewsletterNotFoundError(newsletterName: String)(implicit request: RequestHeader): Unit = {
-    logErrorWithRequestId(s"Newsletter not found: Couldn't find $newsletterName")
+    logInfoWithRequestId(
+      s"The newsletter $newsletterName used in an email sign-up form could not be found by the NewsletterSignupAgent. It may no longer exist.",
+    )
   }
 
   def renderFormFromNameWithParentComponent(

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -276,7 +276,7 @@ class EmailSignupController(
 
   def logNewsletterNotFoundError(newsletterName: String)(implicit request: RequestHeader): Unit = {
     logInfoWithRequestId(
-      s"The newsletter $newsletterName used in an email sign-up form could not be found by the NewsletterSignupAgent. It may no longer exist.",
+      s"The newsletter $newsletterName used in an email sign-up form could not be found by the NewsletterSignupAgent. It may no longer exist or $newsletterName may be an outdated reference number.",
     )
   }
 


### PR DESCRIPTION
Some requests for newsletter forms are made for newsletters that do not exist. This is currently being logged as an error, but that suggests it's a problem with the platform that we should fix. In reality, a missing newsletter is a content issue rather than a problem with the platform, so it should be logged as a piece of information rather than an error.

Part of #28060. Thanks to @dblatcher for help debugging this.
