### PR TITLE
Support dcr flag for most viewed gallery json endpoint

### DIFF
--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -54,17 +54,16 @@ class MostViewedGalleryController(
   def renderMostViewed(): Action[AnyContent] =
     Action { implicit request =>
       getMostViewedGallery() match {
-        case Nil => Cached(15) { JsonNotFound() }
+        case Nil => Cached(60) { JsonNotFound() }
         case galleries if request.forceDCR =>
           val data = OnwardCollectionResponse(
             heading = MostGalleriesLabel,
-            trails = galleries.map(_.faciaContent).map(Trail.pressedContentToTrail).take(10),
+            trails = galleries.map(_.faciaContent).map(Trail.pressedContentToTrail).take(5),
           )
-          Cached(30.minutes)(JsonComponent.fromWritable(data))
+          Cached(15.minutes)(JsonComponent.fromWritable(data))
         case galleries => renderMostViewedGallery(galleries)
       }
     }
-  def renderMostViewedHtml(): Action[AnyContent] = renderMostViewed()
 
   private def getMostViewedGallery()(implicit request: RequestHeader): List[RelatedContentItem] = {
     val size = request.getQueryString("size").getOrElse("6").toInt

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -42,7 +42,6 @@ GET        /embed/contentcard/*path                   controllers.RecommendedCon
 GET        /most-read/*path                           controllers.MostPopularController.renderHtml(path)
 GET        /related/*path                             controllers.RelatedController.renderHtml(path)
 GET        /top-stories                               controllers.TopStoriesController.renderTopStoriesHtml()
-GET        /gallery/most-viewed                       controllers.MostViewedGalleryController.renderMostViewedHtml()
 
 # Experimental
 GET        /cards/opengraph/*path.json                controllers.CardController.opengraph(path)


### PR DESCRIPTION
## What does this change?
This PR adds `?dcr` support for the following `most-viewed` endpoint **/gallery/most-viewed.json**

In this change, the `/gallery/most-viewed` endpoint (html version of most-viewed) is removed because it is not being used. By checking the router configuration [redirects.conf](https://github.com/guardian/platform/blob/main/router/files/redirects.conf#L1851) we can see that the calls to this endpoint are being redirected to `/most-read` 

You can also check that the https://api.nextgen.guardianapps.co.uk/gallery/most-viewed returns 404 and https://theguardian.com/gallery/most-viewed is redirected to https://www.theguardian.com/most-read


This PR fixes [#14448](https://github.com/guardian/dotcom-rendering/issues/14448)