### PR TITLE
Stop logging entire front JSON in facia-press CODE

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -262,7 +262,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         // temporary logging to investigate fronts weirdness on code - log entire front out
         if (Configuration.environment.stage == "CODE") {
           logInfoWithCustomFields(
-            s"Pressed data for front $path : ${Json.stringify(Json.toJson(pressedFronts.full))} ",
+            s"Pressed data for front $path",
             customFields = List(
               LogFieldString("messageId", messageId),
               LogFieldString("pressPath", path),


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
