### PR TITLE
Handle requests for Apps version of Galleries

### DIFF
--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -56,12 +56,16 @@ class GalleryController(
   ) = {
     val pageType = PageType(model, request, context)
 
-    remoteRenderer.getGallery(
-      wsClient,
-      model,
-      pageType,
-      blocks,
-    )
+    if (request.isApps) {
+      remoteRenderer.getAppsGallery(wsClient, model, pageType, blocks)
+    } else {
+      remoteRenderer.getGallery(
+        wsClient,
+        model,
+        pageType,
+        blocks,
+      )
+    }
   }
 
   def lightboxJson(path: String): Action[AnyContent] =

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -425,6 +425,18 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     post(ws, json, Configuration.rendering.articleBaseURL + "/Article", gallery.metadata.cacheTime)
   }
 
+  def getAppsGallery(
+      ws: WSClient,
+      gallery: GalleryPage,
+      pageType: PageType,
+      blocks: Blocks,
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = DotcomRenderingDataModel.forGallery(gallery, request, pageType, blocks)
+
+    val json = DotcomRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsArticle", gallery.metadata.cacheTime)
+  }
+
   def getCrossword(
       ws: WSClient,
       crosswordPage: CrosswordPageWithContent,


### PR DESCRIPTION
Closes: https://github.com/guardian/dotcom-rendering/issues/14526

## What is the value of this and can you measure success?
We need this in order to go live with Galleries in DCAR.

## What does this change?
Requests in galleries articles with suffix `?dcr=apps` will be sent to a separate endpoint in DCR that handles the Apps version of articles.

## Screenshots


| Before      | After      |
|-------------|------------|
| <img width="1629" height="895" alt="image" src="https://github.com/user-attachments/assets/6183aa6a-a50f-4eb0-aca5-ed44bf0d9ca1" /> | <img width="1677" height="939" alt="image" src="https://github.com/user-attachments/assets/30b0b3cb-7d3e-4081-9a61-a736a57255d5" /> |
| <img width="1714" height="567" alt="image" src="https://github.com/user-attachments/assets/b100b049-9a8f-4e60-95dd-276c93556e99" /> | <img width="1707" height="457" alt="image" src="https://github.com/user-attachments/assets/0aa1ddde-c829-4cc2-b535-ec53e1e679c1" /> |




## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
