### PR TITLE
Start All Boosts AB test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -39,15 +39,6 @@ object SourcepointConsentGeolocation
       participationGroup = Perc0B,
     )
 
-object AllBoosts
-    extends Experiment(
-      name = "all-boosts",
-      description = "All non-feature cards on network fronts are boosted",
-      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-      sellByDate = LocalDate.of(2025, 12, 1),
-      participationGroup = Perc0C,
-    )
-
 object DarkModeWeb
     extends Experiment(
       name = "dark-mode-web",
@@ -55,6 +46,15 @@ object DarkModeWeb
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2025, 10, 31),
       participationGroup = Perc0D,
+    )
+
+object AllBoosts
+    extends Experiment(
+      name = "all-boosts",
+      description = "All non-feature cards on network fronts are boosted",
+      owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+      sellByDate = LocalDate.of(2025, 12, 1),
+      participationGroup = Perc5A,
     )
 
 object GoogleOneTap


### PR DESCRIPTION
## What does this change?

Sets the "All Boosts" [experiment](https://github.com/guardian/frontend/pull/28246) to 5%.

The logic for the test can be found in this [DCR PR](https://github.com/guardian/dotcom-rendering/pull/14509).