### PR TITLE
Extend `prebid946` and `top-above-nav-250-reservation` 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -55,7 +55,7 @@ trait ABTestSwitches {
     "This test is being used to test v9.46.0 of Prebid ahead of general upgrade.",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 8, 29)),
+    sellByDate = Some(LocalDate.of(2025, 9, 12)),
     exposeClientSide = true,
     highImpact = false,
   )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -52,6 +52,6 @@ object TopAboveNav250Reservation
       name = "top-above-nav-250-reservation",
       description = "Reserve 250px for top-above-nav instead of 90px",
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 8, 29),
+      sellByDate = LocalDate.of(2025, 9, 12),
       participationGroup = Perc2A,
     )


### PR DESCRIPTION
## What does this change?

This PR extends two Commercial tests `prebid946` and `top-above-nav-250-reservation` as they might still be required. 

Related `prebid946` PR https://github.com/guardian/commercial/pull/2181


