### PR TITLE
Ensure adFree and hideSupportMessaging features are recognised and persisted

### DIFF
--- a/static/src/javascripts/projects/common/modules/userFeatures/cookies/adFree.ts
+++ b/static/src/javascripts/projects/common/modules/userFeatures/cookies/adFree.ts
@@ -1,0 +1,11 @@
+import { getCookie } from '@guardian/libs';
+import { userBenefitsDataIsUpToDate } from './userBenefitsExpiry';
+
+export const AD_FREE_USER_COOKIE = 'GU_AF1';
+
+export const adFreeDataIsPresent = (isSignedIn: boolean): boolean =>
+	getAdFreeCookie() !== null || // If the user has an ad-free cookie give them ad-free
+	(isSignedIn && !userBenefitsDataIsUpToDate()); // If they are signed in and their benefits are out of date, give them ad-free for now
+
+export const getAdFreeCookie = (): string | null =>
+	getCookie({ name: AD_FREE_USER_COOKIE });

--- a/static/src/javascripts/projects/common/modules/userFeatures/cookies/cookieHelpers.ts
+++ b/static/src/javascripts/projects/common/modules/userFeatures/cookies/cookieHelpers.ts
@@ -1,5 +1,7 @@
 import { removeCookie, setCookie } from '@guardian/libs';
+import { AD_FREE_USER_COOKIE } from './adFree';
 import { ALLOW_REJECT_ALL_COOKIE } from './allowRejectAll';
+import { HIDE_SUPPORT_MESSAGING_COOKIE } from './hideSupportMessaging';
 import { USER_BENEFITS_EXPIRY_COOKIE } from './userBenefitsExpiry';
 
 export const timeInDaysFromNow = (daysFromNow: number): number => {
@@ -20,7 +22,10 @@ export const createOrRenewCookie = (
 	});
 };
 
+
 export const deleteAllCookies = (): void => {
 	removeCookie({ name: USER_BENEFITS_EXPIRY_COOKIE });
+	removeCookie({ name: AD_FREE_USER_COOKIE });
+	removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
 	removeCookie({ name: ALLOW_REJECT_ALL_COOKIE });
 };

--- a/static/src/javascripts/projects/common/modules/userFeatures/cookies/hideSupportMessaging.ts
+++ b/static/src/javascripts/projects/common/modules/userFeatures/cookies/hideSupportMessaging.ts
@@ -1,0 +1,9 @@
+import { getCookie } from '@guardian/libs';
+
+export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
+
+export const hideSupportMessaging = (): boolean =>
+	getHideSupportMessagingCookie() !== null;
+
+export const getHideSupportMessagingCookie = (): string | null =>
+	getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });

--- a/static/src/javascripts/projects/common/modules/userFeatures/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/userFeatures/user-features.ts
@@ -4,10 +4,11 @@
  * https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
  */
 
-// import { getAuthStatus, isUserLoggedInOktaRefactor } from '../../lib/identity';
 import { getAuthStatus, isUserLoggedIn } from '../identity/api';
+import { AD_FREE_USER_COOKIE } from './cookies/adFree';
 import { ALLOW_REJECT_ALL_COOKIE } from './cookies/allowRejectAll';
 import { createOrRenewCookie } from './cookies/cookieHelpers';
+import { HIDE_SUPPORT_MESSAGING_COOKIE } from './cookies/hideSupportMessaging';
 import {
 	USER_BENEFITS_EXPIRY_COOKIE,
 	userBenefitsDataNeedsRefreshing,
@@ -41,8 +42,14 @@ const requestNewData = async () => {
 
 const persistResponse = (userBenefitsResponse: UserBenefits) => {
 	createOrRenewCookie(USER_BENEFITS_EXPIRY_COOKIE);
+	if (userBenefitsResponse.hideSupportMessaging) {
+		createOrRenewCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
+	}
 	if (userBenefitsResponse.allowRejectAll) {
 		createOrRenewCookie(ALLOW_REJECT_ALL_COOKIE);
+	}
+	if (userBenefitsResponse.adFree) {
+		createOrRenewCookie(AD_FREE_USER_COOKIE);
 	}
 };
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Ensures the code in frontend matches [the logic in dotcom-rendering for user features](https://github.com/guardian/dotcom-rendering/blob/3a323301a76f8f336790e27695cbb98afca0f1ab/dotcom-rendering/src/client/userFeatures/user-features.ts) for the ad free cookie and the hide support messaging cookie

This is important so that the response from the user benefits API is persisted as cookie values for use elsewhere in the application

## What does this change?

Adds adFree and hideSupportMessaging cookie helpers and includes these in the user-features file for persisting the user benefits response as cookie values

## What next?

We also have [a user-features file in the commercial directory](https://github.com/guardian/frontend/blob/40de4ca634ef26f145f6bc938452285e2207624c/static/src/javascripts/projects/common/modules/commercial/user-features.ts). We should consolidate these two into one place and remove duplicated code
