### PR TITLE
Rename isFilterUS value to isUSProductionOffice for clarity

### DIFF
--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -45,7 +45,7 @@ object GalleryCaptionCleaners {
         page.gallery.content.fields.showAffiliateLinks,
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
         tags = page.gallery.content.tags.tags.map(_.id),
-        page.gallery.content.isTheFilterUS,
+        page.gallery.content.isUSProductionOffice,
       ),
     )
 

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -82,7 +82,7 @@ object BodyProcessor {
         pageUrl = request.uri,
         showAffiliateLinks = article.content.fields.showAffiliateLinks,
         tags = article.content.tags.tags.map(_.id),
-        isTheFilterUS = article.content.isTheFilterUS,
+        isUSProductionOffice = article.content.isUSProductionOffice,
       ),
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -87,7 +87,7 @@ final case class Content(
     fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists { tag => tag.id == "tone/advertisement-features" }
   lazy val isTheFilter: Boolean = tags.tags.exists { tag => tag.id == "thefilter/series/the-filter" }
-  lazy val isTheFilterUS: Boolean = productionOffice.exists(_.toLowerCase == "us")
+  lazy val isUSProductionOffice: Boolean = productionOffice.exists(_.toLowerCase == "us")
   lazy val campaigns: List[Campaign] =
     _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -206,7 +206,7 @@ object DotcomRenderingUtils {
           edition,
           article.trail.webPublicationDate,
           article.content.isGallery,
-          article.content.isTheFilterUS,
+          article.content.isUSProductionOffice,
         ),
       )
       .filter(PageElement.isSupported)

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -966,7 +966,7 @@ object PageElement {
       edition: Edition,
       webPublicationDate: DateTime,
       isGallery: Boolean,
-      isTheFilterUS: Boolean,
+      isUSProductionOffice: Boolean,
   ): List[PageElement] = {
 
     def extractAtom: Option[Atom] =
@@ -984,7 +984,7 @@ object PageElement {
     element.`type` match {
       case Text =>
         val textCleaners =
-          TextCleaner.affiliateLinks(pageUrl, addAffiliateLinks, isTheFilterUS) _ andThen
+          TextCleaner.affiliateLinks(pageUrl, addAffiliateLinks, isUSProductionOffice) _ andThen
             TextCleaner.sanitiseLinks(edition)
 
         for {
@@ -1076,7 +1076,7 @@ object PageElement {
         List(
           ImageBlockElement(
             ImageMedia(imageAssets.toSeq),
-            imageDataFor(element, isGallery, pageUrl, addAffiliateLinks, isTheFilterUS),
+            imageDataFor(element, isGallery, pageUrl, addAffiliateLinks, isUSProductionOffice),
             element.imageTypeData.flatMap(_.displayCredit),
             Role(element.imageTypeData.flatMap(_.role), defaultRole),
             imageSources,
@@ -1456,7 +1456,7 @@ object PageElement {
         element.linkTypeData
           .map(d =>
             LinkBlockElement(
-              AffiliateLinksCleaner.replaceUrlInLink(d.url, pageUrl, addAffiliateLinks, isTheFilterUS),
+              AffiliateLinksCleaner.replaceUrlInLink(d.url, pageUrl, addAffiliateLinks, isUSProductionOffice),
               d.label,
               d.linkType.getOrElse(LinkType.ProductButton),
             ),
@@ -1556,7 +1556,7 @@ object PageElement {
                 webPublicationDate,
                 item,
                 isGallery,
-                isTheFilterUS,
+                isUSProductionOffice,
               )
             }.toSeq,
             listElementType = listTypeData.`type`.map(_.name),
@@ -1577,7 +1577,7 @@ object PageElement {
               webPublicationDate,
               timelineTypeData,
               isGallery,
-              isTheFilterUS,
+              isUSProductionOffice,
             ),
           )
         }.toList
@@ -1595,7 +1595,7 @@ object PageElement {
             webPublicationDate,
             productTypeData,
             isGallery,
-            isTheFilterUS,
+            isUSProductionOffice,
           )
         }.toList
 
@@ -1615,7 +1615,7 @@ object PageElement {
       webPublicationDate: DateTime,
       timelineTypeData: TimelineElementFields,
       isGallery: Boolean,
-      isTheFilterUS: Boolean,
+      isUSProductionOffice: Boolean,
   ) = {
     timelineTypeData.sections.map { section =>
       TimelineSection(
@@ -1640,7 +1640,7 @@ object PageElement {
                   edition,
                   webPublicationDate,
                   isGallery,
-                  isTheFilterUS,
+                  isUSProductionOffice,
                 )
                 .headOption
             },
@@ -1658,7 +1658,7 @@ object PageElement {
                 edition,
                 webPublicationDate,
                 isGallery,
-                isTheFilterUS,
+                isUSProductionOffice,
               )
             }.toSeq,
           )
@@ -1678,7 +1678,7 @@ object PageElement {
       webPublicationDate: DateTime,
       item: v1.ListItem,
       isGallery: Boolean,
-      isTheFilterUS: Boolean,
+      isUSProductionOffice: Boolean,
   ) = {
     ListItem(
       elements = item.elements.flatMap { element =>
@@ -1695,7 +1695,7 @@ object PageElement {
           edition,
           webPublicationDate,
           isGallery,
-          isTheFilterUS,
+          isUSProductionOffice,
         )
       }.toSeq,
       title = item.title,
@@ -1719,19 +1719,19 @@ object PageElement {
       webPublicationDate: DateTime,
       product: ProductElementFields,
       isGallery: Boolean,
-      isTheFilterUS: Boolean,
+      isUSProductionOffice: Boolean,
   ) = {
 
     def createProductCta(
         cta: ApiProductCta,
         pageUrl: String,
         addAffiliateLinks: Boolean,
-        isTheFilterUS: Boolean,
+        isUSProductionOffice: Boolean,
     ): Option[ProductCta] = {
       for {
         // URL must exist and be non-empty
         url <- AffiliateLinksCleaner
-          .replaceUrlInLink(cta.url, pageUrl, addAffiliateLinks, isTheFilterUS)
+          .replaceUrlInLink(cta.url, pageUrl, addAffiliateLinks, isUSProductionOffice)
           .filter(_.nonEmpty)
 
         // Must have either non-empty text, or both non-empty price & retailer
@@ -1791,7 +1791,7 @@ object PageElement {
             edition,
             webPublicationDate,
             isGallery,
-            isTheFilterUS,
+            isUSProductionOffice,
           )
         }
         .toSeq,
@@ -1802,7 +1802,7 @@ object PageElement {
       starRating = product.starRating.getOrElse("none-selected"),
       productCtas = product.productCtas
         .getOrElse(Seq.empty)
-        .flatMap(cta => createProductCta(cta, pageUrl, addAffiliateLinks, isTheFilterUS))
+        .flatMap(cta => createProductCta(cta, pageUrl, addAffiliateLinks, isUSProductionOffice))
         .toList,
       customAttributes = product.customAttributes
         .getOrElse(Seq.empty)
@@ -2130,7 +2130,7 @@ object PageElement {
       isGallery: Boolean,
       pageUrl: String,
       addAffiliateLinks: Boolean,
-      isTheFilterUS: Boolean,
+      isUSProductionOffice: Boolean,
   ): Map[String, String] = {
     element.imageTypeData.map { d =>
       Map(
@@ -2138,7 +2138,7 @@ object PageElement {
         "alt" -> d.alt,
         "caption" -> {
           if (isGallery) {
-            d.caption.map(TextCleaner.cleanGalleryCaption(_, pageUrl, addAffiliateLinks, isTheFilterUS))
+            d.caption.map(TextCleaner.cleanGalleryCaption(_, pageUrl, addAffiliateLinks, isUSProductionOffice))
           } else {
             d.caption
           }

--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -12,14 +12,14 @@ import scala.util.matching.Regex
 
 object TextCleaner {
 
-  def affiliateLinks(pageUrl: String, addAffiliateLinks: Boolean, isTheFilterUS: Boolean)(
+  def affiliateLinks(pageUrl: String, addAffiliateLinks: Boolean, isUSProductionOffice: Boolean)(
       html: String,
   ): String = {
     if (addAffiliateLinks) {
       val doc = Jsoup.parseBodyFragment(html)
       val links = AffiliateLinksCleaner.getAffiliateableLinks(doc)
       val skimlinksId =
-        if (isTheFilterUS) affiliateLinksConfig.skimlinksUSId else affiliateLinksConfig.skimlinksDefaultId
+        if (isUSProductionOffice) affiliateLinksConfig.skimlinksUSId else affiliateLinksConfig.skimlinksDefaultId
       links.foreach(el => {
         el.attr(
           "href",
@@ -41,7 +41,7 @@ object TextCleaner {
       caption: String,
       pageUrl: String,
       shouldAddAffiliateLinks: Boolean,
-      isTheFilterUS: Boolean,
+      isUSProductionOffice: Boolean,
   ): String = {
 
     val cleaners = List(
@@ -49,7 +49,7 @@ object TextCleaner {
       GalleryAffiliateLinksCleaner(
         pageUrl,
         shouldAddAffiliateLinks,
-        isTheFilterUS,
+        isUSProductionOffice,
       ),
     )
 
@@ -165,12 +165,13 @@ object GalleryCaptionCleaner extends HtmlCleaner {
 case class GalleryAffiliateLinksCleaner(
     pageUrl: String,
     shouldAddAffiliateLinks: Boolean,
-    isTheFilterUS: Boolean,
+    isUSProductionOffice: Boolean,
 ) extends HtmlCleaner
     with GuLogging {
 
   override def clean(document: Document): Document = {
-    val skimlinksId = if (isTheFilterUS) affiliateLinksConfig.skimlinksUSId else affiliateLinksConfig.skimlinksDefaultId
+    val skimlinksId =
+      if (isUSProductionOffice) affiliateLinksConfig.skimlinksUSId else affiliateLinksConfig.skimlinksDefaultId
 
     if (shouldAddAffiliateLinks) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, skimlinksId)

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -867,7 +867,7 @@ case class AffiliateLinksCleaner(
     showAffiliateLinks: Option[Boolean],
     appendDisclaimer: Option[Boolean] = None,
     tags: List[String],
-    isTheFilterUS: Boolean,
+    isUSProductionOffice: Boolean,
 ) extends HtmlCleaner
     with GuLogging {
 
@@ -880,7 +880,7 @@ case class AffiliateLinksCleaner(
         tags,
       )
     ) {
-      val skimlinksId = if (isTheFilterUS) skimlinksUSId else skimlinksDefaultId
+      val skimlinksId = if (isUSProductionOffice) skimlinksUSId else skimlinksDefaultId
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, skimlinksId)
     } else document
   }
@@ -907,9 +907,9 @@ object AffiliateLinksCleaner {
       url: Option[String],
       pageUrl: String,
       addAffiliateLinks: Boolean,
-      isTheFilterUS: Boolean,
+      isUSProductionOffice: Boolean,
   ): Option[String] = {
-    val skimlinksId = if (isTheFilterUS) skimlinksUSId else skimlinksDefaultId
+    val skimlinksId = if (isUSProductionOffice) skimlinksUSId else skimlinksDefaultId
     val httpsUrl = url.map(ensureHttps)
     httpsUrl match {
       case Some(link) if addAffiliateLinks && SkimLinksCache.isSkimLink(link) =>


### PR DESCRIPTION
## What does this change?
Renames the `isFilterUS` value to `isUSProductionOffice`. Doesn't change any of the logic as we're happy with how this is working, but renames the value to make what it represents clearer. 

We check this value to see if we want to use the US Skimlinks account ID. We originally implemented this for The Filter US, hence the value name, but we also want to use the US Skimlinks ID for other articles written in the US which then become affiliated. Because this includes articles which are not tagged with the Filter US series tag, we don't want to restrict the value to only Filter US articles. So it makes sense to update this value name now to make the logic clearer for others to understand without needing the additional context.

Thanks to @cemms1 for flagging! See her [original suggestion and discussion here](https://github.com/guardian/frontend/pull/28365).