### PR TITLE
Set Looping Video AB test to 0%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -19,6 +19,15 @@ object ActiveExperiments extends ExperimentsDefinition {
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
 
+object LoopingVideo
+    extends Experiment(
+      name = "looping-video",
+      description = "Enable looping videos on DCR",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 9, 30),
+      participationGroup = Perc0A,
+    )
+
 object TopAboveNav250Reservation
     extends Experiment(
       name = "top-above-nav-250-reservation",
@@ -44,13 +53,4 @@ object DCRJavascriptBundle
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 7, 30),
       participationGroup = Perc0E,
-    )
-
-object LoopingVideo
-    extends Experiment(
-      name = "looping-video",
-      description = "Enable looping videos on DCR",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 9, 30),
-      participationGroup = Perc50,
     )


### PR DESCRIPTION
## What does this change?

Sets the Looping Video experiment to 0%.

## Why?

We wish to release Looping Video to all users, so no longer require the 50% bucket. We still require the switch this experiment creates and we would like to run an AB test next week, so the test is set to 0%.
