### PR TITLE
Extend `topAboveNav250Reservation` test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -63,7 +63,7 @@ object TopAboveNav250Reservation
       name = "top-above-nav-250-reservation",
       description = "Reserve 250px for top-above-nav instead of 90px",
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 9, 12),
+      sellByDate = LocalDate.of(2025, 9, 26),
       participationGroup = Perc2A,
     )
 


### PR DESCRIPTION
## What does this change?

This PR extends the server-side test `topAboveNav250Reservation` until discussed next week.
