### PR TITLE
Update 'Ops metrics' configuration for migrated `commercial` stack

### DIFF
--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -55,7 +55,12 @@ object LoadBalancer extends GuLogging {
       "frontend-sport",
       targetGroup = Some("targetgroup/fronte-Targe-LJMDWMGH5FPD/e777dd4276b0bf29"),
     ),
-    LoadBalancer("frontend-PROD-commercial-ELB", "Commercial", "frontend-commercial"),
+    LoadBalancer(
+      "app/fronte-LoadB-4KxztKWTJxEu/faee39a2eecb4c1a",
+      "Commercial",
+      "frontend-commercial",
+      targetGroup = Some("targetgroup/fronte-Targe-C8VZWOPZ3TTS/271f997aea40fb19"),
+    ),
     LoadBalancer(
       "app/fronte-LoadB-NpLaks0rT7va/e5a6b5bea5119952",
       "Onward",


### PR DESCRIPTION
## What is the value of this and can you measure success?

Adds new load balancer ID and target group for GuCDK `commercial` stack.

Refer to the [original PR which added support for Application Load Balancers for the migrated `discussion` stack for additional context and detail](https://github.com/guardian/frontend/pull/27865).

