### PR TITLE
Extend expiry date for dark mode and JS bundle experiments

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -42,7 +42,7 @@ object DarkModeWeb
       name = "dark-mode-web",
       description = "Enable dark mode on web",
       owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 7, 30),
+      sellByDate = LocalDate.of(2025, 10, 31),
       participationGroup = Perc0D,
     )
 
@@ -51,6 +51,6 @@ object DCRJavascriptBundle
       name = "dcr-javascript-bundle",
       description = "DCAR JS bundle experiment to test replacing Preact with React",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 7, 30),
+      sellByDate = LocalDate.of(2025, 8, 29),
       participationGroup = Perc0E,
     )


### PR DESCRIPTION
## What does this change?

Extends dark mode and JS bundle experiments by 3 months and 1 month respectively as these expire later this week