### PR TITLE
Extend Prebid AB test switch by 2 weeks

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -55,7 +55,7 @@ trait ABTestSwitches {
     "This test is being used to test v9.46.0 of Prebid ahead of general upgrade.",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 9, 30)),
+    sellByDate = Some(LocalDate.of(2025, 10, 14)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

This expires today, we're extending by 2 weeks whilst we wait on the results.
