### PR TITLE
Remove "Whole Picture" feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -627,15 +627,4 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  val WholePictureLogoSwitch = Switch(
-    SwitchGroup.Feature,
-    "whole-picture-logo",
-    "Enables the Whole Picture logo for the US edition.",
-    owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }


### PR DESCRIPTION
## What does this change?

Removes the Whole Picture feature switch: https://github.com/guardian/frontend/pull/28241

The Whole Picture campaign has ended.
