### PR TITLE
Add separate section in commercial admin app adtests page for CommDev ones

### DIFF
--- a/admin/app/views/commercial/adTests.scala.html
+++ b/admin/app/views/commercial/adTests.scala.html
@@ -1,7 +1,7 @@
 @import common.dfp.GuLineItem
 @import tools.DfpLink
 
-@(timestamp: String, groupedLineItems: Seq[(String, Seq[GuLineItem])])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(timestamp: String, commDevLineItems: Seq[(String, Seq[GuLineItem])], groupedLineItems: Seq[(String, Seq[GuLineItem])])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Ad Tests", isAuthed = true) {
 
@@ -11,16 +11,40 @@
 <p>Last updated: @timestamp</p>
 <p>This page shows ready and delivering line items that are hidden behind a test cookie.</p >
 
+<h2>CommDev Test Order Line Items</h2>
 <table>
-    <thead><tr><th>Cookie</th><th>Line items</th></tr></thead>
+    <thead><tr><th class="cookie">Cookie</th><th>Line items</th></tr></thead>
+    <tbody>
+    @for((testValue, lineItems) <- commDevLineItems) {
+        <tr id="cookie-@testValue" class="cookie-row">
+            <td class="cookie"><code>@testValue</code></td>
+            <td>
+            @for(lineItem <- lineItems) {
+                @{lineItem.name} (<a href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a>)
+                <br />
+            }
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>
+
+<h2>Line Items</h2>
+<table>
+    <thead>
+        <tr>
+            <th class="cookie">Cookie</th>
+            <th>Line items</th>
+        </tr>
+    </thead>
     <tbody>
     @for((testValue, lineItems) <- groupedLineItems) {
         <tr id="cookie-@testValue" class="cookie-row">
-            <td align="right" valign="top"><button value="@testValue" class="cookie">@testValue</button></td>
+            <td class="cookie"><code>@testValue</code></td>
             <td>
             @for(lineItem <- lineItems) {
-                @{lineItem.name} (<a href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a>
-                )<br />
+                @{lineItem.name} (<a href="@DfpLink.lineItem(lineItem.id)" target="_blank">@{lineItem.id}</a>)
+                <br />
             }
             </td>
         </tr>

--- a/admin/public/css/commercial.css
+++ b/admin/public/css/commercial.css
@@ -95,3 +95,8 @@ dl.error, dd.error {
     font-size: 12px;
     overflow-wrap: break-word
 }
+
+.cookie {
+    text-align: right;
+    vertical-align: top;
+}


### PR DESCRIPTION
## What is the value of this and can you measure success?

Ensures we can more easily see which ad tests have been configured under the CommDev test order versus those created by other teams or people

## What does this change?

- Adds a separate table for adtests configured for line items under the CommDev test order

- Changes the ad test values from a `<button>` to `<code>` in the HTML

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/1307e4e2-6b08-469d-a47f-e1b8396138ba
[after]: https://github.com/user-attachments/assets/793f0e47-0719-46c0-b358-9f59593c9d10
