### PR TITLE
AMP interactives depend on switch

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -126,12 +126,12 @@ class InteractiveController(
         case Right((page, blocks)) => {
           val tier = InteractivePicker.getRenderingTier(path)
           (requestFormat, tier) match {
-            case (AppsFormat, DotcomRendering)    => renderApps(page, blocks)
-            case (AmpFormat, DotcomRendering)     => renderAmp(page, blocks)
-            case (JsonFormat, DotcomRendering)    => renderJson(page, blocks)
-            case (HtmlFormat, PressedInteractive) => servePressedPage(path)
-            case (HtmlFormat, DotcomRendering)    => renderHtml(page, blocks)
-            case _                                => renderNonDCR(page)
+            case (AppsFormat, DotcomRendering)                                          => renderApps(page, blocks)
+            case (AmpFormat, DotcomRendering) if page.interactive.content.shouldAmplify => renderAmp(page, blocks)
+            case (JsonFormat, DotcomRendering)                                          => renderJson(page, blocks)
+            case (HtmlFormat, PressedInteractive)                                       => servePressedPage(path)
+            case (HtmlFormat, DotcomRendering)                                          => renderHtml(page, blocks)
+            case _                                                                      => renderNonDCR(page)
           }
         }
         case Left(result) => Future.successful(result)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -130,7 +130,7 @@ class InteractiveController(
             case (AmpFormat, DotcomRendering) if page.interactive.content.shouldAmplify => renderAmp(page, blocks)
             case (JsonFormat, DotcomRendering)                                          => renderJson(page, blocks)
             case (HtmlFormat, PressedInteractive)                                       => servePressedPage(path)
-            case (HtmlFormat, DotcomRendering)                                          => renderHtml(page, blocks)
+            case (HtmlFormat | AmpFormat, DotcomRendering)                              => renderHtml(page, blocks)
             case _                                                                      => renderNonDCR(page)
           }
         }

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -128,9 +128,9 @@ class InteractiveController(
           (requestFormat, tier) match {
             case (AppsFormat, DotcomRendering)                                          => renderApps(page, blocks)
             case (AmpFormat, DotcomRendering) if page.interactive.content.shouldAmplify => renderAmp(page, blocks)
+            case (HtmlFormat | AmpFormat, DotcomRendering)                              => renderHtml(page, blocks)
             case (JsonFormat, DotcomRendering)                                          => renderJson(page, blocks)
             case (HtmlFormat, PressedInteractive)                                       => servePressedPage(path)
-            case (HtmlFormat | AmpFormat, DotcomRendering)                              => renderHtml(page, blocks)
             case _                                                                      => renderNonDCR(page)
           }
         }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -95,6 +95,8 @@ final case class Content(
     val shouldAmplifyContent = {
       if (tags.isLiveBlog) {
         AmpLiveBlogSwitch.isSwitchedOn
+      } else if (tags.isInteractive) {
+        AmpArticleSwitch.isSwitchedOn
       } else if (tags.isArticle) {
         val hasBodyBlocks: Boolean = fields.blocks.exists(b => b.body.nonEmpty)
         // Some Labs pages have quiz atoms but are not tagged as quizzes


### PR DESCRIPTION
The AMP switch should also determine whether AMP versions of interactives are available.

**Note:** I recommend hiding whitespace for the diff.
