### PR TITLE
Remove asgMigrationInProgress from facia press deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -41,8 +41,6 @@ deployments:
     template: frontend
   facia-press:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   identity:
     template: frontend
   onward:


### PR DESCRIPTION
## What is the value of this and can you measure success?
This should be merged following removal of the legacy facia-press infrastructure https://github.com/guardian/platform/pull/1975 so we don't break dotcom:frontend-all deployments.
