### PR TITLE
Remove Euros 2025 from the nav bar

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -115,8 +115,6 @@ object NavLinks {
   private val footballResults = NavLink("Results", "/football/results", Some("football/results"))
   private val footballCompetitions = NavLink("Competitions", "/football/competitions", Some("football/competitions"))
   private val footballClubs = NavLink("Clubs", "/football/teams", Some("football/teams"))
-  private val footballWomenEuro2025 =
-    NavLink("Euro 2025", "/football/women-s-euro-2025", Some("football/women-s-euro-2025"))
 
   private val soccerSchedules = footballFixtures.copy(title = "Schedules")
 
@@ -130,7 +128,6 @@ object NavLinks {
       footballResults,
       footballCompetitions,
       footballClubs,
-      footballWomenEuro2025,
     ),
   )
   val usSoccer = NavLink(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -220,13 +220,6 @@
 							"longTitle": "football/teams",
 							"children": [],
 							"classList": []
-						},
-						{
-							"title": "Euro 2025",
-							"url": "/football/women-s-euro-2025",
-							"longTitle": "football/women-s-euro-2025",
-							"children": [],
-							"classList": []
 						}
 					],
 					"classList": []
@@ -469,13 +462,6 @@
 							"title": "Clubs",
 							"url": "/football/teams",
 							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Euro 2025",
-							"url": "/football/women-s-euro-2025",
-							"longTitle": "football/women-s-euro-2025",
 							"children": [],
 							"classList": []
 						}
@@ -2028,13 +2014,6 @@
 							"longTitle": "football/teams",
 							"children": [],
 							"classList": []
-						},
-						{
-							"title": "Euro 2025",
-							"url": "/football/women-s-euro-2025",
-							"longTitle": "football/women-s-euro-2025",
-							"children": [],
-							"classList": []
 						}
 					],
 					"classList": []
@@ -2643,13 +2622,6 @@
 							"longTitle": "football/teams",
 							"children": [],
 							"classList": []
-						},
-						{
-							"title": "Euro 2025",
-							"url": "/football/women-s-euro-2025",
-							"longTitle": "football/women-s-euro-2025",
-							"children": [],
-							"classList": []
 						}
 					],
 					"classList": []
@@ -2837,13 +2809,6 @@
 							"title": "Clubs",
 							"url": "/football/teams",
 							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Euro 2025",
-							"url": "/football/women-s-euro-2025",
-							"longTitle": "football/women-s-euro-2025",
 							"children": [],
 							"classList": []
 						}
@@ -3636,13 +3601,6 @@
 							"longTitle": "football/teams",
 							"children": [],
 							"classList": []
-						},
-						{
-							"title": "Euro 2025",
-							"url": "/football/women-s-euro-2025",
-							"longTitle": "football/women-s-euro-2025",
-							"children": [],
-							"classList": []
 						}
 					],
 					"classList": []
@@ -3830,13 +3788,6 @@
 							"title": "Clubs",
 							"url": "/football/teams",
 							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Euro 2025",
-							"url": "/football/women-s-euro-2025",
-							"longTitle": "football/women-s-euro-2025",
 							"children": [],
 							"classList": []
 						}


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
Euros 2025 is over and should not be included in the football sub-nav bar. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] 

[before]: https://github.com/user-attachments/assets/b5009210-8878-421e-969b-579999056a40
[after]: https://github.com/user-attachments/assets/7d177f05-ff18-4af3-af74-0388c779c051


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
