### PR TITLE
Update user features logic for ad free and benefits data expiry

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
@@ -47,7 +47,7 @@ const getAuthStatus = getAuthStatus_ as jest.MockedFunction<
 >;
 
 const PERSISTENCE_KEYS = {
-	USER_FEATURES_EXPIRY_COOKIE: 'gu_user_features_expiry',
+	USER_BENEFITS_EXPIRY_COOKIE: 'gu_user_benefits_expiry',
 	PAYING_MEMBER_COOKIE: 'gu_paying_member',
 	RECURRING_CONTRIBUTOR_COOKIE: 'gu_recurring_contributor',
 	AD_FREE_USER_COOKIE: 'GU_AF1',
@@ -80,7 +80,7 @@ const setAllFeaturesData = (opts: { isExpired: boolean }) => {
 		adFreeExpiryDate.getTime().toString(),
 	);
 	addCookie(
-		PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+		PERSISTENCE_KEYS.USER_BENEFITS_EXPIRY_COOKIE,
 		expiryDate.getTime().toString(),
 	);
 	addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'test');
@@ -90,7 +90,7 @@ const deleteAllFeaturesData = () => {
 	removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
 	removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
 	removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
-	removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.USER_BENEFITS_EXPIRY_COOKIE);
 	removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
 	removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
 	removeCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE);
@@ -136,7 +136,7 @@ describe('Refreshing the features data', () => {
 			).toBe('true');
 			expect(
 				getCookie({
-					name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+					name: PERSISTENCE_KEYS.USER_BENEFITS_EXPIRY_COOKIE,
 				}),
 			).toEqual(expect.stringMatching(/\d{13}/));
 			expect(
@@ -193,7 +193,7 @@ describe('Refreshing the features data', () => {
 			).toBeNull();
 			expect(
 				getCookie({
-					name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+					name: PERSISTENCE_KEYS.USER_BENEFITS_EXPIRY_COOKIE,
 				}),
 			).toBeNull();
 		});
@@ -230,6 +230,15 @@ describe('The isAdFreeUser getter', () => {
 		jest.resetAllMocks();
 		isUserLoggedIn.mockResolvedValue(false);
 		expect(isAdFreeUser()).toBe(false);
+	});
+
+	it('Is true when the user is logged in with the ad free cookie', () => {
+		jest.resetAllMocks();
+		const oneDayInMillis = 24 * 60 * 60 * 1000;
+		const cookieExpiry = new Date(Date.now() + (oneDayInMillis * 2))
+		addCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE, cookieExpiry.getTime(), 2, true);
+		isUserLoggedIn.mockResolvedValue(true);
+		expect(isAdFreeUser()).toBe(true);
 	});
 });
 
@@ -451,7 +460,7 @@ describe('Storing new feature data', () => {
 	it('Puts an expiry date in an accompanying cookie', () =>
 		refresh().then(() => {
 			const expiryDate = getCookie({
-				name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+				name: PERSISTENCE_KEYS.USER_BENEFITS_EXPIRY_COOKIE,
 			});
 			expect(expiryDate).toBeTruthy();
 			// @ts-expect-error -- we’re testing it
@@ -461,7 +470,7 @@ describe('Storing new feature data', () => {
 	it('The expiry date is in the future', () =>
 		refresh().then(() => {
 			const expiryDateString = getCookie({
-				name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+				name: PERSISTENCE_KEYS.USER_BENEFITS_EXPIRY_COOKIE,
 			});
 			// @ts-expect-error -- we’re testing it
 			const expiryDateEpoch = parseInt(expiryDateString, 10);

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -13,7 +13,7 @@ import {
 import { cookieIsExpiredOrMissing, timeInDaysFromNow } from './lib/cookie';
 
 // Persistence keys
-const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
+const USER_BENEFITS_EXPIRY_COOKIE = 'gu_user_benefits_expiry';
 const PAYING_MEMBER_COOKIE = 'gu_paying_member';
 const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
 const DIGITAL_SUBSCRIBER_COOKIE = 'gu_digital_subscriber';
@@ -67,7 +67,7 @@ const userHasData = () => {
 	const cookie =
 		getAdFreeCookie() ??
 		getCookie({ name: ACTION_REQUIRED_FOR_COOKIE }) ??
-		getCookie({ name: USER_FEATURES_EXPIRY_COOKIE }) ??
+		getCookie({ name: USER_BENEFITS_EXPIRY_COOKIE }) ??
 		getCookie({ name: PAYING_MEMBER_COOKIE }) ??
 		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) ??
 		getCookie({ name: ONE_OFF_CONTRIBUTION_DATE_COOKIE }) ??
@@ -102,7 +102,7 @@ const validateResponse = (
 
 const persistResponse = (JsonResponse: UserFeaturesResponse) => {
 	setCookie({
-		name: USER_FEATURES_EXPIRY_COOKIE,
+		name: USER_BENEFITS_EXPIRY_COOKIE,
 		value: timeInDaysFromNow(1),
 	});
 	setCookie({
@@ -143,7 +143,7 @@ const persistResponse = (JsonResponse: UserFeaturesResponse) => {
 
 const deleteOldData = (): void => {
 	removeCookie({ name: AD_FREE_USER_COOKIE });
-	removeCookie({ name: USER_FEATURES_EXPIRY_COOKIE });
+	removeCookie({ name: USER_BENEFITS_EXPIRY_COOKIE });
 	removeCookie({ name: PAYING_MEMBER_COOKIE });
 	removeCookie({ name: RECURRING_CONTRIBUTOR_COOKIE });
 	removeCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
@@ -182,7 +182,7 @@ const requestNewData = () => {
 };
 
 const featuresDataIsOld = () =>
-	cookieIsExpiredOrMissing(USER_FEATURES_EXPIRY_COOKIE);
+	cookieIsExpiredOrMissing(USER_BENEFITS_EXPIRY_COOKIE);
 
 const userNeedsNewFeatureData = (): boolean =>
 	featuresDataIsOld() || (isDigitalSubscriber() && !adFreeDataIsPresent());
@@ -357,8 +357,7 @@ const fakeOneOffContributor = (): void => {
 	});
 };
 
-const isAdFreeUser = (): boolean =>
-	isDigitalSubscriber() || adFreeDataIsPresent();
+const isAdFreeUser = (): boolean => adFreeDataIsPresent();
 
 // Extend the expiry of the contributions cookie by 1 year beyond the date of the contribution
 const extendContribsCookieExpiry = (): void => {


### PR DESCRIPTION
## What does this change?

- Updates `USER_FEATURES_EXPIRY_COOKIE` to `USER_BENEFITS_EXPIRY_COOKIE`
- Removes `isDigitalSubscriber` from the `adFree` logic


## Why

This logic was updated in this DCR PR https://github.com/guardian/dotcom-rendering/pull/13277 so reflecting this in frontend too
There may be other cookies to update here in terms of supporter revenue decisions, but I'll update the ones that mainly affect commercial in this PR

We don't run client-side javascript in frontend very much these days but until it's totally switched off, we should keep it roughly in sync with other places