### PR TITLE
Remove MostViewedSocialController from dev-build

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -76,8 +76,6 @@ GET            /discussion/profile/:id/replies.json                             
 GET            /discussion/profile/:id/picks.json                                                                                controllers.ProfileActivityController.profilePicks(id: String)
 
 # Onward
-GET            /most-read-facebook.json                                                                                          controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "facebook")
-GET            /most-read-twitter.json                                                                                           controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")
 GET            /most-read.json                                                                                                   controllers.MostPopularController.render(path = "")
 GET            /most-read/*path.json                                                                                             controllers.MostPopularController.render(path)
 GET            /most-read-geo.json                                                                                               controllers.MostPopularController.renderPopularGeo()


### PR DESCRIPTION
## What is the value of this and can you measure success?
 
Removes leftover code from https://github.com/guardian/frontend/pull/28121 to fix dev-build
