### PR TITLE
Adds 'The Filter' to US lifestyle sub nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -176,7 +176,7 @@ object NavLinks {
   val fashion = NavLink("Fashion", "/fashion")
   val fashionAu = NavLink("Fashion", "/au/lifeandstyle/fashion")
   val theFilterUk = NavLink("The Filter", "/uk/thefilter")
-  val theFilterUs = NavLink("The Filter US", "/thefilter-us")
+  val theFilterUs = NavLink("The Filter", "/thefilter-us")
   val food = NavLink("Food", "/food")
   val foodAu = NavLink("Food", "/au/food")
   val relationshipsAu = NavLink("Relationships", "/au/lifeandstyle/relationships")

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -176,7 +176,7 @@ object NavLinks {
   val fashion = NavLink("Fashion", "/fashion")
   val fashionAu = NavLink("Fashion", "/au/lifeandstyle/fashion")
   val theFilterUk = NavLink("The Filter", "/uk/thefilter")
-  val theFilterUs = NavLink("The Filter US", "/us/thefilter") // todo this path needs to be confirmed
+  val theFilterUs = NavLink("The Filter US", "/thefilter-us")
   val food = NavLink("Food", "/food")
   val foodAu = NavLink("Food", "/au/food")
   val relationshipsAu = NavLink("Relationships", "/au/lifeandstyle/relationships")

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -176,6 +176,7 @@ object NavLinks {
   val fashion = NavLink("Fashion", "/fashion")
   val fashionAu = NavLink("Fashion", "/au/lifeandstyle/fashion")
   val theFilterUk = NavLink("The Filter", "/uk/thefilter")
+  val theFilterUs = NavLink("The Filter US", "/us/thefilter") //todo this path needs to be confirmed
   val food = NavLink("Food", "/food")
   val foodAu = NavLink("Food", "/au/food")
   val relationshipsAu = NavLink("Relationships", "/au/lifeandstyle/relationships")
@@ -580,6 +581,7 @@ object NavLinks {
   )
   val usLifestylePillar = ukLifestylePillar.copy(
     children = List(
+      theFilterUs,
       usWellness,
       fashion,
       food,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -176,7 +176,7 @@ object NavLinks {
   val fashion = NavLink("Fashion", "/fashion")
   val fashionAu = NavLink("Fashion", "/au/lifeandstyle/fashion")
   val theFilterUk = NavLink("The Filter", "/uk/thefilter")
-  val theFilterUs = NavLink("The Filter US", "/us/thefilter") //todo this path needs to be confirmed
+  val theFilterUs = NavLink("The Filter US", "/us/thefilter") // todo this path needs to be confirmed
   val food = NavLink("Food", "/food")
   val foodAu = NavLink("Food", "/au/food")
   val relationshipsAu = NavLink("Relationships", "/au/lifeandstyle/relationships")

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1408,6 +1408,12 @@
 			"longTitle": "Lifestyle home",
 			"iconName": "home",
 			"children": [
+                {
+                    "title": "The Filter US",
+                    "url": "/us/thefilter", //todo this path needs to be confirmed
+                    "children": [],
+                    "classList": []
+                },
 				{
 					"title": "Wellness",
 					"url": "/us/wellness",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1409,7 +1409,7 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "The Filter US",
+					"title": "The Filter",
 					"url": "/thefilter-us",
 					"children": [],
 					"classList": []

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1410,7 +1410,7 @@
 			"children": [
                 {
                     "title": "The Filter US",
-                    "url": "/us/thefilter", //todo this path needs to be confirmed
+                    "url": "/thefilter-us",
                     "children": [],
                     "classList": []
                 },

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1408,12 +1408,12 @@
 			"longTitle": "Lifestyle home",
 			"iconName": "home",
 			"children": [
-                {
-                    "title": "The Filter US",
-                    "url": "/thefilter-us",
-                    "children": [],
-                    "classList": []
-                },
+				{
+					"title": "The Filter US",
+					"url": "/thefilter-us",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Wellness",
 					"url": "/us/wellness",


### PR DESCRIPTION
Don't merge until we have the go ahead! 

## What does this change?
Adds The Filter to the US Lifestyle subnav. On click it directs the user to `/thefilter-us`.

## Screenshots
The Filter now part of the Lifestyle Sub Nav. 
<img width="2528" height="470" alt="image" src="https://github.com/user-attachments/assets/7656e4af-39fa-4a77-b6a0-dfae0ddd2090" />

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary - tested on CODE
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
