### PR TITLE
adds a feature switch to deal with multiple GuCreative types during m…

### DIFF
--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -67,7 +67,11 @@ class DfpDataCacheLifecycle(
     new Job[Unit] {
       val name: String = "DFP-Template-Creatives-Cache"
       val interval: Int = 2
-      def run() = dfpTemplateCreativeCacheJob.run()
+      def run(): Future[Unit] = if (LineItemJobs.isSwitchedOn) {
+        dfpTemplateCreativeCacheJob.run()
+      } else {
+        Future.successful(()) // Do nothing when switched off
+      }
     },
   )
 

--- a/admin/app/dfp/DfpTemplateCreativeCacheJob.scala
+++ b/admin/app/dfp/DfpTemplateCreativeCacheJob.scala
@@ -11,9 +11,9 @@ class DfpTemplateCreativeCacheJob(dfpApi: DfpApi) {
 
   def run()(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {
-      val cached = Store.getDfpTemplateCreatives
+      val cached = Store.getDfpTemplateCreatives // s3
       val threshold = GuCreative.lastModified(cached) getOrElse now.minusMonths(1)
-      val recentlyModified = dfpApi.readTemplateCreativesModifiedSince(threshold)
+      val recentlyModified = dfpApi.readTemplateCreativesModifiedSince(threshold) // GAM
       val merged = GuCreative.merge(cached, recentlyModified)
       Store.putDfpTemplateCreatives(Json.stringify(Json.toJson(merged)))
     }

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -73,7 +73,7 @@ trait Store extends GuLogging with Dates {
     if (LineItemJobs.isSwitchedOn) {
       // New system: read wrapper format from new key
       val wrapper = for (doc <- S3.get(dfpCreativesKey)) yield {
-        Json.parse(doc).as[GuCreativeWrapper]
+        Json.parse(doc).as[GuCreativeReport]
       }
       wrapper.map(_.creatives).getOrElse(Nil)
     } else {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -501,6 +501,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val dfpCustomFieldsKey = s"$gamRoot/custom-fields.json"
     lazy val dfpCreativeTemplatesKey = s"$gamRoot/creative-templates.json"
     lazy val dfpTemplateCreativesKey = s"$dfpRoot/template-creatives.json"
+    lazy val dfpCreativesKey = s"$dfpRoot/creatives.json"
     lazy val dfpCustomTargetingKey =
       if (LineItemJobs.isSwitchedOn) s"$gamRoot/custom-targeting-key-values.json"
       else s"$dfpRoot/custom-targeting-key-values.json"

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -386,6 +386,15 @@ object GuCreativeTemplateParameter {
   )(GuCreativeTemplateParameter.apply _)
 }
 
+case class GuCreativeWrapper(
+    updatedTimeStamp: String,
+    creatives: Seq[GuCreative],
+)
+
+object GuCreativeWrapper {
+  implicit val guCreativeWrapperFormat: Format[GuCreativeWrapper] = Json.format[GuCreativeWrapper]
+}
+
 case class GuCreative(
     id: Long,
     name: String,

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -386,13 +386,13 @@ object GuCreativeTemplateParameter {
   )(GuCreativeTemplateParameter.apply _)
 }
 
-case class GuCreativeWrapper(
+case class GuCreativeReport(
     updatedTimeStamp: String,
     creatives: Seq[GuCreative],
 )
 
-object GuCreativeWrapper {
-  implicit val guCreativeWrapperFormat: Format[GuCreativeWrapper] = Json.format[GuCreativeWrapper]
+object GuCreativeReport {
+  implicit val guCreativeReportFormat: Format[GuCreativeReport] = Json.format[GuCreativeReport]
 }
 
 case class GuCreative(


### PR DESCRIPTION
## Why

The Admin app renders DFP template creatives to help the commercial team manage ad campaigns via the Guardian tools. We are migrating DFP data sync jobs from this codebase to the dedicated line-item-jobs repository for better separation of concerns.
**Related PR:** https://github.com/guardian/line-item-jobs/pull/123

As part of this migration, we're updating the S3 storage schema for template creatives from a flat array to a wrapper object with metadata.

## What does this change?
This PR implements dual schema support to enable a safe migration between the old and new systems:

Schema Changes:
- Old format: Direct Seq[GuCreative] array stored in S3
- New format: GuCreativeWrapper object containing timestamp + creatives array
- Two S3 keys: dfpTemplateCreativesKey (old) and dfpCreativesKey (new)

Feature Switch Logic:
- LineItemJobs.isSwitchedOn = false: Uses old cache job + old S3 format
- LineItemJobs.isSwitchedOn = true: Uses line-item-jobs + new S3 format
- getDfpTemplateCreatives method automatically selects the correct key/parser

We are aiming for 
- Zero downtime - Both systems working independently
- Easy testing - Can test new format without affecting old system
- Data comparison - Can compare outputs from both systems
- Safe rollback - If new system fails, old system unaffected
- Clean separation - Clear boundary between old and new data

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering


<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
