### PR TITLE
Remove Jackson Databind group from Scala Steward config

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -2,6 +2,5 @@
 
 # Overrides the grouping rules from the main config.
 pullRequests.grouping = [
-  { name = "jackson-databind", "title" = "chore(deps): Jackson Databind dependency updates", "filter" = [{"group" = "com.fasterxml.jackson.core", "artifact" = "jackson-databind"}] }
   { name = "jackson", "title" = "chore(deps): Jackson dependency updates", "filter" = [{"group" = "com.fasterxml.jackson.*"}] }
 ]


### PR DESCRIPTION
## Why?
We don't need a separate group. The existing one is enough for Scala Steward to update correctly all the Jackson dependencies.

