### PR TITLE
Bump @guardian/libs to 25.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
-		"@guardian/libs": "23.0.0",
+		"@guardian/libs": "25.3.0",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2936,7 +2936,7 @@ __metadata:
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:6.0.1"
     "@guardian/identity-auth-frontend": "npm:8.1.0"
-    "@guardian/libs": "npm:23.0.0"
+    "@guardian/libs": "npm:25.3.0"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
     "@guardian/source-foundations": "npm:16.0.0"
@@ -3104,16 +3104,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/libs@npm:23.0.0":
-  version: 23.0.0
-  resolution: "@guardian/libs@npm:23.0.0"
+"@guardian/libs@npm:25.3.0":
+  version: 25.3.0
+  resolution: "@guardian/libs@npm:25.3.0"
+  dependencies:
+    "@guardian/ophan-tracker-js": "npm:2.2.10"
   peerDependencies:
+    "@guardian/ophan-tracker-js": ^2.2.10
     tslib: ^2.6.2
     typescript: ~5.5.2
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/bfd4990f674fb39fb01aaf8a7780287c1b01369657d1afaddc22af6974a05b49dd7f7b4cc1c89e5921e7b00c7707533d86c5bedbc0628596ca6d23f9c1909139
+  checksum: 10c0/655513a6d4bda1c14355aa353ab2edbc767d8495e5682196539b026ec1bbe57064904eeeabafaffc3a86807d394f09dfacd9a6fe011378ae27a11c710ce8da17
+  languageName: node
+  linkType: hard
+
+"@guardian/ophan-tracker-js@npm:2.2.10":
+  version: 2.2.10
+  resolution: "@guardian/ophan-tracker-js@npm:2.2.10"
+  dependencies:
+    "@guardian/tsconfig": "npm:^1.0.0"
+  checksum: 10c0/e43f520953d0ff18ddb398694f05061f36621a1246720ccce6960de7ed380a7ab4283fdba681f24142418405fec33bece25e6cf198ae0719bee51a37dbfe7cc4
   languageName: node
   linkType: hard
 
@@ -3188,6 +3200,13 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/00daddb850869cd2dbe3bf769076e089e2d3774eea19f0e472475c8cf6c72121e3bf30ecc4ef6c33795c04ad54940be110ecf5201c858dcc28810f72130e4abc
+  languageName: node
+  linkType: hard
+
+"@guardian/tsconfig@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@guardian/tsconfig@npm:1.0.0"
+  checksum: 10c0/1c7e6981b17e5a5bd452553ac2709ba938aecc642fb02e0e68a3eea54827d5a13dc67e701900b55b8e21d26a757d14901ac3424095ceafeb554fe029b1056b9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?

This PR is bumping guardian/libs to the latest version.

## Why?

In this version of guardian/libs, we are making additional requests to Sourcepoint to track mismatches between our geolocation and theirs.


