### PR TITLE
Update `isTheFilterUS` logic to depend on `isTheFilter` 

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -87,7 +87,7 @@ final case class Content(
     fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists { tag => tag.id == "tone/advertisement-features" }
   lazy val isTheFilter: Boolean = tags.tags.exists { tag => tag.id == "thefilter/series/the-filter" }
-  lazy val isTheFilterUS: Boolean = productionOffice.exists(_.toLowerCase == "us")
+  lazy val isTheFilterUS: Boolean = isTheFilter && productionOffice.exists(_.toLowerCase == "us")
   lazy val campaigns: List[Campaign] =
     _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

The logic was previously only checking if the production office was the US. This means for any content produced by the US office, the value of `isTheFilterUS` will be true. We now check if the content is The Filter too

This logic was introduced in https://github.com/guardian/frontend/pull/28213

## What does this change?

`isTheFilterUS` has been updated to be _both_ `isTheFilter` _and_ marked as from the US production office


