### PR TITLE
Add `disableChildDirected` switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -170,6 +170,17 @@ trait CommercialSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val disableChildDirected: Switch = Switch(
+    group = Commercial,
+    name = "disable-child-directed",
+    description = "Disable child-directed treatment for ads",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }
 
 trait PrebidSwitches {


### PR DESCRIPTION
## What does this change?

This PR ads a Commercial feature switch to disable child-directed treatment in ads. For more details https://github.com/guardian/commercial/pull/2185

## Checklist

- [x] Tested locally, and on CODE if necessary
