### PR TITLE
Group Jackson dependencies in Scala Steward config

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,0 +1,7 @@
+# This extends the main config found here: https://github.com/guardian/scala-steward-public-repos/blob/main/scala-steward.conf
+
+# Overrides the grouping rules from the main config.
+pullRequests.grouping = [
+  { name = "jackson-databind", "title" = "chore(deps): Jackson Databind dependency updates", "filter" = [{"group" = "com.fasterxml.jackson.core", "artifact" = "jackson-databind"}] }
+  { name = "jackson", "title" = "chore(deps): Jackson dependency updates", "filter" = [{"group" = "com.fasterxml.jackson.*"}] }
+]


### PR DESCRIPTION
## What does this change?
Groups Jackson dependencies in Scala Steward config.

## Why?
After this PR: https://github.com/guardian/scala-steward-public-repos/pull/103/ Scala Steward raises a separate PR for all non-AWS dependencies. We would like to override this behaviour for the Jackson dependencies because they should all be in the same version.

I am keeping Jackson Databind separate from the other Jackson dependencies because it [seems](https://github.com/orgs/playframework/discussions/11222) I think it is not guaranteed that they will always be the same.
