### PR TITLE
Refactor: Introduce `BlocksOn[Page]` parameter object

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -7,16 +7,17 @@ import conf.switches.Switches
 import contentapi.ContentApiClient
 import implicits.{AmpFormat, AppsFormat, HtmlFormat, JsonFormat}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model.{InteractivePage, _}
 import model.content.InteractiveAtom
 import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
+import model.meta.BlocksOn
+import model._
 import org.apache.commons.lang.StringEscapeUtils
 import pages.InteractiveHtmlPage
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import renderers.DotcomRenderingService
 import services.dotcomrendering.{DotcomRendering, InteractivePicker, PressedInteractive}
-import services.{CAPILookup, USElection2020AmpPages, _}
+import services.{CAPILookup, USElection2020AmpPages}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -72,17 +73,14 @@ class InteractiveController(
     capiLookup.lookup(path, range = Some(ArticleBlocks))
   }
 
-  def toModel(response: ItemResponse)(implicit
-      request: RequestHeader,
-  ): Either[Result, (InteractivePage, Blocks)] = {
-    val interactive = response.content map { Interactive.make }
-    val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
-    val page = interactive.map(i => InteractivePage(i, StoryPackages(i.metadata.id, response)))
-
-    ModelOrResult(page, response) match {
-      case Right(page)     => Right((page, blocks))
-      case Left(exception) => Left(exception)
-    }
+  def modelAndRender(
+      response: ItemResponse,
+  )(render: BlocksOn[InteractivePage] => Future[Result])(implicit req: RequestHeader): Future[Result] = {
+    val content = response.content
+    ModelOrResult(
+      content.map(Interactive.make).map(i => InteractivePage(i, StoryPackages(i.metadata.id, response))),
+      response,
+    ).fold(Future.successful, page => render(BlocksOn(page, content.flatMap(_.blocks).getOrElse(Blocks()))))
   }
 
   override def canRender(i: ItemResponse): Boolean = i.content.exists(_.isInteractive)
@@ -94,47 +92,43 @@ class InteractiveController(
     Future.successful(res)
   }
 
-  def renderHtml(page: InteractivePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
-    val pageType = PageType.apply(page, request, context)
-    remoteRenderer.getInteractive(wsClient, page, blocks, pageType)
+  def renderHtml(pageBlocks: BlocksOn[InteractivePage])(implicit request: RequestHeader): Future[Result] = {
+    val pageType = PageType.apply(pageBlocks.page, request, context)
+    remoteRenderer.getInteractive(wsClient, pageBlocks, pageType)
   }
 
-  def renderJson(page: InteractivePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
+  def renderJson(pageBlocks: BlocksOn[InteractivePage])(implicit request: RequestHeader): Future[Result] = {
     val data =
-      DotcomRenderingDataModel.forInteractive(page, blocks, request, PageType.apply(page, request, context))
+      DotcomRenderingDataModel.forInteractive(pageBlocks, request, PageType.apply(pageBlocks.page, request, context))
     val dataJson = DotcomRenderingDataModel.toJson(data)
-    val res = common.renderJson(dataJson, page).as("application/json")
+    val res = common.renderJson(dataJson, pageBlocks.page).as("application/json")
     Future.successful(res)
   }
 
-  def renderAmp(page: InteractivePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
-    val pageType = PageType.apply(page, request, context)
-    remoteRenderer.getAMPInteractive(wsClient, page, blocks, pageType)
+  def renderAmp(pageBlocks: BlocksOn[InteractivePage])(implicit request: RequestHeader): Future[Result] = {
+    val pageType = PageType.apply(pageBlocks.page, request, context)
+    remoteRenderer.getAMPInteractive(wsClient, pageBlocks, pageType)
   }
 
-  def renderApps(page: InteractivePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
-    val pageType = PageType.apply(page, request, context)
-    remoteRenderer.getAppsInteractive(wsClient, page, blocks, pageType)
+  def renderApps(pageBlocks: BlocksOn[InteractivePage])(implicit request: RequestHeader): Future[Result] = {
+    val pageType = PageType.apply(pageBlocks.page, request, context)
+    remoteRenderer.getAppsInteractive(wsClient, pageBlocks, pageType)
   }
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     val requestFormat = request.getRequestFormat
     val isUSElectionAMP = USElection2020AmpPages.pathIsSpecialHanding(path) && requestFormat == AmpFormat
 
-    def render(model: Either[Result, (InteractivePage, Blocks)]): Future[Result] = {
-      model match {
-        case Right((page, blocks)) => {
-          val tier = InteractivePicker.getRenderingTier(path)
-          (requestFormat, tier) match {
-            case (AppsFormat, DotcomRendering)                                          => renderApps(page, blocks)
-            case (AmpFormat, DotcomRendering) if page.interactive.content.shouldAmplify => renderAmp(page, blocks)
-            case (HtmlFormat | AmpFormat, DotcomRendering)                              => renderHtml(page, blocks)
-            case (JsonFormat, DotcomRendering)                                          => renderJson(page, blocks)
-            case (HtmlFormat, PressedInteractive)                                       => servePressedPage(path)
-            case _                                                                      => renderNonDCR(page)
-          }
-        }
-        case Left(result) => Future.successful(result)
+    def render(pageBlocks: BlocksOn[InteractivePage]): Future[Result] = {
+      val page = pageBlocks.page
+      val tier = InteractivePicker.getRenderingTier(path)
+      (requestFormat, tier) match {
+        case (AppsFormat, DotcomRendering)                                          => renderApps(pageBlocks)
+        case (AmpFormat, DotcomRendering) if page.interactive.content.shouldAmplify => renderAmp(pageBlocks)
+        case (HtmlFormat | AmpFormat, DotcomRendering)                              => renderHtml(pageBlocks)
+        case (JsonFormat, DotcomRendering)                                          => renderJson(pageBlocks)
+        case (HtmlFormat, PressedInteractive)                                       => servePressedPage(path)
+        case _                                                                      => renderNonDCR(page)
       }
     }
 
@@ -143,8 +137,7 @@ class InteractiveController(
     } else {
       val res = for {
         resp <- lookupItemResponse(path)
-        model = toModel(resp)
-        result <- render(model)
+        result <- modelAndRender(resp)(render)
       } yield result
 
       res.recover(convertApiExceptionsWithoutEither)

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -1,24 +1,23 @@
 package test
 
-import controllers.InteractiveController
-import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, PrivateMethodTester}
 import conf.Configuration.interactive.cdnPath
-import play.api.libs.ws.WSClient
-import com.gu.contentapi.client.model.v1.Blocks
-import model.dotcomrendering.PageType
+import controllers.InteractiveController
 import model.InteractivePage
+import model.dotcomrendering.PageType
+import model.meta.BlocksOn
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, PrivateMethodTester}
+import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result, Results}
+import play.api.test.Helpers._
 
 import scala.concurrent.Future
 
 class DCRFake() extends renderers.DotcomRenderingService {
   override def getInteractive(
       ws: WSClient,
-      page: InteractivePage,
-      blocks: Blocks,
+      pageBlocks: BlocksOn[InteractivePage],
       pageType: PageType,
   )(implicit request: RequestHeader): Future[Result] = {
     Future.successful(Results.Ok("test"))

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -167,7 +167,7 @@ class LiveBlogController(
               val pageType: PageType = PageType(blog, request, context)
               remoteRenderer.getArticle(
                 ws,
-                pageBlocks.copy(page = blog),
+                pageBlocks,
                 pageType,
                 newsletter = None,
                 filterKeyEvents,

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -12,6 +12,7 @@ import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import model.liveblog.BodyBlock
 import model.liveblog.BodyBlock.{KeyEvent, SummaryEvent}
 import model._
+import model.meta.BlocksOn
 import pages.{ArticleEmailHtmlPage, LiveBlogHtmlPage, MinuteHtmlPage}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -46,10 +47,12 @@ class LiveBlogController(
   def renderEmail(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
       mapModel(path, ArticleBlocks) {
-        case (minute: MinutePage, _) =>
-          Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(minute), minute))
-        case (blog: LiveBlogPage, _) => Future.successful(common.renderEmail(LiveBlogHtmlPage.html(blog), blog))
-        case _                       => Future.successful(NotFound)
+        _.page match {
+          case minute: MinutePage =>
+            Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(minute), minute))
+          case blog: LiveBlogPage => Future.successful(common.renderEmail(LiveBlogHtmlPage.html(blog), blog))
+          case _                  => Future.successful(NotFound)
+        }
       }
     }
   }
@@ -96,29 +99,31 @@ class LiveBlogController(
       val filter = shouldFilter(filterKeyEvents)
       val range = getRange(lastUpdate, page)
 
-      mapModel(path, range, filter) {
-        case (blog: LiveBlogPage, _) if rendered.contains(false) => getJsonForFronts(blog)
+      mapModel(path, range, filter) { pageBlocks =>
+        pageBlocks.page match {
+          case blog: LiveBlogPage if rendered.contains(false) => getJsonForFronts(blog)
 
-        /** When DCR requests new blocks from the client, it will add a `lastUpdate` parameter. If no such parameter is
-          * present, we should return a JSON representation of the whole payload that would be sent to DCR when
-          * initially server side rendering the LiveBlog page.
-          */
-        case (blog: LiveBlogPage, blocks) if request.forceDCR && lastUpdate.isEmpty =>
-          Future.successful(renderDCRJson(blog, blocks, filter))
-        case (blog: LiveBlogPage, blocks) =>
-          getJson(
-            blog,
-            range,
-            isLivePage,
-            filter,
-            blocks.requestedBodyBlocks.getOrElse(Map.empty).map(entry => (entry._1, entry._2.toSeq)),
-          )
-        case (minute: MinutePage, _) =>
-          Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
-        case _ =>
-          Future {
-            Cached(600)(WithoutRevalidationResult(NotFound))
-          }
+          /** When DCR requests new blocks from the client, it will add a `lastUpdate` parameter. If no such parameter
+            * is present, we should return a JSON representation of the whole payload that would be sent to DCR when
+            * initially server side rendering the LiveBlog page.
+            */
+          case blog: LiveBlogPage if request.forceDCR && lastUpdate.isEmpty =>
+            Future.successful(renderDCRJson(pageBlocks.copy(page = blog), filter))
+          case blog: LiveBlogPage =>
+            getJson(
+              blog,
+              range,
+              isLivePage,
+              filter,
+              pageBlocks.blocks.requestedBodyBlocks.getOrElse(Map.empty).map(entry => (entry._1, entry._2.toSeq)),
+            )
+          case minute: MinutePage =>
+            Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
+          case _ =>
+            Future {
+              Cached(600)(WithoutRevalidationResult(NotFound))
+            }
+        }
       }
     }
   }
@@ -130,8 +135,9 @@ class LiveBlogController(
   )(implicit
       request: RequestHeader,
   ): Future[Result] = {
-    mapModel(path, range, filterKeyEvents) { (page, blocks) =>
+    mapModel(path, range, filterKeyEvents) { pageBlocks =>
       {
+        val page = pageBlocks.page
         val isAmpSupported = page.article.content.shouldAmplify
         val pageType: PageType = PageType(page, request, context)
         (page, request.getRequestFormat) match {
@@ -161,8 +167,7 @@ class LiveBlogController(
               val pageType: PageType = PageType(blog, request, context)
               remoteRenderer.getArticle(
                 ws,
-                blog,
-                blocks,
+                pageBlocks.copy(page = blog),
                 pageType,
                 newsletter = None,
                 filterKeyEvents,
@@ -173,14 +178,13 @@ class LiveBlogController(
               Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
             }
           case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType, newsletter = None, filterKeyEvents)
+            remoteRenderer.getAMPArticle(ws, pageBlocks, pageType, newsletter = None, filterKeyEvents)
           case (blog: LiveBlogPage, AmpFormat) =>
             Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
           case (blog: LiveBlogPage, AppsFormat) =>
             remoteRenderer.getAppsArticle(
               ws,
-              blog,
-              blocks,
+              pageBlocks,
               pageType,
               newsletter = None,
               filterKeyEvents,
@@ -331,17 +335,16 @@ class LiveBlogController(
   /** Returns a JSON representation of the payload that's sent to DCR when rendering the whole LiveBlog page.
     */
   private[this] def renderDCRJson(
-      blog: LiveBlogPage,
-      blocks: Blocks,
+      pageBlocks: BlocksOn[LiveBlogPage],
       filterKeyEvents: Boolean,
   )(implicit request: RequestHeader): Result = {
+    val blog = pageBlocks.page
     val pageType: PageType = PageType(blog, request, context)
     val newsletter = newsletterService.getNewsletterForLiveBlog(blog)
 
     val model =
       DotcomRenderingDataModel.forLiveblog(
-        blog,
-        blocks,
+        pageBlocks,
         request,
         pageType,
         filterKeyEvents,
@@ -357,38 +360,38 @@ class LiveBlogController(
       range: BlockRange,
       filterKeyEvents: Boolean = false,
   )(
-      render: (PageWithStoryPackage, Blocks) => Future[Result],
+      render: BlocksOn[PageWithStoryPackage] => Future[Result],
   )(implicit request: RequestHeader): Future[Result] = {
     capiLookup
       .lookup(path, Some(range))
       .map(responseToModelOrResult(range, filterKeyEvents))
       .recover(convertApiExceptions)
       .flatMap {
-        case Right((model, blocks)) => render(model, blocks)
-        case Left(other)            => Future.successful(RenderOtherStatus(other))
+        case Right(pageBlocks) => render(pageBlocks)
+        case Left(other)       => Future.successful(RenderOtherStatus(other))
       }
   }
 
   private[this] def responseToModelOrResult(
       range: BlockRange,
       filterKeyEvents: Boolean,
-  )(response: ItemResponse)(implicit request: RequestHeader): Either[Result, (PageWithStoryPackage, Blocks)] = {
+  )(response: ItemResponse)(implicit request: RequestHeader): Either[Result, BlocksOn[PageWithStoryPackage]] = {
     val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult: Either[Result, ContentType] = ModelOrResult(supportedContent, response)
     val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
 
     val content = supportedContentResult.flatMap {
       case minute: Article if minute.isTheMinute =>
-        Right(MinutePage(minute, StoryPackages(minute.metadata.id, response)), blocks)
+        Right(MinutePage(minute, StoryPackages(minute.metadata.id, response)))
       case liveBlog: Article if liveBlog.isLiveBlog && request.isEmail =>
-        Right(MinutePage(liveBlog, StoryPackages(liveBlog.metadata.id, response)), blocks)
+        Right(MinutePage(liveBlog, StoryPackages(liveBlog.metadata.id, response)))
       case liveBlog: Article if liveBlog.isLiveBlog =>
         createLiveBlogModel(
           liveBlog,
           response,
           range,
           filterKeyEvents,
-        ).map(_ -> blocks)
+        )
       case nonLiveBlogArticle: Article =>
         /** If `isLiveBlog` is false, it must be because the article has no blocks, or lacks the `tone/minutebyminute`
           * tag, or both. Logging these values will help us to identify which is causing the issue.
@@ -404,7 +407,7 @@ class LiveBlogController(
         Left(InternalServerError)
     }
 
-    content
+    content.map(BlocksOn(_, blocks))
   }
 
   def shouldFilter(filterKeyEvents: Option[Boolean]): Boolean = {

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -1,5 +1,6 @@
 package test
 
+import model.meta.BlocksOn
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
 import model.Cached.RevalidatableResult
 import model.dotcomrendering.{OnwardCollectionResponse, PageType}
@@ -20,14 +21,14 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
 
   override def getArticle(
       ws: WSClient,
-      article: PageWithStoryPackage,
-      blocks: Blocks,
+      pageBlocks: BlocksOn[PageWithStoryPackage],
       pageType: PageType,
       newsletter: Option[NewsletterData],
       filterKeyEvents: Boolean,
       forceLive: Boolean,
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
+    val article = pageBlocks.page
     requestedBlogs.enqueue(article)
     Future(
       Cached(article)(RevalidatableResult.Ok(Html("FakeRemoteRender has found you out if you rely on this markup!"))),

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -9,6 +9,7 @@ import conf.switches.Switches
 import conf.{Configuration, Static}
 import model.content.Atom
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
+import model.meta.BlocksOn
 import model.pressed.{PressedContent, SpecialReport}
 import model.{
   ArticleDateTimes,
@@ -156,10 +157,10 @@ object DotcomRenderingUtils {
   }
 
   def blocksForLiveblogPage(
-      liveblog: LiveBlogPage,
-      blocks: APIBlocks,
+      pageBlocks: BlocksOn[LiveBlogPage],
       filterKeyEvents: Boolean,
   ): Seq[APIBlock] = {
+    val blocks = pageBlocks.blocks
     // When the key events filter is on, we'd need all of the key events rather than just the latest 60 blocks
     val allBlocks =
       getKeyEventsIfFiltered(filterKeyEvents, blocks)
@@ -171,7 +172,7 @@ object DotcomRenderingUtils {
     // of the response so we use those
     val relevantBlocks = if (allBlocks.isEmpty) blocks.body.getOrElse(Nil) else allBlocks
 
-    val ids = liveblog.currentPage.currentPage.blocks.map(_.id).toSet
+    val ids = pageBlocks.page.currentPage.currentPage.blocks.map(_.id).toSet
     relevantBlocks.filter(block => ids(block.id))
   }.toSeq
   def stringContainsAffiliateableLinks(textString: String): Boolean = {

--- a/common/app/model/meta/BlocksOn.scala
+++ b/common/app/model/meta/BlocksOn.scala
@@ -1,0 +1,11 @@
+package model.meta
+
+import com.gu.contentapi.client.model.v1.Blocks
+
+/** Blocks are often passed around with the Page they belong to. It makes sense to give them a type that holds the two
+  * together - this reduces parameter-count on many methods, improves consistency, and makes clear what things usefully
+  * belong together for the work we're performing.
+  *
+  * https://docondev.com/blog/2020/6/2/refactoring-introduce-parameter-object
+  */
+case class BlocksOn[+P](page: P, blocks: Blocks)

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -1,5 +1,6 @@
 package model.dotcomrendering.pageElements
 
+import model.meta.BlocksOn
 import com.gu.contentapi.client.model.v1.{Block, BlockAttributes, Blocks, CapiDateTime, Content => ApiContent}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import com.gu.contentapi.client.utils.format.LiveBlogDesign
@@ -168,9 +169,9 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
     )
     when(testCapiBlocks.requestedBodyBlocks) thenReturn (Some(requested))
 
-    val currentPage = getLiveblogPageWithBlockIds(Seq(3, 4, 5, 6, 7, 8))
+    val pageBlocks = BlocksOn(getLiveblogPageWithBlockIds(Seq(3, 4, 5, 6, 7, 8)), testCapiBlocks)
 
-    val result = DotcomRenderingUtils.blocksForLiveblogPage(currentPage, testCapiBlocks, true)
+    val result = DotcomRenderingUtils.blocksForLiveblogPage(pageBlocks, true)
 
     result.map(_.id) should equal(Seq("8", "7", "6", "5", "4", "3"))
   }
@@ -183,9 +184,9 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
     )
     when(testCapiBlocks.requestedBodyBlocks) thenReturn (Some(requested))
 
-    val currentPage = getLiveblogPageWithBlockIds(Seq(3, 4, 5, 6, 7, 8))
+    val pageBlocks = BlocksOn(getLiveblogPageWithBlockIds(Seq(3, 4, 5, 6, 7, 8)), testCapiBlocks)
 
-    val result = DotcomRenderingUtils.blocksForLiveblogPage(currentPage, testCapiBlocks, false)
+    val result = DotcomRenderingUtils.blocksForLiveblogPage(pageBlocks, false)
 
     result.map(_.id) should equal(Seq("6", "7", "8"))
   }


### PR DESCRIPTION
This work aims to support the Live-Harness endpoint functionality being introduced by Fred in https://github.com/guardian/frontend/pull/28417 - we can reduce the size of that implementation by taking a few small refactors in `ArticleController` & `InteractiveController`. Those refactors simplify the code in those controllers, as well as supporting the forthcoming code in the new `LiveHarnessController`:

* https://github.com/guardian/frontend/pull/28417
* https://github.com/guardian/frontend/pull/28438

## Introduce `BlocksOn[Page]` parameter object

`page` and `blocks` are two parameters that are passed together in several method calls, suggesting that they belong together in a single parameter object:

* https://docondev.com/blog/2020/6/2/refactoring-introduce-parameter-object

As the job of the `LiveHarnessController` is to accept new interactive atoms, and then use them to transform an existing page-&-block combination, the transformation can be expressed a little more clearly when a single `pageBlocks` value encompasses both page & blocks.

## Controller method refactors

On `ArticleController`:

* Three identical methods (`renderArticle()`, `renderJson()`, `renderEmail()`) are now implemented only in `renderArticle()`, with the other 2 methods delegating to `renderArticle()`.
* Common code in `renderItem()` & `renderArticle()` has been extracted into `mapAndRender()`, which also supports an optional `pageBlocks` modifier, useful for the forthcoming live-harness work.

On `InteractiveController`:

* `toModel()` is changed to `modelAndRender()`, which now incorporates common `Either`-handling logic (previously in `renderItem()`), and accepts a rendering-function parameter, invoked on the happy-path when the Page has been found & modelled. This enables us to concisely express the rendering we want to perform, useful for the forthcoming live-harness work.

On `LiveBlogController`:

* `match` statements within `renderEmail()` & `renderJson()` have been simplified - they were previously matching on tuple-pairs where the second value did not affect the match.

## Testing

Successfully [deployed](https://riffraff.gutools.co.uk/deployment/view/d20413c3-902f-453f-9822-fd3ebb22636b) to CODE.

### Interactive

https://m.code.dev-theguardian.com/politics/ng-interactive/2025/nov/20/you-be-the-chancellor-play-our-interactive-budget-game

<img width="1917" height="604" alt="image" src="https://github.com/user-attachments/assets/5b2c0e29-237a-46ea-8b2d-e4b44c9ddd28" />

### Live blog

https://m.code.dev-theguardian.com/politics/live/2017/jun/09/election-2017-theresa-may-speaks-outside-downing-street-after-shock-result-hunh-parliament-live

<img width="1917" height="604" alt="image" src="https://github.com/user-attachments/assets/de02d56b-eeae-4a7d-815a-14927f21df85" />


### Article

https://m.code.dev-theguardian.com/tv-and-radio/article/2024/jun/22/radiant-charm-scene-stealing-tears-and-steamy-kisses-ncuti-gatwa-is-the-new-golden-age-of-doctor-who

<img width="1917" height="856" alt="image" src="https://github.com/user-attachments/assets/ce9d35d2-82ae-4c78-a2de-42e95826dd7f" />
