### PR TITLE
Adds Whole Picture logo switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -627,4 +627,15 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val WholePictureLogoSwitch = Switch(
+    SwitchGroup.Feature,
+    "whole-picture-logo",
+    "Enables the Whole Picture logo for the US edition.",
+    owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

This switch will allow better control of when we display the alternative logo in the US

## What does this change?

Adds a switch to toggle whether the Whole Picture Guardian logo is displayed
