### PR TITLE
Update ownership of `dark-mode-web` experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -41,7 +41,7 @@ object DarkModeWeb
     extends Experiment(
       name = "dark-mode-web",
       description = "Enable dark mode on web",
-      owners = Seq(Owner.withGithub("jakeii"), Owner.withEmail("dotcom.platform@theguardian.com")),
+      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 10, 31),
       participationGroup = Perc0D,
     )


### PR DESCRIPTION
## What does this change?

Updates ownership of `dark-mode-web` experiment to make the WebX team the sole owner as this is a platform feature