### PR TITLE
Add AB Test Switch for prebid946 AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -59,4 +59,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-prebid946",
+    "This test is being used to test v9.46.0 of Prebid ahead of general upgrade.",
+    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 8, 29)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Adds a feature switch for the Commercial client-side prebid946 AB test, that we're launching here: https://github.com/guardian/commercial/pull/2156