### PR TITLE
Add 0% labs redesign experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -72,6 +72,6 @@ object LabsRedesign
       name = "labs-redesign",
       description = "Allows opting in to preview the Guardian Labs redesign work",
       owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 12, 1),
+      sellByDate = LocalDate.of(2025, 12, 16),
       participationGroup = Perc0C,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -16,6 +16,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       SourcepointConsentGeolocation,
       GoogleOneTap,
       ConsentOrPayEuropeInternalTest,
+      LabsRedesign,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -64,4 +65,13 @@ object GoogleOneTap
       owners = Seq(Owner.withEmail("identity.dev@theguardian.com")),
       sellByDate = LocalDate.of(2025, 12, 1),
       participationGroup = Perc10A,
+    )
+
+object LabsRedesign
+    extends Experiment(
+      name = "labs-redesign",
+      description = "Allows opting in to preview the Guardian Labs redesign work",
+      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
+      sellByDate = LocalDate.of(2025, 12, 1),
+      participationGroup = Perc0C,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows previewing the upcoming Labs redesigns ahead of release by opting into the 0% test in production.

## What does this change?

Adds a 0% experiment for the Labs redesign work

