### PR TITLE
Extend dark mode test expiry date

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -51,6 +51,6 @@ object DarkModeWeb
       name = "dark-mode-web",
       description = "Enable dark mode on web",
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 10, 31),
+      sellByDate = LocalDate.of(2026, 1, 30),
       participationGroup = Perc0D,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?

Extends expiry date of the dark mode test by another 3 months as it is about to expire 🎃