### PR TITLE
Create Hide Trails experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,9 +16,19 @@ object ActiveExperiments extends ExperimentsDefinition {
       SourcepointConsentGeolocation,
       GoogleOneTap,
       OpinionNoAvatar,
+      HideTrails,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
+
+object HideTrails
+    extends Experiment(
+      name = "hide-trails",
+      description = "Hide card trails on desktop on network fronts",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 12, 1),
+      participationGroup = Perc0A,
+    )
 
 object SourcepointConsentGeolocation
     extends Experiment(


### PR DESCRIPTION
## What does this change?

Creates a 0% experiment that will be used to test click-through on network fronts when the trail text is hidden on large screen sizes on web.

Further details of this test can be found in the [DCR PR](https://github.com/guardian/dotcom-rendering/pull/14488) where the logic is implemented.