### PR TITLE
Update details of personalised highlights test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/personalised-highlights.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/personalised-highlights.js
@@ -1,16 +1,18 @@
 
 export const personalisedHighlights = {
 	id: 'PersonalisedHighlights',
-	start: '2025-10-29',
-	expiry: '2025-12-04',
+	start: '2025-11-17',
+	expiry: '2025-12-01',
 	author: 'Anna Beddow',
 	description: 'Allow user behaviour to personalise the ordering of cards in the highlights container.',
-    audience: 0,
-	audienceOffset: 0,
+    audience: 0.75,
+    audienceOffset: 0.75,
 	successMeasure: '',
-	audienceCriteria: '',
-	idealOutcome: '',
+	audienceCriteria: 'All users, globally.',
+    idealOutcome:
+        'Increase click through rate on highlights container',
 	showForSensitive: true,
+
 	canRun: () => true,
 	variants: [
 		{


### PR DESCRIPTION
## What does this change?
Update personalise highlights test details to the following
	start: '2025-11-17',
	expiry: '2025-12-01',
	audience: 0.75,
	
The expiry date is for 2 weeks time. Its possible this test will be turned off after 1 week, depending on when significance is reached. 

**This increases the audience share from 0% to 75%**

## Why?
We would like to turn this test live for up to 2 weeks.

DCR companion PR is available https://github.com/guardian/dotcom-rendering/pull/14849