### PR TITLE
Remove `directToRouter` troubleshooter test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ val common = library("common")
       awsCore,
       awsCloudwatch,
       awsDynamodb,
-      awsEc2,
       awsKinesis,
       awsS3,
       awsSns,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,6 @@ object Dependencies {
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion
   val awsDynamodb = "software.amazon.awssdk" % "dynamodb" % awsSdk2Version
-  val awsEc2 = "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion
   val awsKinesis = "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion
   val awsS3 = "software.amazon.awssdk" % "s3" % awsSdk2Version
   val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"


### PR DESCRIPTION
The admin app contains a troubleshooting page for testing dotcom URLs:

https://frontend.gutools.co.uk/troubleshoot/pages

This included a test for checking whether router instances for a particular URL can be hit - however, the _"Can fetch directly from Router load balancer"_ test is no longer working - since PR https://github.com/guardian/frontend/pull/17487, the test has been hitting router EC2 instances directly, rather than the load-balancer, and as it happens, neither of these are now accessible to the Admin app instances (likely because of our increasing adoption of AWS FSBP and CDK).

Removing it allows us to remove a dependency on the AWS EC2 SDK v1, which would otherwise need to be updated to v2.

Paired with @rtyley 

Fixes #26510.

## Screenshots

| Before | After |
|--------|--------|
| <img width="792" height="587" alt="image" src="https://github.com/user-attachments/assets/70abf6cc-b892-45df-ba44-941b7076aaf9" /> | <img width="775" height="491" alt="image" src="https://github.com/user-attachments/assets/2955aa97-f60a-497b-a865-bb74acb0ba0c" /> | 


## Testing

Deployed to CODE and tested ok for this url:

https://frontend.code.dev-gutools.co.uk/troubleshoot/test?id=frontend-facia&testPath=%2Fuk

## Associated PRs

We will also remove the `ec2:DescribeInstances` permission from [Admin's CDK configuration](https://github.com/guardian/platform/blame/4181daac8fbcabcdffbaa028596a39f1e8181651/cdk/lib/admin.ts#L252C9-L252C30):

* https://github.com/guardian/platform/pull/1938

