### PR TITLE
Add a feature switch to enable CORS on looping videos

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -627,4 +627,15 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val EnableLoopVideoCORS = Switch(
+    SwitchGroup.Feature,
+    "enable-loop-video-cors",
+    "Enable CORS on loop videos",
+    owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+    sellByDate = Some(LocalDate.of(2026, 2, 16)),
+    safeState = Off,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
Adds a feature switch to enable a controlled rollout of CORS on looping video on DCR.