### PR TITLE
Add a feature switch for rendering hosted content pages in DCR

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -645,7 +645,7 @@ trait FeatureSwitches {
     description = "Render hosted content pages with DCR",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = Some(LocalDate.of(2026, 4, 15)),
     exposeClientSide = false,
     highImpact = false,
   )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -638,4 +638,15 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val DCRHostedContent = Switch(
+    group = SwitchGroup.Feature,
+    name = "dcr-hosted-content",
+    description = "Render hosted content pages with DCR",
+    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

We are migrating Hosted Content pages from frontend-rendered to DCR-rendered. Setting up a switch for this feature is one of the first steps as part of this work.

## What does this change?

Adds a feature switch to control whether we allow Hosted Content to be rendered via DCR
