### PR TITLE
Remove `AbsoluteServerTimes` experiment

### DIFF
--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -70,15 +70,4 @@ trait JournalismSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  val AbsoluteServerTimes = Switch(
-    SwitchGroup.Journalism,
-    name = "absolute-server-times",
-    description = "Force times on the server to be absolute to improve caching",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/14686
Depends on: https://github.com/guardian/dotcom-rendering/pull/14660

## Background
The switch was introduced in:
* https://github.com/guardian/frontend/pull/27166

## Why?
We are now removing it because we never enabled it for long-term. This will simplify another piece of work: https://github.com/guardian/dotcom-rendering/pull/14660. See details [here](https://docs.google.com/document/d/1tecB_0ytdAK9XLcjTpumdHUD04-TCDuqDNsxlk5kCnI/edit?tab=t.0#heading=h.2736oayszx8j).



