### PR TITLE
Add configuration file for scala-steward

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,0 +1,7 @@
+# This extends the main config found here: https://github.com/guardian/scala-steward-public-repos/blob/main/scala-steward.conf
+
+# Overrides the grouping rules from the main config. We want to update most dependencies individually,
+# to prevent PRs becoming too large and complex.
+pullRequests.grouping = [
+  { name = "aws", "title" = "chore(deps): AWS dependency updates", "filter" = [{"group" = "software.amazon"}, {"group" = "software.amazon.*"}, {"group" = "com.amazonaws"}, {"group" = "com.amazonaws.*"}] },
+]


### PR DESCRIPTION
The main change is to override the grouping rules, to group fewer changes than the default config. We've found that in this project the resulting grouped PRs are large and complex (#27455), and therefore hard to review. We'd like smaller PRs with fewer changes.
