### PR TITLE
Extend the expiry of the labs redesign switch by one month

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -622,7 +622,7 @@ trait FeatureSwitches {
     "guardian-labs-redesign",
     "Shows the new style labs containers and cards",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
-    sellByDate = Some(LocalDate.of(2025, 11, 18)),
+    sellByDate = Some(LocalDate.of(2025, 12, 16)),
     safeState = Off,
     exposeClientSide = true,
     highImpact = false,


### PR DESCRIPTION
## What does this change?

Sets the expiry date of the Guardian Labs Redesign feature switch to 16th December 2025

This matches the server-side experiment expiry date: 

https://github.com/guardian/frontend/blob/27631fa67a259bb7960cd3d2eceb3b71d282cafb/common/app/experiments/Experiments.scala#L46
