### PR TITLE
Update nav and footer links

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -143,7 +143,6 @@ object FooterLinks {
   val auListTwo = List(
     allTopics("au"),
     allWriters("au"),
-    FooterLink("Events", "/guardian-masterclasses/guardian-masterclasses-australia", "au : footer : masterclasses"),
     digitalNewspaperArchive,
     taxStrategy("au"),
     facebook("au"),

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -245,12 +245,7 @@ object NavLinks {
   val jobs = NavLink("Search jobs", "https://jobs.theguardian.com")
   val apps =
     NavLink("The Guardian app", "https://app.adjust.com/16xt6hai")
-  val auWeekend = NavLink(
-    "Australia Weekend",
-    "/info/ng-interactive/2021/mar/17/make-sense-of-the-week-with-australia-weekend?INTCMP=header_au_weekend",
-  )
   val printShop = NavLink("Guardian Print Shop", "/artanddesign/series/gnm-print-sales")
-  val auEvents = NavLink("Events", "/guardian-live-australia")
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val guardianLive =
@@ -703,20 +698,21 @@ object NavLinks {
     guardianLicensing,
   )
   val auBrandExtensions = List(
-    auEvents,
+    guardianLive,
     digitalNewspaperArchive,
-    auWeekend,
     guardianLicensing,
     aboutUs,
   )
   val usBrandExtensions = List(
     jobs,
+    guardianLive,
     digitalNewspaperArchive,
     guardianLicensing,
     aboutUs,
   )
   val intBrandExtensions = List(
     jobs,
+    guardianLive,
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
     guardianLicensing,
@@ -724,6 +720,7 @@ object NavLinks {
   )
   val eurBrandExtensions = List(
     jobs,
+    guardianLive,
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
     guardianLicensing,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -248,8 +248,16 @@ object NavLinks {
   val printShop = NavLink("Guardian Print Shop", "/artanddesign/series/gnm-print-sales")
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
-  val guardianLive =
+  val guardianLiveUK =
     NavLink("Live events", "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown")
+  val guardianLiveAU =
+    NavLink("Live events", "https://www.theguardian.com/guardian-live-events?INTCMP=live_au_header_dropdown")
+  val guardianLiveUS =
+    NavLink("Live events", "https://www.theguardian.com/guardian-live-events?INTCMP=live_us_header_dropdown")
+  val guardianLiveEUR =
+    NavLink("Live events", "https://www.theguardian.com/guardian-live-events?INTCMP=live_eur_header_dropdown")
+  val guardianLiveINT =
+    NavLink("Live events", "https://www.theguardian.com/guardian-live-events?INTCMP=live_int_header_dropdown")
   val guardianLicensing = NavLink("Guardian Licensing", s"https://licensing.theguardian.com/")
   val jobsRecruiter = NavLink(
     "Hire with Guardian Jobs",
@@ -690,7 +698,7 @@ object NavLinks {
     jobs,
     jobsRecruiter,
     holidays.copy(url = holidays.url + "?INTCMP=holidays_uk_web_newheader"),
-    guardianLive,
+    guardianLiveUK,
     aboutUs,
     digitalNewspaperArchive,
     printShop,
@@ -698,32 +706,32 @@ object NavLinks {
     guardianLicensing,
   )
   val auBrandExtensions = List(
-    guardianLive,
     digitalNewspaperArchive,
     guardianLicensing,
+    guardianLiveAU,
     aboutUs,
   )
   val usBrandExtensions = List(
     jobs,
-    guardianLive,
     digitalNewspaperArchive,
     guardianLicensing,
+    guardianLiveUS,
     aboutUs,
   )
   val intBrandExtensions = List(
     jobs,
-    guardianLive,
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
     guardianLicensing,
+    guardianLiveINT,
     aboutUs,
   )
   val eurBrandExtensions = List(
     jobs,
-    guardianLive,
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
     guardianLicensing,
+    guardianLiveEUR,
     aboutUs,
   )
 

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1666,6 +1666,12 @@
 				"classList": []
 			},
 			{
+				"title": "Live events",
+				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
+				"children": [],
+				"classList": []
+			},
+			{
 				"title": "Digital Archive",
 				"url": "https://theguardian.newspapers.com",
 				"children": [],
@@ -2360,20 +2366,14 @@
 		],
 		"brandExtensions": [
 			{
-				"title": "Events",
-				"url": "/guardian-live-australia",
+				"title": "Live events",
+				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
 				"children": [],
 				"classList": []
 			},
 			{
 				"title": "Digital Archive",
 				"url": "https://theguardian.newspapers.com",
-				"children": [],
-				"classList": []
-			},
-			{
-				"title": "Australia Weekend",
-				"url": "/info/ng-interactive/2021/mar/17/make-sense-of-the-week-with-australia-weekend?INTCMP=header_au_weekend",
 				"children": [],
 				"classList": []
 			},
@@ -3241,6 +3241,12 @@
 			{
 				"title": "Search jobs",
 				"url": "https://jobs.theguardian.com",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Live events",
+				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
 				"children": [],
 				"classList": []
 			},
@@ -4228,6 +4234,12 @@
 			{
 				"title": "Search jobs",
 				"url": "https://jobs.theguardian.com",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Live events",
+				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
 				"children": [],
 				"classList": []
 			},

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1666,12 +1666,6 @@
 				"classList": []
 			},
 			{
-				"title": "Live events",
-				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
-				"children": [],
-				"classList": []
-			},
-			{
 				"title": "Digital Archive",
 				"url": "https://theguardian.newspapers.com",
 				"children": [],
@@ -1680,6 +1674,12 @@
 			{
 				"title": "Guardian Licensing",
 				"url": "https://licensing.theguardian.com/",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Live events",
+				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_us_header_dropdown",
 				"children": [],
 				"classList": []
 			},
@@ -2366,12 +2366,6 @@
 		],
 		"brandExtensions": [
 			{
-				"title": "Live events",
-				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
-				"children": [],
-				"classList": []
-			},
-			{
 				"title": "Digital Archive",
 				"url": "https://theguardian.newspapers.com",
 				"children": [],
@@ -2380,6 +2374,12 @@
 			{
 				"title": "Guardian Licensing",
 				"url": "https://licensing.theguardian.com/",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Live events",
+				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_au_header_dropdown",
 				"children": [],
 				"classList": []
 			},
@@ -3245,12 +3245,6 @@
 				"classList": []
 			},
 			{
-				"title": "Live events",
-				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
-				"children": [],
-				"classList": []
-			},
-			{
 				"title": "Holidays",
 				"url": "https://holidays.theguardian.com?INTCMP=holidays_int_web_newheader",
 				"children": [],
@@ -3265,6 +3259,12 @@
 			{
 				"title": "Guardian Licensing",
 				"url": "https://licensing.theguardian.com/",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Live events",
+				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_eur_header_dropdown",
 				"children": [],
 				"classList": []
 			},
@@ -4238,12 +4238,6 @@
 				"classList": []
 			},
 			{
-				"title": "Live events",
-				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_uk_header_dropdown",
-				"children": [],
-				"classList": []
-			},
-			{
 				"title": "Holidays",
 				"url": "https://holidays.theguardian.com?INTCMP=holidays_int_web_newheader",
 				"children": [],
@@ -4258,6 +4252,12 @@
 			{
 				"title": "Guardian Licensing",
 				"url": "https://licensing.theguardian.com/",
+				"children": [],
+				"classList": []
+			},
+			{
+				"title": "Live events",
+				"url": "https://www.theguardian.com/guardian-live-events?INTCMP=live_int_header_dropdown",
 				"children": [],
 				"classList": []
 			},


### PR DESCRIPTION
## What does this change?
Updates the nav and footer across editions. These changes were requested by central production. 

## Changes

**- Update "Live events" link in all editions (web):**
Use the same link as the UK edition:
https://www.theguardian.com/guardian-live-events?INTCMP=live_{EDITION}_header_dropdown

For Australia, this replaces the current link:
https://www.theguardian.com/guardian-live-australia (no longer promoted).

**- Remove outdated links/content in Australia edition:**
Footer: Remove "Events" link that points to the old Masterclasses page.
Header: Remove "Australia Weekend" (Editions product no longer exists).

## Screenshot
**headers**
<img width="491" height="557" alt="Screenshot 2025-08-13 at 13 27 55" src="https://github.com/user-attachments/assets/f7dfd398-36c0-4f7f-ad1b-399c863b8f3a" />
<img width="491" height="557" alt="Screenshot 2025-08-13 at 13 27 38" src="https://github.com/user-attachments/assets/73b02fe2-235f-49f6-8b9e-b0ee0118009e" />

<img width="492" height="530" alt="Screenshot 2025-08-13 at 13 28 16" src="https://github.com/user-attachments/assets/1cf790c5-6aef-4e1e-bcdb-7a1d22c6381a" />
<img width="492" height="530" alt="Screenshot 2025-08-13 at 13 28 03" src="https://github.com/user-attachments/assets/1997d4e4-8456-477b-b902-6de3163fa3b1" />

**AUS footer**

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4a364093-4417-4bc7-89bf-0961e455f201
[after]: https://github.com/user-attachments/assets/fb9b8932-8acc-44e4-8d3f-9fb612afd602


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
