### PR TITLE
Stop sending empty `h2` tags when gallery caption does not have a title

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -152,11 +152,13 @@ object GalleryCaptionCleaner extends HtmlCleaner {
     // <strong> is removed in place of having a <h2> element
     firstStrong.foreach(_.remove())
 
-    captionTitle.html(captionTitleText)
-
-    galleryCaption.body.prependChild(captionTitle)
-
-    galleryCaption
+    if (captionTitleText.isEmpty) {
+      galleryCaption
+    } else {
+      captionTitle.html(captionTitleText)
+      galleryCaption.body.prependChild(captionTitle)
+      galleryCaption
+    }
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/14556

## What is the value of this and can you measure success?
It stops adding unnecessary elements to the DOM

## What does this change?
Wraps the title of a gallery to an `h2` tag only if the title exists.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1356" height="629" alt="image" src="https://github.com/user-attachments/assets/ca6c02b1-33b5-4d57-97a6-46759037f76c" /> | <img width="1393" height="656" alt="image" src="https://github.com/user-attachments/assets/f908140d-c690-463f-a4ad-f1bbe67dff2d" /> |
| <img width="1322" height="557" alt="image" src="https://github.com/user-attachments/assets/a91048ce-b992-4f1b-9f73-660a9c933e6d" /> | <img width="1301" height="644" alt="image" src="https://github.com/user-attachments/assets/bcbfff86-796d-43a3-b204-b9f5a51bd433" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
