### PR TITLE
Remove `DisableChildDirected` test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -59,15 +59,4 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  Switch(
-    ABTests,
-    "ab-disable-child-directed",
-    "Test disabling child-directed treatment for ads",
-    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 9, 19)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }


### PR DESCRIPTION
## What does this change?

This PR removes the `DisableChildDirected` AB test. Check related work https://github.com/guardian/commercial/pull/2218