### PR TITLE
feat: Add Google One Tap experiment

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -59,4 +59,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-google-one-tap",
+    "This test is being used to prototype and roll out single sign-on with Google One Tap.",
+    owners = Seq(Owner.withEmail("identity.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 12, 1)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { auxiaSignInGate } from './tests/auxia-sign-in-gate';
+import { googleOneTap } from './tests/google-one-tap';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -11,4 +12,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
 	auxiaSignInGate,
+	googleOneTap
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/google-one-tap.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/google-one-tap.js
@@ -1,0 +1,24 @@
+
+export const googleOneTap = {
+	id: 'GoogleOneTap',
+	start: '2025-07-30',
+	expiry: '2025-12-01',
+	author: 'Ash (Identity & Trust)',
+	description:
+		'This test is being used to prototype and roll out single sign-on with Google One Tap.',
+	audience: 0,
+	audienceOffset: 0,
+	successMeasure:
+		'There are no new client side errors and the users are able to sign in with Google One Tap',
+	audienceCriteria: 'Signed-out Chrome Users on Fronts',
+	idealOutcome:
+		'Increased sign in conversion rate for users who have Google accounts and Chrome',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'variant',
+			test: () => {},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?

Adds a new experiment for testing and rolling out Google One Tap. We've previously experimented with Google One Tap in a [POC PR](https://github.com/guardian/dotcom-rendering/pull/13468) and now we want to try build a more concrete implementation.

By putting Google One Tap behind a 0% AB Test we'll be able to invite stakeholders to test Google One Tap in PROD without releasing it to our readers.

We believe that by implementing Google One Tap we can increase conversion rate for Chrome users with Google Accounts that are not signed into the Guardian and thus grow our contactable base.

<hr>

_See equivalent PR for DCR: https://github.com/guardian/dotcom-rendering/pull/14318_
