### PR TITLE
Add footer link to the accessibility settings page

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -168,6 +168,11 @@ object FooterLinks {
     FooterLink("Search jobs", "https://jobs.theguardian.com", "uk : footer : jobs"),
     FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
     FooterLink("Tips", "https://www.theguardian.com/tips", "uk : footer : tips"),
+    FooterLink(
+      "Accessibility settings",
+      "https://www.theguardian.com/help/accessibility-help",
+      "uk : footer : accessibility settings",
+    ),
   )
 
   val usListThree = List(
@@ -179,6 +184,11 @@ object FooterLinks {
     FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
     FooterLink("Search jobs", "https://jobs.theguardian.com", "us : footer : jobs"),
     FooterLink("Tips", "https://www.theguardian.com/tips", "us : footer : tips"),
+    FooterLink(
+      "Accessibility settings",
+      "https://www.theguardian.com/help/accessibility-help",
+      "us : footer : accessibility settings",
+    ),
   )
 
   val auListThree = List(
@@ -190,6 +200,11 @@ object FooterLinks {
     ),
     cookiePolicy,
     FooterLink("Tips", "https://www.theguardian.com/tips", "au : footer : tips"),
+    FooterLink(
+      "Accessibility settings",
+      "https://www.theguardian.com/help/accessibility-help",
+      "au : footer : accessibility settings",
+    ),
   )
 
   val intListThree = List(
@@ -204,6 +219,11 @@ object FooterLinks {
       "international : footer : uk-jobs",
     ),
     FooterLink("Tips", "https://www.theguardian.com/tips", "int : footer : tips"),
+    FooterLink(
+      "Accessibility settings",
+      "https://www.theguardian.com/help/accessibility-help",
+      "int : footer : accessibility settings",
+    ),
   )
 
   def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -19,6 +19,11 @@ object FooterLinks {
   val privacyPolicy = FooterLink("Privacy policy", "/info/privacy", "privacy")
   val cookiePolicy = FooterLink("Cookie policy", "/info/cookies", "cookie")
   val termsAndConditions = FooterLink("Terms & conditions", "/help/terms-of-service", "terms")
+  val accessibilitySettings = FooterLink(
+    "Accessibility settings",
+    "/help/accessibility-help",
+    "accessibility settings",
+  )
 
   def help(edition: String): FooterLink =
     FooterLink(
@@ -168,11 +173,7 @@ object FooterLinks {
     FooterLink("Search jobs", "https://jobs.theguardian.com", "uk : footer : jobs"),
     FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
     FooterLink("Tips", "https://www.theguardian.com/tips", "uk : footer : tips"),
-    FooterLink(
-      "Accessibility settings",
-      "https://www.theguardian.com/help/accessibility-help",
-      "uk : footer : accessibility settings",
-    ),
+    accessibilitySettings,
   )
 
   val usListThree = List(
@@ -184,11 +185,7 @@ object FooterLinks {
     FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
     FooterLink("Search jobs", "https://jobs.theguardian.com", "us : footer : jobs"),
     FooterLink("Tips", "https://www.theguardian.com/tips", "us : footer : tips"),
-    FooterLink(
-      "Accessibility settings",
-      "https://www.theguardian.com/help/accessibility-help",
-      "us : footer : accessibility settings",
-    ),
+    accessibilitySettings,
   )
 
   val auListThree = List(
@@ -200,11 +197,7 @@ object FooterLinks {
     ),
     cookiePolicy,
     FooterLink("Tips", "https://www.theguardian.com/tips", "au : footer : tips"),
-    FooterLink(
-      "Accessibility settings",
-      "https://www.theguardian.com/help/accessibility-help",
-      "au : footer : accessibility settings",
-    ),
+    accessibilitySettings,
   )
 
   val intListThree = List(
@@ -219,11 +212,7 @@ object FooterLinks {
       "international : footer : uk-jobs",
     ),
     FooterLink("Tips", "https://www.theguardian.com/tips", "int : footer : tips"),
-    FooterLink(
-      "Accessibility settings",
-      "https://www.theguardian.com/help/accessibility-help",
-      "int : footer : accessibility settings",
-    ),
+    accessibilitySettings,
   )
 
   def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
This allows users to more easily set their accessibility preferences. The word `settings` has been used instead of `preferences` inline with other links in the footer (e.g. `privacy settings`)

## Screenshots

<img width="2700" height="906" alt="Screenshot 2025-07-17 at 14 37 36" src="https://github.com/user-attachments/assets/af5221c2-3d27-4233-88fe-e5c59f4d63f0" />



## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
