### PR TITLE
Remove `DfpDataCacheLifecycle` from dev-build

### DIFF
--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -13,7 +13,6 @@ import controllers._
 import cricket.conf.CricketLifecycle
 import cricket.controllers.CricketControllers
 import dev.DevAssetsController
-import dfp.DfpDataCacheLifecycle
 import feed._
 import football.controllers._
 import http.{CorsHttpErrorHandler, DevBuildParametersHttpRequestHandler, DevFilters}
@@ -87,7 +86,6 @@ trait AppComponents
     List(
       wire[AdminLifecycle],
       wire[OnwardJourneyLifecycle],
-      wire[DfpDataCacheLifecycle],
       wire[ConfigAgentLifecycle],
       wire[SurgingContentAgentLifecycle],
       wire[SectionsLookUpLifecycle],


### PR DESCRIPTION
## What is the value of this and can you measure success?

This was deleted in https://github.com/guardian/frontend/pull/28169 but was not removed from dev-build, so it is currently failing to compile locally

## What does this change?

Removes `DfpDataCacheLifecycle` from dev-build
