### PR TITLE
Update Admiral lifecycle

### DIFF
--- a/commercial/app/agents/AdmiralAgent.scala
+++ b/commercial/app/agents/AdmiralAgent.scala
@@ -11,14 +11,15 @@ class AdmiralAgent(wsClient: WSClient) extends GuLogging with implicits.WSReques
 
   private val scriptCache = Box[Option[String]](None)
 
-  private val admiralUrl = Configuration.commercial.admiralUrl;
+  private val environment = Configuration.environment.stage
+  private val admiralUrl = Configuration.commercial.admiralUrl
 
   private def fetchBootstrapScript(implicit ec: ExecutionContext): Future[String] = {
     log.info(s"Fetching Admiral's bootstrap script via the Install Tag API")
     admiralUrl match {
-      case Some(admiralUrl) =>
+      case Some(baseUrl) =>
         wsClient
-          .url(admiralUrl)
+          .url(s"$baseUrl?cacheable=1&environment=$environment")
           .withRequestTimeout(2.seconds)
           .getOKResponse()
           .map(_.body)

--- a/commercial/app/controllers/AdmiralController.scala
+++ b/commercial/app/controllers/AdmiralController.scala
@@ -18,7 +18,7 @@ class AdmiralController(admiralAgent: AdmiralAgent, val controllerComponents: Co
     Action { implicit request =>
       admiralAgent.getBootstrapScript match {
         case Some(script) =>
-          Cached(10.minutes)(
+          Cached(1.hour)(
             RevalidatableResult(Ok(script).as("text/javascript; charset=utf-8"), script),
           )
         case None => NotFound

--- a/commercial/app/jobs/AdmiralLifecycle.scala
+++ b/commercial/app/jobs/AdmiralLifecycle.scala
@@ -25,7 +25,9 @@ class AdmiralLifecycle(
   override def start(): Unit = {
     jobs.deschedule("AdmiralAgentRefreshJob")
 
-    jobs.scheduleEvery("AdmiralAgentRefreshJob", 2.hours) {
+    // Why 6 hours?
+    // The Admiral script returned from the "Install Tag" API is unlikely to change frequently
+    jobs.scheduleEvery("AdmiralAgentRefreshJob", 6.hours) {
       admiralAgent.refresh()
     }
 


### PR DESCRIPTION
## What does this change?

- Reduces the frequency of Admiral API calls (refreshes every 6 hours instead of every 2)
- Removes query parameters from the SSM parameter, keeping them in the code instead. This should improve overall understanding of the code.
- Provides `environment` as a query parameter alongside `cacheable` as this is encouraged in [the documentation](https://docs.getadmiral.com/docs/install-api)
- Caches response from controller for 1 hour rather than 10 minutes

## Why

The Admiral script is unlikely to change regularly so we don't need to be able to fetch the absolute latest data at any time

Including the query parameter in the CODE rather than keeping in configuration makes it easier to see what is going on, and easier to add other parameters (like `environment` for instance)
