### PR TITLE
Speedup CI: Use 8core-ubuntu-latest-frontend runner for build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: 'Build'
 
 on:
   pull_request:
@@ -14,7 +14,7 @@ permissions:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:
@@ -61,7 +61,7 @@ jobs:
 
   build:
     needs: [client-validate, client-build]
-    runs-on: ubuntu-latest
+    runs-on: 8core-ubuntu-latest-frontend
     steps:
       - uses: actions/checkout@v4
 
@@ -100,7 +100,7 @@ jobs:
       - name: Test Summary
         uses: test-summary/action@v2
         with:
-          paths: "test-results/**/TEST-*.xml"
+          paths: 'test-results/**/TEST-*.xml'
         if: always()
 
       - uses: guardian/actions-riff-raff@v4.1.2


### PR DESCRIPTION
## What is the value of this and can you measure success?

Use the [8core-ubuntu-latest-frontend](https://github.com/organizations/guardian/settings/actions/github-hosted-runners/25?viewing_from_runner_group=false) runner for build job

This improves the CI time from ~9mins to ~6.5mins

Rough calculation shows this should incur marginal cost:

```
= (build.yaml invocations) * (avg time for build new runner) * (runner cost)
= 254 * 5m * 0.032 per min
= $38.1 per month = $457 per year
```

We've made an order of magnitude more savings in other areas so I think this is acceptable.

The cost should come down over time as we remove redundant rendering code and tests from Frontend.

I considered merging the client jobs back into the main build job. The overall build time was roughly the same, however we would incur more time on the more expensive runners rather than the default cheap runners (for open-source), so I left the configuration of the jobs the same.

References

- action stats for [last month](https://github.com/organizations/guardian/settings/actions/github-hosted-runners/25?viewing_from_runner_group=false)
- [build time](https://github.com/guardian/frontend/actions/runs/16754506150) using the new runner
- [runner costs](https://docs.github.com/en/billing/concepts/product-billing/github-actions#per-minute-rates-for-x64-powered-larger-runners)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/928b06e3-0d97-4097-a19a-7acb1470cf3f
[after]: https://github.com/user-attachments/assets/67206341-6057-47b3-a035-2796ec61d8f1
