### PR TITLE
Implements usage of the right Rechaptcha secret key for validation of Visible Recaptcha

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -287,9 +287,11 @@ class GuardianConfiguration extends GuLogging {
     lazy val subscribeWithGoogleApiUrl =
       configuration.getStringProperty("google.subscribeWithGoogleApiUrl").getOrElse("https://swg.theguardian.com")
     lazy val googleRecaptchaSiteKey = configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKey")
-    lazy val googleRecaptchaSiteKeyVisible = configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKeyVisible")
+    lazy val googleRecaptchaSiteKeyVisible =
+      configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKeyVisible")
     lazy val googleRecaptchaSecret = configuration.getMandatoryStringProperty("google.googleRecaptchaSecret")
-    lazy val googleRecaptchaSecretVisible = configuration.getMandatoryStringProperty("google.googleRecaptchaSecretVisible")
+    lazy val googleRecaptchaSecretVisible =
+      configuration.getMandatoryStringProperty("google.googleRecaptchaSecretVisible")
   }
 
   object affiliateLinks {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -287,7 +287,9 @@ class GuardianConfiguration extends GuLogging {
     lazy val subscribeWithGoogleApiUrl =
       configuration.getStringProperty("google.subscribeWithGoogleApiUrl").getOrElse("https://swg.theguardian.com")
     lazy val googleRecaptchaSiteKey = configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKey")
+    lazy val googleRecaptchaSiteKeyVisible = configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKeyVisible")
     lazy val googleRecaptchaSecret = configuration.getMandatoryStringProperty("google.googleRecaptchaSecret")
+    lazy val googleRecaptchaSecretVisible = configuration.getMandatoryStringProperty("google.googleRecaptchaSecretVisible")
   }
 
   object affiliateLinks {

--- a/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
+++ b/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
@@ -10,9 +10,9 @@ import utils.RemoteAddress
 import scala.concurrent.Future
 
 class GoogleRecaptchaValidationService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
-  def submit(token: String): Future[WSResponse] = {
+  def submit(token: String, isFromManyNewsletters: Boolean = false): Future[WSResponse] = {
     val url = "https://www.google.com/recaptcha/api/siteverify"
-    val secret = if (ManyNewsletterVisibleRecaptcha.isSwitchedOn) {
+    val secret = if (ManyNewsletterVisibleRecaptcha.isSwitchedOn && isFromManyNewsletters) {
       Configuration.google.googleRecaptchaSecretVisible
     } else {
       Configuration.google.googleRecaptchaSecret

--- a/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
+++ b/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
@@ -2,6 +2,7 @@ package services.newsletters
 
 import com.typesafe.scalalogging.LazyLogging
 import conf.Configuration
+import conf.switches.Switches.ManyNewsletterVisibleRecaptcha
 import play.api.libs.json.{Json, Reads}
 import play.api.libs.ws.{WSClient, WSResponse}
 import utils.RemoteAddress
@@ -11,7 +12,12 @@ import scala.concurrent.Future
 class GoogleRecaptchaValidationService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
   def submit(token: String): Future[WSResponse] = {
     val url = "https://www.google.com/recaptcha/api/siteverify"
-    val payload = Map("response" -> Seq(token), "secret" -> Seq(Configuration.google.googleRecaptchaSecret))
+    val secret = if (ManyNewsletterVisibleRecaptcha.isSwitchedOn) {
+      Configuration.google.googleRecaptchaSecretVisible
+    } else {
+      Configuration.google.googleRecaptchaSecret
+    }
+    val payload = Map("response" -> Seq(token), "secret" -> Seq(secret))
     wsClient
       .url(url)
       .post(payload)

--- a/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
+++ b/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
@@ -2,7 +2,6 @@ package services.newsletters
 
 import com.typesafe.scalalogging.LazyLogging
 import conf.Configuration
-import conf.switches.Switches.ManyNewsletterVisibleRecaptcha
 import play.api.libs.json.{Json, Reads}
 import play.api.libs.ws.{WSClient, WSResponse}
 import utils.RemoteAddress
@@ -10,9 +9,9 @@ import utils.RemoteAddress
 import scala.concurrent.Future
 
 class GoogleRecaptchaValidationService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
-  def submit(token: String, isFromManyNewsletters: Boolean = false): Future[WSResponse] = {
+  def submit(token: String, shouldUseVisibleKey: Boolean = false): Future[WSResponse] = {
     val url = "https://www.google.com/recaptcha/api/siteverify"
-    val secret = if (ManyNewsletterVisibleRecaptcha.isSwitchedOn && isFromManyNewsletters) {
+    val secret = if (shouldUseVisibleKey) {
       Configuration.google.googleRecaptchaSecretVisible
     } else {
       Configuration.google.googleRecaptchaSecret


### PR DESCRIPTION
## What is the value of this and can you measure success?

This change enables proper validation of visible reCAPTCHA tokens when the ManyNewsletterVisibleRecaptcha feature flag is enabled. Previously, the system was always using the invisible reCAPTCHA secret key, which fails to work if used to validate visible reCAPTCHA tokens.

Success can be measured by:

- Successful newsletter signups on the All Newsletters page with visible reCAPTCHA

## What does this change?

- Updates GoogleRecaptchaValidationService to check the ManyNewsletterVisibleRecaptcha feature flag
-- When the flag is ON: Uses googleRecaptchaSecretVisible for token validation
-- When the flag is OFF: Uses the existing googleRecaptchaSecret (maintains current behavior)
- Adds the necessary import for the newsletter feature switch

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
