### PR TITLE
Automatically update AMI for GuCDK Facia stack

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -21,6 +21,7 @@ templates:
     - update-ami-for-applications
     - update-ami-for-rss
     - update-ami-for-onward
+    - update-ami-for-facia
 
 deployments:
   admin:
@@ -121,5 +122,13 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIOnward:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-facia:
+    app: facia
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIFacia:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows us to automatically update the AMI for the GuCDK Facia stack

## What does this change?

This allows `dotcom:frontend-all` deployments (including scheduled deployments) to automatically update the AMI
