### PR TITLE
Live harness preview endpoint

### DIFF
--- a/article/app/utils/LiveHarness.scala
+++ b/article/app/utils/LiveHarness.scala
@@ -1,0 +1,65 @@
+package utils
+
+import com.gu.contentapi.client.model.v1.{BlockElement, Blocks, ContentAtomElementFields, ElementType}
+import model.ArticlePage
+import model.content.InteractiveAtom
+import play.api.libs.json.{Json, Reads}
+
+case class LiveHarnessInteractiveAtom(
+    id: String,
+    title: String,
+    css: String,
+    html: String,
+    js: String,
+    weighting: String,
+)
+
+object LiveHarnessInteractiveAtom {
+  implicit val reads: Reads[LiveHarnessInteractiveAtom] = Json.reads
+}
+
+object LiveHarness {
+  def injectInteractiveAtomsIntoArticle(
+      localAtoms: List[LiveHarnessInteractiveAtom],
+      article: ArticlePage,
+      blocks: Blocks,
+  ): (ArticlePage, Blocks) = {
+    val newAtomReferenceElements = localAtoms.map(localAtom => {
+      BlockElement(
+        `type` = ElementType.Contentatom,
+        assets = Seq.empty,
+        contentAtomTypeData = Some(
+          ContentAtomElementFields(
+            atomId = localAtom.id,
+            atomType = "interactive",
+            role = Some(localAtom.weighting),
+            isMandatory = None,
+          ),
+        ),
+      )
+    })
+    val newInteractiveAtoms = localAtoms.map(localAtom => {
+      InteractiveAtom(
+        id = localAtom.id,
+        `type` = "interactive",
+        title = localAtom.title,
+        css = localAtom.css,
+        html = localAtom.html,
+        mainJS = Some(localAtom.js),
+        docData = None,
+        placeholderUrl = None,
+      )
+    })
+    val newAtoms = article.article.content.atoms.map(_.copy(interactives = newInteractiveAtoms))
+    val newArticle =
+      article.copy(article = article.article.copy(content = article.article.content.copy(atoms = newAtoms)))
+    val newElements =
+      newAtomReferenceElements ++ blocks.body.flatMap(_.headOption.map(_.elements)).getOrElse(Seq.empty).toList
+    val newBlocks = blocks.copy(body = blocks.body.map(blocks => {
+      val firstBlock = blocks.headOption.map(_.copy(elements = newElements))
+      val restOfBlocks = blocks.tail
+      firstBlock.toList ++ restOfBlocks
+    }))
+    (newArticle, newBlocks)
+  }
+}

--- a/common/app/http/PanDomainAuthenticated.scala
+++ b/common/app/http/PanDomainAuthenticated.scala
@@ -1,0 +1,138 @@
+package http
+
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.gu.pandomainauth.PanDomain
+import com.gu.pandomainauth.model.{
+  Authenticated,
+  AuthenticatedUser,
+  Expired,
+  GracePeriod,
+  InvalidCookie,
+  NotAuthenticated,
+  NotAuthorized,
+}
+import common.Environment.{awsRegion, stage}
+import conf.Configuration.aws.mandatoryCredentials
+import scala.concurrent.duration.DurationInt
+import com.gu.pandomainauth.PublicSettings
+import com.gu.permissions.{PermissionDefinition, PermissionsProvider}
+
+trait PanDomainAuthenticated {
+
+  private val desktopDomain = stage match {
+    case "DEV"  => "local"
+    case "CODE" => "code"
+    case "PROD" => "prod"
+  }
+
+  lazy val domain: String = s"$desktopDomain.integration.flexible.gnm"
+  lazy val bucket: String = "pan-domain-auth-settings"
+  lazy val system = "frontend"
+
+  lazy val s3: AmazonS3 = AmazonS3ClientBuilder
+    .standard()
+    .withCredentials(mandatoryCredentials)
+    .withRegion(awsRegion)
+    .build()
+
+  private val settingsRefresher = {
+    val theRefresher = new PublicSettings(
+      settingsFileKey = s"$domain.settings",
+      bucketName = "pan-domain-auth-settings",
+      s3Client = s3,
+    )
+    theRefresher.start()
+    theRefresher
+  }
+
+  trait AuthenticationResult
+
+  case class AuthenticationFailure(status: Int, reason: String) extends AuthenticationResult
+
+  case class AuthenticationSuccess(user: Option[AuthenticatedUser]) extends AuthenticationResult
+
+  protected def evaluatePandaAuth(
+      authorizationHeader: String,
+      permissions: PermissionsProvider,
+  ): Option[AuthenticationResult] = {
+    val authHeaderParts = authorizationHeader.split(" ")
+
+    val requiredPermission = PermissionDefinition(
+      name = "preview_access",
+      app = "frontend",
+    )
+
+    if (authHeaderParts.length != 2 || authHeaderParts.head.toLowerCase != "gu-desktop-panda") {
+      Some(
+        AuthenticationFailure(
+          status = 401,
+          reason = "presented Authorization header using incorrect scheme",
+        ),
+      )
+    } else {
+      val authStatus = PanDomain.authStatus(
+        cookieData = authHeaderParts.last,
+        verification = settingsRefresher.verification,
+        validateUser = PanDomain.guardianValidation,
+        apiGracePeriod = 9.hours.toMillis,
+        system = "login-desktop",
+        cacheValidation = true,
+        forceExpiry = false,
+      )
+
+      authStatus match {
+        case Expired(authedUser) =>
+          Some(
+            AuthenticationFailure(
+              status = 419,
+              reason = s"user ${authedUser.user.email} login expired, returning 419",
+            ),
+          )
+
+        case NotAuthorized(authedUser) =>
+          Some(
+            AuthenticationFailure(
+              status = 403,
+              reason = s"user ${authedUser.user.email} failed validation",
+            ),
+          )
+
+        case InvalidCookie(exception) =>
+          Some(
+            AuthenticationFailure(
+              status = 403,
+              reason = "could not validate cookie",
+            ),
+          )
+
+        case NotAuthenticated =>
+          Some(
+            AuthenticationFailure(
+              status = 401,
+              reason = "user did not present a token",
+            ),
+          )
+
+        case GracePeriod(authedUser)
+            if permissions.hasPermission(
+              requiredPermission,
+              authedUser.user.email,
+            ) =>
+          // continue
+          Some(AuthenticationSuccess(user = Some(authedUser)))
+
+        case Authenticated(authedUser) if (permissions.hasPermission(requiredPermission, authedUser.user.email)) =>
+          // continue
+          Some(AuthenticationSuccess(user = Some(authedUser)))
+
+        case _ => // authed but not allowed ComposerAccess
+          Some(
+            AuthenticationFailure(
+              status = 403,
+              reason = "insufficient-permissions",
+            ),
+          )
+      }
+    }
+  }
+}

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -191,6 +191,7 @@ GET     /*path.json                 controllers.ArticleController.renderJson(pat
 GET     /*path/email                controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
+POST    /*path                      controllers.ArticleController.renderLiveHarness(path)
 
 
 # Don't forward requests for favicon.ico to the Content API


### PR DESCRIPTION
Builds on #28328 by adding a `POST` endpoint to the Preview project that allows for interactive atoms in local development to be injected into their parent article and have the full page HTML returned.