### PR TITLE
Don't call old ab tests legacy juuust yet

### DIFF
--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -14,8 +14,8 @@
                 </div>
                 <div class="panel-body">
                     <ul class="nav nav-pills nav-stacked nav-bleed">
-                        <li><a href="@controllers.admin.routes.AnalyticsController.abTests()">A/B Tests</a></li>
-                        <li><a href="@controllers.admin.routes.AnalyticsController.legacyAbTests()">A/B Tests (legacy)</a></li>
+                    <li><a href="@controllers.admin.routes.AnalyticsController.legacyAbTests()">A/B Tests</a></li>
+                        <li><a href="@controllers.admin.routes.AnalyticsController.abTests()">Beta A/B Test Framework Tests</a></li>
                         <li><a href="@controllers.admin.routes.AnalyticsConfidenceController.renderConfidence()">Confidence</a></li>
                     </ul>
                 </div>


### PR DESCRIPTION
## What does this change?
Rename the admin menu items regarding new ab test framework