### PR TITLE
Remove ASG migration parameter from `commercial` deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -38,8 +38,6 @@ deployments:
     template: frontend
   commercial:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   discussion:
     template: frontend
   facia:


### PR DESCRIPTION
## What is the value of this and can you measure success?

This should be merged immediately following removal of the legacy `commercial` infrastructure (https://github.com/guardian/platform/pull/2028). Once that has been done we will no longer be dual-stacking `commercial` and have a single ASG again. We need to remove the ASG migration parameter so that Riff-Raff is no longer trying to update two ASGs which would break `dotcom:frontend-all` deployments.