### PR TITLE
Include query parameters in internal redirects

### DIFF
--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -79,7 +79,7 @@ object InternalRedirect extends implicits.Requests with GuLogging {
       .orElse(response.tag.map(t => internalRedirect("facia", t.id)))
       .orElse(response.section.map(s => internalRedirect("facia", s.id)))
 
-  def contentTypes(response: ItemResponse)(implicit request: RequestHeader): Option[Result] = {
+  private def contentTypes(response: ItemResponse)(implicit request: RequestHeader): Option[Result] = {
     response.content.map {
       case a if a.isArticle || a.isLiveBlog =>
         internalRedirect("type/article", ItemOrRedirect.canonicalPath(a))
@@ -93,8 +93,8 @@ object InternalRedirect extends implicits.Requests with GuLogging {
     }
   }
 
-  def internalRedirect(base: String, id: String)(implicit request: RequestHeader): Result =
-    internalRedirect(base, id, None)
+  private def internalRedirect(base: String, id: String)(implicit request: RequestHeader): Result =
+    internalRedirect(base, id, request.rawQueryStringOption.map("?" + _))
 
   def internalRedirect(base: String, id: String, queryString: Option[String])(implicit
       request: RequestHeader,


### PR DESCRIPTION
## What is the value of this and can you measure success?

Query params like `?dcr=apps` should work for https://www.theguardian.com/tips

## What does this change?

Some requests will be subject to internal redirect when the URL is ambiguous for figuring out which service should handle a request. A current motivating example is `/tips`, which is an interactive but hosted on a section-less/date-less url so looks a lot like a front. Router will send the request to facia, which discovers that "tips" is not a front but is in fact an interactive so asks router to resend the request to applications (nginx calls this an "internal redirect" - see <https://nginx.org/en/docs/http/ngx_http_proxy_module.html#:~:text=%E2%80%9CX%2DAccel%2DRedirect%E2%80%9D%20performs%20an%20internal%20redirect%20to%20the%20specified%20URI>).

This can happen in a few other cases too, and while there is support for including the original query parameters in that internal redirect, the default is to drop them. This seems odd to us, so we've changed that to default to including them, but respecting and not changing the cases where the caller has explicitly chosen to drop the parameters.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
