### PR TITLE
Add basic diagnostics page to check cookies on theguardian.com

### DIFF
--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -39,6 +39,7 @@ trait ApplicationsControllers {
   lazy val siteVerificationController = wire[SiteVerificationController]
   lazy val youtubeController = wire[YoutubeController]
   lazy val nx1ConfigController = wire[Nx1ConfigController]
+  lazy val diagnosticsController = wire[DiagnosticsController]
 
   // A fake geolocation controller to test it locally
   lazy val geolocationController = wire[FakeGeolocationController]

--- a/applications/app/controllers/DiagnosticsController.scala
+++ b/applications/app/controllers/DiagnosticsController.scala
@@ -5,6 +5,9 @@ import model.{ApplicationContext, Cached, DiagnosticsPageMetadata}
 import pages.TagIndexHtmlPage
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
+/** Browser diagnostics was introduced as a temporary page on 15/09/2025 If you still see this comment in 2026, please
+  * notify @cemms1 or feel free to remove See https://github.com/guardian/frontend/pull/28220
+  */
 class DiagnosticsController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
     extends BaseController
     with common.ImplicitControllerExecutionContext {

--- a/applications/app/controllers/DiagnosticsController.scala
+++ b/applications/app/controllers/DiagnosticsController.scala
@@ -1,0 +1,18 @@
+package controllers
+
+import model.Cached.RevalidatableResult
+import model.{ApplicationContext, Cached, DiagnosticsPageMetadata}
+import pages.TagIndexHtmlPage
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+
+class DiagnosticsController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
+    extends BaseController
+    with common.ImplicitControllerExecutionContext {
+
+  def renderDiagnosticsPage(): Action[AnyContent] =
+    Action { implicit request =>
+      Cached(300) {
+        RevalidatableResult.Ok(TagIndexHtmlPage.html(new DiagnosticsPageMetadata()))
+      }
+    }
+}

--- a/applications/app/model/DiagnosticsPageMetadata.scala
+++ b/applications/app/model/DiagnosticsPageMetadata.scala
@@ -1,0 +1,12 @@
+package model
+
+import play.api.libs.json.JsBoolean
+
+class DiagnosticsPageMetadata extends StandalonePage {
+  override val metadata = MetaData.make(
+    id = "Browser Diagnostics",
+    section = Some(SectionId.fromId("Index")),
+    webTitle = "Browser Diagnostics",
+    javascriptConfigOverrides = Map("isDiagnosticsPage" -> JsBoolean(true)),
+  )
+}

--- a/applications/app/model/DiagnosticsPageMetadata.scala
+++ b/applications/app/model/DiagnosticsPageMetadata.scala
@@ -8,5 +8,6 @@ class DiagnosticsPageMetadata extends StandalonePage {
     section = Some(SectionId.fromId("Index")),
     webTitle = "Browser Diagnostics",
     javascriptConfigOverrides = Map("isDiagnosticsPage" -> JsBoolean(true)),
+    shouldGoogleIndex = false,
   )
 }

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -6,6 +6,7 @@ import html.{HtmlPage, Styles}
 import model.{
   ApplicationContext,
   ContributorsListing,
+  DiagnosticsPageMetadata,
   PreferencesMetaData,
   StandalonePage,
   SubjectsListing,
@@ -20,7 +21,8 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.preferences.index
-import html.HtmlPageHelpers.{ContentCSSFile}
+import views.html.browserDiagnostics.diagnosticsPage
+import html.HtmlPageHelpers.ContentCSSFile
 
 object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
 
@@ -39,10 +41,11 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
     implicit val p: StandalonePage = page
 
     val content: Html = page match {
-      case p: TagIndexPage        => tagIndexBody(p)
-      case p: PreferencesMetaData => index(p)
-      case p: ContributorsListing => tagIndexListingBody("contributors", p.metadata.webTitle, p.listings)
-      case p: SubjectsListing     => tagIndexListingBody("subjects", p.metadata.webTitle, p.listings)
+      case p: TagIndexPage            => tagIndexBody(p)
+      case p: PreferencesMetaData     => index(p)
+      case p: ContributorsListing     => tagIndexListingBody("contributors", p.metadata.webTitle, p.listings)
+      case p: SubjectsListing         => tagIndexListingBody("subjects", p.metadata.webTitle, p.listings)
+      case p: DiagnosticsPageMetadata => diagnosticsPage(p)
 
       case unsupported =>
         throw new RuntimeException(

--- a/applications/app/views/browserDiagnostics/diagnosticsPage.scala.html
+++ b/applications/app/views/browserDiagnostics/diagnosticsPage.scala.html
@@ -2,11 +2,6 @@
 
 @import views.html.fragments.containers.facia_cards.containerScaffold
 
-@containerScaffold("Cookies sent via HTTP request", "http-cookies") {
-    <ul>
-        <li>GU_AF1: @request.cookies.find(_.name == "GU_AF1").getOrElse("unset")</li>
-        <li>gu_user_benefits_expiry: @request.cookies.find(_.name == "gu_user_benefits_expiry").getOrElse("unset")</li>
-        <li>gu_hide_support_messaging: @request.cookies.find(_.name == "gu_hide_support_messaging").getOrElse("unset")</li>
-        <li>gu_allow_reject_all: @request.cookies.find(_.name == "gu_allow_reject_all").getOrElse("unset")</li>
-    </ul>
+@containerScaffold("User benefits cookies", "user-benefits-cookies") {
+    <div id="diagnostics-cookies">Loading&hellip;</div>
 }

--- a/applications/app/views/browserDiagnostics/diagnosticsPage.scala.html
+++ b/applications/app/views/browserDiagnostics/diagnosticsPage.scala.html
@@ -1,0 +1,12 @@
+@(metaData: model.DiagnosticsPageMetadata)(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@import views.html.fragments.containers.facia_cards.containerScaffold
+
+@containerScaffold("Cookies sent via HTTP request", "http-cookies") {
+    <ul>
+        <li>GU_AF1: @request.cookies.find(_.name == "GU_AF1").getOrElse("unset")</li>
+        <li>gu_user_benefits_expiry: @request.cookies.find(_.name == "gu_user_benefits_expiry").getOrElse("unset")</li>
+        <li>gu_hide_support_messaging: @request.cookies.find(_.name == "gu_hide_support_messaging").getOrElse("unset")</li>
+        <li>gu_allow_reject_all: @request.cookies.find(_.name == "gu_allow_reject_all").getOrElse("unset")</li>
+    </ul>
+}

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -64,6 +64,10 @@ OPTIONS    /story-questions/answers/signup                                      
 # Preferences
 GET        /preferences                                                         controllers.PreferencesController.indexPrefs()
 
+
+# Cookies
+GET        /browser-diagnostics                                                 controllers.DiagnosticsController.renderDiagnosticsPage()
+
 # opt-in/out routes
 GET        /opt/$choice<in|out|delete>/:feature                                 controllers.OptInController.handle(feature, choice)
 GET        /opt/reset                                                           controllers.OptInController.reset()

--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -4,12 +4,14 @@ import common.{CanonicalLink, Edition}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import conf.Configuration
+import com.gu.contentapi.client.model.v1.Content
 import experiments.ActiveExperiments
+import layout.ContentCard
 import model.{PressedPage, RelatedContentItem}
 import navigation.{FooterLinks, Nav}
 import play.api.libs.json.{JsObject, JsValue, Json, OWrites}
 import play.api.mvc.RequestHeader
-import views.support.{CamelCase, JavaScriptPage, Commercial}
+import views.support.{CamelCase, JavaScriptPage}
 import ab.ABTests
 
 case class DotcomFrontsRenderingDataModel(
@@ -92,7 +94,7 @@ object DotcomFrontsRenderingDataModel {
       config = combinedConfig,
       commercialProperties = commercialProperties,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),
-      isAdFreeUser = Commercial.isAdFree(request),
+      isAdFreeUser = views.support.Commercial.isAdFree(request),
       isNetworkFront = page.isNetworkFront,
       mostViewed = mostViewed.map(content => Trail.pressedContentToTrail(content.faciaContent)(request)),
       deeplyRead = deeplyRead,

--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -4,14 +4,12 @@ import common.{CanonicalLink, Edition}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import conf.Configuration
-import com.gu.contentapi.client.model.v1.Content
 import experiments.ActiveExperiments
-import layout.ContentCard
 import model.{PressedPage, RelatedContentItem}
 import navigation.{FooterLinks, Nav}
 import play.api.libs.json.{JsObject, JsValue, Json, OWrites}
 import play.api.mvc.RequestHeader
-import views.support.{CamelCase, JavaScriptPage}
+import views.support.{CamelCase, JavaScriptPage, Commercial}
 import ab.ABTests
 
 case class DotcomFrontsRenderingDataModel(
@@ -94,7 +92,7 @@ object DotcomFrontsRenderingDataModel {
       config = combinedConfig,
       commercialProperties = commercialProperties,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),
-      isAdFreeUser = views.support.Commercial.isAdFree(request),
+      isAdFreeUser = Commercial.isAdFree(request),
       isNetworkFront = page.isNetworkFront,
       mostViewed = mostViewed.map(content => Trail.pressedContentToTrail(content.faciaContent)(request)),
       deeplyRead = deeplyRead,

--- a/static/src/javascripts/bootstraps/enhanced/browser-diagnostics.js
+++ b/static/src/javascripts/bootstraps/enhanced/browser-diagnostics.js
@@ -1,0 +1,44 @@
+import React, { Component, render } from 'preact/compat';
+
+class DiagnosticsCookies extends Component {
+    constructor() {
+        super();
+    }
+
+    render() {
+		const cookiesAsObject = Object.fromEntries(
+			document.cookie
+				.split(';')
+				.map(s => s.trim().split('='))
+		);
+
+		const userBenefitsCookies = [
+			'GU_AF1', // Ad free
+			'gu_hide_support_messaging',
+			'gu_allow_reject_all',
+			'gu_user_benefits_expiry',
+		];
+
+        return (
+			<ul>
+				{userBenefitsCookies.map((cookieName) => (
+					<li key={cookieName}>
+						{`${cookieName}: ${cookiesAsObject[cookieName] || 'unset'}`}
+					</li>
+				))}
+			</ul>
+		);
+    }
+}
+
+const init = () => {
+    const element = document.getElementById(
+        'diagnostics-cookies'
+    );
+
+    if (element) {
+        render(<DiagnosticsCookies />, element);
+    }
+};
+
+export { init };

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -278,6 +278,19 @@ const bootEnhanced = () => {
                 );
             }
 
+			if (config.get('page.isDiagnosticsPage')) {
+				require.ensure(
+					[],
+					require => {
+						bootstrapContext(
+							'browser-diagnostics',
+							require('bootstraps/enhanced/browser-diagnostics').init
+						);
+					},
+					'browser-diagnostics'
+				);
+			}
+
             if (config.get('page.section') === 'newsletter-signup-page') {
                 require.ensure(
                     [],


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are trying to understand why some users are seeing ads despite being signed in with an account that has the ad free benefit.

The current diagnostics data provided via MMA (manage my account) indicates that they should not be seeing ads so this page may help to give greater understanding of why they may not be seeing ads. The [diagnostics page on MMA](https://manage.theguardian.com/help-centre/diagnostic-information) displays the values for cookies stored in the browser (fetched using `document.cookie`) 
See manage-frontend implementation here: https://github.com/guardian/manage-frontend/blob/e2de8e70a4540888fbfe5268ad9cceb792708cb2/client/components/helpCentre/diagnosticInformation/CookieInformation.tsx

This page allows us to see which cookies are stored on theguardian.com domain rather than on subdomains. With this new information about cookies stored on the correct domain, we should be able to understand whether the cookie is being sent in the request or not. 

- If the cookies are being sent in the request (ie are stored on theguardian.com), we can limit the problem down to how the code is handling these cookies.
- If the cookies are not being sent in the request (ie those which are on profile or manage subdomains but not on theguardian.com domain), the problem is with how the cookies are being set or how the browser is storing these cookies

## What does this change?

Adds basic diagnostics page to be used alongside the existing one at https://manage.theguardian.com/help-centre/diagnostic-information

This code is largely copied from the [preferences page](https://www.theguardian.com/preferences)

This new diagnostics page displays the cookies stored on theguardian.com domain rather than those on the profile.theguardian.com or manage.theguardian.com domains. 
This ensures we understand which cookies should be being sent through to the server

## Screenshots

Signed out:
<img width="1326" height="618" alt="image" src="https://github.com/user-attachments/assets/7ae4296c-9974-4da4-99f4-166c7804ce2e" />

Signed in with all benefits:
<img width="1326" height="618" alt="image" src="https://github.com/user-attachments/assets/192fe946-f1ae-4585-a797-1fec73aaceab" />
