### PR TITLE
Only add new server side test header if in a new framework server-side test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -14,7 +14,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       DarkModeWeb,
       DCRJavascriptBundle,
       TopAboveNav250Reservation,
-      RolloutAddingServerABTestsToVaryHeader,
       SourcepointConsentGeolocation,
       GoogleOneTap,
     )
@@ -65,13 +64,4 @@ object TopAboveNav250Reservation
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2025, 8, 29),
       participationGroup = Perc2A,
-    )
-
-object RolloutAddingServerABTestsToVaryHeader
-    extends Experiment(
-      name = "rollout-adding-server-ab-tests-to-vary-header",
-      description = "Rollout adding server AB tests to the vary header",
-      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 9, 30),
-      participationGroup = Perc2B,
     )

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -17,7 +17,7 @@ import conf.switches.Switches.{EnableNewServerSideABTestsHeader}
 
 import scala.concurrent.{ExecutionContext, Future}
 import experiments.Experiment
-import experiments.{ActiveExperiments, RolloutAddingServerABTestsToVaryHeader}
+import experiments.{ActiveExperiments}
 
 class GzipperConfig() extends GzipFilterConfig {
   override val shouldGzip: (RequestHeader, Result) => Boolean = (request, result) => {
@@ -116,23 +116,23 @@ class ABTestingFilter(implicit val mat: Materializer, executionContext: Executio
   private val abTestHeader = "X-GU-Server-AB-Tests"
 
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
-    if (
-      EnableNewServerSideABTestsHeader.isSwitchedOff || !ActiveExperiments.isParticipating(
-        RolloutAddingServerABTestsToVaryHeader,
-      )(request)
-    ) {
+    if (EnableNewServerSideABTestsHeader.isSwitchedOff) {
       nextFilter(request)
     } else {
       val r = ABTests.decorateRequest(request, abTestHeader)
       nextFilter(r).map { result =>
-        val varyHeaderValues = result.header.headers.get("Vary").toSeq ++ Seq(abTestHeader)
-        val abTestHeaderValue = request.headers.get(abTestHeader).getOrElse("")
-        val responseHeaders =
-          Map(abTestHeader -> abTestHeaderValue, "Vary" -> varyHeaderValues.mkString(",")).filterNot { case (_, v) =>
-            v.isEmpty
-          }.toSeq
+        if (ABTests.allTests(r).isEmpty) {
+          result
+        } else {
+          val varyHeaderValues = result.header.headers.get("Vary").toSeq ++ Seq(abTestHeader)
+          val abTestHeaderValue = request.headers.get(abTestHeader).getOrElse("")
+          val responseHeaders =
+            Map(abTestHeader -> abTestHeaderValue, "Vary" -> varyHeaderValues.mkString(",")).filterNot { case (_, v) =>
+              v.isEmpty
+            }.toSeq
 
-        result.withHeaders(responseHeaders: _*)
+          result.withHeaders(responseHeaders: _*)
+        }
       }
     }
   }


### PR DESCRIPTION
## What does this change?
The [strategy to rollout adding the new test header using the old framework](https://github.com/guardian/frontend/pull/28166) won't work due to the way the old framework manipulates the `Vary` header itself.

<img width="898" height="400" alt="Screenshot 2025-08-26 at 13 35 24" src="https://github.com/user-attachments/assets/2e2cebf7-98dc-441b-ba80-e475d74c7553" />

As different variation of the `Vary` header for the same resources are cached differently, once the test ended it would have the same result as just rolling out to 100% instantly.

What we can do instead is have the new framework roll it's own header out, by only adding `X-Gu-Server-Ab-Tests` if a request is actually in a test, this way we can create a small test to build up the cache, roll it out to 100%, then change the behaviour to always add the header again.

