### PR TITLE
add trail text and gallery count to trail type

### DIFF
--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -1,6 +1,6 @@
 package agents
 
-import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.v1.{Content, ElementType}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RenderingFormat
 import common._
 import contentapi.ContentApiClient
@@ -123,6 +123,9 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       avatarUrl = None,
       branding = None,
       discussion = DiscussionSettings.fromTrail(FaciaContentConvert.contentToFaciaContent(content)),
+      trailText = content.fields.flatMap(_.trailText),
+      galleryCount =
+        content.elements.map(_.count(el => el.`type` == ElementType.Image && el.relation == "gallery")).filter(_ > 0),
     )
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -241,6 +241,13 @@ object DotcomRenderingUtils {
     }
   }
 
+  def withoutNull(json: JsObject): JsObject = {
+    json match {
+      case JsObject(fields) => JsObject(fields.filterNot { case (_, value) => value == JsNull })
+      case other            => other
+    }
+  }
+
   def withoutDeepNull(json: JsValue): JsValue = {
     json match {
       case JsObject(fields) =>

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -241,13 +241,6 @@ object DotcomRenderingUtils {
     }
   }
 
-  def withoutNull(json: JsObject): JsObject = {
-    json match {
-      case JsObject(fields) => JsObject(fields.filterNot { case (_, value) => value == JsNull })
-      case other            => other
-    }
-  }
-
   def withoutDeepNull(json: JsValue): JsValue = {
     json match {
       case JsObject(fields) =>

--- a/common/app/model/dotcomrendering/Trail.scala
+++ b/common/app/model/dotcomrendering/Trail.scala
@@ -34,8 +34,8 @@ case class Trail(
     avatarUrl: Option[String],
     branding: Option[Branding],
     discussion: DiscussionSettings,
-    trailText: Option[String] = None,
-    galleryCount: Option[Int] = None,
+    trailText: Option[String],
+    galleryCount: Option[Int],
 )
 
 object Trail {
@@ -56,7 +56,7 @@ object Trail {
 
   implicit val discussionWrites: OWrites[DiscussionSettings] = Json.writes[DiscussionSettings]
 
-  implicit val OnwardItemWrites: OWrites[Trail] = OWrites { trail =>
+  implicit val OnwardItemWrites: Writes[Trail] = Writes { trail =>
     val jsObject = Json.obj(
       "url" -> trail.url,
       "linkText" -> trail.linkText,
@@ -129,44 +129,6 @@ object Trail {
       masterImage <- trailPicture.masterImage
       url <- masterImage.url
     } yield url
-
-  def contentCardToTrail(contentCard: ContentCard): Option[Trail] = {
-    for {
-      properties <- contentCard.properties
-      maybeContent <- properties.maybeContent
-      metadata = maybeContent.metadata
-      pillar <- metadata.pillar
-      url <- properties.webUrl
-      headline = contentCard.header.headline
-      isLiveBlog = properties.isLiveBlog
-      showByline = properties.showByline
-      webPublicationDate <- contentCard.webPublicationDate.map(x => x.toDateTime().toString())
-      shortUrl <- contentCard.shortUrl
-    } yield Trail(
-      url = url,
-      linkText = "",
-      showByline = showByline,
-      byline = contentCard.byline.map(x => x.get),
-      masterImage = getMasterUrl(maybeContent.trail.trailPicture),
-      image = maybeContent.trail.thumbnailPath,
-      carouselImages = getImageSources(maybeContent.trail.trailPicture),
-      ageWarning = None,
-      isLiveBlog = isLiveBlog,
-      pillar = TrailUtils.normalisePillar(Some(pillar)),
-      designType = metadata.designType.toString,
-      format = metadata.format.getOrElse(ContentFormat.defaultContentFormat),
-      webPublicationDate = webPublicationDate,
-      headline = headline,
-      mediaType = contentCard.mediaType.map(x => x.toString),
-      shortUrl = shortUrl,
-      kickerText = contentCard.header.kicker.flatMap(_.properties.kickerText),
-      starRating = contentCard.starRating,
-      avatarUrl = contentCardToAvatarUrl(contentCard),
-      branding = contentCard.branding,
-      discussion = contentCard.discussionSettings,
-      trailText = contentCard.trailText,
-    )
-  }
 
   def pressedContentToTrail(content: PressedContent)(implicit
       request: RequestHeader,

--- a/common/app/model/dotcomrendering/Trail.scala
+++ b/common/app/model/dotcomrendering/Trail.scala
@@ -5,6 +5,7 @@ import com.gu.commercial.branding.{Branding, BrandingType, Dimensions, Logo => C
 import common.{Edition, LinkTo}
 import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
 import layout.{ContentCard, DiscussionSettings}
+import model.dotcomrendering.DotcomRenderingUtils.withoutNull
 import model.{Article, ContentFormat, ImageMedia, InlineImage, Pillar}
 import model.pressed.PressedContent
 import play.api.libs.json.{Json, OWrites, Writes}
@@ -33,6 +34,8 @@ case class Trail(
     avatarUrl: Option[String],
     branding: Option[Branding],
     discussion: DiscussionSettings,
+    trailText: Option[String] = None,
+    galleryCount: Option[Int] = None,
 )
 
 object Trail {
@@ -53,7 +56,35 @@ object Trail {
 
   implicit val discussionWrites: OWrites[DiscussionSettings] = Json.writes[DiscussionSettings]
 
-  implicit val OnwardItemWrites: OWrites[Trail] = Json.writes[Trail]
+  implicit val OnwardItemWrites: OWrites[Trail] = OWrites { trail =>
+    val jsObject = Json.obj(
+      "url" -> trail.url,
+      "linkText" -> trail.linkText,
+      "showByline" -> trail.showByline,
+      "byline" -> trail.byline,
+      "masterImage" -> trail.masterImage,
+      "image" -> trail.image,
+      "carouselImages" -> trail.carouselImages,
+      "ageWarning" -> trail.ageWarning,
+      "isLiveBlog" -> trail.isLiveBlog,
+      "pillar" -> trail.pillar,
+      "designType" -> trail.designType,
+      "format" -> trail.format,
+      "webPublicationDate" -> trail.webPublicationDate,
+      "headline" -> trail.headline,
+      "mediaType" -> trail.mediaType,
+      "shortUrl" -> trail.shortUrl,
+      "kickerText" -> trail.kickerText,
+      "starRating" -> trail.starRating,
+      "avatarUrl" -> trail.avatarUrl,
+      "branding" -> trail.branding,
+      "discussion" -> trail.discussion,
+      "trailText" -> trail.trailText,
+      "galleryCount" -> trail.galleryCount,
+    )
+
+    withoutNull(jsObject)
+  }
 
   private def contentCardToAvatarUrl(contentCard: ContentCard): Option[String] = {
 
@@ -133,6 +164,7 @@ object Trail {
       avatarUrl = contentCardToAvatarUrl(contentCard),
       branding = contentCard.branding,
       discussion = contentCard.discussionSettings,
+      trailText = contentCard.trailText,
     )
   }
 
@@ -168,6 +200,8 @@ object Trail {
       avatarUrl = None,
       branding = content.branding(Edition(request)),
       discussion = DiscussionSettings.fromTrail(content),
+      trailText = content.card.trailText,
+      galleryCount = content.card.galleryCount,
     )
   }
 }


### PR DESCRIPTION
## What does this change?
This PR is updating the `Trail` type with 2 extra fields `trailText` & `galleryCount`. Both of these fields are optional. 

This PR fixes a part of [#14448](https://github.com/guardian/dotcom-rendering/issues/14448)