### PR TITLE
Bump facia-client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val common = library("common")
     Test / javaOptions += "-Dconfig.file=common/conf/test.conf",
     libraryDependencies ++= Seq(
       apacheCommonsLang,
-      awsCloudwatchSdkV2,
+      awsCloudwatch,
       awsDynamodb,
       awsKinesis,
       awsS3,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "1.12.791"
   val awsSdk2Version = "2.35.11"
-  val capiVersion = "38.0.0"
-  val faciaVersion = "24.0.0"
+  val capiVersion = "39.0.0"
+  val faciaVersion = "26.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -30,7 +30,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.16.1"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "32.0.0"
+  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "33.0.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,7 @@ import sbt._
 
 object Dependencies {
   val identityLibVersion = "4.31"
-  val awsVersion = "1.12.791"
-  val awsSdk2Version = "2.35.11"
+  val awsVersion = "2.35.11"
   val capiVersion = "39.0.0"
   val faciaVersion = "26.0.0"
   val dispatchVersion = "0.13.1"
@@ -13,17 +12,17 @@ object Dependencies {
   val jerseyVersion = "1.19.4"
   val playJsonVersion = "3.0.5"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.16.0"
-  val awsCloudwatchSdkV2 = "software.amazon.awssdk" % "cloudwatch" % awsSdk2Version
-  val awsDynamodb = "software.amazon.awssdk" % "dynamodb" % awsSdk2Version
-  val awsKinesis = "software.amazon.awssdk" % "kinesis" % awsSdk2Version
-  val awsS3 = "software.amazon.awssdk" % "s3" % awsSdk2Version
+  val awsCloudwatch = "software.amazon.awssdk" % "cloudwatch" % awsVersion
+  val awsDynamodb = "software.amazon.awssdk" % "dynamodb" % awsVersion
+  val awsKinesis = "software.amazon.awssdk" % "kinesis" % awsVersion
+  val awsS3 = "software.amazon.awssdk" % "s3" % awsVersion
   val eTagCachingS3 = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0"
-  val awsSes = "software.amazon.awssdk" % "ses" % awsSdk2Version
-  val awsSns = "software.amazon.awssdk" % "sns" % awsSdk2Version
-  val awsSts = "software.amazon.awssdk" % "sts" % awsSdk2Version
-  val awsSqs = "software.amazon.awssdk" % "sqs" % awsSdk2Version
-  val awsSsm = "software.amazon.awssdk" % "ssm" % awsSdk2Version
-  val awsElasticloadbalancing = "software.amazon.awssdk" % "elasticloadbalancing" % awsSdk2Version
+  val awsSes = "software.amazon.awssdk" % "ses" % awsVersion
+  val awsSns = "software.amazon.awssdk" % "sns" % awsVersion
+  val awsSts = "software.amazon.awssdk" % "sts" % awsVersion
+  val awsSqs = "software.amazon.awssdk" % "sqs" % awsVersion
+  val awsSsm = "software.amazon.awssdk" % "ssm" % awsVersion
+  val awsElasticloadbalancing = "software.amazon.awssdk" % "elasticloadbalancing" % awsVersion
   val closureCompiler = "com.google.javascript" % "closure-compiler" % "v20240317"
   val commonsHttpClient = "commons-httpclient" % "commons-httpclient" % "3.1"
   val commonsLang = "commons-lang" % "commons-lang" % "2.6"


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/28361

## What does this change?
* Bumps facia-client to the latest version. The new facia-client contains a breaking change because it removes the legacy `ApiClient()` but we don't need to make any code changes in this PR because  we are already using the new `ApiClient.withCaching` introduced in:
     * https://github.com/guardian/frontend/pull/27715
* Also bumps capi-client and content-api-models-json to their latest versions to avoid getting binary incompatibility errors in compilation.
* Removes AWS SDK v1 version from `Dependencies`

## Why?
This update removes AWS SDK v1 from the classpath

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1155" height="628" alt="image" src="https://github.com/user-attachments/assets/a9c6a45b-4679-4219-b7c5-a89fc8276369" /> | <img width="1337" height="260" alt="image" src="https://github.com/user-attachments/assets/13541455-3f73-463e-b54f-c6b1058d37e2" /> |


## Checklist

- [X] Tested locally, and on CODE if necessary
- [X] Will not break dotcom-rendering
