### PR TITLE
Remove feature switch and 0% test to enable CORS on looping videos

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -628,14 +628,4 @@ trait FeatureSwitches {
     highImpact = false,
   )
 
-  val EnableLoopVideoCORS = Switch(
-    SwitchGroup.Feature,
-    "enable-loop-video-cors",
-    "Enable CORS on loop videos",
-    owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-    sellByDate = Some(LocalDate.of(2026, 2, 16)),
-    safeState = Off,
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,7 +15,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       GoogleOneTap,
       ConsentOrPayEuropeInternalTest,
       LabsRedesign,
-      LoopVideoLoad,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -54,12 +53,4 @@ object DarkModeWeb
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2026, 1, 30),
       participationGroup = Perc0D,
-    )
-object LoopVideoLoad
-    extends Experiment(
-      name = "loop-video-load",
-      description = "Monitor loop video load times",
-      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2026, 1, 30),
-      participationGroup = Perc0E,
     )


### PR DESCRIPTION
Remove feature switch and 0% test to enable CORS on looping videos. This has now been fully tested and can be safely rolled out. 

DCR companion PR is https://github.com/guardian/dotcom-rendering/pull/14806