### PR TITLE
Add controller and routes for opt in/out for new ab test framework

### DIFF
--- a/applications/app/controllers/AbTestsOptInController.scala
+++ b/applications/app/controllers/AbTestsOptInController.scala
@@ -43,13 +43,17 @@ class AbTestsOptInController(val controllerComponents: ControllerComponents) ext
       case None => Map.empty[String, String]
     }
   }
-  private def opt(choice: String, testType: String, testName: String, testGroup: String)(implicit
+  private def opt(choice: String, testType: String, testNameGroup: String)(implicit
       request: RequestHeader,
   ): Result = {
     val cookieName = testType match {
       case "server" => serverForceTestCookie
       case "client" => clientForceTestCookie
     }
+
+    val parts = testNameGroup.split(":")
+    val testName = parts(0).trim
+    val testGroup = parts(1).trim
 
     choice match {
       case "in"  => optIn(testName, testGroup, cookieName)
@@ -98,11 +102,11 @@ class AbTestsOptInController(val controllerComponents: ControllerComponents) ext
       )
     }
 
-  def handle(choice: String, testType: String, test: String, group: String): Action[AnyContent] =
+  def handle(choice: String, testType: String, testNameGroup: String): Action[AnyContent] =
     Action { implicit request =>
       Cached(60)(
         WithoutRevalidationResult(
-          opt(choice, testType, test, group),
+          opt(choice, testType, testNameGroup),
         ),
       )
     }

--- a/applications/app/controllers/AbTestsOptInController.scala
+++ b/applications/app/controllers/AbTestsOptInController.scala
@@ -1,0 +1,109 @@
+package controllers
+
+import experiments.ParticipationGroups
+import model.Cached
+import model.Cached.WithoutRevalidationResult
+import play.api.mvc._
+
+import scala.concurrent.duration._
+import ab.ABTests
+
+class AbTestsOptInController(val controllerComponents: ControllerComponents) extends BaseController {
+
+  private val lifetime: Int = 90.days.toSeconds.toInt
+
+  private val serverForceTestCookie = "gu_force_server_test_groups"
+  private val clientForceTestCookie = "gu_force_client_test_groups"
+
+  private def getTestsFromParam(groups: String): Map[String, String] = groups
+    .split(",")
+    .collect {
+      case test if test.split(":").length == 2 =>
+        val parts = test.split(":")
+        parts(0).trim -> parts(1).trim
+    }
+    .toMap
+
+  private def readCookie(implicit request: RequestHeader, typeStr: String): Map[String, String] = {
+    val cookieName = typeStr match {
+      case "server" => serverForceTestCookie
+      case "client" => clientForceTestCookie
+    }
+
+    request.cookies.get(cookieName) match {
+      case Some(cookie) =>
+        cookie.value
+          .split(",")
+          .collect {
+            case test if test.split(":").length == 2 =>
+              val parts = test.split(":")
+              parts(0).trim -> parts(1).trim
+          }
+          .toMap
+      case None => Map.empty[String, String]
+    }
+  }
+  private def opt(choice: String, testType: String, testName: String, testGroup: String)(implicit
+      request: RequestHeader,
+  ): Result = {
+    val cookieName = testType match {
+      case "server" => serverForceTestCookie
+      case "client" => clientForceTestCookie
+    }
+
+    choice match {
+      case "in"  => optIn(testName, testGroup, cookieName)
+      case "out" => optOut(testName, testGroup, cookieName)
+    }
+  }
+
+  private def optIn(
+      testName: String,
+      testGroup: String,
+      cookieName: String,
+  )(implicit request: RequestHeader): Result = {
+    val currentTests = readCookie(request, if (cookieName == serverForceTestCookie) "server" else "client")
+    val updatedTests = currentTests + (testName -> testGroup)
+    val cookieValue = updatedTests.map { case (k, v) => s"$k:$v" }.mkString(",")
+
+    SeeOther("/").withCookies(Cookie(cookieName, cookieValue, maxAge = Some(lifetime)))
+  }
+
+  private def optOut(
+      testName: String,
+      testGroup: String,
+      cookieName: String,
+  )(implicit request: RequestHeader): Result = {
+    val currentTests = readCookie(request, if (cookieName == serverForceTestCookie) "server" else "client")
+    val updatedTests = currentTests.filter({ case (k, v) => !(k == testName && v == testGroup) })
+
+    if (updatedTests.isEmpty) {
+      SeeOther("/").discardingCookies(DiscardingCookie(cookieName))
+    } else {
+      val cookieValue = updatedTests.map { case (k, v) => s"$k:$v" }.mkString(",")
+      SeeOther("/").withCookies(Cookie(cookieName, cookieValue, maxAge = Some(lifetime)))
+    }
+  }
+
+  def reset(): Action[AnyContent] =
+    Action { implicit request =>
+      Cached(60)(
+        WithoutRevalidationResult(
+          SeeOther("/")
+            .discardingCookies(
+              DiscardingCookie(serverForceTestCookie),
+              DiscardingCookie(clientForceTestCookie),
+            ),
+        ),
+      )
+    }
+
+  def handle(choice: String, testType: String, test: String, group: String): Action[AnyContent] =
+    Action { implicit request =>
+      Cached(60)(
+        WithoutRevalidationResult(
+          opt(choice, testType, test, group),
+        ),
+      )
+    }
+}

--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -27,6 +27,7 @@ trait ApplicationsControllers {
   lazy val AtomPageController = wire[AtomPageController]
   lazy val preferencesController = wire[PreferencesController]
   lazy val optInController = wire[OptInController]
+  lazy val abTestsOptInController = wire[AbTestsOptInController]
   lazy val newspaperController = wire[NewspaperController]
   lazy val quizController = wire[QuizController]
   lazy val allIndexController = wire[AllIndexController]

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -76,8 +76,8 @@ GET        /opt/$choice<in|out|delete>/:feature                                 
 GET        /opt/reset                                                           controllers.OptInController.reset()
 
 # A/B test opt-in/out routes for beta AB testing framework
-GET        /ab-tests/opt/$choice<in|out>/$type<server|client>/:test/:group      controllers.AbTestsOptInController.handle(choice, type, test, group)
-GET        /ab-tests/opt/reset                                                  controllers.AbTestsOptInController.reset()
+GET        /ab-tests/$type<server|client>/opt-$choice<in|out>/:testGroup                                                         controllers.AbTestsOptInController.handle(choice, type, testGroup)
+GET        /ab-tests/opt/reset                                                                                                   controllers.AbTestsOptInController.reset()
 
 GET        /getnext/$tag<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/*path                controllers.ImageContentController.getNextLightboxJson(path, tag, direction = "next")
 GET        /getprev/$tag<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/*path                controllers.ImageContentController.getNextLightboxJson(path, tag, direction = "prev")

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -75,6 +75,10 @@ GET        /browser-diagnostics                                                 
 GET        /opt/$choice<in|out|delete>/:feature                                 controllers.OptInController.handle(feature, choice)
 GET        /opt/reset                                                           controllers.OptInController.reset()
 
+# A/B test opt-in/out routes for beta AB testing framework
+GET        /ab-tests/opt/$choice<in|out>/$type<server|client>/:test/:group      controllers.AbTestsOptInController.handle(choice, type, test, group)
+GET        /ab-tests/opt/reset                                                  controllers.AbTestsOptInController.reset()
+
 GET        /getnext/$tag<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/*path                controllers.ImageContentController.getNextLightboxJson(path, tag, direction = "next")
 GET        /getprev/$tag<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/*path                controllers.ImageContentController.getNextLightboxJson(path, tag, direction = "prev")
 

--- a/applications/test/AbTestsOptInControllerTest.scala
+++ b/applications/test/AbTestsOptInControllerTest.scala
@@ -20,8 +20,8 @@ import play.api.mvc.Cookie
     new AbTestsOptInController(Helpers.stubControllerComponents())
 
   "AbTestsOptInController" should "opt in to a server test group with empty cookie" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/in/server/test-group:variant")
-    val result = abTestsOptInController.handle("in", "server", "test-group", "variant")(request)
+    val request = FakeRequest("GET", "/ab-tests/server/opt-in/test-group:variant")
+    val result = abTestsOptInController.handle("in", "server", "test-group:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -32,8 +32,8 @@ import play.api.mvc.Cookie
   }
 
   it should "opt in to a client test group with empty cookie" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/in/client/test-group/control")
-    val result = abTestsOptInController.handle("in", "client", "test-group", "control")(request)
+    val request = FakeRequest("GET", "/ab-tests/client/opt-in/test-group:control")
+    val result = abTestsOptInController.handle("in", "client", "test-group:control")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -44,9 +44,9 @@ import play.api.mvc.Cookie
   }
 
   it should "opt in to a server test group with existing cookie" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/in/server/test-group-2/variant")
+    val request = FakeRequest("GET", "/ab-tests/server/opt-in/test-group-2:variant")
       .withCookies(Cookie("gu_force_server_test_groups", "test-group-1:control"))
-    val result = abTestsOptInController.handle("in", "server", "test-group-2", "variant")(request)
+    val result = abTestsOptInController.handle("in", "server", "test-group-2:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -60,9 +60,9 @@ import play.api.mvc.Cookie
   }
 
   it should "opt in to a client test group with existing cookie" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/in/client/test-group-2/variant")
+    val request = FakeRequest("GET", "/ab-tests/client/opt-in/test-group-2:variant")
       .withCookies(Cookie("gu_force_client_test_groups", "test-group-1:control"))
-    val result = abTestsOptInController.handle("in", "client", "test-group-2", "variant")(request)
+    val result = abTestsOptInController.handle("in", "client", "test-group-2:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -76,9 +76,9 @@ import play.api.mvc.Cookie
   }
 
   it should "update existing test group when opting in again" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/in/server/test-group/variant")
+    val request = FakeRequest("GET", "/ab-tests/server/opt-in/test-group:variant")
       .withCookies(Cookie("gu_force_server_test_groups", "test-group:control,other-group:variant"))
-    val result = abTestsOptInController.handle("in", "server", "test-group", "variant")(request)
+    val result = abTestsOptInController.handle("in", "server", "test-group:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -92,9 +92,9 @@ import play.api.mvc.Cookie
   }
 
   it should "opt out of a server test group when it's the only one" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/out/server/test-group/variant")
+    val request = FakeRequest("GET", "/ab-tests/oserver/pt-out/test-group:variant")
       .withCookies(Cookie("gu_force_server_test_groups", "test-group:variant"))
-    val result = abTestsOptInController.handle("out", "server", "test-group", "variant")(request)
+    val result = abTestsOptInController.handle("out", "server", "test-group:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -105,9 +105,9 @@ import play.api.mvc.Cookie
   }
 
   it should "opt out of a client test group when it's the only one" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/out/client/test-group/control")
+    val request = FakeRequest("GET", "/ab-tests/oclient/pt-out/test-group:control")
       .withCookies(Cookie("gu_force_client_test_groups", "test-group:control"))
-    val result = abTestsOptInController.handle("out", "client", "test-group", "control")(request)
+    val result = abTestsOptInController.handle("out", "client", "test-group:control")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -118,9 +118,11 @@ import play.api.mvc.Cookie
   }
 
   it should "opt out of a server test group and keep other groups" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/out/server/test-group-2/variant")
-      .withCookies(Cookie("gu_force_server_test_groups", "test-group-1:control,test-group-2:variant,test-group-3:control"))
-    val result = abTestsOptInController.handle("out", "server", "test-group-2", "variant")(request)
+    val request = FakeRequest("GET", "/ab-tests/oserver/pt-out/test-group-2:variant")
+      .withCookies(
+        Cookie("gu_force_server_test_groups", "test-group-1:control,test-group-2:variant,test-group-3:control"),
+      )
+    val result = abTestsOptInController.handle("out", "server", "test-group-2:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -135,9 +137,11 @@ import play.api.mvc.Cookie
   }
 
   it should "opt out of a client test group and keep other groups" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/out/client/test-group-2/variant")
-      .withCookies(Cookie("gu_force_client_test_groups", "test-group-1:control,test-group-2:variant,test-group-3:control"))
-    val result = abTestsOptInController.handle("out", "client", "test-group-2", "variant")(request)
+    val request = FakeRequest("GET", "/ab-tests/oclient/pt-out/test-group-2:variant")
+      .withCookies(
+        Cookie("gu_force_client_test_groups", "test-group-1:control,test-group-2:variant,test-group-3:control"),
+      )
+    val result = abTestsOptInController.handle("out", "client", "test-group-2:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -152,9 +156,9 @@ import play.api.mvc.Cookie
   }
 
   it should "handle opting out when the group is not in the cookie" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/out/server/non-existent-group/variant")
+    val request = FakeRequest("GET", "/ab-tests/oserver/pt-out/non-existent-group:variant")
       .withCookies(Cookie("gu_force_server_test_groups", "test-group:control"))
-    val result = abTestsOptInController.handle("out", "server", "non-existent-group", "variant")(request)
+    val result = abTestsOptInController.handle("out", "server", "non-existent-group:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -167,8 +171,8 @@ import play.api.mvc.Cookie
   }
 
   it should "handle opting out when there is no cookie" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/out/server/test-group/variant")
-    val result = abTestsOptInController.handle("out", "server", "test-group", "variant")(request)
+    val request = FakeRequest("GET", "/ab-tests/oserver/pt-out/test-group:variant")
+    val result = abTestsOptInController.handle("out", "server", "test-group:variant")(request)
 
     status(result) should be(303)
     redirectLocation(result) should be(Some("/"))
@@ -196,8 +200,8 @@ import play.api.mvc.Cookie
   }
 
   it should "have correct cookie lifetime for opt in" in {
-    val request = FakeRequest("GET", "/ab-tests/opt/in/server/test-groupv/ariant")
-    val result = abTestsOptInController.handle("in", "server", "test-group", "variant")(request)
+    val request = FakeRequest("GET", "/ab-tests/server/opt-in/test-group:variant")
+    val result = abTestsOptInController.handle("in", "server", "test-group:variant")(request)
 
     val cookies = Helpers.cookies(result)
     val cookie = cookies.get("gu_force_server_test_groups").get

--- a/applications/test/AbTestsOptInControllerTest.scala
+++ b/applications/test/AbTestsOptInControllerTest.scala
@@ -1,0 +1,208 @@
+package test
+
+import controllers.AbTestsOptInController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import play.api.test.Helpers._
+import play.api.test.{FakeRequest, Helpers}
+import play.api.mvc.Cookie
+
+@DoNotDiscover class AbTestsOptInControllerTest
+    extends AnyFlatSpec
+    with Matchers
+    with ConfiguredTestSuite
+    with BeforeAndAfterAll
+    with WithMaterializer
+    with WithTestApplicationContext {
+
+  lazy val abTestsOptInController =
+    new AbTestsOptInController(Helpers.stubControllerComponents())
+
+  "AbTestsOptInController" should "opt in to a server test group with empty cookie" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/in/server/test-group:variant")
+    val result = abTestsOptInController.handle("in", "server", "test-group", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    cookies.get("gu_force_server_test_groups") should not be None
+    cookies.get("gu_force_server_test_groups").get.value should be("test-group:variant")
+  }
+
+  it should "opt in to a client test group with empty cookie" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/in/client/test-group/control")
+    val result = abTestsOptInController.handle("in", "client", "test-group", "control")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    cookies.get("gu_force_client_test_groups") should not be None
+    cookies.get("gu_force_client_test_groups").get.value should be("test-group:control")
+  }
+
+  it should "opt in to a server test group with existing cookie" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/in/server/test-group-2/variant")
+      .withCookies(Cookie("gu_force_server_test_groups", "test-group-1:control"))
+    val result = abTestsOptInController.handle("in", "server", "test-group-2", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    val cookieValue = cookies.get("gu_force_server_test_groups").get.value
+
+    // Cookie should contain both test groups
+    cookieValue should include("test-group-1:control")
+    cookieValue should include("test-group-2:variant")
+  }
+
+  it should "opt in to a client test group with existing cookie" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/in/client/test-group-2/variant")
+      .withCookies(Cookie("gu_force_client_test_groups", "test-group-1:control"))
+    val result = abTestsOptInController.handle("in", "client", "test-group-2", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    val cookieValue = cookies.get("gu_force_client_test_groups").get.value
+
+    // Cookie should contain both test groups
+    cookieValue should include("test-group-1:control")
+    cookieValue should include("test-group-2:variant")
+  }
+
+  it should "update existing test group when opting in again" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/in/server/test-group/variant")
+      .withCookies(Cookie("gu_force_server_test_groups", "test-group:control,other-group:variant"))
+    val result = abTestsOptInController.handle("in", "server", "test-group", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    val cookieValue = cookies.get("gu_force_server_test_groups").get.value
+
+    // test-group should be updated to variant
+    cookieValue should include("test-group:variant")
+    cookieValue should include("other-group:variant")
+  }
+
+  it should "opt out of a server test group when it's the only one" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/out/server/test-group/variant")
+      .withCookies(Cookie("gu_force_server_test_groups", "test-group:variant"))
+    val result = abTestsOptInController.handle("out", "server", "test-group", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    // Cookie should be discarded when no test groups remain
+    cookies.get("gu_force_server_test_groups").map(_.maxAge) should be(Some(Some(-86400)))
+  }
+
+  it should "opt out of a client test group when it's the only one" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/out/client/test-group/control")
+      .withCookies(Cookie("gu_force_client_test_groups", "test-group:control"))
+    val result = abTestsOptInController.handle("out", "client", "test-group", "control")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    // Cookie should be discarded when no test groups remain
+    cookies.get("gu_force_client_test_groups").map(_.maxAge) should be(Some(Some(-86400)))
+  }
+
+  it should "opt out of a server test group and keep other groups" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/out/server/test-group-2/variant")
+      .withCookies(Cookie("gu_force_server_test_groups", "test-group-1:control,test-group-2:variant,test-group-3:control"))
+    val result = abTestsOptInController.handle("out", "server", "test-group-2", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    val cookieValue = cookies.get("gu_force_server_test_groups").get.value
+
+    // test-group-2 should be removed but others should remain
+    cookieValue should include("test-group-1:control")
+    cookieValue should not include "test-group-2"
+    cookieValue should include("test-group-3:control")
+  }
+
+  it should "opt out of a client test group and keep other groups" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/out/client/test-group-2/variant")
+      .withCookies(Cookie("gu_force_client_test_groups", "test-group-1:control,test-group-2:variant,test-group-3:control"))
+    val result = abTestsOptInController.handle("out", "client", "test-group-2", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    val cookieValue = cookies.get("gu_force_client_test_groups").get.value
+
+    // test-group-2 should be removed but others should remain
+    cookieValue should include("test-group-1:control")
+    cookieValue should not include "test-group-2"
+    cookieValue should include("test-group-3:control")
+  }
+
+  it should "handle opting out when the group is not in the cookie" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/out/server/non-existent-group/variant")
+      .withCookies(Cookie("gu_force_server_test_groups", "test-group:control"))
+    val result = abTestsOptInController.handle("out", "server", "non-existent-group", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    val cookieValue = cookies.get("gu_force_server_test_groups").get.value
+
+    // Original cookie should remain unchanged
+    cookieValue should be("test-group:control")
+  }
+
+  it should "handle opting out when there is no cookie" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/out/server/test-group/variant")
+    val result = abTestsOptInController.handle("out", "server", "test-group", "variant")(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    // Cookie should be discarded (even though it didn't exist)
+    cookies.get("gu_force_server_test_groups").map(_.maxAge) should be(Some(Some(-86400)))
+  }
+
+  it should "reset all AB test cookies" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/reset")
+      .withCookies(
+        Cookie("gu_force_server_test_groups", "test-group-1:control"),
+        Cookie("gu_force_client_test_groups", "test-group-2:variant"),
+      )
+    val result = abTestsOptInController.reset()(request)
+
+    status(result) should be(303)
+    redirectLocation(result) should be(Some("/"))
+
+    val cookies = Helpers.cookies(result)
+    // Both cookies should be discarded
+    cookies.get("gu_force_server_test_groups").map(_.maxAge) should be(Some(Some(-86400)))
+    cookies.get("gu_force_client_test_groups").map(_.maxAge) should be(Some(Some(-86400)))
+  }
+
+  it should "have correct cookie lifetime for opt in" in {
+    val request = FakeRequest("GET", "/ab-tests/opt/in/server/test-groupv/ariant")
+    val result = abTestsOptInController.handle("in", "server", "test-group", "variant")(request)
+
+    val cookies = Helpers.cookies(result)
+    val cookie = cookies.get("gu_force_server_test_groups").get
+
+    // 90 days in seconds
+    cookie.maxAge should be(Some(7776000))
+  }
+}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -286,8 +286,8 @@ GET            /opt/$choice<in|out|delete>/:feature                             
 GET            /opt/reset                                                                                                        controllers.OptInController.reset()
 
 # A/B test opt-in/out routes for beta AB testing framework
-GET        /ab-tests/opt/$choice<in|out>/$type<server|client>/:test/:group      controllers.AbTestsOptInController.handle(choice, type, test, group)
-GET        /ab-tests/opt/reset                                                  controllers.AbTestsOptInController.reset()
+GET        /ab-tests/$type<server|client>/opt-$choice<in|out>/:testGroup                                                         controllers.AbTestsOptInController.handle(choice, type, testGroup)
+GET        /ab-tests/opt/reset                                                                                                   controllers.AbTestsOptInController.reset()
 
 # Applications (must come before wildcard)
 GET            /sitemaps/news.xml                                                                                                controllers.SiteMapController.renderNewsSiteMap()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -285,6 +285,10 @@ GET            /series/*path.json                                               
 GET            /opt/$choice<in|out|delete>/:feature                                                                              controllers.OptInController.handle(feature, choice)
 GET            /opt/reset                                                                                                        controllers.OptInController.reset()
 
+# A/B test opt-in/out routes for beta AB testing framework
+GET        /ab-tests/opt/$choice<in|out>/$type<server|client>/:test/:group      controllers.AbTestsOptInController.handle(choice, type, test, group)
+GET        /ab-tests/opt/reset                                                  controllers.AbTestsOptInController.reset()
+
 # Applications (must come before wildcard)
 GET            /sitemaps/news.xml                                                                                                controllers.SiteMapController.renderNewsSiteMap()
 GET            /sitemaps/video.xml                                                                                               controllers.SiteMapController.renderVideoSiteMap()


### PR DESCRIPTION
## What is the value of this and can you measure success?
The current implementation of opting in/out for new beta AB Test framework is implemented in VCL and only works for a single test at a time. 

We've discovered that's a bit of a limitation, as sometimes testing multiple tests interacting is useful, especially with long running tests for example sign in gate tests or dark mode.

As the current opt in behaviour is implemented in VCL, it's difficult to adapt for multiple tests as Fastly VCL doesn’t support arrays/loops/unbounded code, so working with lists (of ab tests) is difficult.

The URLs simply need to add or remove tests from cookies, so we can move it to frontend where it's much easier to implement the logic.

As the cookies will contain multiple tests, our Fastly VCL can no longer lookup the forced test(s) (due to limitations described above), which is fine and maybe even useful to be able to opt into expired tests. 
But it also means that it can't determine the type (server or client) of test, so we must have separate URLs and cookies for server and client tests, which Fastly will add to the appropriate server or client test header/cookie. 
 
## What does this change?
Add a new controller and routes for the opting in and out of tests in the new framework

The URLs look like:
`https://theguardian.com/ab-tests/client/opt-in/test:variant`
and 
`https://theguardian.com/ab-tests/server/opt-out/test:variant`
there's also `https://theguardian.com/ab-tests/opt/reset` to remove all forced test participations.

There are corresponding changes to fastly and router
