### PR TITLE
Handle gallery affiliate links for dcar

### DIFF
--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -69,7 +69,7 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content) // TODO:
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 
     val edition = Edition(request)

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -69,7 +69,7 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content) // TODO:
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 
     val edition = Edition(request)

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -480,9 +480,6 @@ object DotcomRenderingDataModel {
     val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
     val shouldAddDisclaimer = hasAffiliateLinks(content, bodyBlocks)
 
-    println(s"shouldAddDisclaimer: ${shouldAddDisclaimer}")
-    println(s"shouldAddAffiliateLinks: ${shouldAddAffiliateLinks}")
-
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(
       webPublicationDate = content.trail.webPublicationDate,
       firstPublicationDate = content.fields.firstPublicationDate,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -456,7 +456,7 @@ object DotcomRenderingDataModel {
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
-    val content: ContentType = page.item
+    val content = page.item
     val isImmersive = content.metadata.format.exists(_.display == ImmersiveDisplay)
     val isPaidContent = content.metadata.designType.contains(AdvertisementFeature)
 
@@ -472,7 +472,6 @@ object DotcomRenderingDataModel {
     ): Boolean = {
       content match {
         case gallery: Gallery => gallery.lightbox.containsAffiliateableLinks
-        // TODO: I think the below could be used for galleries too, because the bodyHtml includes all the caption texts as well
         case _ => blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
       }
     }

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -124,7 +124,6 @@ object Block {
         content,
         shouldAddAffiliateLinks,
         isMainBlock,
-        content.metadata.format.exists(_.display == ImmersiveDisplay),
         campaigns,
         calloutsUrl,
       ),

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -2,7 +2,7 @@ package model.dotcomrendering
 
 import com.github.nscala_time.time.Imports.DateTime
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
-import com.gu.contentapi.client.utils.format.LiveBlogDesign
+import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, LiveBlogDesign}
 import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
 import common.Edition
 import conf.switches.Switches
@@ -184,7 +184,6 @@ object DotcomRenderingUtils {
       article: ContentType,
       affiliateLinks: Boolean,
       isMainBlock: Boolean,
-      isImmersive: Boolean,
       campaigns: Option[JsValue],
       calloutsUrl: Option[String],
   ): List[PageElement] = {
@@ -200,12 +199,13 @@ object DotcomRenderingUtils {
           pageUrl = request.uri,
           atoms = atoms,
           isMainBlock,
-          isImmersive,
+          article.content.metadata.format.exists(_.display == ImmersiveDisplay),
           campaigns,
           calloutsUrl,
           article.elements.thumbnail,
           edition,
           article.trail.webPublicationDate,
+          article.content.isGallery,
         ),
       )
       .filter(PageElement.isSupported)

--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -5,7 +5,7 @@ import conf.Configuration.{affiliateLinks => affiliateLinksConfig}
 import model.{Tag, Tags}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import views.support.{AffiliateLinksCleaner, GalleryCaptionCleaner, HtmlCleaner}
+import views.support.{AffiliateLinksCleaner, HtmlCleaner}
 
 import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
@@ -128,6 +128,27 @@ object TagLinker {
     } else {
       (el, terms)
     }
+  }
+}
+
+object GalleryCaptionCleaner extends HtmlCleaner {
+  override def clean(galleryCaption: Document): Document = {
+    // There is an inconsistent number of <br> tags in gallery captions.
+    // To create some consistency, re will remove them all.
+    galleryCaption.getElementsByTag("br").remove()
+
+    val firstStrong = Option(galleryCaption.getElementsByTag("strong").first())
+    val captionTitle = galleryCaption.createElement("h2")
+    val captionTitleText = firstStrong.map(_.html()).getOrElse("")
+
+    // <strong> is removed in place of having a <h2> element
+    firstStrong.foreach(_.remove())
+
+    captionTitle.html(captionTitleText)
+
+    galleryCaption.body.prependChild(captionTitle)
+
+    galleryCaption
   }
 }
 


### PR DESCRIPTION
## What does this change?
Looking into the frontend version of the Gallery affiliate links, there are three main tasks that need to be completed for DCR migration. 

- Check if the captions contain affiliate links
- Determine if affiliate links should be added, based on the following conditions: switch, `showAffiliateLinks` field, `alwaysOffTags` config & tags
- If both of above conditions are true, affiliate links disclaimer is added in the header section of the page
- Clean the captions by replacing the affiliate links with Simlinks

### Note: 
In `galleryBody` twirl template the `GalleryCaptionCleaners` is used for every image item to clean the caption. There are 2 cleaners involved: 
- **GalleryCaptionCleaner** which does the following:
  - removes `<br>` tags
  - retrieves the text content within the first `<strong>` and wraps it with `<h2>` element
  - removes the `<strong>` element
  - prepends the created `h2` at the start of the caption
- **AffiliateLinksCleaner** which does the following: checks if affiliate links should be added using the `shouldAddAffiliateLinks` function and then replaces affiliate links with Simlinks if necessary

### Some updates:
I’ve re-created the two cleaners for the DCR model with adjustments:
- **GalleryCaptionCleaner**: Removed the addition of the unnecessary `gallery__caption__title` class for DCR.
- **AffiliateLinksCleaner**: The `shouldAddAffiliateLinks` check, which was previously applied to every image item, is no longer needed since the result of this check is already available in the DotcomRenderingDataModel. Instead the parapeter `shouldAddAffiliateLinks` is used in the new cleaner

Relevant DCAR PR: https://github.com/guardian/dotcom-rendering/pull/14303

Fixes [#12292](https://github.com/guardian/dotcom-rendering/issues/12292)