### PR TITLE
Extend Admiral AB test switch by one day

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,7 +44,7 @@ trait ABTestSwitches {
     "Testing the Admiral integration for adblock recovery on theguardian.com",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 9, 24)),
+    sellByDate = Some(LocalDate.of(2025, 9, 25)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What does this change?

Extends Admiral AB test switch by one day to avoid it expiring before a decision is made on how to proceed
