### PR TITLE
Remove ASG migration parameter from Facia deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -39,8 +39,6 @@ deployments:
     template: frontend
   facia:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   facia-press:
     template: frontend
     parameters:


### PR DESCRIPTION
## What is the value of this and can you measure success?

As we're no longer running the old and new infrastructure as dual stacks we can remove the `asgMigrationInProgress` parameter as we have a single Facia stack again. 

This should be merged following removal of the legacy Facia infrastructure (https://github.com/guardian/platform/pull/1955) to prevent `dotcom:frontend-all` deployments failing.
