### PR TITLE
Remove obsolete thread pool

### DIFF
--- a/facia/conf/application.conf
+++ b/facia/conf/application.conf
@@ -26,14 +26,6 @@ pekko {
       }
     }
   }
-
-  blocking-operations {
-    executor = "thread-pool-executor"
-    throughput = 10
-    thread-pool-executor {
-      fixed-pool-size = 128
-    }
-  }
 }
 
 play {


### PR DESCRIPTION
The `blocking-operations` thread-pool is no longer used anywhere in the `facia` app, so we don't need to create it anymore  (I should have listened to @ioannakok [back in 2023](https://github.com/guardian/frontend/pull/26338#discussion_r1284678412)!)

#### Future candidate for deletion...

The [`BlockingOperations`](https://github.com/guardian/frontend/blob/main/common/app/concurrent/BlockingOperations.scala) class (introduced with https://github.com/guardian/frontend/pull/18359 in 2017) is currently only used in one place - the `ParameterStoreService` in the `admin` app (in service of the [frontend.gutools.co.uk/config](https://frontend.gutools.co.uk/config) tool, introduced with https://github.com/guardian/frontend/pull/18529):

https://github.com/guardian/frontend/blob/217a2052fc96439af5df1d0ed6af1f390543ab5d/admin/app/services/ParameterStoreService.scala#L13-L21

If `parameterStore.getPath()` was updated to use an async SSM client, and return a `Future`, we could drop `BlockingOperations` (note that the method is also used for initialising config, which Play takes _without_ `Future`s).

https://github.com/guardian/frontend/blob/ad0b97b291ce031c77a7982207643150ac00dd5e/common/app/services/ParameterStore.scala#L23
