### PR TITLE
Replace targeted experiences with value in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 /static/src/javascripts/projects/commercial/ @guardian/commercial-dev
 /commercial/ @guardian/commercial-dev
 
-# Targeted Experiences (TX)
-/static/src/javascripts/projects/common/modules/commercial/braze @guardian/tx-engineers
+# Value (Supporter Revenue)
+/static/src/javascripts/projects/common/modules/commercial/braze @guardian/value


### PR DESCRIPTION
## What does this change?

This replaces the Targeted Experiences team (which does not exist anymore) with the Value team in the CODEOWNERS file as owners of the Braze code.

Permissions on the repository also need to be updated for this.
