### PR TITLE
Replace old gate AB tests with switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -7,39 +7,6 @@ import conf.switches.Expiry.never
 trait ABTestSwitches {
   Switch(
     ABTests,
-    "ab-sign-in-gate-main-control",
-    "Control audience for the sign in gate to 9% audience. Will never see the sign in gate.",
-    owners = Seq(Owner.withGithub("coldlink")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 12, 1)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
-    "ab-sign-in-gate-main-variant",
-    "Show sign in gate to 90% of users on 3rd article view, variant/full audience",
-    owners = Seq(Owner.withGithub("coldlink")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 12, 1)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
-    "ab-auxia-sign-in-gate",
-    "Experimental use of Auxia to drive the client-side SignIn gate",
-    owners = Seq(Owner.withEmail("growth@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2026, 1, 30)),
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
-  Switch(
-    ABTests,
     "ab-no-auxia-sign-in-gate",
     "Defines a control group who should not have sign-in gate journeys handled by Auxia",
     owners = Seq(Owner.withEmail("growth@guardian.co.uk")),

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -649,4 +649,15 @@ trait FeatureSwitches {
     exposeClientSide = false,
     highImpact = false,
   )
+
+  val SignInGate = Switch(
+    group = SwitchGroup.Feature,
+    name = "sign-in-gate",
+    description = "Enable sign-in gate on articles",
+    owners = Seq(Owner.withEmail("value.dev@guardian.co.uk"), Owner.withEmail("growth.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
We have several old AB tests relating to the sign-in gate which are no longer relevant.
This PR removes them.

All gates are now served by [support-dotcom-components](https://github.com/guardian/support-dotcom-components/blob/main/docs/signinGate.md).

The only `ABTest` that remains is the `NoAuxiaSignInGate` [test](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/experiments/tests/no-auxia-sign-in-gate.ts), which we use to exclude a portion of the audience from Auxia messaging.

This PR also adds a new feature switch for sign-in gates. This means all gates can be disabled from the Frontend switchboard in an emergency. Separately, there is already a switch in the RRCP for disabling the use of Auxia for gates.

DCR PR: https://github.com/guardian/dotcom-rendering/pull/14930