### PR TITLE
Extend expiry date of Admiral AB test by one week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,7 +44,7 @@ trait ABTestSwitches {
     "Testing the Admiral integration for adblock recovery on theguardian.com",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 9, 17)),
+    sellByDate = Some(LocalDate.of(2025, 9, 24)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows Admiral Ad Block Recovery AB test to run for an extra week if needed

## What does this change?

Extends expiry date of Admiral AB test by one week
