### PR TITLE
Extend JS bundle experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -43,7 +43,7 @@ object DCRJavascriptBundle
       name = "dcr-javascript-bundle",
       description = "DCAR JS bundle experiment to test replacing Preact with React",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 8, 29),
+      sellByDate = LocalDate.of(2025, 9, 30),
       participationGroup = Perc0E,
     )
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Extends expiry date of `dcr-javascript-bundle` experiment by another month as it is due to expire at the end of the week.

(As we're not actively working on https://github.com/guardian/dotcom-rendering/issues/13736 at the moment it may make sense to remove this experiment completely.)