### PR TITLE
Bump @guardian/libs to 26.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
-		"@guardian/libs": "26.0.0",
+		"@guardian/libs": "26.0.1",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2936,7 +2936,7 @@ __metadata:
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:6.0.1"
     "@guardian/identity-auth-frontend": "npm:8.1.0"
-    "@guardian/libs": "npm:26.0.0"
+    "@guardian/libs": "npm:26.0.1"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
     "@guardian/source-foundations": "npm:16.0.0"
@@ -3104,9 +3104,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/libs@npm:26.0.0":
-  version: 26.0.0
-  resolution: "@guardian/libs@npm:26.0.0"
+"@guardian/libs@npm:26.0.1":
+  version: 26.0.1
+  resolution: "@guardian/libs@npm:26.0.1"
   dependencies:
     "@guardian/ophan-tracker-js": "npm:2.2.10"
   peerDependencies:
@@ -3116,7 +3116,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/3ccd52f63345282ef19c9b24d12f3f643f159583d918eebd549e160405cb0fab407185812a709a948ce9b20ef8be45dee8381a0d7390d89e5d7f0d61f1a9b6b6
+  checksum: 10c0/c6b04143860528adfbff2edcca79ae723371db22c8ef6583469ee62834c921b2a4c695be69148820a6c9cf55bcd7df382d62b313735d86ff548525d197307989
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?
 Bumping @guardian/libs to 26.0.1 which is the latest version. 

Tested by deploying to CODE and using monitoring tool.


