### PR TITLE
Bump `editorial-permissions-client`

### DIFF
--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -13,7 +13,6 @@ import play.api.http.HttpConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 import services.{OphanApi, ParameterStoreService, RedirectService}
-import conf.Configuration.aws.mandatoryCredentials
 import org.apache.pekko.stream.Materializer
 import utils.AWSv2
 

--- a/admin/app/jobs/R2PagePressJob.scala
+++ b/admin/app/jobs/R2PagePressJob.scala
@@ -22,7 +22,6 @@ class R2PagePressJob(wsClient: WSClient, redirects: RedirectService)(implicit ex
     extends GuLogging {
   private lazy val waitTimeSeconds = Configuration.r2Press.pressQueueWaitTimeInSeconds
   private lazy val maxMessages = Configuration.r2Press.pressQueueMaxMessages
-  private lazy val credentials = Configuration.aws.mandatoryCredentials
   private lazy val sqsClient =
     SqsAsyncClient
       .builder()

--- a/common/app/http/GuardianAuthWithExemptions.scala
+++ b/common/app/http/GuardianAuthWithExemptions.scala
@@ -7,12 +7,12 @@ import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher, S3BucketLoader}
 import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 import common.Environment.stage
-import conf.Configuration.aws.mandatoryCredentials
 import model.ApplicationContext
 import org.apache.pekko.stream.Materializer
 import play.api.Mode
 import play.api.libs.ws.WSClient
 import play.api.mvc._
+import utils.AWSv2
 
 import java.net.URL
 import scala.concurrent.Future
@@ -38,7 +38,7 @@ class GuardianAuthWithExemptions(
     PermissionsConfig(
       stage = if (stage == "PROD") "PROD" else "CODE",
       region = Regions.EU_WEST_1.getName,
-      awsCredentials = mandatoryCredentials,
+      awsCredentials = AWSv2.credentials,
     ),
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.12"
   val panDomainAuth = "com.gu" %% "pan-domain-auth-play_3-0" % "13.0.0"
-  val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "4.0.0"
+  val editorialPermissions = "com.gu" %% "editorial-permissions-client" % "5.0.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"
   val rome = "rome" % "rome" % romeVersion


### PR DESCRIPTION
## What does this change?
Bump `editorial-permissions-client`

## Why?
To keep up-to-date and also to remove AWS SDK v1 from the classpath

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ccf9e658-62f5-4407-b6c4-81862c14ef7e" />

## Testing
Tested admin and preview tools login in CODE and it works

## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering

