### PR TITLE
Bump `pan-domain-authentication` to 13.0.0

### DIFF
--- a/common/app/http/GuardianAuthWithExemptions.scala
+++ b/common/app/http/GuardianAuthWithExemptions.scala
@@ -1,7 +1,6 @@
 package http
 
 import com.amazonaws.regions.Regions
-import software.amazon.awssdk.core.sync.ResponseTransformer
 import software.amazon.awssdk.services.s3.S3Client
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
@@ -58,13 +57,7 @@ class GuardianAuthWithExemptions(
   override lazy val panDomainSettings = PanDomainAuthSettingsRefresher(
     domain = toolsDomainSuffix,
     system,
-    new S3BucketLoader {
-      def inputStreamFetching(key: String) =
-        s3Client.getObject(
-          _.bucket("pan-domain-auth-settings").key(key),
-          ResponseTransformer.toInputStream(),
-        )
-    },
+    S3BucketLoader.forAwsSdkV2(s3Client, "pan-domain-auth-settings"),
   )
 
   override def authCallbackUrl = s"https://$toolsDomainPrefix.$toolsDomainSuffix$oauthCallbackPath"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.5.9" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.12"
-  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "9.0.2"
+  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "13.0.0"
   val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "4.0.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"


### PR DESCRIPTION
Bumps https://github.com/guardian/pan-domain-authentication to version 13.0.0. This is a prerequisite to work on adding a new auth method and endpoint to the preview project. (See https://github.com/guardian/frontend/pull/28328#issuecomment-3498249883.)