### PR TITLE
Add `commons-beanutils` as a direct dependency of the `admin` app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,9 +122,8 @@ val admin = application("admin")
       awsElasticloadbalancing,
       awsSes,
       scalaUri,
+      commonsBeanutils,
     ),
-    // 08.07.2025: pinning commons-beanutils which is a transitive dependency of dfp-axis
-    dependencyOverrides += "commons-beanutils" % "commons-beanutils" % "1.11.0",
     RoutesKeys.routesImport += "bindables._",
     RoutesKeys.routesImport += "org.joda.time.LocalDate",
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -87,6 +87,10 @@ object Dependencies {
   val pekkoSerializationJackson = "org.apache.pekko" %% "pekko-serialization-jackson" % pekkoVersion
   val pekkoActorTyped = "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion
 
+  // 16.07.2025: pinning commons-beanutils which is a transitive dependency of dfp-axis version `5.9.0`
+  // We can remove this when a future version of dfp-axis includes a more up-to-date version of this library
+  val commonsBeanutils = "commons-beanutils" % "commons-beanutils" % "1.11.0"
+
   val logstash = ("net.logstash.logback" % "logstash-logback-encoder" % "8.0")
     .excludeAll(ExclusionRule("com.fasterxml.jackson.core")) // Avoid conflicts with Play's Jackson dependency
   val janino = "org.codehaus.janino" % "janino" % "3.1.12"


### PR DESCRIPTION
## What does this change?

Adds `commons-beanutils` as a direct dependency of the `admin` app

## Why

We want to ensure the `dfp-axis` package uses version `1.11.0` instead of version `1.9.4` of `commons-beanutils`, which wasn't fully resolved by the previous attempt in #28073

## Notes

I tried to pin the dependency `commons-beanutils` to version `1.11.0` in #28073 and although this seemed to suggest that `1.11.0` was being used in most places, the `dev-build` app was still using the older version (`1.9.4`).

`dependencyOverrides` is useful if you want to pin to an _older_ version of a package rather than pinning to a newer version. It is safer in sbt to directly install the dependency rather than using `dependencyOverrides`, since we can only ever install one version of a package in a project (unlike in the npm ecosystem)

Together with @rtyley, we used the same `sbt-dependency-graph` tree method as used in [our Github Workflow](https://github.com/guardian/frontend/blob/main/.github/workflows/sbt-dependency-graph.yaml): https://github.com/scalacenter/sbt-dependency-submission, which [we can use locally](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file#how-to-generate-a-snapshot-locally) by including as an sbt plugin and running `githubGenerateSnapshot` inside the sbt shell

We then used `jq` to search for uses of the old `1.9.4` package in the output of the generated snapshot:

```shell
jq '.manifests[] | select(.resolved | has("commons-beanutils:commons-beanutils:1.9.4")) | .name' <path-to-snapshot-json-file>
```


### Other possible approaches to this problem

The usage found after #28073 was actually in the `dev-build` app rather than the `admin` app. There's an argument that we don't need to treat dev dependencies with the same level of scrutiny as production ones, so we could have also excluded `dev-build` from the dependency graph for Dependabot
