### PR TITLE
Extend the Admiral AB test switch by one month

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,7 +44,7 @@ trait ABTestSwitches {
     "Testing the Admiral integration for adblock recovery on theguardian.com",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 10, 23)),
+    sellByDate = Some(LocalDate.of(2025, 11, 26)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are extending the AB test for Admiral Adblock Recovery by one month to allow a smoother handover to another team

## What does this change?

Extend the Admiral AB test switch by one month