### PR TITLE
Create 0% experiment for all boosts experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,6 +11,7 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
+      AllBoosts,
       DarkModeWeb,
       SourcepointConsentGeolocation,
       GoogleOneTap,
@@ -18,6 +19,15 @@ object ActiveExperiments extends ExperimentsDefinition {
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
+
+object ConsentOrPayEuropeInternalTest
+    extends Experiment(
+      name = "consent-or-pay-europe-internal-test",
+      description = "Releasing Consent or Pay to Europe for internal testing",
+      owners = Seq(Owner.withEmail("identity.dev@guardian.co.uk")),
+      sellByDate = LocalDate.of(2026, 4, 1),
+      participationGroup = Perc0A,
+    )
 
 object SourcepointConsentGeolocation
     extends Experiment(
@@ -29,13 +39,13 @@ object SourcepointConsentGeolocation
       participationGroup = Perc0B,
     )
 
-object GoogleOneTap
+object AllBoosts
     extends Experiment(
-      name = "google-one-tap",
-      description = "Signing into the Guardian with Google One Tap",
-      owners = Seq(Owner.withEmail("identity.dev@theguardian.com")),
+      name = "all-boosts",
+      description = "All non-feature cards on network fronts are boosted",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
       sellByDate = LocalDate.of(2025, 12, 1),
-      participationGroup = Perc10A,
+      participationGroup = Perc0C,
     )
 
 object DarkModeWeb
@@ -47,11 +57,11 @@ object DarkModeWeb
       participationGroup = Perc0D,
     )
 
-object ConsentOrPayEuropeInternalTest
+object GoogleOneTap
     extends Experiment(
-      name = "consent-or-pay-europe-internal-test",
-      description = "Releasing Consent or Pay to Europe for internal testing",
-      owners = Seq(Owner.withEmail("identity.dev@guardian.co.uk")),
-      sellByDate = LocalDate.of(2026, 4, 1),
-      participationGroup = Perc0A,
+      name = "google-one-tap",
+      description = "Signing into the Guardian with Google One Tap",
+      owners = Seq(Owner.withEmail("identity.dev@theguardian.com")),
+      sellByDate = LocalDate.of(2025, 12, 1),
+      participationGroup = Perc10A,
     )


### PR DESCRIPTION
## What does this change?

Creates a 0% experiment for an AB test that will test whether boosting all cards on the network fronts on mobile will have a positive effect on click-through rate.

There is a [PR in DCR](https://github.com/guardian/dotcom-rendering/pull/14509) to implement the logic.

Reorders experiments by Percentage group
