### PR TITLE
Bump @guardian/libs to 26.0.0

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -59,6 +59,8 @@ class DevParametersHttpRequestHandler(
     "amzn_debug_mode", // set to `1` to enable A9 debugging
     "force-braze-message", // JSON encoded representation of "extras" data from Braze
     "dcr", // force page to render in DCR
+    "_sp_env", // allow testing of Sourcepoint stage campaign
+    "_sp_geo_override", // allow Sourcepoint geolocation override for testing purposes
   )
 
   val commercialParams = Seq(

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
-		"@guardian/libs": "25.3.0",
+		"@guardian/libs": "26.0.0",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "16.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^11.14.0",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/commercial-core": "27.1.0",
+		"@guardian/commercial-core": "28.0.0",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,17 +2848,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/commercial-core@npm:27.1.0":
-  version: 27.1.0
-  resolution: "@guardian/commercial-core@npm:27.1.0"
+"@guardian/commercial-core@npm:28.0.0":
+  version: 28.0.0
+  resolution: "@guardian/commercial-core@npm:28.0.0"
   dependencies:
     "@guardian/ab-core": "npm:8.0.1"
-    "@guardian/libs": "npm:22.5.0"
+    "@guardian/libs": "npm:25.2.0"
     "@types/googletag": "npm:~3.3.0"
   peerDependencies:
-    "@guardian/ab-core": 8.0.1
-    "@guardian/libs": 22.5.0
-  checksum: 10c0/1ac790dddf212efef61a8f06a3c581a1d98df3b16abc3f4d767dfbef7161f168c63b2ef8988d38e102055f8f2ff13ae312072f3f243984fcfe15ae42e5b3cbd9
+    "@guardian/ab-core": ^8.0.1
+    "@guardian/libs": ^25.2.0
+  checksum: 10c0/8ca720a7fe7afa2cc0f182106cce990b316b6b77fb9cd58693b4417497d80286316211cfaf3999670a037f132da96c22f978b2ec4552709762d5dd4d32880afe
   languageName: node
   linkType: hard
 
@@ -2931,7 +2931,7 @@ __metadata:
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^11.14.0"
     "@guardian/ab-core": "npm:8.0.0"
-    "@guardian/commercial-core": "npm:27.1.0"
+    "@guardian/commercial-core": "npm:28.0.0"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:6.0.1"
@@ -3091,16 +3091,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/libs@npm:22.5.0":
-  version: 22.5.0
-  resolution: "@guardian/libs@npm:22.5.0"
+"@guardian/libs@npm:25.2.0":
+  version: 25.2.0
+  resolution: "@guardian/libs@npm:25.2.0"
+  dependencies:
+    "@guardian/ophan-tracker-js": "npm:2.2.10"
   peerDependencies:
+    "@guardian/ophan-tracker-js": ^2.2.10
     tslib: ^2.6.2
     typescript: ~5.5.2
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/6199ef6b64949328d4560e44f645cd0211a0641da6ecd3193aaee034558a44ca25ab93ef54d7bdac6105cd96370115d013658da9cd90367d1eb59a18a6026f33
+  checksum: 10c0/41dd40a6c2ac0d9270924e5b4c2d3e6b703c1aaf8dd84f7a69cd76d4250a6782bd98d9c5e8508d6abd781bf3f2bdf57b001634fb88e9ac8597ff06b728eff998
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2936,7 +2936,7 @@ __metadata:
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:6.0.1"
     "@guardian/identity-auth-frontend": "npm:8.1.0"
-    "@guardian/libs": "npm:25.3.0"
+    "@guardian/libs": "npm:26.0.0"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
     "@guardian/source-foundations": "npm:16.0.0"
@@ -3104,9 +3104,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/libs@npm:25.3.0":
-  version: 25.3.0
-  resolution: "@guardian/libs@npm:25.3.0"
+"@guardian/libs@npm:26.0.0":
+  version: 26.0.0
+  resolution: "@guardian/libs@npm:26.0.0"
   dependencies:
     "@guardian/ophan-tracker-js": "npm:2.2.10"
   peerDependencies:
@@ -3116,7 +3116,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/655513a6d4bda1c14355aa353ab2edbc767d8495e5682196539b026ec1bbe57064904eeeabafaffc3a86807d394f09dfacd9a6fe011378ae27a11c710ce8da17
+  checksum: 10c0/3ccd52f63345282ef19c9b24d12f3f643f159583d918eebd549e160405cb0fab407185812a709a948ce9b20ef8be45dee8381a0d7390d89e5d7f0d61f1a9b6b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

This PR is bumping @guardian/libs to the latest version, which implements Consent or Pay Europe behind a 0% A/B Test and Switch.

It also allows the following parameters to be appended to the url in the Dev environment:
- _sp_env
- _sp_geo_override

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
