### PR TITLE
Remove ASG migration parameter from `preview` deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -49,8 +49,6 @@ deployments:
     template: frontend
   preview:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   rss:
     template: frontend
   sport:


### PR DESCRIPTION
## What is the value of this and can you measure success?

This should be merged immediately following removal of the legacy `preview` infrastructure (https://github.com/guardian/platform/pull/2006). Once that has been done we will no longer be dual-stacking the `preview` infrastructure and have a single ASG. We need to remove the ASG migration parameter so that Riff-Raff is no longer trying to update two ASGs which would break `dotcom:frontend-all` deployments.