### PR TITLE
Allow Riff-Raff to update 2 article ASGs during GuCDK migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -23,6 +23,7 @@ templates:
     - update-ami-for-onward
     - update-ami-for-facia
     - update-ami-for-facia-press
+    - update-ami-for-article
 
 deployments:
   admin:
@@ -33,6 +34,8 @@ deployments:
     template: frontend
   article:
     template: frontend
+    parameters:
+          asgMigrationInProgress: true
   commercial:
     template: frontend
   discussion:
@@ -139,5 +142,13 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIFaciapress:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-article:
+    app: article
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIArticle:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR allows us to automatically update the AMI for the article stack and allow Riff-Raff to update 2 article ASGs during GuCDK migration.
## What does this change?
This allows dotcom:frontend-all deployments (including scheduled deployments) to automatically update the AMI used by the new GuCDK stack (introduced in https://github.com/guardian/platform/pull/1954).

To be deployed after https://github.com/guardian/platform/pull/1991

Part of https://github.com/guardian/platform/issues/1949

The AMI update for the legacy stack (which uses nested stacks) should remain unchanged.

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
