### PR TITLE
Delete `scala-steward.conf`

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,7 +1,0 @@
-# This extends the main config found here: https://github.com/guardian/scala-steward-public-repos/blob/main/scala-steward.conf
-
-# Overrides the grouping rules from the main config. We want to update most dependencies individually,
-# to prevent PRs becoming too large and complex.
-pullRequests.grouping = [
-  { name = "non_aws", "title" = "chore(deps): Non-AWS dependency updates", "filter" = [{"group" = "*"}] },
-]


### PR DESCRIPTION
This was used for testing, and we no longer need it since we don't want the non-AWS group.

See #28354 and #28415.
