### PR TITLE
Highlights client side multivariant test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -66,7 +66,7 @@ trait ABTestSwitches {
     "Allow personalised highlights to be shown on the front page",
     owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 12, 20)),
+    sellByDate = Some(LocalDate.of(2025, 12, 4)),
     exposeClientSide = true,
     highImpact = false,
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -59,4 +59,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-personalised-highlights",
+    "Allow personalised highlights to be shown on the front page",
+    owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2025, 12, 20)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import {personalisedHighlights} from "common/modules/experiments/tests/personalised-highlights";
 import { auxiaSignInGate } from './tests/auxia-sign-in-gate';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -10,5 +11,6 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
-	auxiaSignInGate
+	auxiaSignInGate,
+	personalisedHighlights
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/personalised-highlights.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/personalised-highlights.js
@@ -1,0 +1,34 @@
+
+export const personalisedHighlights = {
+	id: 'PersonalisedHighlights',
+	start: '2025-10-29',
+	expiry: '2025-12-04',
+	author: 'Anna Beddow',
+	description: 'Allow user behaviour to personalise the ordering of cards in the highlights container.',
+    audience: 0,
+	audienceOffset: 0,
+	successMeasure: '',
+	audienceCriteria: '',
+	idealOutcome: '',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: () => {},
+		},
+        {
+            id: 'click-tracking',
+            test: () => {},
+        },
+        {
+            id: 'view-tracking',
+            test: () => {}
+        },
+        {
+            id: 'click-and-view-tracking',
+            test: () => {},
+        },
+	],
+};
+


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
Adds the boilerplate for a multivariant client side test for personalising the order of the highlights container. The test will have 1 control and 3 variants (click-tracking, view-tracking, click-and-view-tracking). 

For initial testing purposes, this has been set up as a 0% test.

We are still finalising requirements from D&I so some details of the test will change (eg audience segment size). 