### PR TITLE
updates commercialShared dependancy

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -97,7 +97,7 @@ object Dependencies {
   val targetingClient = "com.gu.targeting-client" %% "client-play-json-v30" % "1.1.9"
   val scanamo = "org.scanamo" %% "scanamo" % "2.0.0"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.8.1"
-  val commercialShared = "com.gu" %% "commercial-shared" % "6.2.3"
+  val commercialShared = "com.gu" %% "commercial-shared" % "6.2.5"
   val playJson = "org.playframework" %% "play-json" % playJsonVersion
   val playJsonJoda = "org.playframework" %% "play-json-joda" % playJsonVersion
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.16"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Addresses vulnerability highlighted in https://github.com/guardian/commercial-shared/security/dependabot/2

## What does this change?
This PR bumps the commercialShared dependancy as referenced in: https://github.com/guardian/commercial-shared/pull/69
