### PR TITLE
Run onward journey jobs at different times

### DIFF
--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -73,7 +73,7 @@ class OnwardJourneyLifecycle(
     // Every 60 minutes
     // Added 30 second offset to avoid conflicting with the jobs that run every 5 minutes
     // 07m:30s, 37m:30s, 07m:30s, etc
-    jobs.schedule("DayMostPopularAgentRefreshJob", "30 7/60 * * * ?") { dayMostPopularAgent.refresh() }
+    jobs.schedule("DayMostPopularAgentRefreshJob", "30 7 * * * ?") { dayMostPopularAgent.refresh() }
 
     pekkoAsync.after1s {
       mostPopularAgent.refresh()

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -45,17 +45,17 @@ class OnwardJourneyLifecycle(
     // Spreading the jobs in a way that they all run have 30 seconds apart from each others
     // Every 5 minutes
     jobs.schedule("MostPopularAgentRefreshJob", "0 0/5 * * * ?") { mostPopularAgent.refresh() }
-    jobs.schedule("GeoMostPopularAgentRefreshJob", "30 0/5 * * * ?") { geoMostPopularAgent.refresh() }
-    jobs.schedule("DeeplyReadAgentRefreshJob", "0 1/5 * * * ?") { deeplyReadAgent.refresh() }
+    jobs.schedule("GeoMostPopularAgentRefreshJob", "0 1/5 * * * ?") { geoMostPopularAgent.refresh() }
+    jobs.schedule("DeeplyReadAgentRefreshJob", "0 2/5 * * * ?") { deeplyReadAgent.refresh() }
 
     // Every 30 minutes
-    jobs.schedule("MostViewedVideoAgentRefreshJob", "30 1/30 * * * ?") { mostViewedVideoAgent.refresh() }
-    jobs.schedule("MostViewedAudioAgentRefreshJob", "0 2/30 * * * ?") { mostViewedAudioAgent.refresh() }
-    jobs.schedule("MostViewedGalleryAgentRefreshJob", "30 2/30 * * * ?") { mostViewedGalleryAgent.refresh() }
-    jobs.schedule("MostReadAgentRefreshJob", "0 3/30 * * * ?") { mostReadAgent.refresh() }
+    jobs.schedule("MostViewedVideoAgentRefreshJob", "0 3/30 * * * ?") { mostViewedVideoAgent.refresh() }
+    jobs.schedule("MostViewedAudioAgentRefreshJob", "0 4/30 * * * ?") { mostViewedAudioAgent.refresh() }
+    jobs.schedule("MostViewedGalleryAgentRefreshJob", "30 5/30 * * * ?") { mostViewedGalleryAgent.refresh() }
+    jobs.schedule("MostReadAgentRefreshJob", "30 6/30 * * * ?") { mostReadAgent.refresh() }
 
     // Every 60 minutes
-    jobs.schedule("DayMostPopularAgentRefreshJob", "30 3/60 * * * ?") { dayMostPopularAgent.refresh() }
+    jobs.schedule("DayMostPopularAgentRefreshJob", "30 7/60 * * * ?") { dayMostPopularAgent.refresh() }
 
     pekkoAsync.after1s {
       mostPopularAgent.refresh()

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -42,19 +42,30 @@ class OnwardJourneyLifecycle(
 
     descheduleAll()
 
-    // Spreading the jobs in a way that they all run have 30 seconds apart from each others
+    // Spreading the jobs to avoid running them all simultaneously
     // Every 5 minutes
+    // 00m:00s, 05m:00s, 10m:00s, etc
     jobs.schedule("MostPopularAgentRefreshJob", "0 0/5 * * * ?") { mostPopularAgent.refresh() }
+    // 01m:00s, 06m:00s, 11m:00s, etc
     jobs.schedule("GeoMostPopularAgentRefreshJob", "0 1/5 * * * ?") { geoMostPopularAgent.refresh() }
+    // 01m:00s, 06m:00s, 11m:00s, etc
     jobs.schedule("DeeplyReadAgentRefreshJob", "0 2/5 * * * ?") { deeplyReadAgent.refresh() }
 
     // Every 30 minutes
+    // 03m:00s, 33m:00s, 03m:00s, etc
     jobs.schedule("MostViewedVideoAgentRefreshJob", "0 3/30 * * * ?") { mostViewedVideoAgent.refresh() }
+    // 04m:00s, 34m:00s, 04m:00s, etc
     jobs.schedule("MostViewedAudioAgentRefreshJob", "0 4/30 * * * ?") { mostViewedAudioAgent.refresh() }
+    // Added 30 second offset to avoid conflicting with the jobs that run every 5 minutes
+    // 05m:30s, 35m:30s, 05m:30s, etc
     jobs.schedule("MostViewedGalleryAgentRefreshJob", "30 5/30 * * * ?") { mostViewedGalleryAgent.refresh() }
+    // Added 30 second offset to avoid conflicting with the jobs that run every 5 minutes
+    // 06m:30s, 36m:30s, 06m:30s, etc
     jobs.schedule("MostReadAgentRefreshJob", "30 6/30 * * * ?") { mostReadAgent.refresh() }
 
     // Every 60 minutes
+    // Added 30 second offset to avoid conflicting with the jobs that run every 5 minutes
+    // 07m:30s, 37m:30s, 07m:30s, etc
     jobs.schedule("DayMostPopularAgentRefreshJob", "30 7/60 * * * ?") { dayMostPopularAgent.refresh() }
 
     pekkoAsync.after1s {

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -33,9 +33,16 @@ class OnwardJourneyLifecycle(
   }
 
   private def descheduleAll(): Unit = {
-    jobs.deschedule("OnwardJourneyAgentsHighFrequencyRefreshJob")
-    jobs.deschedule("OnwardJourneyAgentsMediumFrequencyRefreshJob")
-    jobs.deschedule("OnwardJourneyAgentsLowFrequencyRefreshJob")
+    jobs.deschedule("MostPopularAgentRefreshJob")
+    jobs.deschedule("GeoMostPopularAgentRefreshJob")
+    jobs.deschedule("DeeplyReadAgentRefreshJob")
+
+    jobs.deschedule("MostViewedVideoAgentRefreshJob")
+    jobs.deschedule("MostViewedAudioAgentRefreshJob")
+    jobs.deschedule("MostViewedGalleryAgentRefreshJob")
+    jobs.deschedule("MostReadAgentRefreshJob")
+
+    jobs.deschedule("DayMostPopularAgentRefreshJob")
   }
 
   override def start(): Unit = {

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -42,22 +42,20 @@ class OnwardJourneyLifecycle(
 
     descheduleAll()
 
-    jobs.scheduleEveryNMinutes("OnwardJourneyAgentsHighFrequencyRefreshJob", 5) {
-      mostPopularAgent.refresh()
-      geoMostPopularAgent.refresh()
-      deeplyReadAgent.refresh()
-    }
+    // Spreading the jobs in a way that they all run have 30 seconds apart from each others
+    // Every 5 minutes
+    jobs.schedule("MostPopularAgentRefreshJob", "0 0/5 * * * ?") { mostPopularAgent.refresh() }
+    jobs.schedule("GeoMostPopularAgentRefreshJob", "30 0/5 * * * ?") { geoMostPopularAgent.refresh() }
+    jobs.schedule("DeeplyReadAgentRefreshJob", "0 1/5 * * * ?") { deeplyReadAgent.refresh() }
 
-    jobs.scheduleEveryNMinutes("OnwardJourneyAgentsMediumFrequencyRefreshJob", 30) {
-      mostViewedVideoAgent.refresh()
-      mostViewedAudioAgent.refresh()
-      mostViewedGalleryAgent.refresh()
-      mostReadAgent.refresh()
-    }
+    // Every 30 minutes
+    jobs.schedule("MostViewedVideoAgentRefreshJob", "30 1/30 * * * ?") { mostViewedVideoAgent.refresh() }
+    jobs.schedule("MostViewedAudioAgentRefreshJob", "0 2/30 * * * ?") { mostViewedAudioAgent.refresh() }
+    jobs.schedule("MostViewedGalleryAgentRefreshJob", "30 2/30 * * * ?") { mostViewedGalleryAgent.refresh() }
+    jobs.schedule("MostReadAgentRefreshJob", "0 3/30 * * * ?") { mostReadAgent.refresh() }
 
-    jobs.scheduleEveryNMinutes("OnwardJourneyAgentsLowFrequencyRefreshJob", 60) {
-      dayMostPopularAgent.refresh()
-    }
+    // Every 60 minutes
+    jobs.schedule("DayMostPopularAgentRefreshJob", "30 3/60 * * * ?") { dayMostPopularAgent.refresh() }
 
     pekkoAsync.after1s {
       mostPopularAgent.refresh()


### PR DESCRIPTION
## What is the value of this and can you measure success?
This work should reduce the number of CAPI timeouts  in preview app.
## What does this change?
This PR updates the schedules for the jobs within the `OnwardJourneyLifecycle`. 

There are 3 groups of jobs in this life cycle, they are all given different minute offset to run at, but to avoid conflict some of them are also given 30 second offset. 
**- Runs every 5 minutes:** These jobs are spaced 1 minute from each other
**- Runs every 30 minutes:** These jobs are spaces 1 minute from each other. But 2 of the jobs could be conflicting with the faster jobs that run every 5 minutes, so a 30 second offset was added to avoid that. 
**- Runs every 1 hour:** This job can conflict with 1 of the faster jobs that run every 5 minutes so 30 second offset was added 


This PR is part of the [#28059](https://github.com/guardian/frontend/issues/28059)