### PR TITLE
Disable email sending in non-production environments

### DIFF
--- a/admin/app/services/EmailService.scala
+++ b/admin/app/services/EmailService.scala
@@ -1,6 +1,7 @@
 package services
 
 import common.{GuLogging, PekkoAsync}
+import conf.Configuration
 import software.amazon.awssdk.services.ses.SesAsyncClient
 import software.amazon.awssdk.services.ses.model.{Destination => EmailDestination, _}
 import utils.AWSv2
@@ -27,6 +28,12 @@ class EmailService(pekkoAsync: PekkoAsync) extends GuLogging {
       textBody: Option[String] = None,
       htmlBody: Option[String] = None,
   )(implicit executionContext: ExecutionContext): Future[SendEmailResponse] = {
+
+    // Don't send emails in non-prod environments
+    if (Configuration.environment.isNonProd) {
+      log.info(s"Skipping email send in non-prod: from=$from to=$to subject=$subject")
+      return Future.successful(SendEmailResponse.builder().messageId("non-prod-mock").build())
+    }
 
     log.info(s"Sending email from $from to $to about $subject")
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
The migration to the AWS SDK v2 credential provider (AWSv2.credentials) in [this pr](https://github.com/guardian/frontend/pull/28325)  inadvertently enabled the CODE environment to send emails by allowing it to use the instance profile (previously it failed silently due to missing explicit keys). Therefore we have been receiving two emails. One come from the code admin service. This change should prevent those emails.
## What does this change?
Prevents emails from being sent in non prod environments following the [AWS SDK v2 migration for SES](https://github.com/guardian/frontend/pull/28325).

The service now returns a mock successful response in non-prod environments instead of calling AWS SES, while logging what would have been sent for debugging purposes.
