### PR TITLE
AWS STS v2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,7 @@ val common = library("common")
       awsKinesis,
       awsS3,
       awsSns,
-      awsSts, // AWS SDK v1 still used for CAPI-preview related code for now
-      awsV2Sts, // AWS SDK v2 used for Fronts API access
+      awsV2Sts,
       awsSqs,
       awsSsm,
       eTagCachingS3,
@@ -70,7 +69,7 @@ val common = library("common")
       pekkoSerializationJackson,
       pekkoActorTyped,
       janino,
-    ) ++ jackson
+    ) ++ jackson,
   )
 
 val commonWithTests = withTests(common)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -244,10 +244,12 @@ class GuardianConfiguration extends GuLogging {
     lazy val capiPreviewRoleToAssume: Option[String] =
       configuration.getStringProperty("content.api.preview.roleToAssume")
 
-    lazy val capiPreviewCredentials: AWSCredentialsProvider = new AWSCredentialsProviderChain(
-      Seq(new ProfileCredentialsProvider("capi")) ++
-        capiPreviewRoleToAssume.map(new STSAssumeRoleSessionCredentialsProvider.Builder(_, "capi").build()): _*,
-    )
+    lazy val capiPreviewCredentials: software.amazon.awssdk.auth.credentials.AwsCredentialsProvider = {
+      import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
+      capiPreviewRoleToAssume
+        .map(roleArn => utils.AWSv2.stsCredentials("capi", roleArn, sessionName = "capi"))
+        .getOrElse(ProfileCredentialsProvider.create("capi"))
+    }
 
     lazy val nextPreviousPageSize: Int =
       configuration.getIntegerProperty("content.api.nextPreviousPageSize").getOrElse(50)

--- a/common/app/utils/AWSv2.scala
+++ b/common/app/utils/AWSv2.scala
@@ -36,12 +36,19 @@ object AWSv2 {
 
   val STS: StsClient = build[StsClient, StsClientBuilder](StsClient.builder())
 
-  def stsCredentials(devProfile: String, roleArn: String): AwsCredentialsProvider = credentialsForDevAndProd(
+  /** Assume a role (roleArn) with STS while allowing local dev to fall back to a profile. sessionName defaults to
+    * "frontend" but can be overridden per caller.
+    */
+  def stsCredentials(
+      devProfile: String,
+      roleArn: String,
+      sessionName: String = "frontend",
+  ): AwsCredentialsProvider = credentialsForDevAndProd(
     devProfile,
     StsAssumeRoleCredentialsProvider
       .builder()
       .stsClient(STS)
-      .refreshRequest(AssumeRoleRequest.builder.roleSessionName("frontend").roleArn(roleArn).build)
+      .refreshRequest(AssumeRoleRequest.builder.roleSessionName(sessionName).roleArn(roleArn).build)
       .build(),
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -95,7 +95,7 @@ object Dependencies {
   val playJson = "org.playframework" %% "play-json" % playJsonVersion
   val playJsonJoda = "org.playframework" %% "play-json-joda" % playJsonVersion
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.16"
-  val capiAws = "com.gu" %% "content-api-client-aws" % "0.7.6"
+  val capiAws = "com.gu" %% "content-api-client-aws" % "1.0.1"
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "5.3.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,6 @@ object Dependencies {
   val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
   val awsSes = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion
   val awsSns = "com.amazonaws" % "aws-java-sdk-sns" % awsVersion
-  val awsSts = "com.amazonaws" % "aws-java-sdk-sts" % awsVersion
   val awsV2Sts = "software.amazon.awssdk" % "sts" % awsSdk2Version
   val awsSqs = "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion
   val awsSsm = "com.amazonaws" % "aws-java-sdk-ssm" % awsVersion


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR removes all remaining AWS STS v1 usages, migrating CAPI preview credential acquisition to AWS SDK v2 (including a flexible sessionName) and bumping content-api-client-aws to 1.0.1 where the signer accepts v2 credentials. It deletes the legacy v1 STS dependency and streamlines build configuration.
## What does this change?
Resolves https://github.com/guardian/frontend/issues/26515