### PR TITLE
Extend the Admiral AB test expiry to Jan 2026

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -55,7 +55,7 @@ trait ABTestSwitches {
     "Testing the Admiral integration for adblock recovery on theguardian.com",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 11, 26)),
+    sellByDate = Some(LocalDate.of(2026, 1, 21)),
     exposeClientSide = true,
     highImpact = false,
   )


### PR DESCRIPTION
## What does this change?

Extends the life of the Admiral Adblock Recovery AB test

## Why?

We are transferring ownership outside of CommDev and need more time to do this before the test expires