### PR TITLE
Automatically update the AMI for facia-press stack and allow Riff-Raff to update 2 facia-press ASGs during GuCDK migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -21,6 +21,7 @@ templates:
     - update-ami-for-applications
     - update-ami-for-rss
     - update-ami-for-onward
+    - update-ami-for-facia-press
 
 deployments:
   admin:
@@ -39,6 +40,8 @@ deployments:
     template: frontend
   facia-press:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   identity:
     template: frontend
   onward:
@@ -121,5 +124,13 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIOnward:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-facia-press:
+    app: facia-press
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIFaciaPress:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -132,7 +132,7 @@ deployments:
     type: ami-cloudformation-parameter
     parameters:
       amiParametersToTags:
-        AMIFaciaPress:
+        AMIFaciapress:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD
   update-ami-for-facia:


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR allows us to automatically update the AMI for the facia-press stack and allow Riff-Raff to update 2 facia-press ASGs during GuCDK migration.

This allows dotcom:frontend-all deployments (including scheduled deployments) to automatically update the AMI used by the new GuCDK stack (introduced in https://github.com/guardian/platform/pull/1915)

To be deployed after https://github.com/guardian/platform/pull/1927

Part of https://github.com/guardian/platform/issues/1911 

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
