### PR TITLE
Log "info" when tag index not found

### DIFF
--- a/applications/app/controllers/TagIndexController.scala
+++ b/applications/app/controllers/TagIndexController.scala
@@ -18,7 +18,7 @@ class TagIndexController(val controllerComponents: ControllerComponents)(implici
     Action { implicit request =>
       TagIndexesS3.getIndex(keywordType, page) match {
         case Left(TagIndexNotFound) =>
-          logErrorWithRequestId(s"404 error serving tag index page for $keywordType $page")
+          logInfoWithRequestId(s"404 error serving tag index page for $keywordType $page")
           NotFound
 
         case Left(TagIndexReadError(error)) =>


### PR DESCRIPTION
Requests to retrieve tag index pages result in a 404 (not found) when the tag index does not exist. This is currently being logged as an error, but that suggests it's a problem with the platform that we should fix. In reality, a tag index that does not exist is not something that's likely to change, or that we can "fix", so it should be logged as a piece of information rather than an error.

Part of #28060.
