### PR TITLE
Support new media atom fields

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -255,6 +255,7 @@ object PressedContentFormat {
   implicit val imageMediaFormat: OFormat[ImageMedia] = Json.format[ImageMedia]
   implicit val videoMediaFormat: OFormat[VideoMedia] = Json.format[VideoMedia]
   implicit val videoElementFormat: OFormat[VideoElement] = Json.format[VideoElement]
+  implicit val assetDimensionsFormat: OFormat[AssetDimensions] = Json.format[AssetDimensions]
   implicit val mediaAssetFormat: OFormat[MediaAsset] = Json.format[MediaAsset]
   implicit val mediaAtomFormat: OFormat[MediaAtom] = Json.format[MediaAtom]
   implicit val mediaTypeFormat: MediaTypeFormat.type = MediaTypeFormat

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -434,12 +434,14 @@ object MapBlockElement {
 case class MediaAtomBlockElementMediaAsset(
     url: String,
     mimeType: Option[String],
+    dimensions: Option[AssetDimensions],
+    aspectRatio: Option[String],
 )
 object MediaAtomBlockElementMediaAsset {
   implicit val MediaAtomBlockElementMediaAssetWrites: Writes[MediaAtomBlockElementMediaAsset] =
     Json.writes[MediaAtomBlockElementMediaAsset]
   def fromMediaAsset(asset: MediaAsset): MediaAtomBlockElementMediaAsset = {
-    MediaAtomBlockElementMediaAsset(asset.id, asset.mimeType)
+    MediaAtomBlockElementMediaAsset(asset.id, asset.mimeType, asset.dimensions, asset.aspectRatio)
   }
 }
 case class MediaAtomBlockElement(
@@ -452,6 +454,7 @@ case class MediaAtomBlockElement(
     expired: Option[Boolean],
     activeVersion: Option[Long],
     channelId: Option[String],
+    videoPlayerFormat: Option[VideoPlayerFormat],
 ) extends PageElement
 object MediaAtomBlockElement {
   implicit val MediaAtomBlockElementWrites: Writes[MediaAtomBlockElement] = Json.writes[MediaAtomBlockElement]
@@ -1313,6 +1316,7 @@ object PageElement {
                     mediaAtom.expired,
                     mediaAtom.activeVersion,
                     mediaAtom.channelId,
+                    mediaAtom.videoPlayerFormat,
                   ),
                 )
             }

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -396,9 +396,10 @@ class ContentTest
     val contentNoByline = content("video", Nil).content
     val contentWithByline = content("video", Nil, byline).content
 
-    val mediaAtomWithSource = Some(MediaAtom("", "", Nil, "", None, atomSource, None, None, None, None, None))
-    val mediaAtomWithNoSource = Some(MediaAtom("", "", Nil, "", None, None, None, None, None, None, None))
-    val mediaAtomWithEmptySource = Some(MediaAtom("", "", Nil, "", None, emptySource, None, None, None, None, None))
+    val mediaAtomWithSource = Some(MediaAtom("", "", Nil, "", None, atomSource, None, None, None, None, None, None))
+    val mediaAtomWithNoSource = Some(MediaAtom("", "", Nil, "", None, None, None, None, None, None, None, None))
+    val mediaAtomWithEmptySource =
+      Some(MediaAtom("", "", Nil, "", None, emptySource, None, None, None, None, None, None))
 
     Video(contentNoByline, None, None).bylineWithSource should be(None)
     Video(contentNoByline, videoSource, None).bylineWithSource should be(videoSource.map(s => s"Source: $s"))

--- a/common/test/views/fragments/atoms/YoutubeSpec.scala
+++ b/common/test/views/fragments/atoms/YoutubeSpec.scala
@@ -21,6 +21,8 @@ class YoutubeSpec extends MixedPlaySpec {
             platform = Youtube,
             mimeType = None,
             assetType = Video,
+            dimensions = None,
+            aspectRatio = None,
           ),
         ),
         title = "",
@@ -31,6 +33,7 @@ class YoutubeSpec extends MixedPlaySpec {
         activeVersion = None,
         channelId = None,
         trailImage = None,
+        videoPlayerFormat = None,
       )
       val displayCaption = false
       val view = views.html.fragments.atoms

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -34,6 +34,8 @@ class AtomCleanerTest extends AnyFlatSpec with Matchers with WithTestApplication
       platform = MediaAssetPlatform.Youtube,
       mimeType = None,
       assetType = Video,
+      dimensions = None,
+      aspectRatio = None,
     )
 
   val youTubeAtom = Some(
@@ -53,6 +55,7 @@ class AtomCleanerTest extends AnyFlatSpec with Matchers with WithTestApplication
           activeVersion = None,
           channelId = None,
           trailImage = Some(image),
+          videoPlayerFormat = None,
         ),
       ),
       interactives = Nil,


### PR DESCRIPTION
Co-Authored-By: Jonathon Herbert <jonathon.herbert@guardian.co.uk>

## What does this change?

Adds frontend support for the new media atom fields added here: https://github.com/guardian/content-atom/pull/184

These fields have been available in the scala client since [v39.0.0](https://github.com/guardian/content-api-scala-client/releases/tag/v39.0.0).

This will allow us to start using them in DCR.

## Screenshots

Run frontend locally and visit:

http://localhost:9000/world/2025/nov/19/moscow-passes-laws-to-boost-defences-against-ukrainian-strikes.json?dcr=true

Note the new fields `aspectRatio`, `dimensions`, and `videoPlayerFormat` are all coming through:

<img width="1391" height="662" alt="Screenshot 2025-11-19 at 16 23 53" src="https://github.com/user-attachments/assets/41efcee4-7545-4523-bed6-c70393600689" />

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering - yes, I ran DCR locally and visited [here](http://localhost:3030/Article/https://www.theguardian.com/world/2025/nov/19/moscow-passes-laws-to-boost-defences-against-ukrainian-strikes), all seems fine
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->

## Related PRs

- [content-atom](https://github.com/guardian/content-atom/pull/184)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3218)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3219)
- [content-api-models](https://github.com/guardian/content-api-models/pull/271)
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3220)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/460)
- [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/369)
- [frontend](https://github.com/guardian/frontend/pull/28326) <- you are here
- [DCR](https://github.com/guardian/dotcom-rendering/pull/14843)