### PR TITLE
Add AB test switch for Admiral adblocker recovery

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -37,4 +37,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-admiral-adblock-recovery",
+    "Testing the Admiral integration for adblock recovery on theguardian.com",
+    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 8, 29)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Adds AB test switch ahead of implementing the Admiral ad blocker detection script in `@guardian/commercial` so that we can control the test status

## What does this change?

- Adds AB testing switch for Admiral third party integration

