### PR TITLE
Swap the Admiral Adblock Recovery AB test switch to a feature switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -40,17 +40,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-admiral-adblock-recovery",
-    "Testing the Admiral integration for adblock recovery on theguardian.com",
-    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 10, 23)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-compare-client-test-with-new-framework",
     "Compare behaviour of new ab testing framework with existing one",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -627,4 +627,15 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val AdmiralAdblockRecovery = Switch(
+    SwitchGroup.Feature,
+    "admiral-adblock-recovery",
+    "Enables Admiral Adblock Recovery to run on the site",
+    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+    sellByDate = never,
+    safeState = Off,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

The AB test has ended for the Admiral Adblock Recovery solution so we're moving it to a feature switch to control future usage of this feature

## What does this change?

Removes the Admiral AB test switch in favour of using a more permanent feature switch

---------

_Implementation PR here: https://github.com/guardian/frontend/pull/28098_
