### PR TITLE
Create non-AWS Scala Steward group

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -3,5 +3,5 @@
 # Overrides the grouping rules from the main config. We want to update most dependencies individually,
 # to prevent PRs becoming too large and complex.
 pullRequests.grouping = [
-  { name = "aws", "title" = "chore(deps): AWS dependency updates", "filter" = [{"group" = "software.amazon"}, {"group" = "software.amazon.*"}, {"group" = "com.amazonaws"}, {"group" = "com.amazonaws.*"}] },
+  { name = "non_aws", "title" = "chore(deps): Non-AWS dependency updates", "filter" = [{"group" = "*"}] },
 ]


### PR DESCRIPTION
We would like to test whether we can add a new group and have it work alongside the list of centrally configured groups.

Whether or not this works we will revert it, as on frontend we don't want a single group for all non-AWS dependencies. This is just for testing.

This replaces the previous AWS group, as this was not successful in overriding the centrally configured AWS group (see #28354).
