### PR TITLE
Add a client ab test switch for a 10% test to compare pageviews with new framework

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -59,4 +59,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-compare-client-test-with-new-framework",
+    "Compare behaviour of new ab testing framework with existing one",
+    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 10, 31)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What does this change?
Add a switch for test added in https://github.com/guardian/dotcom-rendering/pull/14656