### PR TITLE
Create 0% Experiment for No Boosts AB test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -37,6 +37,15 @@ object TopAboveNav250Reservation
       participationGroup = Perc0B,
     )
 
+object NoBoosts
+    extends Experiment(
+      name = "no-boosts",
+      description = "Test the impact of removing boosts (excluding Splash) from the Flexible General container",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 9, 30),
+      participationGroup = Perc0C,
+    )
+
 object DarkModeWeb
     extends Experiment(
       name = "dark-mode-web",


### PR DESCRIPTION
## What does this change?

Adds a server side AB test to test the impact of removing the boost effect from cards within the Flexible General container on the UK network front. The Splash slot is excluded and will render as normal.

There is a [PR in DCR](https://github.com/guardian/dotcom-rendering/pull/14305) that implements the logic.