### PR TITLE
Slowly rollout vary header change for new server side ab test header

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,6 +15,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       DCRJavascriptBundle,
       LoopingVideo,
       TopAboveNav250Reservation,
+      RolloutAddingServerABTestsToVaryHeader,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -53,4 +54,13 @@ object LoopingVideo
       owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
       sellByDate = LocalDate.of(2025, 9, 30),
       participationGroup = Perc5A,
+    )
+
+object RolloutAddingServerABTestsToVaryHeader
+    extends Experiment(
+      name = "rollout-adding-server-ab-tests-to-vary-header",
+      description = "Rollout adding server AB tests to the vary header",
+      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+      sellByDate = LocalDate.of(2025, 9, 30),
+      participationGroup = Perc1A,
     )

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -16,6 +16,8 @@ import ab.ABTests
 import conf.switches.Switches.{EnableNewServerSideABTestsHeader}
 
 import scala.concurrent.{ExecutionContext, Future}
+import experiments.Experiment
+import experiments.{ActiveExperiments, RolloutAddingServerABTestsToVaryHeader}
 
 class GzipperConfig() extends GzipFilterConfig {
   override val shouldGzip: (RequestHeader, Result) => Boolean = (request, result) => {
@@ -114,7 +116,11 @@ class ABTestingFilter(implicit val mat: Materializer, executionContext: Executio
   private val abTestHeader = "X-GU-Server-AB-Tests"
 
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
-    if (EnableNewServerSideABTestsHeader.isSwitchedOff) {
+    if (
+      EnableNewServerSideABTestsHeader.isSwitchedOff || !ActiveExperiments.isParticipating(
+        RolloutAddingServerABTestsToVaryHeader,
+      )(request)
+    ) {
       nextFilter(request)
     } else {
       val r = ABTests.decorateRequest(request, abTestHeader)


### PR DESCRIPTION
## What does this change?
It's possible that flipping the switch that adds `x-gu-server-ab-tests` to the `Vary` header could cause a spike in cache misses and requests to origin (even if `x-gu-server-ab-tests` is empty 100% of the time).

Switch and header code added in https://github.com/guardian/frontend/pull/28108

So to reduce the potential impact of this we can use the current server side test framework to slowly roll this out, starting at 1%, monitoring, increase to 2% and so on.
