### PR TITLE
Elastic Load Balancing aws sdk v2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   val awsSts = "software.amazon.awssdk" % "sts" % awsSdk2Version
   val awsSqs = "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion
   val awsSsm = "software.amazon.awssdk" % "ssm" % awsSdk2Version
-  val awsElasticloadbalancing = "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion
+  val awsElasticloadbalancing = "software.amazon.awssdk" % "elasticloadbalancing" % awsSdk2Version
   val closureCompiler = "com.google.javascript" % "closure-compiler" % "v20240317"
   val commonsHttpClient = "commons-httpclient" % "commons-httpclient" % "3.1"
   val commonsLang = "commons-lang" % "commons-lang" % "2.6"


### PR DESCRIPTION
## What is the value of this and can you measure success?
Bumps Elastic Load Balancing from AWS SDK v1 to v2: replacing aws-java-sdk-elasticloadbalancing with software.amazon.awssdk:elasticloadbalancing and migrate LoadBalancer.scala to the v2 client API.
Simplifies credentials via AWSv2.credentials and updates region handling.
[Tested on code ](https://riffraff.gutools.co.uk/deployment/view/934dba3c-1d90-4854-9b59-258314378ad1)
Resolves https://github.com/guardian/frontend/issues/26518
