### PR TITLE
Remove expiring Prebid AB test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,17 +51,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-prebid946",
-    "This test is being used to test v9.46.0 of Prebid ahead of general upgrade.",
-    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 10, 14)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-compare-client-test-with-new-framework",
     "Compare behaviour of new ab testing framework with existing one",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),


### PR DESCRIPTION
## What does this change?

Removes the AB test switch corresponding to the client-side commercial AB test for the Prebid upgrade

## Why

We've already turned off the test and [switched to using the later version of Prebid](https://github.com/guardian/commercial/pull/2247), so we can tidy up by removing the frontend switch for this test
