### PR TITLE
remove creative ids routes and related logic

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -3,7 +3,7 @@ package controllers.admin
 import common.dfp.{GuCustomField, GuLineItem}
 import common.{ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import conf.Configuration
-import dfp.{DfpApi, DfpDataExtractor}
+import dfp.{DfpDataExtractor}
 import model._
 import services.ophan.SurgingContentAgent
 import play.api.libs.json.{JsString, Json}
@@ -16,7 +16,6 @@ import scala.util.Try
 
 class CommercialController(
     val controllerComponents: ControllerComponents,
-    dfpApi: DfpApi,
 )(implicit context: ApplicationContext)
     extends BaseController
     with GuLogging
@@ -93,24 +92,6 @@ class CommercialController(
 
       Cached(5.minutes) {
         JsonComponent.fromWritable(lineItems)
-      }
-    }
-
-  def getCreativesListing(lineitemId: String, section: String): Action[AnyContent] =
-    Action { implicit request: RequestHeader =>
-      val validSections: List[String] = List("uk", "lifeandstyle", "sport", "science")
-
-      val previewUrls: Seq[String] =
-        (for {
-          lineItemId <- Try(lineitemId.toLong).toOption
-          validSection <- validSections.find(_ == section)
-        } yield {
-          dfpApi.getCreativeIds(lineItemId) flatMap (dfpApi
-            .getPreviewUrl(lineItemId, _, s"https://theguardian.com/$validSection"))
-        }) getOrElse Nil
-
-      Cached(5.minutes) {
-        JsonComponent.fromWritable(previewUrls)
       }
     }
 

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -25,17 +25,6 @@ class DfpApi(dataMapper: DataMapper) extends GuLogging {
     }
   }
 
-  def getCreativeIds(lineItemId: Long): Seq[Long] = {
-    val stmtBuilder = new StatementBuilder()
-      .where("status = :status AND lineItemId = :lineItemId")
-      .withBindVariableValue("status", LineItemCreativeAssociationStatus._ACTIVE)
-      .withBindVariableValue("lineItemId", lineItemId)
-
-    withDfpSession { session =>
-      session.lineItemCreativeAssociations.get(stmtBuilder) map (id => Long2long(id.getCreativeId))
-    }
-  }
-
   def getPreviewUrl(lineItemId: Long, creativeId: Long, url: String): Option[String] =
     for {
       session <- SessionWrapper()

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -75,7 +75,6 @@ GET         /commercial/keyvalues/csv/*key                                      
 GET         /commercial/invalid-lineitems                                                           controllers.admin.CommercialController.renderInvalidItems()
 GET         /commercial/custom-fields                                                               controllers.admin.CommercialController.renderCustomFields()
 GET         /commercial/adgrabber/order/:orderId                                                    controllers.admin.CommercialController.getLineItemsForOrder(orderId: String)
-GET         /commercial/adgrabber/previewUrls/:lineItemId/:section                                  controllers.admin.CommercialController.getCreativesListing(lineItemId: String, section: String)
 GET         /commercial/adops/ads-txt                                                               controllers.admin.commercial.AdsDotTextEditController.renderAdsDotText()
 POST        /commercial/adops/ads-txt                                                               controllers.admin.commercial.AdsDotTextEditController.postAdsDotText()
 GET         /commercial/adops/app-ads-txt                                                           controllers.admin.commercial.AdsDotTextEditController.renderAppAdsDotText()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -263,7 +263,6 @@ GET         /commercial/keyvalues/csv/*key                                      
 GET         /commercial/invalid-lineitems                                                                                        controllers.admin.CommercialController.renderInvalidItems()
 GET         /commercial/custom-fields                                                                                            controllers.admin.CommercialController.renderCustomFields()
 GET         /commercial/adgrabber/order/:orderId                                                                                 controllers.admin.CommercialController.getLineItemsForOrder(orderId: String)
-GET         /commercial/adgrabber/previewUrls/:lineItemId/:section                                                               controllers.admin.CommercialController.getCreativesListing(lineItemId: String, section: String)
 GET         /commercial/adops/ads-txt                                                                                            controllers.admin.commercial.AdsDotTextEditController.renderAdsDotText()
 POST        /commercial/adops/ads-txt                                                                                            controllers.admin.commercial.AdsDotTextEditController.postAdsDotText()
 GET         /commercial/adops/app-ads-txt                                                                                        controllers.admin.commercial.AdsDotTextEditController.renderAppAdsDotText()

--- a/docs/05-commercial/04-non-refreshable-line-items.md
+++ b/docs/05-commercial/04-non-refreshable-line-items.md
@@ -13,7 +13,7 @@ Information about whether a line item should refresh isn't available when slots 
 
 The list of non-refreshable line item IDs is generated every 2 minutes via a call to the Google Ad Manager API. The resulting array is filtered to exclude prebid and amazon line items (see above) and stored in S3. The filename in S3 is `non-refreshable-lineitem-ids-v1.json`.
 
-See: [job schedule](https://github.com/guardian/frontend/blob/main/admin/app/dfp/DfpDataCacheLifecycle.scala), [job](https://github.com/guardian/frontend/blob/main/admin/app/dfp/DfpDataCacheJob.scala), [GAM API call](https://github.com/guardian/frontend/blob/main/admin/app/dfp/DfpApi.scala)
+See: [GAM API call](https://github.com/guardian/frontend/blob/main/admin/app/dfp/DfpApi.scala)
 
 ## How the list is consumed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,14 +58,13 @@
 
 ## [Features and components](06-features-and-components/)
 - [How are trail pictures picked in Frontend?](06-features-and-components/01-trail-images.md)
-- [Tag combiners](06-features-and-components/03-tag-combiners.md)
+- [theguardian.com/font-loader](06-features-and-components/03-font-loader-route.md)
 
 ## [Performance](07-performance/)
 - [Performance reading list](07-performance/01-performance-reading.md)
 
 ## [Archives](99-archives/)
 - [Recipe for Breton crêpes](99-archives/crepes.md)
-- [theguardian.com/font-loader](99-archives/font-loader-route.md)
 
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,13 +58,14 @@
 
 ## [Features and components](06-features-and-components/)
 - [How are trail pictures picked in Frontend?](06-features-and-components/01-trail-images.md)
-- [theguardian.com/font-loader](06-features-and-components/03-font-loader-route.md)
+- [Tag combiners](06-features-and-components/03-tag-combiners.md)
 
 ## [Performance](07-performance/)
 - [Performance reading list](07-performance/01-performance-reading.md)
 
 ## [Archives](99-archives/)
 - [Recipe for Breton crêpes](99-archives/crepes.md)
+- [theguardian.com/font-loader](99-archives/font-loader-route.md)
 
 
 ---


### PR DESCRIPTION
## What is the value of this and can you measure success?
**Removes legacy creative template functionality** from the admin app as part of migrating DFP data jobs to the [`line-item-jobs`](https://github.com/guardian/line-item-jobs) repository.


## What does this change?
The creative preview services previously:

- DfpApi.getCreativeIds() - Fetched creative IDs associated with line items from GAM API
- DfpApi.getPreviewUrl() - Generated preview URLs for creatives on specific Guardian sections
- CommercialController.getCreativesListing() - API endpoint combining creative IDs with preview URLs

Code Removal:

- DfpApi.getCreativeIds() - GAM API method to fetch creative IDs for line items
- CommercialController.getCreativesListing() - Controller method combining creative data with preview URLs
- Route handlers - /commercial/adgrabber/previewUrls/:lineItemId/:section endpoint
- GAM API dependencies - Reduced usage of SessionWrapper.lineItemCreativeAssociations
- Creative preview workflow - Ability to preview ads on different Guardian sections

✅ Application Health
Admin app starts successfully without creative preview dependencies
Other commercial admin pages (/commercial/invalid-lineitems, /commercial/pageskins) function normally
DfpApi compiles with remaining GAM API methods intact

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
