### PR TITLE
Always add new ab test header

### DIFF
--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -121,18 +121,15 @@ class ABTestingFilter(implicit val mat: Materializer, executionContext: Executio
     } else {
       val r = ABTests.decorateRequest(request, abTestHeader)
       nextFilter(r).map { result =>
-        if (ABTests.allTests(r).isEmpty) {
-          result
-        } else {
-          val varyHeaderValues = result.header.headers.get("Vary").toSeq ++ Seq(abTestHeader)
-          val abTestHeaderValue = request.headers.get(abTestHeader).getOrElse("")
-          val responseHeaders =
-            Map(abTestHeader -> abTestHeaderValue, "Vary" -> varyHeaderValues.mkString(",")).filterNot { case (_, v) =>
-              v.isEmpty
-            }.toSeq
+        val varyHeaderValues = result.header.headers.get("Vary").toSeq ++ Seq(abTestHeader)
+        val abTestHeaderValue = request.headers.get(abTestHeader).getOrElse("")
+        val responseHeaders =
+          Map(abTestHeader -> abTestHeaderValue, "Vary" -> varyHeaderValues.mkString(",")).filterNot { case (_, v) =>
+            v.isEmpty
+          }.toSeq
 
-          result.withHeaders(responseHeaders: _*)
-        }
+        result.withHeaders(responseHeaders: _*)
+
       }
     }
   }


### PR DESCRIPTION
## What does this change?
Always add the new ab test header (`X-Gu-Server-Ab-Tests`) to the vary header.

The initial concern about the change mentioned in https://github.com/guardian/frontend/pull/28166 is unfounded(Causing a big spike in cache misses and requests to origin). [Since being able to inspect the vary header in prod](https://github.com/guardian/fastly-edge-cache/pull/1098) I've observed that simply flipping server side tests on and off does this already without impact!

So we can go ahead and roll it out.
