### PR TITLE
Add switch for dcar gallery article

### DIFF
--- a/applications/app/services/dotcomrendering/GalleryPicker.scala
+++ b/applications/app/services/dotcomrendering/GalleryPicker.scala
@@ -1,6 +1,7 @@
 package services.dotcomrendering
 
 import common.GuLogging
+import conf.switches.Switches.DCARGalleyPages
 import model.Cors.RichRequestHeader
 import model.GalleryPage
 import play.api.mvc.RequestHeader
@@ -12,8 +13,20 @@ object GalleryPicker extends GuLogging {
   )(implicit
       request: RequestHeader,
   ): RenderType = {
-    DotcomponentsLogger.logger.logRequest(s"path executing in web", Map.empty, galleryPage.gallery)
 
-    LocalRender
+    val tier = {
+      if (request.forceDCROff) LocalRender
+      else if (request.forceDCR) RemoteRender
+      else if (DCARGalleyPages.isSwitchedOn) RemoteRender
+      else LocalRender
+    }
+
+    if (tier == RemoteRender) {
+      DotcomponentsLogger.logger.logRequest(s"path executing in dotcomponents", Map.empty, galleryPage.gallery)
+    } else {
+      DotcomponentsLogger.logger.logRequest(s"path executing in web", Map.empty, galleryPage.gallery)
+    }
+
+    tier
   }
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -607,6 +607,17 @@ trait FeatureSwitches {
     highImpact = false,
   )
 
+  val DCARGalleyPages = Switch(
+    SwitchGroup.Feature,
+    "dcar-gallery-pages",
+    "If this switch is on, the gallery article will be rendered by DCAR",
+    owners = Seq(Owner.withGithub("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+    highImpact = false,
+  )
+
   val EnableNewServerSideABTestsHeader = Switch(
     SwitchGroup.Feature,
     "enable-new-server-side-tests-header",


### PR DESCRIPTION
## What is the value of this and can you measure success?
Adding switch for rendering Gallery articles with DCAR and also letting the use of `?dcr` query parameter in order to force rendering galleries by DCAR

Fixes [#27553](https://github.com/guardian/frontend/issues/27553)