### PR TITLE
Drop references to the carrot ad slot

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -78,7 +78,7 @@ class DevParametersHttpRequestHandler(
     "dll", // Disable lazy loading of ads
     "iasdebug", // IAS troubleshooting
     "cmpdebug", // CMP troubleshooting
-    "sfdebug", // enable spacefinder visualiser. '1' = inline ads (first pass), '2' = inline ads (second pass), 'carrot' = carrot ads
+    "sfdebug", // enable spacefinder visualiser. '1' = inline ads (first pass), '2' = inline ads (second pass)
     "rikerdebug", // enable debug logging for Canadian ad setup managed by the Globe and Mail
     "forceSendMetrics", // enable force sending of commercial metrics
     "multiSticky", // enable multiple sticky ads in the right column, for the purpose of qualitative testing

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -413,7 +413,7 @@
     padding: 0;
     margin: 0;
 
-    &:not(.ad-slot--im):not(.ad-slot--carrot):not(.ad-slot--offset-right) {
+    &:not(.ad-slot--im):not(.ad-slot--offset-right) {
         width: 100%;
     }
 
@@ -432,31 +432,6 @@
 .ad-slot--merchandising,
 .ad-slot--merchandising-high {
     min-height: 250px;
-}
-
-// See implementation on DCR
-// mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
-.ad-slot--carrot {
-    min-height: 0px;
-    padding: 0;
-    margin: 5px $gs-gutter $gs-baseline 0;
-
-    float: left;
-    clear: both;
-
-    @include mq($until: mobileLandscape) {
-        width: $gs-gutter * 6.5;
-        margin-bottom: $gs-baseline * 0.5;
-        margin-right: $gs-gutter * 0.5;
-    }
-
-    @include mq(mobileLandscape) {
-        width: gs-span(3);
-    }
-
-    @include mq(wide) {
-        margin-left: -1 * (gs-span(3) + $gs-gutter);
-    }
 }
 
 .ad-slot--fabric-v1 {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -38,7 +38,7 @@
             padding-right: gs-span(1) + $gs-gutter;
 
             // Unruly video expands to 100%; this negative right margin affects Unruly on Tablet
-            .ad-slot:not(.ad-slot--im):not(.ad-slot--unruly):not(.ad-slot--carrot) {
+            .ad-slot:not(.ad-slot--im):not(.ad-slot--unruly) {
                 margin-right: -1 * (gs-span(1) + $gs-gutter);
             }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -37,7 +37,7 @@
             padding-right: gs-span(1) + $gs-gutter;
 
             // Unruly video expands to 100%; this negative right margin affects Unruly on Tablet
-            .ad-slot:not(.ad-slot--im):not(.ad-slot--unruly):not(.ad-slot--carrot) {
+            .ad-slot:not(.ad-slot--im):not(.ad-slot--unruly) {
                 margin-right: -1 * (gs-span(1) + $gs-gutter);
             }
 


### PR DESCRIPTION
## What does this change?
The carrot ad slot has been deprecated, not many references here in frontend to tidy up!