### PR TITLE
Remove obsolete feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -386,18 +386,6 @@ trait FeatureSwitches {
     highImpact = false,
   )
 
-  // Election interactive header switch
-  val InteractiveHeaderSwitch = Switch(
-    SwitchGroup.Feature,
-    "interactive-full-header-switch",
-    "If switched on, the header on all interactives will display in full.",
-    owners = Seq(Owner.withName("unknown")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
   val slotBodyEnd = Switch(
     SwitchGroup.Feature,
     "slot-body-end",

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -24,8 +24,6 @@ import scala.jdk.CollectionConverters._
 import scala.util.Try
 import implicits.Booleans._
 import org.joda.time.DateTime
-import conf.switches.Switches.InteractiveHeaderSwitch
-import _root_.contentapi.SectionTagLookUp.sectionId
 
 sealed trait ContentType {
   def content: Content
@@ -1009,7 +1007,6 @@ object Interactive {
       contentType = Some(contentType),
       adUnitSuffix = section + "/" + contentType.name.toLowerCase,
       twitterPropertiesOverrides = Map("twitter:title" -> fields.linkText),
-      contentWithSlimHeader = InteractiveHeaderSwitch.isSwitchedOff,
       opengraphPropertiesOverrides = opengraphProperties,
     )
     val contentOverrides = content.copy(


### PR DESCRIPTION
## What is the value of this and can you measure success?

Remove InteractiveHeaderSwitch, which is no longer necessary after https://github.com/guardian/dotcom-rendering/pull/14242.

## Screenshots

N/A

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] ~Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)~
- [ ] ~Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)~
  - [ ] ~[Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)~
  - [ ] ~[Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)~
  - [ ] ~[Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)~

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
