### PR TITLE
Add switch to enable HLS on web

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -660,4 +660,15 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val EnableHlsWeb = Switch(
+    group = SwitchGroup.Feature,
+    name = "enable-hls-web",
+    description = "Enable HLS web streaming on web",
+    owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
We want to re-enable HLS on self-hosted video on web. We want this functionality behind a feature switch so that we can quickly turn it off, are not 100% confident that this change will not cause issues: https://github.com/guardian/dotcom-rendering/pull/14788