### PR TITLE
Allow Riff-Raff to update both Facia ASGs during GuCDK migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -38,6 +38,8 @@ deployments:
     template: frontend
   facia:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   facia-press:
     template: frontend
   identity:


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are [dual-stacking](https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md) Facia as we migrate to GuCDK. This means all infrastructure components (load balancer, autoscaling group etc.) are temporarily duplicated.

Riff-Raff normally expects to find exactly one matching autoscaling group for a set of tags. When deploying it will update the application code for that autoscaling group only. If Riff-Raff finds more than one autoscaling group with the same set of tags the deployment will fail.

This change adds the `asgMigrationInProgress` parameter to Facia's config to allow Riff-Raff to update both autoscaling groups when deploying.

This relies on https://github.com/guardian/platform/pull/1925 being applied first.

## Checklist

[Validated with Riff-Raff](https://riffraff.gutools.co.uk/configuration/validation)

<img width="1153" height="333" alt="Screenshot 2025-07-28 at 17 35 11" src="https://github.com/user-attachments/assets/0e2c5805-d92c-4f64-ad5a-58aa7f2256fe" />
