### PR TITLE
HMAC auth check

### DIFF
--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -35,6 +35,7 @@ trait AdminControllers {
     toolsDomainPrefix = "frontend",
     oauthCallbackPath = routes.GuardianAuthWithExemptions.oauthCallback.path,
     AWSv2.S3Sync,
+    AWSv2.secretsClient,
     system = "frontend-admin",
     extraDoNotAuthenticatePathPrefixes = Seq(
       // Date: 06 July 2021

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ val common = library("common")
       awsDynamodb,
       awsKinesis,
       awsS3,
+      awsSecretsManager,
       awsSns,
       awsSts, // AWS SDK v1 still used for CAPI-preview related code for now
       awsV2Sts, // AWS SDK v2 used for Fronts API access
@@ -39,6 +40,7 @@ val common = library("common")
       jSoup,
       json4s,
       panDomainAuth,
+      panDomainHMAC,
       editorialPermissions,
       quartzScheduler,
       redisClient,

--- a/common/app/utils/AWSv2.scala
+++ b/common/app/utils/AWSv2.scala
@@ -7,6 +7,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3AsyncClientBuilder, S3Client, S3ClientBuilder}
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 import software.amazon.awssdk.services.sts.{StsClient, StsClientBuilder}
@@ -45,4 +46,9 @@ object AWSv2 {
       .build(),
   )
 
+  val secretsClient = SecretsManagerClient
+    .builder()
+    .region(region)
+    .credentialsProvider(credentials)
+    .build()
 }

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -97,6 +97,7 @@ trait AppComponents
     toolsDomainPrefix = "preview",
     oauthCallbackPath = routes.GuardianAuthWithExemptions.oauthCallback.path,
     AWSv2.S3Sync,
+    AWSv2.secretsClient,
     system = "preview",
     extraDoNotAuthenticatePathPrefixes = healthCheck.healthChecks.map(_.path),
     requiredEditorialPermissionName = "preview_access",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
   val awsDynamodb = "software.amazon.awssdk" % "dynamodb" % awsSdk2Version
   val awsKinesis = "software.amazon.awssdk" % "kinesis" % awsSdk2Version
   val awsS3 = "software.amazon.awssdk" % "s3" % awsSdk2Version
+  val awsSecretsManager = "software.amazon.awssdk" % "secretsmanager" % awsSdk2Version
   val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
   val awsSes = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion
   val awsSns = "com.amazonaws" % "aws-java-sdk-sns" % awsVersion
@@ -58,7 +59,8 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.5.9" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.12"
-  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "9.0.2"
+  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "12.0.0"
+  val panDomainHMAC = "com.gu" %% "panda-hmac-play_3-0" % "12.0.0"
   val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "4.0.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"


### PR DESCRIPTION
This adds a HMAC auth check to the preview project. This is part of work on a live harness service for interactive atom development. We've added `awsSecretsManager` and `panDomainHMAC` as dependencies and added a HMAC fork in `GuardianAuthWithExceptions` that validates HMAC requests.

We want to be able to hit preview and this allows us to do so in a way that's consistent with existing auth checks.