### PR TITLE
Set top-above-nav 250px reservation test to 2%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -35,7 +35,7 @@ object TopAboveNav250Reservation
       description = "Reserve 250px for top-above-nav instead of 90px",
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2025, 8, 29),
-      participationGroup = Perc0B,
+      participationGroup = Perc2A,
     )
 
 object DarkModeWeb


### PR DESCRIPTION
## What does this change?
Launch the test! See https://github.com/guardian/dotcom-rendering/pull/14198 for details on the test.