### PR TITLE
Extend expiration of user benefits cookies to 30 days

### DIFF
--- a/static/src/javascripts/projects/common/modules/userFeatures/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/userFeatures/user-features.ts
@@ -4,6 +4,7 @@
  * https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
  */
 
+import { removeCookie } from '@guardian/libs';
 import { getAuthStatus, isUserLoggedIn } from '../identity/api';
 import { AD_FREE_USER_COOKIE } from './cookies/adFree';
 import { ALLOW_REJECT_ALL_COOKIE } from './cookies/allowRejectAll';
@@ -22,36 +23,72 @@ export type UserBenefits = {
 };
 
 const refreshUserBenefits = async (): Promise<void> => {
-	if (
-		(await isUserLoggedIn()) &&
-		userBenefitsDataNeedsRefreshing()
-	) {
+	if ((await isUserLoggedIn()) && userBenefitsDataNeedsRefreshing()) {
 		await requestNewData();
 	}
 };
 
 const requestNewData = async () => {
 	const authStatus = await getAuthStatus();
-	if (
-		authStatus.kind !== 'SignedIn'
-	) {
+	if (authStatus.kind !== 'SignedIn') {
 		return Promise.reject('The user is not signed in');
 	}
 	return syncDataFromUserBenefitsApi(authStatus).then(persistResponse);
 };
 
+const USER_BENEFITS_COOKIE_EXPIRATION_IN_DAYS = 30;
+
+/**
+ * Persist the user benefits response to cookies
+ *
+ * If new cookies are added/removed/edited, update the persistUserBenefitsCookies function in Gateway.
+ * In gateway, the cookies are set after authentication.
+ *
+ * This code also exist in dotcom-rendering, so any changes here should be mirrored there.
+ *
+ * @param {UserBenefits} userBenefitsResponse
+ */
 const persistResponse = (userBenefitsResponse: UserBenefits) => {
 	createOrRenewCookie(USER_BENEFITS_EXPIRY_COOKIE);
+
+	// All of these user benefits cookies are now valid for 30 days. Previously
+	// they were short lived (1-2 days) but this resulted in edge cases where if
+	// a signed in user didn't visit the site for more than a couple of days
+	// when they returned their first page view wouldn't reflect their benefits
+	// (i.e. they would see ads). This is due to a race condition between the
+	// user benefits refresh and the ads code. However, we don't want to delay
+	// ads until after the user benefits have been refreshed as that would
+	// impact performance. So instead, extend the expiry of the cookie. Note:
+	// this may result in a user getting benefits they no longer have on the
+	// first returning pageview, but this will be correct from the second page
+	// view onwards. We think this is OK. This also means we now remove cookies
+	// if the user benefits response says they no longer have the benefit,
+	// rather than simply letting the cookie expire.
 	if (userBenefitsResponse.hideSupportMessaging) {
-		createOrRenewCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
+		createOrRenewCookie(
+			HIDE_SUPPORT_MESSAGING_COOKIE,
+			USER_BENEFITS_COOKIE_EXPIRATION_IN_DAYS,
+		);
+	} else {
+		removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
 	}
+
 	if (userBenefitsResponse.allowRejectAll) {
-		createOrRenewCookie(ALLOW_REJECT_ALL_COOKIE);
+		createOrRenewCookie(
+			ALLOW_REJECT_ALL_COOKIE,
+			USER_BENEFITS_COOKIE_EXPIRATION_IN_DAYS,
+		);
+	} else {
+		removeCookie({ name: ALLOW_REJECT_ALL_COOKIE });
 	}
+
 	if (userBenefitsResponse.adFree) {
-		// Ad free cookie has an expiry of 2 days from now
-		// See https://github.com/guardian/gateway/blob/52f810a88fa9ce23c6a794916251748718742c3d/src/server/lib/user-features.ts#L111-L115
-		createOrRenewCookie(AD_FREE_USER_COOKIE, 2);
+		createOrRenewCookie(
+			AD_FREE_USER_COOKIE,
+			USER_BENEFITS_COOKIE_EXPIRATION_IN_DAYS,
+		);
+	} else {
+		removeCookie({ name: AD_FREE_USER_COOKIE });
 	}
 };
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Before this change signed-in users who didn't visit the site for > 2 days would sometimes see ads on their first returning pageview, even if they have a product which gives them ad free access. This change makes this less likely to happen by extending the expiration of user benefits cookies.

## What does this change?

This PR extends the expiration of all user benefits cookies to 30 days - `GU_AF1`, `gu_allow_reject_all`, `gu_hide_support_messaging`.

Previously user benefits cookies were short lived (1-2 days) but this resulted in edge cases as described above. This is due to a race condition between the user benefits refresh and the ads code. However, we don't want to delay ads until after the user benefits have been refreshed as that would impact performance. So instead, extend the expiry of the cookie.

Note: this may result in a user getting benefits they no longer have on the first returning pageview, but this will be correct from the second page view onwards. We think this is OK.

This also means we now remove cookies if the user benefits response says they no longer have the benefit, rather than simply letting the cookie expire.

See also guardian/dotcom-rendering#14810.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
