### PR TITLE
Allow Riff-Raff to update `preview` AMI and both ASGs during migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -51,6 +51,8 @@ deployments:
     template: frontend
   preview:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   rss:
     template: frontend
   sport:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -24,6 +24,7 @@ templates:
     - update-ami-for-facia
     - update-ami-for-facia-press
     - update-ami-for-article
+    - update-ami-for-preview
 
 deployments:
   admin:
@@ -150,5 +151,13 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIArticle:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-preview:
+    app: preview
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIPreview:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are [dual-stacking](https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md) `preview` as we migrate to GuCDK. This means all infrastructure components (load balancer, autoscaling group etc.) are temporarily duplicated.

Riff-Raff normally expects to find exactly one matching autoscaling group for a set of tags. When deploying it will update the application code for that autoscaling group only. If Riff-Raff finds more than one autoscaling group with the same set of tags the deployment will fail.

This change adds the `asgMigrationInProgress` parameter to `preview` to allow Riff-Raff to update both autoscaling groups when deploying.

This also adds config to allow `dotcom:frontend-all` deployments (including scheduled deployments) to automatically update the `preview` AMI.

This relies on https://github.com/guardian/platform/pull/1992 being applied first.

## Checklist

[Validated with Riff-Raff](https://riffraff.gutools.co.uk/configuration/validation)

<img width="1153" height="334" alt="Screenshot 2025-09-05 at 16 40 39" src="https://github.com/user-attachments/assets/bd6d3645-657c-494c-ae3a-294d333b1ea8" />
