### PR TITLE
Live harness endpoint for Preview

### DIFF
--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -35,6 +35,7 @@ trait AdminControllers {
     toolsDomainPrefix = "frontend",
     oauthCallbackPath = routes.GuardianAuthWithExemptions.oauthCallback.path,
     AWSv2.S3Sync,
+    AWSv2.secretsClient,
     system = "frontend-admin",
     extraDoNotAuthenticatePathPrefixes = Seq(
       // Date: 06 July 2021

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -8,13 +8,14 @@ import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import model._
 import pages.{ArticleEmailHtmlPage, ArticleHtmlPage}
-import play.api.libs.json.{Json, JsValue}
+import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import renderers.DotcomRenderingService
 import services.{CAPILookup, NewsletterService}
 import services.dotcomrendering.{ArticlePicker, PressedArticle, RemoteRender}
 import views.support._
+import utils.{LiveHarness, LiveHarnessInteractiveAtom}
 
 import scala.concurrent.Future
 
@@ -57,6 +58,19 @@ class ArticleController(
     Action.async { implicit request =>
       mapModel(path, ArticleBlocks) { (article, blocks) =>
         render(path, article, blocks)
+      }
+    }
+  }
+
+  def renderLiveHarness(path: String): Action[JsValue] = {
+    Action.async(parse.json) { implicit request =>
+      request.body.validate[List[LiveHarnessInteractiveAtom]].asEither match {
+        case Right(value) =>
+          mapModel(path, ArticleBlocks) { (article, blocks) =>
+            val (newArticle, newBlocks) = LiveHarness.injectInteractiveAtomsIntoArticle(value, article, blocks)
+            render(path, newArticle, newBlocks)
+          }
+        case Left(value) => Future(BadRequest(value.toString()))
       }
     }
   }

--- a/article/app/utils/LiveHarness.scala
+++ b/article/app/utils/LiveHarness.scala
@@ -1,0 +1,65 @@
+package utils
+
+import com.gu.contentapi.client.model.v1.{BlockElement, Blocks, ContentAtomElementFields, ElementType}
+import model.ArticlePage
+import model.content.InteractiveAtom
+import play.api.libs.json.{Json, Reads}
+
+case class LiveHarnessInteractiveAtom(
+    id: String,
+    title: String,
+    css: String,
+    html: String,
+    js: String,
+    weighting: String,
+)
+
+object LiveHarnessInteractiveAtom {
+  implicit val reads: Reads[LiveHarnessInteractiveAtom] = Json.reads
+}
+
+object LiveHarness {
+  def injectInteractiveAtomsIntoArticle(
+      localAtoms: List[LiveHarnessInteractiveAtom],
+      article: ArticlePage,
+      blocks: Blocks,
+  ): (ArticlePage, Blocks) = {
+    val newAtomReferenceElements = localAtoms.map(localAtom => {
+      BlockElement(
+        `type` = ElementType.Contentatom,
+        assets = Seq.empty,
+        contentAtomTypeData = Some(
+          ContentAtomElementFields(
+            atomId = localAtom.id,
+            atomType = "interactive",
+            role = Some(localAtom.weighting),
+            isMandatory = None,
+          ),
+        ),
+      )
+    })
+    val newInteractiveAtoms = localAtoms.map(localAtom => {
+      InteractiveAtom(
+        id = localAtom.id,
+        `type` = "interactive",
+        title = localAtom.title,
+        css = localAtom.css,
+        html = localAtom.html,
+        mainJS = Some(localAtom.js),
+        docData = None,
+        placeholderUrl = None,
+      )
+    })
+    val newAtoms = article.article.content.atoms.map(_.copy(interactives = newInteractiveAtoms))
+    val newArticle =
+      article.copy(article = article.article.copy(content = article.article.content.copy(atoms = newAtoms)))
+    val newElements =
+      newAtomReferenceElements ++ blocks.body.flatMap(_.headOption.map(_.elements)).getOrElse(Seq.empty).toList
+    val newBlocks = blocks.copy(body = blocks.body.map(blocks => {
+      val firstBlock = blocks.headOption.map(_.copy(elements = newElements))
+      val restOfBlocks = blocks.tail
+      firstBlock.toList ++ restOfBlocks
+    }))
+    (newArticle, newBlocks)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ val common = library("common")
       awsDynamodb,
       awsKinesis,
       awsS3,
+      awsSecretsManager,
       awsSns,
       awsSts, // AWS SDK v1 still used for CAPI-preview related code for now
       awsV2Sts, // AWS SDK v2 used for Fronts API access
@@ -39,6 +40,7 @@ val common = library("common")
       jSoup,
       json4s,
       panDomainAuth,
+      panDomainHMAC,
       editorialPermissions,
       quartzScheduler,
       redisClient,

--- a/common/app/utils/AWSv2.scala
+++ b/common/app/utils/AWSv2.scala
@@ -7,6 +7,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3AsyncClientBuilder, S3Client, S3ClientBuilder}
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 import software.amazon.awssdk.services.sts.{StsClient, StsClientBuilder}
@@ -45,4 +46,9 @@ object AWSv2 {
       .build(),
   )
 
+  val secretsClient = SecretsManagerClient
+    .builder()
+    .region(region)
+    .credentialsProvider(credentials)
+    .build()
 }

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -97,6 +97,7 @@ trait AppComponents
     toolsDomainPrefix = "preview",
     oauthCallbackPath = routes.GuardianAuthWithExemptions.oauthCallback.path,
     AWSv2.S3Sync,
+    AWSv2.secretsClient,
     system = "preview",
     extraDoNotAuthenticatePathPrefixes = healthCheck.healthChecks.map(_.path),
     requiredEditorialPermissionName = "preview_access",

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -191,6 +191,7 @@ GET     /*path.json                 controllers.ArticleController.renderJson(pat
 GET     /*path/email                controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
+POST    /*path                      controllers.ArticleController.renderLiveHarness(path)
 
 
 # Don't forward requests for favicon.ico to the Content API

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
   val awsDynamodb = "software.amazon.awssdk" % "dynamodb" % awsSdk2Version
   val awsKinesis = "software.amazon.awssdk" % "kinesis" % awsSdk2Version
   val awsS3 = "software.amazon.awssdk" % "s3" % awsSdk2Version
+  val awsSecretsManager = "software.amazon.awssdk" % "secretsmanager" % awsSdk2Version
   val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
   val awsSes = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion
   val awsSns = "com.amazonaws" % "aws-java-sdk-sns" % awsVersion
@@ -58,7 +59,8 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.5.9" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.12"
-  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "9.0.2"
+  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "12.0.0"
+  val panDomainHMAC = "com.gu" %% "panda-hmac-play_3-0" % "12.0.0"
   val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "4.0.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"


### PR DESCRIPTION
This adds a `POST` endpoint to the Preview project that allows for interactive atoms in local development to be injected into their parent article and have the full page HTML returned.