### PR TITLE
Create Server-Side Ab Test and Switch for Consent or Pay Europe release

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -14,4 +14,15 @@ trait IdentitySwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val consentOrPayEurope = Switch(
+    SwitchGroup.Identity,
+    "consent-or-pay-europe",
+    "Releasing Consent or Pay to Europe",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = LocalDate.of(2026, 4, 1),
+    exposeClientSide = false,
+    highImpact = false,
+  )
 }

--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -21,8 +21,8 @@ trait IdentitySwitches {
     "Releasing Consent or Pay to Europe",
     owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
     safeState = Off,
-    sellByDate = LocalDate.of(2026, 4, 1),
-    exposeClientSide = false,
+    sellByDate = never,
+    exposeClientSide = true,
     highImpact = false,
   )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,6 +16,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       SourcepointConsentGeolocation,
       GoogleOneTap,
       HideTrails,
+      ConsentOrPayEurope,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -64,4 +65,13 @@ object HideTrails
       owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
       sellByDate = LocalDate.of(2025, 12, 1),
       participationGroup = Perc5A,
+    )
+
+object ConsentOrPayEurope
+    extends Experiment(
+      name = "consent-or-pay-europe",
+      description = "Releasing Consent or Pay to Europe",
+      owners = Seq(Owner.withEmail("identity.dev@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 12, 1),
+      participationGroup = Perc0A,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,7 +16,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       SourcepointConsentGeolocation,
       GoogleOneTap,
       HideTrails,
-      ConsentOrPayEurope,
+      ConsentOrPayEuropeInternalTest,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -72,6 +72,6 @@ object ConsentOrPayEurope
       name = "consent-or-pay-europe",
       description = "Releasing Consent or Pay to Europe",
       owners = Seq(Owner.withEmail("identity.dev@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 12, 1),
+      sellByDate = LocalDate.of(2026, 4, 1),
       participationGroup = Perc0A,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -67,10 +67,10 @@ object HideTrails
       participationGroup = Perc5A,
     )
 
-object ConsentOrPayEurope
+object ConsentOrPayEuropeInternalTest
     extends Experiment(
-      name = "consent-or-pay-europe",
-      description = "Releasing Consent or Pay to Europe",
+      name = "consent-or-pay-europe-internal-test",
+      description = "Releasing Consent or Pay to Europe for internal testing",
       owners = Seq(Owner.withEmail("identity.dev@guardian.co.uk")),
       sellByDate = LocalDate.of(2026, 4, 1),
       participationGroup = Perc0A,


### PR DESCRIPTION
## What does this change?
This PR adds a serverside ab-test and switch for the Consent or Pay Europe release. 
- The AB Test is set to 0% to allow for stakeholders to opt in for testing. 
- The switch allows to release the Consent or Pay europe.

