### PR TITLE
Remove `AdYouLike` switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -361,17 +361,6 @@ trait PrebidSwitches {
     highImpact = false,
   )
 
-  val prebidAdYouLike: Switch = Switch(
-    group = CommercialPrebid,
-    name = "prebid-ad-you-like",
-    description = "Include AdYouLike adapter in Prebid auctions",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
   val prebidCriteo: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-criteo",


### PR DESCRIPTION
## What does this change?

This PR removes the `AdYouLike` switch permanently. Check related work  https://github.com/guardian/commercial/pull/2142 for more details.

## Checklist

- [x] Tested locally, and on CODE if necessary
