### PR TITLE
Switch for no-auxia control group

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -40,6 +40,17 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-no-auxia-sign-in-gate",
+    "Defines a control group who should not have sign-in gate journeys handled by Auxia",
+    owners = Seq(Owner.withEmail("growth@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2027, 11, 1)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
+  Switch(
+    ABTests,
     "ab-admiral-adblock-recovery",
     "Testing the Admiral integration for adblock recovery on theguardian.com",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),


### PR DESCRIPTION
This is to keep a fixed 5% of the global audience excluded from Auxia for sign-in gates.
See DCR PR for details: https://github.com/guardian/dotcom-rendering/pull/14775
Any dotcom AB test has to be defined in frontend as well.