### PR TITLE
Reorder links on network footers

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -1,6 +1,10 @@
 package navigation
 
 import common.{Edition, editions}
+import common.editions.Uk.{networkFrontId => UK}
+import common.editions.Us.{networkFrontId => US}
+import common.editions.Au.{networkFrontId => AU}
+import common.editions.International.{networkFrontId => INT}
 
 case class FooterLink(
     text: String,
@@ -81,43 +85,43 @@ object FooterLinks {
     /* Column one */
 
     val ukListOne = List(
-      FooterLink("About us", "/about", "uk : footer : about us"),
-      help("uk"),
+      FooterLink("About us", "/about", s"$UK : footer : about us"),
+      help(UK),
       complaintsAndCorrections,
-      FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
-      tipUsOff("uk"),
+      FooterLink("Contact us", "/help/contact-us", s"$UK : footer : contact us"),
+      tipUsOff(UK),
       secureDrop,
       privacyPolicy,
       cookiePolicy,
-      modernSlaveryActStatement("uk"),
-      taxStrategy("uk"),
+      modernSlaveryActStatement(UK),
+      taxStrategy(UK),
       termsAndConditions,
     )
 
     val usListOne = List(
-      FooterLink("About us", "/info/about-guardian-us", "us : footer : about us"),
-      help("us"),
+      FooterLink("About us", "/info/about-guardian-us", s"$US : footer : about us"),
+      help(US),
       complaintsAndCorrections,
-      FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
-      tipUsOff("us"),
+      FooterLink("Contact us", "/info/about-guardian-us/contact", s"$US : footer : contact us"),
+      tipUsOff(US),
       secureDrop,
       privacyPolicy,
       cookiePolicy,
-      taxStrategy("us"),
+      taxStrategy(US),
       termsAndConditions,
     )
 
     val auListOne = List(
-      FooterLink("About us", "/info/about-guardian-australia", "au : footer : about us"),
-      FooterLink("Information", "/info", "au : footer : information"),
-      help("au"),
+      FooterLink("About us", "/info/about-guardian-australia", s"$AU : footer : about us"),
+      FooterLink("Information", "/info", s"$AU : footer : information"),
+      help(AU),
       complaintsAndCorrections,
-      FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
-      tipUsOff("au"),
+      FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", s"$AU : footer : contact us"),
+      tipUsOff(AU),
       secureDrop,
       privacyPolicy,
       cookiePolicy,
-      taxStrategy("au"),
+      taxStrategy(AU),
       termsAndConditions,
     )
 
@@ -136,36 +140,36 @@ object FooterLinks {
 
     /* Column two */
     val ukListTwo = List(
-      allTopics("uk"),
-      allWriters("uk"),
-      newsletters("uk"),
+      allTopics(UK),
+      allWriters(UK),
+      newsletters(UK),
       digitalNewspaperArchive,
-      facebook("uk"),
-      instagram("uk"),
-      linkedin("uk"),
-      youtube("uk"),
+      facebook(UK),
+      instagram(UK),
+      linkedin(UK),
+      youtube(UK),
     )
 
     val usListTwo = List(
-      allTopics("us"),
-      allWriters("us"),
-      newsletters("us"),
+      allTopics(US),
+      allWriters(US),
+      newsletters(US),
       digitalNewspaperArchive,
-      facebook("us"),
-      instagram("us"),
-      linkedin("us"),
-      youtube("us"),
+      facebook(US),
+      instagram(US),
+      linkedin(US),
+      youtube(US),
     )
 
     val auListTwo = List(
-      allTopics("au"),
-      allWriters("au"),
-      newsletters("au"),
+      allTopics(AU),
+      allWriters(AU),
+      newsletters(AU),
       digitalNewspaperArchive,
-      facebook("au"),
-      instagram("au"),
-      linkedin("au"),
-      youtube("au"),
+      facebook(AU),
+      instagram(AU),
+      linkedin(AU),
+      youtube(AU),
     )
 
     val intListTwo = List(
@@ -182,11 +186,11 @@ object FooterLinks {
     /* Column three */
 
     val ukListThree = List(
-      FooterLink("Advertise with us", "https://advertising.theguardian.com", "uk : footer : advertise with us"),
-      FooterLink("Guardian Labs", "/guardian-labs", "uk : footer : guardian labs"),
-      searchJobs("uk"),
-      FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
-      workForUs("uk"),
+      FooterLink("Advertise with us", "https://advertising.theguardian.com", s"$UK : footer : advertise with us"),
+      FooterLink("Guardian Labs", "/guardian-labs", s"$UK : footer : guardian labs"),
+      searchJobs(UK),
+      FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", s"$UK : footer : patrons"),
+      workForUs(UK),
       accessibilitySettings,
     )
 
@@ -194,11 +198,11 @@ object FooterLinks {
       FooterLink(
         "Advertise with us",
         "https://usadvertising.theguardian.com",
-        "us : footer : advertise with us",
+        s"$US : footer : advertise with us",
       ),
-      FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
-      searchJobs("us"),
-      workForUs("us"),
+      FooterLink("Guardian Labs", "/guardian-labs-us", s"$US : footer : guardian labs"),
+      searchJobs(US),
+      workForUs(US),
       accessibilitySettings,
     )
 
@@ -206,10 +210,10 @@ object FooterLinks {
       FooterLink(
         "Advertise with us",
         "https://ausadvertising.theguardian.com/",
-        "au : footer : advertise with us",
+        s"$AU : footer : advertise with us",
       ),
-      FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
-      workForUs("australia"),
+      FooterLink("Guardian Labs", "/guardian-labs-australia", s"$AU : footer : guardian labs"),
+      workForUs(AU),
       accessibilitySettings,
     )
 

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -50,14 +50,6 @@ object FooterLinks {
       "https://uploads.guim.co.uk/2025/09/05/Tax_strategy_for_the_year_ended_31_March_2025.pdf",
       s"${edition} : footer : tax strategy",
     )
-  def facebook(edition: String): FooterLink =
-    FooterLink("Facebook", "https://www.facebook.com/theguardian", s"${edition} : footer : facebook")
-  def youtube(edition: String): FooterLink =
-    FooterLink("YouTube", "https://www.youtube.com/user/TheGuardian", s"${edition} : footer : youtube")
-  def linkedin(edition: String): FooterLink =
-    FooterLink("LinkedIn", "https://www.linkedin.com/company/theguardian", s"${edition} : footer : linkedin")
-  def instagram(edition: String): FooterLink =
-    FooterLink("Instagram", "https://www.instagram.com/guardian", s"${edition} : footer : instagram")
   def newsletters(edition: String): FooterLink = {
     FooterLink(
       text = "Newsletters",
@@ -77,6 +69,54 @@ object FooterLinks {
   }
   def searchJobs(edition: String): FooterLink = {
     FooterLink("Search jobs", "https://jobs.theguardian.com", s"$edition : footer : jobs")
+  }
+
+  def socialLinks(edition: String): Iterable[FooterLink] = {
+    /*
+     * The `socials` list preserves the order of the links in the footer.
+     * Change the order here, if required.
+     */
+    val socials = List(
+      "bluesky" -> "Bluesky",
+      "facebook" -> "Facebook",
+      "instagram" -> "Instagram",
+      "linkedin" -> "LinkedIn",
+      "threads" -> "Threads",
+      "tiktok" -> "TikTok",
+      "youtube" -> "YouTube",
+    )
+
+    val defaultLinks: Map[String, String] = Map(
+      "bluesky" -> "https://bsky.app/profile/theguardian.com",
+      "facebook" -> "https://www.facebook.com/theguardian",
+      "instagram" -> "https://www.instagram.com/guardian",
+      "linkedin" -> "https://www.linkedin.com/company/theguardian",
+      "threads" -> "https://www.threads.com/@guardian",
+      "tiktok" -> "https://www.tiktok.com/@guardian",
+      "youtube" -> "https://www.youtube.com/user/TheGuardian",
+    )
+
+    /* Some editions have regional accounts. We can override the defaults here */
+    val editionOverrides: Map[String, Map[String, String]] = Map(
+      "au" -> Map(
+        "bluesky" -> "https://bsky.app/profile/australia.theguardian.com",
+        "facebook" -> "https://www.facebook.com/theguardianaustralia",
+        "instagram" -> "https://www.instagram.com/guardianaustralia",
+        "linkedin" -> "https://www.linkedin.com/company/theguardianaustralia",
+        "threads" -> "https://www.threads.com/@guardianaustralia",
+        "tiktok" -> "https://www.tiktok.com/@guardianaustralia",
+        "youtube" -> "https://www.youtube.com/@GuardianAustralia",
+      ),
+      "us" -> Map(
+        "bluesky" -> "https://bsky.app/profile/us.theguardian.com",
+        "threads" -> "https://www.threads.com/@guardian_us",
+      ),
+    )
+    val urls: Map[String, String] = defaultLinks ++ editionOverrides.getOrElse(edition, Map.empty)
+
+    socials.map { case (key, displayName) =>
+      FooterLink(displayName, urls(key), s"$edition : footer : $displayName")
+    }
   }
 
   /* Column one */
@@ -143,33 +183,21 @@ object FooterLinks {
     allWriters(UK),
     newsletters(UK),
     digitalNewspaperArchive,
-    facebook(UK),
-    instagram(UK),
-    linkedin(UK),
-    youtube(UK),
-  )
+  ) ++ socialLinks(UK)
 
   val usListTwo = List(
     allTopics(US),
     allWriters(US),
     newsletters(US),
     digitalNewspaperArchive,
-    facebook(US),
-    instagram(US),
-    linkedin(US),
-    youtube(US),
-  )
+  ) ++ socialLinks(US)
 
   val auListTwo = List(
     allTopics(AU),
     allWriters(AU),
     newsletters(AU),
     digitalNewspaperArchive,
-    facebook(AU),
-    instagram(AU),
-    linkedin(AU),
-    youtube(AU),
-  )
+  ) ++ socialLinks(AU)
 
   def genericListTwo(edition: String): List[FooterLink] = {
     List(
@@ -177,11 +205,7 @@ object FooterLinks {
       allWriters(edition),
       newsletters(edition),
       digitalNewspaperArchive,
-      facebook(edition),
-      instagram(edition),
-      linkedin(edition),
-      youtube(edition),
-    )
+    ) ++ socialLinks(edition)
   }
 
   /* Column three */

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -5,6 +5,7 @@ import common.editions.Uk.{networkFrontId => UK}
 import common.editions.Us.{networkFrontId => US}
 import common.editions.Au.{networkFrontId => AU}
 import common.editions.International.{networkFrontId => INT}
+import common.editions.Europe.{networkFrontId => EUR}
 
 case class FooterLink(
     text: String,
@@ -64,66 +65,62 @@ object FooterLinks {
       dataLinkName = s"$edition : footer : newsletters",
     )
   }
-
-    def modernSlaveryActStatement(edition: String): FooterLink = {
-      FooterLink(
-        "Modern Slavery Act",
-        "https://uploads.guim.co.uk/2025/09/05/Modern_Slavery_Statement_2025.pdf",
-        s"$edition : footer : modern slavery act statement",
-      )
-    }
-
-    def tipUsOff(edition: String): FooterLink = {
-      FooterLink("Tip us off", "https://www.theguardian.com/tips", s"$edition : footer : tips")
-    }
-
+  def modernSlaveryActStatement(edition: String): FooterLink = {
+    FooterLink(
+      "Modern Slavery Act",
+      "https://uploads.guim.co.uk/2025/09/05/Modern_Slavery_Statement_2025.pdf",
+      s"$edition : footer : modern slavery act statement",
+    )
+  }
+  def tipUsOff(edition: String): FooterLink = {
+    FooterLink("Tip us off", "https://www.theguardian.com/tips", s"$edition : footer : tips")
+  }
   def searchJobs(edition: String): FooterLink = {
     FooterLink("Search jobs", "https://jobs.theguardian.com", s"$edition : footer : jobs")
   }
 
+  /* Column one */
 
-    /* Column one */
+  val ukListOne = List(
+    FooterLink("About us", "/about", s"$UK : footer : about us"),
+    help(UK),
+    complaintsAndCorrections,
+    FooterLink("Contact us", "/help/contact-us", s"$UK : footer : contact us"),
+    tipUsOff(UK),
+    secureDrop,
+    privacyPolicy,
+    cookiePolicy,
+    modernSlaveryActStatement(UK),
+    taxStrategy(UK),
+    termsAndConditions,
+  )
 
-    val ukListOne = List(
-      FooterLink("About us", "/about", s"$UK : footer : about us"),
-      help(UK),
-      complaintsAndCorrections,
-      FooterLink("Contact us", "/help/contact-us", s"$UK : footer : contact us"),
-      tipUsOff(UK),
-      secureDrop,
-      privacyPolicy,
-      cookiePolicy,
-      modernSlaveryActStatement(UK),
-      taxStrategy(UK),
-      termsAndConditions,
-    )
+  val usListOne = List(
+    FooterLink("About us", "/info/about-guardian-us", s"$US : footer : about us"),
+    help(US),
+    complaintsAndCorrections,
+    FooterLink("Contact us", "/info/about-guardian-us/contact", s"$US : footer : contact us"),
+    tipUsOff(US),
+    secureDrop,
+    privacyPolicy,
+    cookiePolicy,
+    taxStrategy(US),
+    termsAndConditions,
+  )
 
-    val usListOne = List(
-      FooterLink("About us", "/info/about-guardian-us", s"$US : footer : about us"),
-      help(US),
-      complaintsAndCorrections,
-      FooterLink("Contact us", "/info/about-guardian-us/contact", s"$US : footer : contact us"),
-      tipUsOff(US),
-      secureDrop,
-      privacyPolicy,
-      cookiePolicy,
-      taxStrategy(US),
-      termsAndConditions,
-    )
-
-    val auListOne = List(
-      FooterLink("About us", "/info/about-guardian-australia", s"$AU : footer : about us"),
-      FooterLink("Information", "/info", s"$AU : footer : information"),
-      help(AU),
-      complaintsAndCorrections,
-      FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", s"$AU : footer : contact us"),
-      tipUsOff(AU),
-      secureDrop,
-      privacyPolicy,
-      cookiePolicy,
-      taxStrategy(AU),
-      termsAndConditions,
-    )
+  val auListOne = List(
+    FooterLink("About us", "/info/about-guardian-australia", s"$AU : footer : about us"),
+    FooterLink("Information", "/info", s"$AU : footer : information"),
+    help(AU),
+    complaintsAndCorrections,
+    FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", s"$AU : footer : contact us"),
+    tipUsOff(AU),
+    secureDrop,
+    privacyPolicy,
+    cookiePolicy,
+    taxStrategy(AU),
+    termsAndConditions,
+  )
 
   def genericListOne(edition: String): List[FooterLink] = {
     List(
@@ -140,39 +137,39 @@ object FooterLinks {
     )
   }
 
-    /* Column two */
-    val ukListTwo = List(
-      allTopics(UK),
-      allWriters(UK),
-      newsletters(UK),
-      digitalNewspaperArchive,
-      facebook(UK),
-      instagram(UK),
-      linkedin(UK),
-      youtube(UK),
-    )
+  /* Column two */
+  val ukListTwo = List(
+    allTopics(UK),
+    allWriters(UK),
+    newsletters(UK),
+    digitalNewspaperArchive,
+    facebook(UK),
+    instagram(UK),
+    linkedin(UK),
+    youtube(UK),
+  )
 
-    val usListTwo = List(
-      allTopics(US),
-      allWriters(US),
-      newsletters(US),
-      digitalNewspaperArchive,
-      facebook(US),
-      instagram(US),
-      linkedin(US),
-      youtube(US),
-    )
+  val usListTwo = List(
+    allTopics(US),
+    allWriters(US),
+    newsletters(US),
+    digitalNewspaperArchive,
+    facebook(US),
+    instagram(US),
+    linkedin(US),
+    youtube(US),
+  )
 
-    val auListTwo = List(
-      allTopics(AU),
-      allWriters(AU),
-      newsletters(AU),
-      digitalNewspaperArchive,
-      facebook(AU),
-      instagram(AU),
-      linkedin(AU),
-      youtube(AU),
-    )
+  val auListTwo = List(
+    allTopics(AU),
+    allWriters(AU),
+    newsletters(AU),
+    digitalNewspaperArchive,
+    facebook(AU),
+    instagram(AU),
+    linkedin(AU),
+    youtube(AU),
+  )
 
   def genericListTwo(edition: String): List[FooterLink] = {
     List(
@@ -187,39 +184,39 @@ object FooterLinks {
     )
   }
 
-    /* Column three */
+  /* Column three */
 
-    val ukListThree = List(
-      FooterLink("Advertise with us", "https://advertising.theguardian.com", s"$UK : footer : advertise with us"),
-      FooterLink("Guardian Labs", "/guardian-labs", s"$UK : footer : guardian labs"),
-      searchJobs(UK),
-      FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", s"$UK : footer : patrons"),
-      workForUs(UK),
-      accessibilitySettings,
-    )
+  val ukListThree = List(
+    FooterLink("Advertise with us", "https://advertising.theguardian.com", s"$UK : footer : advertise with us"),
+    FooterLink("Guardian Labs", "/guardian-labs", s"$UK : footer : guardian labs"),
+    searchJobs(UK),
+    FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", s"$UK : footer : patrons"),
+    workForUs(UK),
+    accessibilitySettings,
+  )
 
-    val usListThree = List(
-      FooterLink(
-        "Advertise with us",
-        "https://usadvertising.theguardian.com",
-        s"$US : footer : advertise with us",
-      ),
-      FooterLink("Guardian Labs", "/guardian-labs-us", s"$US : footer : guardian labs"),
-      searchJobs(US),
-      workForUs(US),
-      accessibilitySettings,
-    )
+  val usListThree = List(
+    FooterLink(
+      "Advertise with us",
+      "https://usadvertising.theguardian.com",
+      s"$US : footer : advertise with us",
+    ),
+    FooterLink("Guardian Labs", "/guardian-labs-us", s"$US : footer : guardian labs"),
+    searchJobs(US),
+    workForUs(US),
+    accessibilitySettings,
+  )
 
-    val auListThree = List(
-      FooterLink(
-        "Advertise with us",
-        "https://ausadvertising.theguardian.com/",
-        s"$AU : footer : advertise with us",
-      ),
-      FooterLink("Guardian Labs", "/guardian-labs-australia", s"$AU : footer : guardian labs"),
-      workForUs(AU),
-      accessibilitySettings,
-    )
+  val auListThree = List(
+    FooterLink(
+      "Advertise with us",
+      "https://ausadvertising.theguardian.com/",
+      s"$AU : footer : advertise with us",
+    ),
+    FooterLink("Guardian Labs", "/guardian-labs-australia", s"$AU : footer : guardian labs"),
+    workForUs(AU),
+    accessibilitySettings,
+  )
 
   def genericListThree(edition: String): List[FooterLink] = {
     List(
@@ -233,15 +230,14 @@ object FooterLinks {
       accessibilitySettings,
       workForUs(edition),
     )
-    }
-
-
-    def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =
-      edition match {
-        case editions.Uk => Seq(ukListOne, ukListTwo, ukListThree)
-        case editions.Us => Seq(usListOne, usListTwo, usListThree)
-        case editions.Au => Seq(auListOne, auListTwo, auListThree)
-        case editions.International => Seq(genericListOne(INT), genericListTwo(INT), genericListThree(INT))
-      }
   }
 
+  def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =
+    edition match {
+      case editions.Uk            => Seq(ukListOne, ukListTwo, ukListThree)
+      case editions.Us            => Seq(usListOne, usListTwo, usListThree)
+      case editions.Au            => Seq(auListOne, auListTwo, auListThree)
+      case editions.International => Seq(genericListOne(INT), genericListTwo(INT), genericListThree(INT))
+      case editions.Europe        => Seq(genericListOne(EUR), genericListTwo(EUR), genericListThree(EUR))
+    }
+}

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -73,6 +73,10 @@ object FooterLinks {
       FooterLink("Tip us off", "https://www.theguardian.com/tips", s"$edition : footer : tips")
     }
 
+  def searchJobs(edition: String): FooterLink = {
+    FooterLink("Search jobs", "https://jobs.theguardian.com", s"$edition : footer : jobs")
+  }
+
 
     /* Column one */
 
@@ -134,47 +138,45 @@ object FooterLinks {
     val ukListTwo = List(
       allTopics("uk"),
       allWriters("uk"),
+      newsletters("uk"),
       digitalNewspaperArchive,
       facebook("uk"),
-      youtube("uk"),
       instagram("uk"),
       linkedin("uk"),
-      newsletters("uk"),
+      youtube("uk"),
     )
 
     val usListTwo = List(
       allTopics("us"),
       allWriters("us"),
+      newsletters("us"),
       digitalNewspaperArchive,
       facebook("us"),
-      youtube("us"),
       instagram("us"),
       linkedin("us"),
-      newsletters("us"),
+      youtube("us"),
     )
 
     val auListTwo = List(
       allTopics("au"),
       allWriters("au"),
+      newsletters("au"),
       digitalNewspaperArchive,
-      taxStrategy("au"),
       facebook("au"),
-      youtube("au"),
       instagram("au"),
       linkedin("au"),
-      newsletters("au"),
+      youtube("au"),
     )
 
     val intListTwo = List(
       allTopics("international"),
       allWriters("international"),
+      newsletters("international"),
       digitalNewspaperArchive,
-      taxStrategy("international"),
       facebook("international"),
-      youtube("international"),
       instagram("international"),
       linkedin("international"),
-      newsletters("international"),
+      youtube("international"),
     )
 
     /* Column three */
@@ -182,7 +184,7 @@ object FooterLinks {
     val ukListThree = List(
       FooterLink("Advertise with us", "https://advertising.theguardian.com", "uk : footer : advertise with us"),
       FooterLink("Guardian Labs", "/guardian-labs", "uk : footer : guardian labs"),
-      FooterLink("Search jobs", "https://jobs.theguardian.com", "uk : footer : jobs"),
+      searchJobs("uk"),
       FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
       workForUs("uk"),
       accessibilitySettings,
@@ -195,21 +197,19 @@ object FooterLinks {
         "us : footer : advertise with us",
       ),
       FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
-      FooterLink("Search jobs", "https://jobs.theguardian.com", "us : footer : jobs"),
+      searchJobs("us"),
       workForUs("us"),
       accessibilitySettings,
     )
 
     val auListThree = List(
-      FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
       FooterLink(
         "Advertise with us",
         "https://ausadvertising.theguardian.com/",
         "au : footer : advertise with us",
       ),
+      FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
       workForUs("australia"),
-      cookiePolicy,
-      FooterLink("Tips", "https://www.theguardian.com/tips", "au : footer : tips"),
       accessibilitySettings,
     )
 
@@ -219,11 +219,7 @@ object FooterLinks {
         "https://advertising.theguardian.com",
         "international : footer : advertise with us",
       ),
-      FooterLink(
-        "Search UK jobs",
-        "https://jobs.theguardian.com",
-        "international : footer : uk-jobs",
-      ),
+      searchJobs("int"), // may need to be changed for a specific title
       FooterLink("Tips", "https://www.theguardian.com/tips", "int : footer : tips"),
       accessibilitySettings,
       workForUs("international"),

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -125,18 +125,20 @@ object FooterLinks {
       termsAndConditions,
     )
 
-    val intListOne = List(
-      FooterLink("About us", "/about", "international : footer : about us"),
-      help("international"),
+  def genericListOne(edition: String): List[FooterLink] = {
+    List(
+      FooterLink("About us", "/about", s"$edition : footer : about us"),
+      help(edition),
       complaintsAndCorrections,
-      FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
-      tipUsOff("international"),
+      FooterLink("Contact us", "/help/contact-us", s"$edition : footer : contact us"),
+      tipUsOff(edition),
       secureDrop,
       privacyPolicy,
       cookiePolicy,
-      taxStrategy("international"),
+      taxStrategy(edition),
       termsAndConditions,
     )
+  }
 
     /* Column two */
     val ukListTwo = List(
@@ -172,16 +174,18 @@ object FooterLinks {
       youtube(AU),
     )
 
-    val intListTwo = List(
-      allTopics("international"),
-      allWriters("international"),
-      newsletters("international"),
+  def genericListTwo(edition: String): List[FooterLink] = {
+    List(
+      allTopics(edition),
+      allWriters(edition),
+      newsletters(edition),
       digitalNewspaperArchive,
-      facebook("international"),
-      instagram("international"),
-      linkedin("international"),
-      youtube("international"),
+      facebook(edition),
+      instagram(edition),
+      linkedin(edition),
+      youtube(edition),
     )
+  }
 
     /* Column three */
 
@@ -217,25 +221,27 @@ object FooterLinks {
       accessibilitySettings,
     )
 
-    val intListThree = List(
+  def genericListThree(edition: String): List[FooterLink] = {
+    List(
       FooterLink(
         "Advertise with us",
         "https://advertising.theguardian.com",
-        "international : footer : advertise with us",
+        s"$edition : footer : advertise with us",
       ),
-      searchJobs("int"), // may need to be changed for a specific title
-      FooterLink("Tips", "https://www.theguardian.com/tips", "int : footer : tips"),
+      FooterLink("Search UK jobs", "https://jobs.theguardian.com", s"$edition : footer : jobs"),
+      FooterLink("Tips", "https://www.theguardian.com/tips", s"$edition : footer : tips"),
       accessibilitySettings,
-      workForUs("international"),
+      workForUs(edition),
     )
+    }
+
 
     def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =
       edition match {
         case editions.Uk => Seq(ukListOne, ukListTwo, ukListThree)
         case editions.Us => Seq(usListOne, usListTwo, usListThree)
         case editions.Au => Seq(auListOne, auListTwo, auListThree)
-        case editions.International => Seq(intListOne, intListTwo, intListThree)
-        case _ => Seq(intListOne, intListTwo, intListThree)
+        case editions.International => Seq(genericListOne(INT), genericListTwo(INT), genericListThree(INT))
       }
   }
 

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -59,6 +59,7 @@ object FooterLinks {
       url = s"/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_${edition.toUpperCase}",
       dataLinkName = s"$edition : footer : newsletters",
     )
+  }
 
     def modernSlaveryActStatement(edition: String): FooterLink = {
       FooterLink(
@@ -66,175 +67,175 @@ object FooterLinks {
         "https://uploads.guim.co.uk/2025/09/05/Modern_Slavery_Statement_2025.pdf",
         s"$edition : footer : modern slavery act statement",
       )
-  }
+    }
+
     def tipUsOff(edition: String): FooterLink = {
       FooterLink("Tip us off", "https://www.theguardian.com/tips", s"$edition : footer : tips")
-
     }
 
 
-  /* Column one */
+    /* Column one */
 
-  val ukListOne = List(
-    FooterLink("About us", "/about", "uk : footer : about us"),
-    help("uk"),
-    complaintsAndCorrections,
-    FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
-    tipUsOff("uk"),
-    secureDrop,
-    privacyPolicy,
-    cookiePolicy,
-    modernSlaveryActStatement("uk"),
-    taxStrategy("uk"),
-    termsAndConditions,
-  )
+    val ukListOne = List(
+      FooterLink("About us", "/about", "uk : footer : about us"),
+      help("uk"),
+      complaintsAndCorrections,
+      FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
+      tipUsOff("uk"),
+      secureDrop,
+      privacyPolicy,
+      cookiePolicy,
+      modernSlaveryActStatement("uk"),
+      taxStrategy("uk"),
+      termsAndConditions,
+    )
 
-  val usListOne = List(
-    FooterLink("About us", "/info/about-guardian-us", "us : footer : about us"),
-    help("us"),
-    complaintsAndCorrections,
-    FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
-    tipUsOff("us"),
-    secureDrop,
-    privacyPolicy,
-    cookiePolicy,
-    taxStrategy("us"),
-    termsAndConditions,
-  )
+    val usListOne = List(
+      FooterLink("About us", "/info/about-guardian-us", "us : footer : about us"),
+      help("us"),
+      complaintsAndCorrections,
+      FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
+      tipUsOff("us"),
+      secureDrop,
+      privacyPolicy,
+      cookiePolicy,
+      taxStrategy("us"),
+      termsAndConditions,
+    )
 
-  val auListOne = List(
-    FooterLink("About us", "/info/about-guardian-australia", "au : footer : about us"),
-    FooterLink("Information", "/info", "au : footer : information"),
-    help("au"),
-    complaintsAndCorrections,
-    FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
-    tipUsOff("au"),
-    secureDrop,
-    privacyPolicy,
-    cookiePolicy,
-    taxStrategy("au"),
-    termsAndConditions,
-  )
+    val auListOne = List(
+      FooterLink("About us", "/info/about-guardian-australia", "au : footer : about us"),
+      FooterLink("Information", "/info", "au : footer : information"),
+      help("au"),
+      complaintsAndCorrections,
+      FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
+      tipUsOff("au"),
+      secureDrop,
+      privacyPolicy,
+      cookiePolicy,
+      taxStrategy("au"),
+      termsAndConditions,
+    )
 
-  val intListOne = List(
-    FooterLink("About us", "/about", "international : footer : about us"),
-    help("international"),
-    complaintsAndCorrections,
-    FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
-    tipUsOff("international"),
-    secureDrop,
-    privacyPolicy,
-    cookiePolicy,
-    taxStrategy("international"),
-    termsAndConditions,
-  )
+    val intListOne = List(
+      FooterLink("About us", "/about", "international : footer : about us"),
+      help("international"),
+      complaintsAndCorrections,
+      FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
+      tipUsOff("international"),
+      secureDrop,
+      privacyPolicy,
+      cookiePolicy,
+      taxStrategy("international"),
+      termsAndConditions,
+    )
 
-  /* Column two */
-  val ukListTwo = List(
-    allTopics("uk"),
-    allWriters("uk"),
-    digitalNewspaperArchive,
-    facebook("uk"),
-    youtube("uk"),
-    instagram("uk"),
-    linkedin("uk"),
-    newsletters("uk"),
-  )
+    /* Column two */
+    val ukListTwo = List(
+      allTopics("uk"),
+      allWriters("uk"),
+      digitalNewspaperArchive,
+      facebook("uk"),
+      youtube("uk"),
+      instagram("uk"),
+      linkedin("uk"),
+      newsletters("uk"),
+    )
 
-  val usListTwo = List(
-    allTopics("us"),
-    allWriters("us"),
-    digitalNewspaperArchive,
-    facebook("us"),
-    youtube("us"),
-    instagram("us"),
-    linkedin("us"),
-    newsletters("us"),
-  )
+    val usListTwo = List(
+      allTopics("us"),
+      allWriters("us"),
+      digitalNewspaperArchive,
+      facebook("us"),
+      youtube("us"),
+      instagram("us"),
+      linkedin("us"),
+      newsletters("us"),
+    )
 
-  val auListTwo = List(
-    allTopics("au"),
-    allWriters("au"),
-    digitalNewspaperArchive,
-    taxStrategy("au"),
-    facebook("au"),
-    youtube("au"),
-    instagram("au"),
-    linkedin("au"),
-    newsletters("au"),
-  )
+    val auListTwo = List(
+      allTopics("au"),
+      allWriters("au"),
+      digitalNewspaperArchive,
+      taxStrategy("au"),
+      facebook("au"),
+      youtube("au"),
+      instagram("au"),
+      linkedin("au"),
+      newsletters("au"),
+    )
 
-  val intListTwo = List(
-    allTopics("international"),
-    allWriters("international"),
-    digitalNewspaperArchive,
-    taxStrategy("international"),
-    facebook("international"),
-    youtube("international"),
-    instagram("international"),
-    linkedin("international"),
-    newsletters("international"),
-  )
+    val intListTwo = List(
+      allTopics("international"),
+      allWriters("international"),
+      digitalNewspaperArchive,
+      taxStrategy("international"),
+      facebook("international"),
+      youtube("international"),
+      instagram("international"),
+      linkedin("international"),
+      newsletters("international"),
+    )
 
-  /* Column three */
+    /* Column three */
 
-  val ukListThree = List(
-    FooterLink("Advertise with us", "https://advertising.theguardian.com", "uk : footer : advertise with us"),
-    FooterLink("Guardian Labs", "/guardian-labs", "uk : footer : guardian labs"),
-    FooterLink("Search jobs", "https://jobs.theguardian.com", "uk : footer : jobs"),
-    FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
-    workForUs("uk"),
-    accessibilitySettings,
-  )
+    val ukListThree = List(
+      FooterLink("Advertise with us", "https://advertising.theguardian.com", "uk : footer : advertise with us"),
+      FooterLink("Guardian Labs", "/guardian-labs", "uk : footer : guardian labs"),
+      FooterLink("Search jobs", "https://jobs.theguardian.com", "uk : footer : jobs"),
+      FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
+      workForUs("uk"),
+      accessibilitySettings,
+    )
 
-  val usListThree = List(
-    FooterLink(
-      "Advertise with us",
-      "https://usadvertising.theguardian.com",
-      "us : footer : advertise with us",
-    ),
-    FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
-    FooterLink("Search jobs", "https://jobs.theguardian.com", "us : footer : jobs"),
-    workForUs("us"),
-    accessibilitySettings,
-  )
+    val usListThree = List(
+      FooterLink(
+        "Advertise with us",
+        "https://usadvertising.theguardian.com",
+        "us : footer : advertise with us",
+      ),
+      FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
+      FooterLink("Search jobs", "https://jobs.theguardian.com", "us : footer : jobs"),
+      workForUs("us"),
+      accessibilitySettings,
+    )
 
-  val auListThree = List(
-    FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
-    FooterLink(
-      "Advertise with us",
-      "https://ausadvertising.theguardian.com/",
-      "au : footer : advertise with us",
-    ),
-    workForUs("australia"),
-    cookiePolicy,
-    FooterLink("Tips", "https://www.theguardian.com/tips", "au : footer : tips"),
-    accessibilitySettings,
-  )
+    val auListThree = List(
+      FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
+      FooterLink(
+        "Advertise with us",
+        "https://ausadvertising.theguardian.com/",
+        "au : footer : advertise with us",
+      ),
+      workForUs("australia"),
+      cookiePolicy,
+      FooterLink("Tips", "https://www.theguardian.com/tips", "au : footer : tips"),
+      accessibilitySettings,
+    )
 
-  val intListThree = List(
-    FooterLink(
-      "Advertise with us",
-      "https://advertising.theguardian.com",
-      "international : footer : advertise with us",
-    ),
-    FooterLink(
-      "Search UK jobs",
-      "https://jobs.theguardian.com",
-      "international : footer : uk-jobs",
-    ),
-    FooterLink("Tips", "https://www.theguardian.com/tips", "int : footer : tips"),
-    accessibilitySettings,
-    workForUs("international"),
-  )
+    val intListThree = List(
+      FooterLink(
+        "Advertise with us",
+        "https://advertising.theguardian.com",
+        "international : footer : advertise with us",
+      ),
+      FooterLink(
+        "Search UK jobs",
+        "https://jobs.theguardian.com",
+        "international : footer : uk-jobs",
+      ),
+      FooterLink("Tips", "https://www.theguardian.com/tips", "int : footer : tips"),
+      accessibilitySettings,
+      workForUs("international"),
+    )
 
-  def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =
-    edition match {
-      case editions.Uk            => Seq(ukListOne, ukListTwo, ukListThree)
-      case editions.Us            => Seq(usListOne, usListTwo, usListThree)
-      case editions.Au            => Seq(auListOne, auListTwo, auListThree)
-      case editions.International => Seq(intListOne, intListTwo, intListThree)
-      case _                      => Seq(intListOne, intListTwo, intListThree)
-    }
+    def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =
+      edition match {
+        case editions.Uk => Seq(ukListOne, ukListTwo, ukListThree)
+        case editions.Us => Seq(usListOne, usListTwo, usListThree)
+        case editions.Au => Seq(auListOne, auListTwo, auListThree)
+        case editions.International => Seq(intListOne, intListTwo, intListThree)
+        case _ => Seq(intListOne, intListTwo, intListThree)
+      }
+  }
 
-}

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -11,8 +11,7 @@ case class FooterLink(
 
 object FooterLinks {
 
-  // Footer column one
-
+  // Helpers
   val complaintsAndCorrections =
     FooterLink("Complaints & corrections", "/info/complaints-and-corrections", "complaints")
   val secureDrop = FooterLink("SecureDrop", "https://www.theguardian.com/securedrop", "securedrop")
@@ -34,6 +33,47 @@ object FooterLinks {
     )
   def workForUs(edition: String): FooterLink =
     FooterLink("Work for us", "https://workforus.theguardian.com", s"${edition} : footer : work for us")
+  def allTopics(edition: String): FooterLink =
+    FooterLink("All topics", "/index/subjects/a", s"${edition} : footer : all topics")
+  def allWriters(edition: String): FooterLink =
+    FooterLink("All writers", "/index/contributors", s"${edition} : footer : all contributors")
+  val digitalNewspaperArchive: FooterLink =
+    FooterLink("Digital newspaper archive", "https://theguardian.newspapers.com", "digital newspaper archive")
+  def taxStrategy(edition: String): FooterLink =
+    FooterLink(
+      "Tax strategy",
+      "https://uploads.guim.co.uk/2025/09/05/Tax_strategy_for_the_year_ended_31_March_2025.pdf",
+      s"${edition} : footer : tax strategy",
+    )
+  def facebook(edition: String): FooterLink =
+    FooterLink("Facebook", "https://www.facebook.com/theguardian", s"${edition} : footer : facebook")
+  def youtube(edition: String): FooterLink =
+    FooterLink("YouTube", "https://www.youtube.com/user/TheGuardian", s"${edition} : footer : youtube")
+  def linkedin(edition: String): FooterLink =
+    FooterLink("LinkedIn", "https://www.linkedin.com/company/theguardian", s"${edition} : footer : linkedin")
+  def instagram(edition: String): FooterLink =
+    FooterLink("Instagram", "https://www.instagram.com/guardian", s"${edition} : footer : instagram")
+  def newsletters(edition: String): FooterLink = {
+    FooterLink(
+      text = "Newsletters",
+      url = s"/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_${edition.toUpperCase}",
+      dataLinkName = s"$edition : footer : newsletters",
+    )
+
+    def modernSlaveryActStatement(edition: String): FooterLink = {
+      FooterLink(
+        "Modern Slavery Act",
+        "https://uploads.guim.co.uk/2025/09/05/Modern_Slavery_Statement_2025.pdf",
+        s"$edition : footer : modern slavery act statement",
+      )
+  }
+    def tipUsOff(edition: String): FooterLink = {
+      FooterLink("Tip us off", "https://www.theguardian.com/tips", s"$edition : footer : tips")
+
+    }
+
+
+  /* Column one */
 
   val ukListOne = List(
     FooterLink("About us", "/about", "uk : footer : about us"),
@@ -82,35 +122,7 @@ object FooterLinks {
     FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
   )
 
-  // Footer column two
-
-  def allTopics(edition: String): FooterLink =
-    FooterLink("All topics", "/index/subjects/a", s"${edition} : footer : all topics")
-  def allWriters(edition: String): FooterLink =
-    FooterLink("All writers", "/index/contributors", s"${edition} : footer : all contributors")
-  val digitalNewspaperArchive: FooterLink =
-    FooterLink("Digital newspaper archive", "https://theguardian.newspapers.com", "digital newspaper archive")
-  def taxStrategy(edition: String): FooterLink =
-    FooterLink(
-      "Tax strategy",
-      "https://uploads.guim.co.uk/2025/09/05/Tax_strategy_for_the_year_ended_31_March_2025.pdf",
-      s"${edition} : footer : tax strategy",
-    )
-  def facebook(edition: String): FooterLink =
-    FooterLink("Facebook", "https://www.facebook.com/theguardian", s"${edition} : footer : facebook")
-  def youtube(edition: String): FooterLink =
-    FooterLink("YouTube", "https://www.youtube.com/user/TheGuardian", s"${edition} : footer : youtube")
-  def linkedin(edition: String): FooterLink =
-    FooterLink("LinkedIn", "https://www.linkedin.com/company/theguardian", s"${edition} : footer : linkedin")
-  def instagram(edition: String): FooterLink =
-    FooterLink("Instagram", "https://www.instagram.com/guardian", s"${edition} : footer : instagram")
-  def newsletters(edition: String): FooterLink =
-    FooterLink(
-      text = "Newsletters",
-      url = s"/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_${edition.toUpperCase}",
-      dataLinkName = s"$edition : footer : newsletters",
-    )
-
+  /* Column two */
   val ukListTwo = List(
     allTopics("uk"),
     allWriters("uk"),
@@ -164,7 +176,7 @@ object FooterLinks {
     newsletters("international"),
   )
 
-  // Footer column three
+  /* Column three */
 
   val ukListThree = List(
     FooterLink("Advertise with us", "https://advertising.theguardian.com", "uk : footer : advertise with us"),

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -79,59 +79,60 @@ object FooterLinks {
     FooterLink("About us", "/about", "uk : footer : about us"),
     help("uk"),
     complaintsAndCorrections,
+    FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
+    tipUsOff("uk"),
     secureDrop,
-    workForUs("uk"),
     privacyPolicy,
     cookiePolicy,
+    modernSlaveryActStatement("uk"),
+    taxStrategy("uk"),
     termsAndConditions,
-    FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
   )
 
   val usListOne = List(
     FooterLink("About us", "/info/about-guardian-us", "us : footer : about us"),
     help("us"),
     complaintsAndCorrections,
+    FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
+    tipUsOff("us"),
     secureDrop,
-    workForUs("us"),
     privacyPolicy,
     cookiePolicy,
+    taxStrategy("us"),
     termsAndConditions,
-    FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
   )
 
   val auListOne = List(
     FooterLink("About us", "/info/about-guardian-australia", "au : footer : about us"),
     FooterLink("Information", "/info", "au : footer : information"),
-    complaintsAndCorrections,
     help("au"),
-    secureDrop,
-    workForUs("australia"),
-    privacyPolicy,
-    termsAndConditions,
+    complaintsAndCorrections,
     FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
+    tipUsOff("au"),
+    secureDrop,
+    privacyPolicy,
+    cookiePolicy,
+    taxStrategy("au"),
+    termsAndConditions,
   )
 
   val intListOne = List(
+    FooterLink("About us", "/about", "international : footer : about us"),
     help("international"),
     complaintsAndCorrections,
+    FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
+    tipUsOff("international"),
     secureDrop,
-    workForUs("international"),
     privacyPolicy,
     cookiePolicy,
+    taxStrategy("international"),
     termsAndConditions,
-    FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
   )
 
   /* Column two */
   val ukListTwo = List(
     allTopics("uk"),
     allWriters("uk"),
-    FooterLink(
-      "Modern Slavery Act",
-      "https://uploads.guim.co.uk/2025/09/05/Modern_Slavery_Statement_2025.pdf",
-      "uk : footer : modern slavery act statement",
-    ),
-    taxStrategy("uk"),
     digitalNewspaperArchive,
     facebook("uk"),
     youtube("uk"),
@@ -144,7 +145,6 @@ object FooterLinks {
     allTopics("us"),
     allWriters("us"),
     digitalNewspaperArchive,
-    taxStrategy("us"),
     facebook("us"),
     youtube("us"),
     instagram("us"),
@@ -183,7 +183,7 @@ object FooterLinks {
     FooterLink("Guardian Labs", "/guardian-labs", "uk : footer : guardian labs"),
     FooterLink("Search jobs", "https://jobs.theguardian.com", "uk : footer : jobs"),
     FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
-    FooterLink("Tips", "https://www.theguardian.com/tips", "uk : footer : tips"),
+    workForUs("uk"),
     accessibilitySettings,
   )
 
@@ -195,7 +195,7 @@ object FooterLinks {
     ),
     FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
     FooterLink("Search jobs", "https://jobs.theguardian.com", "us : footer : jobs"),
-    FooterLink("Tips", "https://www.theguardian.com/tips", "us : footer : tips"),
+    workForUs("us"),
     accessibilitySettings,
   )
 
@@ -206,6 +206,7 @@ object FooterLinks {
       "https://ausadvertising.theguardian.com/",
       "au : footer : advertise with us",
     ),
+    workForUs("australia"),
     cookiePolicy,
     FooterLink("Tips", "https://www.theguardian.com/tips", "au : footer : tips"),
     accessibilitySettings,
@@ -224,6 +225,7 @@ object FooterLinks {
     ),
     FooterLink("Tips", "https://www.theguardian.com/tips", "int : footer : tips"),
     accessibilitySettings,
+    workForUs("international"),
   )
 
   def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] =


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
Reorders the links on network footers as requested by editorial. The order should now be the following. 

NB that privacy settings has been moved into the third column. This link is a DCR island and so it is not moved in this PR. It will be handled in an upcoming PR in DCR.

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Network Front | Column One | Column Two | Column 3
-- | -- | -- | --
UK | About us | All topics | Advertise with us
  | Help | All writers | Guardian Labs
  | Complaints & corrections | Newsletters | Search jobs
  | Contact us | Digital newspaper archive | Patrons
  | Tip us off | Facebook | Work for us
  | SecureDrop | Instagram | Privacy settings
  | Privacy policy | LinkedIn | Accessibility settings
  | Cookie policy | YouTube |  
  | Modern Slavery Act |   |  
  | Tax strategy |   |  
  | Terms & conditions |   |  
  |   |   |  
US | About us | All topics | Advertise with us
  | Help | All writers | Guardian Labs
  | Complaints & corrections | Newsletters | Search jobs
  | Contact us | Digital newspaper archive | Work for us
  | Tip us off | Facebook | Privacy settings
  | SecureDrop | Instagram | Accessibility settings
  | Privacy policy | LinkedIn |  
  | Cookie policy | YouTube |  
  | Tax strategy |   |  
  | Terms & conditions |   |  
  |   |   |  
  |   |   |  
AU | About us | All topics | Advertise with us
  | Information | All writers | Guardian Labs
  | Help | Newsletters | Work for us
  | Complaints & corrections | Digital newspaper archive | Privacy settings
  | Contact us | Facebook | Accessibility settings
  | Tip us off | Instagram |  
  | SecureDrop | LinkedIn |  
  | Privacy policy | YouTube |  
  | Cookie policy |   |  
  | Tax strategy |   |  
  | Terms & conditions |   |  
  |   |   |  
Europe | About us | All topics | Advertise with us
  | Help | All writers | Search UK jobs
  | Complaints & corrections | Newsletters | Work for us
  | Contact us | Digital newspaper archive | Privacy settings
  | Tip us off | Facebook | Accessibility settings
  | SecureDrop | Instagram |  
  | Privacy policy | LinkedIn |  
  | Cookie policy | YouTube |  
  | Tax strategy |   |  
  | Terms & conditions |   |  
  |   |   |  
  |   |   |  
International | About us | All topics | Advertise with us
  | Help | All writers | Search UK jobs
  | Complaints & corrections | Newsletters | Work for us
  | Contact us | Digital newspaper archive | Privacy settings
  | Tip us off | Facebook | Accessibility settings
  | SecureDrop | Instagram |  
  | Privacy policy | LinkedIn |  
  | Cookie policy | YouTube |  
  | Tax strategy |   |  
  | Terms & conditions |   |  
  |   |   |  


It also makes the following refactors:
- Moves any shared footer links into helper methods as per the pattern of this file
- lifts all helper methods to the top to create a distinction between those and the columns
- Imports and uses the network front id instead of floating network ids. This should ensure consistency in tracking moving forward.
- Refactors the International lists into generic lists so that they can be shared with Europe
- Adds a Europe footer so that Europe clicks are tracked appropriately. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![ukb][] | ![uka][] |
| ![usb][] | ![usa][] |
| ![aub][] | ![aua][] |
| ![ieb][] | ![iea][] |

[ukb]: https://github.com/user-attachments/assets/96675e0e-cc89-451f-9a86-727b62050cc7
[uka]: https://github.com/user-attachments/assets/e846c8eb-9d96-4b8b-aa60-46d3662ad3b5
[usb]: https://github.com/user-attachments/assets/e76b2879-5d0a-4959-a5f5-33b8d03eca95
[usa]: https://github.com/user-attachments/assets/d4ed8729-d008-447e-8c35-2d0403989d5f
[aub]: https://github.com/user-attachments/assets/8f73cd79-7137-47c4-8b1a-b2a7f1118770
[aua]: https://github.com/user-attachments/assets/fa5ab66d-829d-428d-ba1a-04c9be0b37a9
[ieb]: https://github.com/user-attachments/assets/df24bcfb-c559-4721-822c-e9c5eb66ef1e
[iea]: https://github.com/user-attachments/assets/3c6271cb-ae15-48f3-8616-8ddca0d5c8e4


## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
