### PR TITLE
Remove asgMigrationInProgress from article deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -34,8 +34,6 @@ deployments:
     template: frontend
   article:
     template: frontend
-    parameters:
-          asgMigrationInProgress: true
   commercial:
     template: frontend
   discussion:


### PR DESCRIPTION
## What is the value of this and can you measure success?

This should be merged following removal of the legacy article infrastructure (https://github.com/guardian/platform/pull/2001) so we don't break `dotcom:frontend-all` deployments.
