### PR TITLE
Remove No Boosts Experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,7 +14,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       DarkModeWeb,
       DCRJavascriptBundle,
       LoopingVideo,
-      NoBoosts,
       TopAboveNav250Reservation,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
@@ -54,13 +53,4 @@ object DCRJavascriptBundle
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 8, 29),
       participationGroup = Perc0E,
-    )
-
-object NoBoosts
-    extends Experiment(
-      name = "no-boosts",
-      description = "Test the impact of removing boosts (excluding Splash) from the Flexible General container",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 9, 30),
-      participationGroup = Perc5A,
     )


### PR DESCRIPTION
## What does this change?

Removes the [No Boosts experiment](https://github.com/guardian/frontend/pull/28129). This test is finished and has been switched off via the switchboard.