### PR TITLE
[WIP] Another way to propogate the choice of recaptcha key

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -287,7 +287,11 @@ class GuardianConfiguration extends GuLogging {
     lazy val subscribeWithGoogleApiUrl =
       configuration.getStringProperty("google.subscribeWithGoogleApiUrl").getOrElse("https://swg.theguardian.com")
     lazy val googleRecaptchaSiteKey = configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKey")
+    lazy val googleRecaptchaSiteKeyVisible =
+      configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKeyVisible")
     lazy val googleRecaptchaSecret = configuration.getMandatoryStringProperty("google.googleRecaptchaSecret")
+    lazy val googleRecaptchaSecretVisible =
+      configuration.getMandatoryStringProperty("google.googleRecaptchaSecretVisible")
   }
 
   object affiliateLinks {

--- a/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
+++ b/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
@@ -9,9 +9,14 @@ import utils.RemoteAddress
 import scala.concurrent.Future
 
 class GoogleRecaptchaValidationService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
-  def submit(token: String): Future[WSResponse] = {
+  def submit(token: String, shouldUseVisibleKey: Boolean): Future[WSResponse] = {
+    val secretKey: String =
+      if (shouldUseVisibleKey)
+        Configuration.google.googleRecaptchaSecretVisible
+      else
+        Configuration.google.googleRecaptchaSecret
     val url = "https://www.google.com/recaptcha/api/siteverify"
-    val payload = Map("response" -> Seq(token), "secret" -> Seq(Configuration.google.googleRecaptchaSecret))
+    val payload = Map("response" -> Seq(token), "secret" -> Seq(secretKey))
     wsClient
       .url(url)
       .post(payload)


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
