### PR TITLE
Extend personalised highlights test and switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -33,7 +33,7 @@ trait ABTestSwitches {
     "Allow personalised highlights to be shown on the front page",
     owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2025, 12, 4)),
+    sellByDate = Some(LocalDate.of(2026, 1, 28)),
     exposeClientSide = true,
     highImpact = false,
   )

--- a/static/src/javascripts/projects/common/modules/experiments/tests/personalised-highlights.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/personalised-highlights.js
@@ -1,16 +1,15 @@
-
 export const personalisedHighlights = {
 	id: 'PersonalisedHighlights',
 	start: '2025-11-17',
-	expiry: '2025-12-01',
+	expiry: '2026-01-28',
 	author: 'Anna Beddow',
-	description: 'Allow user behaviour to personalise the ordering of cards in the highlights container.',
-    audience: 0.75,
-    audienceOffset: 0.75,
+	description:
+		'Allow user behaviour to personalise the ordering of cards in the highlights container.',
+	audience: 0.75,
+	audienceOffset: 0.75,
 	successMeasure: '',
 	audienceCriteria: 'All users, globally.',
-    idealOutcome:
-        'Increase click through rate on highlights container',
+	idealOutcome: 'Increase click through rate on highlights container',
 	showForSensitive: true,
 
 	canRun: () => true,
@@ -19,18 +18,17 @@ export const personalisedHighlights = {
 			id: 'control',
 			test: () => {},
 		},
-        {
-            id: 'click-tracking',
-            test: () => {},
-        },
-        {
-            id: 'view-tracking',
-            test: () => {}
-        },
-        {
-            id: 'click-and-view-tracking',
-            test: () => {},
-        },
+		{
+			id: 'click-tracking',
+			test: () => {},
+		},
+		{
+			id: 'view-tracking',
+			test: () => {},
+		},
+		{
+			id: 'click-and-view-tracking',
+			test: () => {},
+		},
 	],
 };
-


### PR DESCRIPTION
## What does this change?

Extends the Personalised Highlights test and switch to the 28th January.

## Why?

They were both due to expire next week and we may want the test to continue past that date. The 28th January is far enough in the future that we are unlikely to need to extend it again. Once the test has concluded, the test and switch will be removed.
