### PR TITLE
Add match status to the football data

### DIFF
--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -83,8 +83,13 @@ case class TeamAnswer(
     codename: String,
 ) extends NsAnswer
 
-case class MatchDataAnswer(id: String, homeTeam: TeamAnswer, awayTeam: TeamAnswer, comments: Option[String])
-    extends NsAnswer
+case class MatchDataAnswer(
+    id: String,
+    homeTeam: TeamAnswer,
+    awayTeam: TeamAnswer,
+    comments: Option[String],
+    status: String,
+) extends NsAnswer
 
 object NsAnswer {
   val reportedEventTypes = List("booking", "dismissal", "substitution")
@@ -126,13 +131,14 @@ object NsAnswer {
     )
   }
 
-  def makeFromFootballMatch(theMatch: FootballMatch, lineUp: LineUp): MatchDataAnswer = {
+  def makeFromFootballMatch(theMatch: FootballMatch, lineUp: LineUp, matchStatus: String): MatchDataAnswer = {
     val teamColours = TeamColours(lineUp.homeTeam, lineUp.awayTeam)
     MatchDataAnswer(
       theMatch.id,
       makeTeamAnswer(theMatch.homeTeam, lineUp.homeTeam, lineUp.homeTeamPossession, teamColours.home),
       makeTeamAnswer(theMatch.awayTeam, lineUp.awayTeam, lineUp.awayTeamPossession, teamColours.away),
       theMatch.comments,
+      matchStatus,
     )
   }
 
@@ -181,7 +187,7 @@ class MatchController(
           val tier = FootballSummaryPagePicker.getTier()
 
           page.flatMap { page =>
-            val footballMatch = NsAnswer.makeFromFootballMatch(theMatch, page.lineUp)
+            val footballMatch = NsAnswer.makeFromFootballMatch(theMatch, page.lineUp, theMatch.matchStatus)
 
             request.getRequestFormat match {
               case JsonFormat if request.forceDCR =>

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -88,6 +88,7 @@ case class NxMatchData(
     comments: String,
     minByMinUrl: Option[String],
     reportUrl: Option[String],
+    status: String,
 ) extends NxAnswer
 
 object NxAnswer {
@@ -160,6 +161,7 @@ object NxAnswer {
       competition: Option[Competition],
       isResult: Boolean,
       isLive: Boolean,
+      matchStatus: String,
   ): NxMatchData = {
     val teamColours = TeamColours(lineUp.homeTeam, lineUp.awayTeam)
     NxMatchData(
@@ -173,6 +175,7 @@ object NxAnswer {
       comments = theMatch.comments.getOrElse(""),
       minByMinUrl = makeMinByMinUrl(request, theMatch, related),
       reportUrl = makeMatchReportUrl(request, theMatch, related),
+      status = matchStatus,
     )
   }
 
@@ -275,6 +278,7 @@ class MoreOnMatchController(
                     competition,
                     theMatch.isResult,
                     theMatch.isLive,
+                    theMatch.matchStatus,
                   ),
                 )
               }


### PR DESCRIPTION
## What does this change?

This PR adds `status` of the match to the data for the following endpoints:
**- /football/match/:year/:month/:day/$home-v-$away**
This is the endpoint for match summary pages e.g. https://www.theguardian.com/football/match/2025/nov/23/arsenal-v-tottenham-hotspur


**- /football/api/match-nav/:year/:month/:day/:home/:away**
This is the endpoint that's used by DCAR to get match-nav data. For example in football live blogs such as https://www.theguardian.com/football/live/2025/nov/30/chelsea-v-arsenal-premier-league-live a client side call is made to  
https://api.nextgen.guardianapps.co.uk/football/api/match-nav/2025/11/30/4/1006.json?dcr to get the data for the match header

Relevant DCAR PR for this change: https://github.com/guardian/dotcom-rendering/pull/14944/files


Resolves part of [#14902](https://github.com/guardian/dotcom-rendering/issues/14902)
