### PR TITLE
Create Opinion No Avatar 0% Experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,9 +15,19 @@ object ActiveExperiments extends ExperimentsDefinition {
       TopAboveNav250Reservation,
       SourcepointConsentGeolocation,
       GoogleOneTap,
+      OpinionNoAvatar,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
+
+object OpinionNoAvatar
+    extends Experiment(
+      name = "opinion-no-avatar",
+      description = "In the Opinion section on network fronts, replace the avatar with the card image",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 12, 1),
+      participationGroup = Perc0A,
+    )
 
 object SourcepointConsentGeolocation
     extends Experiment(


### PR DESCRIPTION
## What does this change?

Adds a server side AB test to test the impact of replacing avatars with card images in the Opinion and More opinion collections on network fronts.

There is a [PR in DCR](https://github.com/guardian/dotcom-rendering/pull/14369) that implements the logic.