### PR TITLE
remove special ad units get from dfp

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -31,9 +31,7 @@ class CommercialController(
 
   def renderSpecialAdUnits: Action[AnyContent] =
     Action { implicit request =>
-      val specialAdUnits =
-        if (LineItemJobs.isSwitchedOn) { Store.getDfpSpecialAdUnits }
-        else { dfpApi.readSpecialAdUnits(Configuration.commercial.dfpAdUnitGuRoot) }
+      val specialAdUnits = Store.getDfpSpecialAdUnits
       NoCache(Ok(views.html.commercial.specialAdUnits(specialAdUnits)))
     }
 

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -25,28 +25,6 @@ class DfpApi(dataMapper: DataMapper) extends GuLogging {
     }
   }
 
-  def readActiveAdUnits(rootName: String): Seq[GuAdUnit] = {
-
-    val stmtBuilder = new StatementBuilder()
-      .where("status = :status")
-      .withBindVariableValue("status", InventoryStatus._ACTIVE)
-
-    readDescendantAdUnits(rootName, stmtBuilder)
-  }
-
-  def readSpecialAdUnits(rootName: String): Seq[(String, String)] = {
-
-    val statementBuilder = new StatementBuilder()
-      .where("status = :status")
-      .where("explicitlyTargeted = :targeting")
-      .withBindVariableValue("status", InventoryStatus._ACTIVE)
-      .withBindVariableValue("targeting", true)
-
-    readDescendantAdUnits(rootName, statementBuilder) map { adUnit =>
-      (adUnit.id, adUnit.path.mkString("/"))
-    } sortBy (_._2)
-  }
-
   def getCreativeIds(lineItemId: Long): Seq[Long] = {
     val stmtBuilder = new StatementBuilder()
       .where("status = :status AND lineItemId = :lineItemId")


### PR DESCRIPTION
## What is the value of this and can you measure success?
**Removes legacy creative template functionality** from the admin app as part of migrating DFP data jobs to the [`line-item-jobs`](https://github.com/guardian/line-item-jobs) repository.


We have been using a feature switch to ensure the new process (`line-item-jobs`)  has been able to successfully serve the special ad units for the adin app, and are confident its working as expected.

This is a continuation of the work done in https://github.com/guardian/frontend/pull/27968 to decouple frontend applications from direct GAM API dependencies.

**Success metrics:**
- ✅ Commercial app compiles and starts without GAM API dependencies
- ✅ Special ad units data still flows correctly from S3
- ✅ No impact on ad serving or commercial functionality
- ✅ Reduced API rate limiting issues with GAM




## What does this change?

### **Data Flow Migration**
**Before:** Commercial app → GAM API → Special ad units data
**After:** Line-item-jobs → S3 → Commercial app reads from S3

Key changes:
### **Key Changes:**

#### **Commercial App (`commercial/app/`):**
- **DfpAgent**: Removed direct GAM API calls, now reads from S3 via `dfpSpecialAdUnitsKey`
- **AppLoader**: Removed GAM-related lifecycle components and agents
- **Data interface**: Maintained same API for downstream consumers

#### **Dependency Removal:**
- **No more GAM API client** in commercial app
- **No more DFP agents** that require GAM authentication  
- **Simplified startup** - no GAM connection required

#### **Data Source:*
- **S3-first approach**: All special ad units data sourced from JSON files
- **Admin app responsibility**: Data freshness managed by Admin app's scheduled jobs
- **Consistent format**: Same data structure maintained for backward compatibility

### **Migration Strategy:**
- **Zero downtime**: S3 data populated before switching commercial app
- **Fallback ready**: Can revert to direct GAM calls if needed
- **Gradual rollout**: Other DFP data types can follow same pattern

## Screenshots
<img width="755" height="547" alt="Screenshot 2025-07-18 at 15 51 36" src="https://github.com/user-attachments/assets/84a8c58c-3ad7-4d10-83d9-efc7b6e19a3a" />

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
