### PR TITLE
Reduce Google One Tap ab-test to 0

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -53,7 +53,7 @@ object GoogleOneTap
       description = "Signing into the Guardian with Google One Tap",
       owners = Seq(Owner.withEmail("identity.dev@theguardian.com")),
       sellByDate = LocalDate.of(2025, 12, 1),
-      participationGroup = Perc10A,
+      participationGroup = Perc0B,
     )
 
 object LabsRedesign


### PR DESCRIPTION
## What does this change?

Reduce Google One Tap test to 0% to keep it opt in.

