### PR TITLE
Start Opinion No Avatar experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -20,15 +20,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
 
-object OpinionNoAvatar
-    extends Experiment(
-      name = "opinion-no-avatar",
-      description = "In the Opinion section on network fronts, replace the avatar with the card image",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 12, 1),
-      participationGroup = Perc0A,
-    )
-
 object SourcepointConsentGeolocation
     extends Experiment(
       name = "sp-consent-geolocation",
@@ -64,4 +55,13 @@ object TopAboveNav250Reservation
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
       sellByDate = LocalDate.of(2025, 9, 12),
       participationGroup = Perc2A,
+    )
+
+object OpinionNoAvatar
+    extends Experiment(
+      name = "opinion-no-avatar",
+      description = "In the Opinion section on network fronts, replace the avatar with the card image",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 12, 1),
+      participationGroup = Perc5A,
     )


### PR DESCRIPTION
## What does this change?

Sets the Opinion No Avatar experiment to 5%.

The 0% test was created [here](https://github.com/guardian/frontend/pull/28149).

There is a [PR in DCR](https://github.com/guardian/dotcom-rendering/pull/14369) that implements the logic.