### PR TITLE
Basic Live-Harness endpoint functionality (tweaked on top of #28417)

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -73,6 +73,11 @@ class InteractiveController(
     capiLookup.lookup(path, range = Some(ArticleBlocks))
   }
 
+  def modelAndRenderHtml(response: ItemResponse)(
+      modifier: BlocksOn[InteractivePage] => BlocksOn[InteractivePage] = identity,
+  )(implicit req: RequestHeader): Future[Result] =
+    modelAndRender(response)(pageBlocks => renderHtml(modifier(pageBlocks)))
+
   def modelAndRender(
       response: ItemResponse,
   )(render: BlocksOn[InteractivePage] => Future[Result])(implicit req: RequestHeader): Future[Result] = {

--- a/common/app/model/meta/BlocksOn.scala
+++ b/common/app/model/meta/BlocksOn.scala
@@ -8,4 +8,6 @@ import com.gu.contentapi.client.model.v1.Blocks
   *
   * https://docondev.com/blog/2020/6/2/refactoring-introduce-parameter-object
   */
-case class BlocksOn[+P](page: P, blocks: Blocks)
+case class BlocksOn[+P](page: P, blocks: Blocks) {
+  def mapBoth[Q >: P](p: P => Q, b: Blocks => Blocks) = BlocksOn(p(page), b(blocks))
+}

--- a/preview/app/controllers/LiveHarnessController.scala
+++ b/preview/app/controllers/LiveHarnessController.scala
@@ -1,10 +1,63 @@
 package controllers
 
-import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import com.gu.contentapi.client.model.v1.ContentType
+import common.{GuLogging, ImplicitControllerExecutionContext}
+import contentapi.ContentApiClient
+import model.{ApplicationContext, ArticleBlocks, GenericFallback}
+import play.api.libs.json.{JsError, JsSuccess, JsValue}
+import play.api.libs.ws.WSClient
+import play.api.mvc.{Action, BaseController, ControllerComponents}
+import renderers.DotcomRenderingService
+import services.{CAPILookup, NewsletterService}
+import utils.LiveHarness.inject
+import utils.LiveHarnessInteractiveAtom
+
 import scala.concurrent.Future
 
-class LiveHarnessController(val controllerComponents: ControllerComponents) extends BaseController {
-  def renderLiveHarness(path: String): Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok("Hello, world!"))
+class LiveHarnessController(
+    contentApiClient: ContentApiClient,
+    val controllerComponents: ControllerComponents,
+    ws: WSClient,
+    newsletterService: NewsletterService,
+)(implicit val context: ApplicationContext)
+    extends BaseController
+    with GuLogging
+    with ImplicitControllerExecutionContext {
+
+  private val renderingService = DotcomRenderingService()
+
+  private val capiLookup: CAPILookup = new CAPILookup(contentApiClient)
+
+  private val articleController =
+    new ArticleController(
+      contentApiClient,
+      controllerComponents,
+      ws,
+      renderingService,
+      newsletterService,
+    )
+
+  private val interactiveController =
+    new InteractiveController(
+      contentApiClient,
+      ws,
+      controllerComponents,
+      renderingService,
+    )
+
+  def renderLiveHarness(path: String): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    request.body.validate[List[LiveHarnessInteractiveAtom]] match {
+      case JsSuccess(atoms, _) =>
+        capiLookup.lookup(path, Some(ArticleBlocks)).flatMap { response =>
+          response.content
+            .map(_.`type`)
+            .collect {
+              case ContentType.Article     => articleController.mapAndRender(path, GenericFallback)(inject(atoms))
+              case ContentType.Interactive => interactiveController.modelAndRenderHtml(response)(inject(atoms))
+            }
+            .getOrElse(Future(BadRequest))
+        }
+      case JsError(errors) => Future(BadRequest(errors.toString()))
+    }
   }
 }

--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -1,0 +1,68 @@
+package utils
+
+import com.gu.contentapi.client.model.v1.{BlockElement, ContentAtomElementFields, ElementType}
+import model.content.InteractiveAtom
+import model.meta.BlocksOn
+import model.{ArticlePage, Content, ContentPage, InteractivePage}
+import play.api.libs.json.{Json, Reads}
+
+case class LiveHarnessInteractiveAtom(
+    id: String,
+    title: String,
+    css: String,
+    html: String,
+    js: String,
+    weighting: String,
+) {
+  val atom = InteractiveAtom(
+    id = id,
+    `type` = "interactive",
+    title = title,
+    css = css,
+    html = html,
+    mainJS = Some(js),
+    docData = None,
+    placeholderUrl = None,
+  )
+
+  val blockElement = BlockElement(
+    `type` = ElementType.Contentatom,
+    assets = Seq.empty,
+    contentAtomTypeData = Some(
+      ContentAtomElementFields(
+        atomId = id,
+        atomType = "interactive",
+        role = Some(weighting),
+        isMandatory = None,
+      ),
+    ),
+  )
+}
+
+object LiveHarnessInteractiveAtom {
+  implicit val reads: Reads[LiveHarnessInteractiveAtom] = Json.reads
+}
+
+object LiveHarness {
+
+  trait PageUpdater[P <: ContentPage] { def update(page: P, content: Content): P }
+
+  implicit val iu: PageUpdater[InteractivePage] = (ip, nc) => ip.copy(interactive = ip.item.copy(content = nc))
+  implicit val au: PageUpdater[ArticlePage] = (ap, nc) => ap.copy(article = ap.item.copy(content = nc))
+
+  def inject[P <: ContentPage](harnessAtoms: Seq[LiveHarnessInteractiveAtom])(implicit
+      updater: PageUpdater[P],
+  ): BlocksOn[P] => BlocksOn[P] = _.mapBoth(
+    page => {
+      val content = page.item.content
+      updater.update(page, content.copy(atoms = content.atoms.map(_.copy(interactives = harnessAtoms.map(_.atom)))))
+    },
+    blocks =>
+      blocks.copy(body = blocks.body.map { bodyBlocks =>
+        val (headBlockOpt, tailBlocks) = bodyBlocks.splitAt(1)
+        headBlockOpt.map { headBlock =>
+          headBlock.copy(elements = harnessAtoms.map(_.blockElement) ++ headBlock.elements)
+        } ++ tailBlocks
+      }),
+  )
+}

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -193,7 +193,7 @@ GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(pa
 GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
 
 # Harnesses
-POST    /desktop-auth/*path         controllers.LiveHarnessController.renderLiveHarness(path)
+POST    /desktop-auth/render-harness/*path         controllers.LiveHarnessController.renderLiveHarness(path)
 
 # Don't forward requests for favicon.ico to the Content API
 GET        /favicon.ico                                                                        controllers.FaviconController.favicon


### PR DESCRIPTION
This is a tweaked version of the work done in https://github.com/guardian/frontend/pull/28417 (so see the functionality description there!), but built upon the refactors done in https://github.com/guardian/frontend/pull/28437, which allows this implementation to be a bit smaller.

## Changes relative to the original PR #28417

In `LiveHarnessController.renderLiveHarness()`:

* The `ArticleController.mapAndRender()` & `InteractiveController.modelAndRender()` methods introduced in #28437 are useful not only within those controllers, but also more suitable for the work needed in `renderLiveHarness()`, meaning that each case (`ContentType.Article` & `ContentType.Interactive`) can be handled much more concisely - a single line each.
* We can avoid transforming the `JsResult` to an `Either`, and just match on `JsSuccess`/`JsError` rather than `Right`/`Left`
* The `match` statement on the `Option[ContentType]` can be done slightly more concisely using `collect` : https://www.scala-lang.org/api/2.13.18/scala/Option.html#collect[B](pf:PartialFunction[A,B]):Option[B]

In `LiveHarness`:

* The important code in `turnLocalAtomsIntoAtomBlocksAndElements()` - that makes an `InteractiveAtom` or `BlockElement` out of a `LiveHarnessInteractiveAtom` - has moved onto `LiveHarnessInteractiveAtom` itself (so all the references copying data from `localAtom.xxx` fields become just references to `xxx` field itself)
* A fiddly bit of functionality - updating the `content` within a `ContentPage`, which varies depending on whether it's a `ArticlePage` or `InteractivePage` - has been isolated into a `PageUpdater` type class. This allows us to have much clearer code elsewhere - without having to define a content-updating method for every single `ContentPage` type, just the two we care about. Consequently, there's not a need for either of the two `injectInteractiveAtomsIntoPage()` methods that used to exist - just a single `inject()` method, which does the work of `addLocalAtomsToParent()` too.
* We use the handy `splitAt()` method to make a bit of code in `addLocalAtomsToParent()` a bit smaller.

In `InteractiveController`:

* A small new `modelAndRenderHtml()` method is required, to match the behaviour from #28417 which short-circuits a lot of logic to ensure that `renderHtml()` is called.
