### PR TITLE
anchor social share autocrops to top of base crop

### DIFF
--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -150,6 +150,14 @@ class ShareImage(
   val overlayAlignParam = "overlay-align=bottom%2Cleft"
   val overlayWidthParam = "overlay-width=100p"
 
+  // If we only use "fit=crop", then fastly will crop to the centre of the image.
+  // This often means that we lose the tops of people's faces which looks bad,
+  // especially since the switch from 5:4 to 5:3 images means that they tend to be
+  // even taller than the social share image's ratios.
+  // Instead, tell fastly to crop to 40:21 (equivalent to 1200:630), anchoring to the top
+  // vertically, but the centre horizontally, BEFORE it resizes and fits the image to 1200x630.
+  val precropParam = "precrop=40:21,offset-x50,offset-y0"
+
   override def resizeString: String = {
     if (shouldIncludeOverlay) {
       val params = Seq(
@@ -158,6 +166,7 @@ class ShareImage(
         qualityparam,
         autoParam,
         fitParam,
+        precropParam,
         dprParam,
         overlayAlignParam,
         overlayWidthParam,


### PR DESCRIPTION
## What is the value of this and can you measure success?

Anchor the autocrops for social share images to the top of their base crop, to hopefully avoid too many instances of chopping the tops of people's faces.

## What does this change?

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3b91e78a-9430-4d1a-9981-7243bc379a5c

[after]: https://github.com/user-attachments/assets/f4e5488f-6fba-4ae2-89b7-2a85827c2428


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
