### PR TITLE
Create Google One Tap switch

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -25,4 +25,15 @@ trait IdentitySwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val GoogleOneTapSwitch = Switch(
+    SwitchGroup.Identity,
+    "google-one-tap-switch",
+    "Signing into the Guardian with Google One Tap",
+    owners = Seq(Owner.withEmail("identity.dev@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What does this change?
We are rolling out the Google One Tap from 10% of Irish users to 100% using this switch.

In DCR, there's [logic](https://github.com/guardian/dotcom-rendering/blob/25704d445b607b0535d2142ec957362eed99cd38/dotcom-rendering/src/components/GoogleOneTap.importable.tsx#L33) to enable Google One Tap if the user is in the `googleOneTapVariant` ab test or `googleOneTapSwitch` switch is true. This PR creates the switch.







