### PR TITLE
Remove long cache time switches

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -226,26 +226,4 @@ trait PerformanceSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  val ShorterSurrogateCacheForRecentArticles = Switch(
-    SwitchGroup.Performance,
-    "shorter-surrogate-cache-for-recent-articles",
-    "Shorten the surrogate cache time for recent articles for load testing",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    sellByDate = LocalDate.of(2025, 12, 1),
-    exposeClientSide = false,
-    highImpact = false,
-  )
-
-  val ShorterSurrogateCacheForOlderArticles = Switch(
-    SwitchGroup.Performance,
-    "shorter-surrogate-cache-for-older-articles",
-    "Shorten the surrogate cache time for older articles for load testing",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    sellByDate = LocalDate.of(2025, 12, 1),
-    exposeClientSide = false,
-    highImpact = false,
-  )
 }

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -1,8 +1,6 @@
 package model
 
 import conf.switches.Switches.LongCacheSwitch
-import conf.switches.Switches.ShorterSurrogateCacheForOlderArticles
-import conf.switches.Switches.ShorterSurrogateCacheForRecentArticles
 import org.joda.time.DateTime
 import play.api.http.Writeable
 import play.api.mvc._
@@ -19,7 +17,7 @@ object CacheTime {
 
   object Default extends CacheTime(60)
   object LiveBlogActive extends CacheTime(5, Some(60))
-  def RecentlyUpdated = CacheTime(60, if (ShorterSurrogateCacheForRecentArticles.isSwitchedOn) Some(30) else None)
+  def RecentlyUpdated = CacheTime(60, None)
   // There is lambda which invalidates the cache on press events, so the facia cache time can be high.
   object Facia extends CacheTime(60, Some(900))
   object Crosswords extends CacheTime(60, Some(900))
@@ -32,9 +30,8 @@ object CacheTime {
   object FootballMatch extends CacheTime(30)
   object Cricket extends CacheTime(60)
   object FootballTables extends CacheTime(60)
-  private def oldArticleCacheTime = if (ShorterSurrogateCacheForOlderArticles.isSwitchedOn) 60 else longCacheTime
-  def LastDayUpdated = CacheTime(60, Some(oldArticleCacheTime))
-  def NotRecentlyUpdated = CacheTime(60, Some(oldArticleCacheTime))
+  def LastDayUpdated = CacheTime(60, Some(longCacheTime))
+  def NotRecentlyUpdated = CacheTime(60, Some(longCacheTime))
 }
 
 object Cached extends implicits.Dates {


### PR DESCRIPTION
## What is the value of this and can you measure success?

These switches were added as part of the prep work for the big events in 2024: See #27236

While they may be useful in the future, let's remove them for now and add them again if necessary.

## What does this change?

- Remove Surrogate Cache length switches 
