### PR TITLE
Extend expiry date of Admiral ad block recovery test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,7 +44,7 @@ trait ABTestSwitches {
     "Testing the Admiral integration for adblock recovery on theguardian.com",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 8, 29)),
+    sellByDate = Some(LocalDate.of(2025, 9, 17)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

Updates the Admiral ad block recovery AB test switch so that we can let the test run for up to four weeks without needing to update the configuration while we check the numbers after week 1.

## What does this change?

Extends expiry date of the Admiral AB test switch until 17th September, 4 weeks after test intended to go live.
