### PR TITLE
Upgrade to SQS AWS SDK v2

### DIFF
--- a/common/app/common/SQSQueues.scala
+++ b/common/app/common/SQSQueues.scala
@@ -1,105 +1,84 @@
 package common
 
-import java.util.concurrent.{Future => JavaFuture}
-
-import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.sqs.AmazonSQSAsync
-import com.amazonaws.services.sqs.model.{Message => AWSMessage, _}
 import play.api.libs.json.{Json, Reads, Writes}
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.{
+  ChangeMessageVisibilityRequest,
+  ChangeMessageVisibilityResponse,
+  DeleteMessageRequest,
+  Message => AWSMessage,
+  ReceiveMessageRequest,
+  SendMessageRequest,
+  SendMessageResponse,
+}
 
 import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success}
-
-object SQSQueues {
-  implicit class RichAmazonSQSAsyncClient(client: AmazonSQSAsync) {
-    private def createHandler[A <: com.amazonaws.AmazonWebServiceRequest, B]() = {
-      val promise = Promise[B]()
-
-      val handler = new AsyncHandler[A, B] {
-        override def onSuccess(request: A, result: B): Unit = promise.complete(Success(result))
-
-        override def onError(exception: Exception): Unit = promise.complete(Failure(exception))
-      }
-
-      (promise.future, handler)
-    }
-
-    private def asFuture[A <: com.amazonaws.AmazonWebServiceRequest, B](f: AsyncHandler[A, B] => JavaFuture[B]) = {
-      val (future, handler) = createHandler[A, B]()
-      f(handler)
-      future
-    }
-
-    def receiveMessageFuture(request: ReceiveMessageRequest): Future[ReceiveMessageResult] =
-      asFuture[ReceiveMessageRequest, ReceiveMessageResult](client.receiveMessageAsync(request, _))
-
-    def deleteMessageFuture(request: DeleteMessageRequest): Future[DeleteMessageResult] =
-      asFuture[DeleteMessageRequest, DeleteMessageResult](client.deleteMessageAsync(request, _))
-
-    def sendMessageFuture(request: SendMessageRequest): Future[SendMessageResult] =
-      asFuture[SendMessageRequest, SendMessageResult](client.sendMessageAsync(request, _))
-
-    def changeMessageVisibilityFuture(request: ChangeMessageVisibilityRequest): Future[ChangeMessageVisibilityResult] =
-      asFuture[ChangeMessageVisibilityRequest, ChangeMessageVisibilityResult](
-        client.changeMessageVisibilityAsync(request, _),
-      )
-  }
-}
+import scala.concurrent.{ExecutionContext, Future}
 
 case class MessageId(get: String) extends AnyVal
 case class ReceiptHandle(get: String) extends AnyVal
 case class Message[A](id: MessageId, get: A, handle: ReceiptHandle)
 
-class MessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implicit executionContext: ExecutionContext) {
+class MessageQueue[A](client: SqsAsyncClient, queueUrl: String)(implicit executionContext: ExecutionContext) {
 
-  import SQSQueues._
-
-  protected def sendMessage(sendRequest: SendMessageRequest): Future[SendMessageResult] = {
-    client.sendMessageFuture(sendRequest)
+  protected def sendMessage(sendRequest: SendMessageRequest): Future[SendMessageResponse] = {
+    client.sendMessage(sendRequest).asScala
   }
 
-  def retryMessageAfter(handle: ReceiptHandle, timeoutSeconds: Int): Future[ChangeMessageVisibilityResult] = {
-    client.changeMessageVisibilityFuture(new ChangeMessageVisibilityRequest(queueUrl, handle.get, timeoutSeconds))
+  def retryMessageAfter(handle: ReceiptHandle, timeoutSeconds: Int): Future[ChangeMessageVisibilityResponse] = {
+    client
+      .changeMessageVisibility(
+        ChangeMessageVisibilityRequest
+          .builder()
+          .queueUrl(queueUrl)
+          .receiptHandle(handle.get)
+          .visibilityTimeout(timeoutSeconds)
+          .build(),
+      )
+      .asScala
   }
 
   protected def receiveMessages(receiveRequest: ReceiveMessageRequest): Future[mutable.Buffer[AWSMessage]] = {
-    client.receiveMessageFuture(receiveRequest.withQueueUrl(queueUrl)) map { response =>
-      response.getMessages.asScala
+    client.receiveMessage(receiveRequest.toBuilder.queueUrl(queueUrl).build()).asScala map { response =>
+      response.messages().asScala
     }
   }
 
   protected def deleteMessage(handle: ReceiptHandle): Future[Unit] = {
     client
-      .deleteMessageFuture(
-        new DeleteMessageRequest()
-          .withQueueUrl(queueUrl)
-          .withReceiptHandle(handle.get),
+      .deleteMessage(
+        DeleteMessageRequest
+          .builder()
+          .queueUrl(queueUrl)
+          .receiptHandle(handle.get)
+          .build(),
       )
+      .asScala
       .map(_ => ())
   }
 
 }
 
 /** Utility class for SQS queues that pass simple string messages */
-case class TextMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implicit executionContext: ExecutionContext)
+case class TextMessageQueue[A](client: SqsAsyncClient, queueUrl: String)(implicit executionContext: ExecutionContext)
     extends MessageQueue[A](client, queueUrl)(executionContext) {
 
   def receive(request: ReceiveMessageRequest): Future[Seq[Message[String]]] = {
     receiveMessages(request) map { messages =>
       messages.toSeq map { message =>
         Message(
-          MessageId(message.getMessageId),
-          message.getBody,
-          ReceiptHandle(message.getReceiptHandle),
+          MessageId(message.messageId()),
+          message.body(),
+          ReceiptHandle(message.receiptHandle()),
         )
       }
     }
   }
 
   def receiveOne(request: ReceiveMessageRequest): Future[Option[Message[String]]] = {
-    receive(request.withMaxNumberOfMessages(1)) map { messages =>
+    receive(request.toBuilder.maxNumberOfMessages(1).build()) map { messages =>
       messages.toList match {
         case message :: Nil => Some(message)
         case Nil            => None
@@ -113,30 +92,30 @@ case class TextMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implici
 }
 
 /** Utility class for SQS queues that use JSON to serialize their messages */
-case class JsonMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implicit executionContext: ExecutionContext)
+case class JsonMessageQueue[A](client: SqsAsyncClient, queueUrl: String)(implicit executionContext: ExecutionContext)
     extends MessageQueue[A](client, queueUrl)(executionContext) {
 
-  def send(a: A)(implicit writes: Writes[A]): Future[SendMessageResult] =
-    sendMessage(new SendMessageRequest().withQueueUrl(queueUrl).withMessageBody(Json.stringify(Json.toJson(a))))
+  def send(a: A)(implicit writes: Writes[A]): Future[SendMessageResponse] =
+    sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody(Json.stringify(Json.toJson(a))).build())
 
   def receive(request: ReceiveMessageRequest)(implicit reads: Reads[A]): Future[Seq[Message[A]]] = {
     receiveMessages(request) map { messages =>
       messages.toSeq map { message =>
         Message(
-          MessageId(message.getMessageId),
-          Json.fromJson[A](Json.parse(message.getBody)) getOrElse {
+          MessageId(message.messageId()),
+          Json.fromJson[A](Json.parse(message.body())) getOrElse {
             throw new RuntimeException(
-              s"Couldn't parse JSON for message with ID ${message.getMessageId}: '${message.getBody}'",
+              s"Couldn't parse JSON for message with ID ${message.messageId()}: '${message.body}'",
             )
           },
-          ReceiptHandle(message.getReceiptHandle),
+          ReceiptHandle(message.receiptHandle),
         )
       }
     }
   }
 
   def receiveOne(request: ReceiveMessageRequest)(implicit reads: Reads[A]): Future[Option[Message[A]]] = {
-    receive(request.withMaxNumberOfMessages(1)) map { messages =>
+    receive(request.toBuilder.maxNumberOfMessages(1).build()) map { messages =>
       messages.toList match {
         case message :: Nil => Some(message)
         case Nil            => None

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -262,7 +262,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         // temporary logging to investigate fronts weirdness on code - log entire front out
         if (Configuration.environment.stage == "CODE") {
           logInfoWithCustomFields(
-            s"Pressed data for front $path : ${Json.stringify(Json.toJson(pressedFronts.full))} ",
+            s"Pressed data for front $path",
             customFields = List(
               LogFieldString("messageId", messageId),
               LogFieldString("pressPath", path),

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -26,8 +26,6 @@ class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress)(implicit
 
   override lazy val queue: JsonMessageQueue[SNSNotification] =
     (Configuration.faciatool.frontPressCronQueue map { queueUrl =>
-      val credentials = Configuration.aws.mandatoryCredentials
-
       JsonMessageQueue[SNSNotification](
         SqsAsyncClient
           .builder()

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -1,12 +1,13 @@
 package frontpress
 
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.gu.facia.api.models.TrainingPriority
 import common.FaciaPressMetrics.FrontPressCronSuccess
 import common.{JsonMessageQueue, SNSNotification}
 import conf.switches.Switches.FrontPressJobSwitch
 import conf.Configuration
 import services.ConfigAgent
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import utils.AWSv2
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -28,9 +29,10 @@ class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress)(implicit
       val credentials = Configuration.aws.mandatoryCredentials
 
       JsonMessageQueue[SNSNotification](
-        AmazonSQSAsyncClient.asyncBuilder
-          .withCredentials(credentials)
-          .withRegion(conf.Configuration.aws.region)
+        SqsAsyncClient
+          .builder()
+          .credentialsProvider(AWSv2.credentials)
+          .region(AWSv2.region)
           .build(),
         queueUrl,
       )

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -1,12 +1,13 @@
 package frontpress
 
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.gu.facia.api.models.faciapress.{Draft, FrontPath, Live, PressJob}
 import common.LoggingField.{LogFieldLong, LogFieldString}
 import common._
 import conf.Configuration
 import org.joda.time.DateTime
 import services._
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import utils.AWSv2
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -18,7 +19,11 @@ class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFron
     val credentials = Configuration.aws.mandatoryCredentials
 
     JsonMessageQueue[PressJob](
-      AmazonSQSAsyncClient.asyncBuilder.withCredentials(credentials).withRegion(conf.Configuration.aws.region).build(),
+      SqsAsyncClient
+        .builder()
+        .credentialsProvider(AWSv2.credentials)
+        .region(AWSv2.region)
+        .build(),
       queueUrl,
     )
   }) getOrElse {

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -16,8 +16,6 @@ class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFron
 ) extends JsonQueueWorker[PressJob]
     with GuLogging {
   override lazy val queue: JsonMessageQueue[PressJob] = (Configuration.faciatool.frontPressToolQueue map { queueUrl =>
-    val credentials = Configuration.aws.mandatoryCredentials
-
     JsonMessageQueue[PressJob](
       SqsAsyncClient
         .builder()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   val awsSes = "software.amazon.awssdk" % "ses" % awsSdk2Version
   val awsSns = "software.amazon.awssdk" % "sns" % awsSdk2Version
   val awsSts = "software.amazon.awssdk" % "sts" % awsSdk2Version
-  val awsSqs = "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion
+  val awsSqs = "software.amazon.awssdk" % "sqs" % awsSdk2Version
   val awsSsm = "software.amazon.awssdk" % "ssm" % awsSdk2Version
   val awsElasticloadbalancing = "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion
   val closureCompiler = "com.google.javascript" % "closure-compiler" % "v20240317"


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/26516

## Background

There are two queues in the fronts architecture:
1. [`FrontPressCron`](https://github.com/guardian/frontend/blob/6e2c33e2981f5315c1796c4dd5556656cd1d76b7/facia-press/app/frontpress/FrontPressCron.scala). It receives notifications from the [`RefreshFrontsJob`](https://github.com/guardian/frontend/blob/6e2c33e2981f5315c1796c4dd5556656cd1d76b7/admin/app/jobs/RefreshFrontsJob.scala#L46) in the admin app on a cron schedule.
2. [`ToolPressQueueWorker`](https://github.com/guardian/frontend/blob/6e2c33e2981f5315c1796c4dd5556656cd1d76b7/facia-press/app/frontpress/ToolPressQueueWorker.scala). It receives press jobs from the fronts tool whenever a front gets updated.

<img width="857" height="1110" alt="image" src="https://github.com/user-attachments/assets/8c82a323-6c42-413a-acda-3531aadc5057" />


See more about fronts architecture [here](https://github.com/guardian/frontend/blob/6e2c33e2981f5315c1796c4dd5556656cd1d76b7/docs/02-architecture/02-fronts-architecture.md)


## What does this change?
This PR updates the code for these two queues to AWS SDK v2.

## Why?
AWS SDK v1 reaches end-of-support on 31 of December

## Screenshots

Front pages are successfully pressed both when the cron job triggers them and when they are changed from the Fronts Tool.

| Before      | After      |
|-------------|------------|
| <img width="1775" height="1043" alt="image" src="https://github.com/user-attachments/assets/648c89dd-4e99-4128-9529-1ac1979c7965" /> | <img width="2196" height="1044" alt="image" src="https://github.com/user-attachments/assets/772fc60f-9a8e-4fda-b68d-00a1d7d48f81" /> |


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
