### PR TITLE
Set Looping Video test to 5%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -19,15 +19,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
 
-object LoopingVideo
-    extends Experiment(
-      name = "looping-video",
-      description = "Enable looping videos on DCR",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 9, 30),
-      participationGroup = Perc0A,
-    )
-
 object TopAboveNav250Reservation
     extends Experiment(
       name = "top-above-nav-250-reservation",
@@ -53,4 +44,13 @@ object DCRJavascriptBundle
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 8, 29),
       participationGroup = Perc0E,
+    )
+
+object LoopingVideo
+    extends Experiment(
+      name = "looping-video",
+      description = "Test looping videos on DCR",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 9, 30),
+      participationGroup = Perc5A,
     )


### PR DESCRIPTION
## What does this change?

Set the Looping Video experiment to 5%

## Why?

We initially executed a gradual release process where we increased the population of our audience that received looping videos on their network front:
- https://github.com/guardian/frontend/pull/28107
- https://github.com/guardian/frontend/pull/28112
- https://github.com/guardian/frontend/pull/28115

As this was a major change, this allowed us to limit the audience that saw looping videos in case there was a reason that we would have rolled back (broken videos, big negative change in metric(s)). However, we weren't able to scientifically test the effect that looping videos have on our metrics.

Therefore we want to run this AB test which will give us more reliable data on the effect that serving looping videos has on the users experience.

[Link to the corresponding DCR PR](https://github.com/guardian/dotcom-rendering/pull/14377)