### PR TITLE
Allow Riff-Raff to update `commercial` AMI and both ASGs during migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -38,6 +38,8 @@ deployments:
     template: frontend
   commercial:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   discussion:
     template: frontend
   facia:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -25,6 +25,7 @@ templates:
     - update-ami-for-facia-press
     - update-ami-for-article
     - update-ami-for-preview
+    - update-ami-for-commercial
 
 deployments:
   admin:
@@ -157,5 +158,13 @@ deployments:
     parameters:
       amiParametersToTags:
         AMIPreview:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-commercial:
+    app: commercial
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMICommercial:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are [dual-stacking](https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md) `commercial` as we migrate to GuCDK. This means all infrastructure components (load balancer, autoscaling group etc.) are temporarily duplicated.

Riff-Raff normally expects to find exactly one matching autoscaling group for a set of tags. When deploying it will update the application code for that autoscaling group only. If Riff-Raff finds more than one autoscaling group with the same set of tags the deployment will fail.

This change adds the `asgMigrationInProgress` parameter to `commercial` to allow Riff-Raff to update both autoscaling groups when deploying.

This also adds config to allow `dotcom:frontend-all` deployments (including scheduled deployments) to automatically update the `commercial` AMI.

This relies on https://github.com/guardian/platform/pull/2016 being applied first.

## Checklist

[Validated with Riff-Raff](https://riffraff.gutools.co.uk/configuration/validation)

<img width="1150" height="353" alt="Screenshot 2025-09-24 at 15 43 37" src="https://github.com/user-attachments/assets/2c93e387-6857-4904-9f36-7f5e63be27e5" />
