### PR TITLE
Revert "Automatically update the AMI for facia-press stack and allow Riff-Raff to update 2 facia-press ASGs during GuCDK migration"

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -21,7 +21,6 @@ templates:
     - update-ami-for-applications
     - update-ami-for-rss
     - update-ami-for-onward
-    - update-ami-for-facia-press
     - update-ami-for-facia
 
 deployments:
@@ -41,8 +40,6 @@ deployments:
     template: frontend
   facia-press:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   identity:
     template: frontend
   onward:
@@ -125,14 +122,6 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIOnward:
-          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
-          AmigoStage: PROD
-  update-ami-for-facia-press:
-    app: facia-press
-    type: ami-cloudformation-parameter
-    parameters:
-      amiParametersToTags:
-        AMIFaciapress:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD
   update-ami-for-facia:


### PR DESCRIPTION
Reverts guardian/frontend#28128