### PR TITLE
Extend `prebid-ad-unit` test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -55,7 +55,7 @@ trait ABTestSwitches {
     "Test grouping slots to be used by PrebidAdUnit to allow full benefits of bidCache in Prebid",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 8, 12)),
+    sellByDate = Some(LocalDate.of(2025, 8, 21)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What does this change?

This PR extends the `prebid-ad-unit` test by a week while the switch is off. Check related PR  https://github.com/guardian/commercial/pull/2140

