### PR TITLE
Extend `prebid946` test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -55,7 +55,7 @@ trait ABTestSwitches {
     "This test is being used to test v9.46.0 of Prebid ahead of general upgrade.",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 9, 12)),
+    sellByDate = Some(LocalDate.of(2025, 9, 30)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What does this change?

This PR extends `prebid946` test for 2 weeks more. Related work https://github.com/guardian/commercial/pull/2222