### PR TITLE
Only include active assets

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1310,7 +1310,7 @@ object PageElement {
                     mediaAtom.id,
                     mediaAtom.title,
                     mediaAtom.defaultHtml,
-                    mediaAtom.assets.map(MediaAtomBlockElementMediaAsset.fromMediaAsset),
+                    mediaAtom.activeAssets.map(MediaAtomBlockElementMediaAsset.fromMediaAsset),
                     mediaAtom.duration,
                     mediaAtom.posterImage.map(NSImage1.imageMediaToSequence),
                     mediaAtom.expired,


### PR DESCRIPTION
Updates the `assets` field of `MediaAtomBlockElement` to include only active assets.

To see the issue, visit this article:

https://www.theguardian.com/us-news/2025/oct/22/white-house-trump-new-ballroom-demolition

And look at the source of the the self-hosted video. There are 3 sets of assets which correspond to the 3 different versions of the video in Media Atom Maker:

<img width="1178" height="210" alt="Screenshot 2025-11-25 at 11 24 21" src="https://github.com/user-attachments/assets/a79ce7db-c08c-4819-84e1-5fb063d68850" />

We happen to render the most recent (or `active`) version at the moment because the browser picks the first `source` it supports, but we probably shouldn't include the others.

## Screenshots

Tested on CODE with a video with 2 versions

| Before      | After      |
|-------------|------------|
| <img width="1093" height="161" alt="Screenshot 2025-11-25 at 11 44 27" src="https://github.com/user-attachments/assets/4448b48a-619d-4b91-89cf-bcdfca1dba21" /> |  <img width="1090" height="114" alt="Screenshot 2025-11-25 at 11 49 39" src="https://github.com/user-attachments/assets/7370d88e-9066-4dc7-88a4-e16ed5156d91" /> |

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
