### PR TITLE
Prevent error on a sections request

### DIFF
--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -75,6 +75,9 @@ trait IndexControllerCommon
     path match {
       // if this is a section tag e.g. football/football
       case TagPattern(left, right) if left == right => successful(Cached(60)(redirect(left, request.isRss)))
+      // This page does not exist on dotcom, and we don't want to make a CAPI request because that
+      // will trigger a CAPI sections query.
+      case "sections" => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
       case _ =>
         logGoogleBot(request)
         (index(Edition(request), path, inferPage(request), request.isRss) map {


### PR DESCRIPTION
## Summary

`/sections` triggers a CAPI sections query[^1], but frontend tries to parse the response as an `ItemResponse`[^2] and crashes. Since `/sections` is not a page that exists on dotcom, we can avoid this problem by responding with a 404 (not found).

Part of #28060.

## Details

Requests to `/sections` on dotcom currently result in a 500 error. This happens because this path is interpreted as an index page by the applications app's routes file, which results in a call to the `IndexController.render` method:

https://github.com/guardian/frontend/blob/057a1997a175742214e10e5505eafc70167c9471/applications/conf/routes#L137

This is a concrete method on the `IndexControllerCommon` trait, which `IndexController` extends:

https://github.com/guardian/frontend/blob/057a1997a175742214e10e5505eafc70167c9471/common/app/controllers/IndexControllerCommon.scala#L48-L51

`render` in turn calls the `renderItem` method, also implemented on `IndexControllerCommon`.

For this path, the `renderItem` method currently attempts to make an `ItemRequest` to CAPI, and then calls the `renderFaciaFront` method with the result. This method is defined on the extending `IndexController` from the applications app, and ultimately makes a request to DCAR to render a tag page:

https://github.com/guardian/frontend/blob/057a1997a175742214e10e5505eafc70167c9471/applications/app/controllers/IndexController.scala#L28

However, `/sections` is not a tag page. It doesn't have a particular meaning on dotcom, but it does have a special meaning to CAPI, where it returns a list of sections[^1]. There's a separate `SectionsQuery` for this[^3], but in this case frontend is sending CAPI an `ItemQuery`[^4]. However, because this is implemented as an HTTP GET request:

https://github.com/guardian/frontend/blob/057a1997a175742214e10e5505eafc70167c9471/common/app/contentapi/http.scala#L40

with `/sections` as the path, CAPI believes it is being queried for sections, and returns a `SectionsResponse`[^5]. Frontend is expecting an `ItemResponse`:

https://github.com/guardian/frontend/blob/057a1997a175742214e10e5505eafc70167c9471/common/app/services/repositories.scala#L178
https://github.com/guardian/frontend/blob/057a1997a175742214e10e5505eafc70167c9471/common/app/contentapi/ContentApiClient.scala#L174

and therefore the Thrift deserialisation code crashes because the fields do not match.

The solution is to explicitly respond to requests for `/sections` with a 404 (not found), before we get to the point where a CAPI request is made.

[^1]: https://github.com/guardian/content-api-scala-client/blob/9b769f5b1726abc162a908a5fe6a021129de7183/README.md#sections
[^2]: https://github.com/guardian/content-api-models/blob/716ddba6e60198fced203fd538b8e2c1aa685757/models/src/main/thrift/content/v1.thrift#L2003
[^3]: https://github.com/guardian/content-api-scala-client/blob/9b769f5b1726abc162a908a5fe6a021129de7183/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala#L144
[^4]: https://github.com/guardian/content-api-scala-client/blob/9b769f5b1726abc162a908a5fe6a021129de7183/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala#L66
[^5]: https://github.com/guardian/content-api-models/blob/716ddba6e60198fced203fd538b8e2c1aa685757/models/src/main/thrift/content/v1.thrift#L2106
