### PR TITLE
Add a feature switch to control visibility of new labs designs

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -616,4 +616,15 @@ trait FeatureSwitches {
     exposeClientSide = false,
     highImpact = false,
   )
+
+  val GuardianLabsRedesign = Switch(
+    SwitchGroup.Feature,
+    "guardian-labs-redesign",
+    "Shows the new style labs containers and cards",
+    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+    sellByDate = Some(LocalDate.of(2025, 11, 18)),
+    safeState = Off,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What does this change?

Adds a new feature switch to allow development of the new labs designs for cards and containers to continue without affecting the current display of labs containers

This is exposed client side (ie in the request to DCR) to allow DCR to decide which version of labs containers and cards to render
