### PR TITLE
Increase `disableChildDirected` test 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -59,4 +59,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-disable-child-directed",
+    "Test disabling child-directed treatment for ads",
+    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 9, 19)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What does this change?

This PR increase the test size for `disableChildDirected` from 0% to 2.5% variant so in total 5% (variant and control). Related PR https://github.com/guardian/commercial/pull/2189
