### PR TITLE
Set expiry of 2 days for the ad free cookie

### DIFF
--- a/static/src/javascripts/projects/common/modules/userFeatures/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/userFeatures/user-features.ts
@@ -49,7 +49,9 @@ const persistResponse = (userBenefitsResponse: UserBenefits) => {
 		createOrRenewCookie(ALLOW_REJECT_ALL_COOKIE);
 	}
 	if (userBenefitsResponse.adFree) {
-		createOrRenewCookie(AD_FREE_USER_COOKIE);
+		// Ad free cookie has an expiry of 2 days from now
+		// See https://github.com/guardian/gateway/blob/52f810a88fa9ce23c6a794916251748718742c3d/src/server/lib/user-features.ts#L111-L115
+		createOrRenewCookie(AD_FREE_USER_COOKIE, 2);
 	}
 };
 


### PR DESCRIPTION
## What does this change?

Updates the expiry date of the ad free cookie to be two days rather than one.

## Why?

This matches the [logic in gateway](https://github.com/guardian/gateway/blob/252b2b2f24be826da42c6e7c1b1e202594184023/src/server/lib/user-features.ts#L111-L115)

Also see https://github.com/guardian/dotcom-rendering/pull/14505
