### PR TITLE
Remove `prebidBidCache` and `prebidAdUnit` switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,17 +51,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-prebid-ad-unit",
-    "Test grouping slots to be used by PrebidAdUnit to allow full benefits of bidCache in Prebid",
-    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 8, 21)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-google-one-tap",
     "This test is being used to prototype and roll out single sign-on with Google One Tap.",
     owners = Seq(Owner.withEmail("identity.dev@guardian.co.uk")),

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -416,17 +416,6 @@ trait PrebidSwitches {
     highImpact = false,
   )
 
-  val prebidBidCache: Switch = Switch(
-    group = CommercialPrebid,
-    name = "prebid-bid-cache",
-    description = "Enable the Prebid bid cache",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
   val sentinelLogger: Switch = Switch(
     group = Commercial,
     name = "sentinel-logger",


### PR DESCRIPTION
## What does this change?

This PR removes two commercial switches: 

- `prebidBidCache` and this switch is on at the moment. 
-  `prebidAdUnit` which is an AB test related to the prebid bid cache work.

For more details check https://github.com/guardian/commercial/pull/2152

## Checklist

- [x] Tested locally, and on CODE if necessary
