### PR TITLE
Editionalise The Filter in the US and update test

### DIFF
--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -12,6 +12,7 @@ object Us
       timezone = DateTimeZone.forID("America/New_York"),
       locale = Some(Locale.forLanguageTag("en-us")),
       networkFrontId = "us",
+      editionalisedSections = Edition.commonEditionalisedSections :+ "thefilter",
       navigationLinks = EditionNavLinks(
         NavLinks.usNewsPillar,
         NavLinks.usOpinionPillar,

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -127,8 +127,8 @@ class LinkToTest extends AnyFlatSpec with Matchers with implicits.FakeRequests {
     TheGuardianLinkTo("/thefilter", Europe) should endWith(s"www.theguardian.com/uk/thefilter")
   }
 
-  it should "correctly editionalise thefilter US to point to uk/thefilter temporarily until we create us/thefilter" in {
-    TheGuardianLinkTo("/thefilter", Us) should endWith(s"www.theguardian.com/uk/thefilter")
+  it should "correctly editionalise thefilter US to point to us/thefilter" in {
+    TheGuardianLinkTo("/thefilter", Us) should endWith(s"www.theguardian.com/us/thefilter")
   }
 
   object TestCanonicalLink extends CanonicalLink


### PR DESCRIPTION
## What does this change?
Adds The Filter to the list of US editionalised sections, and updates the unit test accordingly. The Filter US launches on the 30th September, and this change makes sure that readers on the US edition are pointed to the correct version of the front.

Do not merge until 30th September!
