### PR TITLE
Increase facia timeout

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -290,13 +290,6 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       })
   }
 
-  private def getTimeout: Duration = {
-    if (Configuration.environment.stage == "DEV")
-      Configuration.rendering.timeout * 5
-    else
-      Configuration.rendering.timeout * 2
-  }
-
   def getFront(
       ws: WSClient,
       page: PressedPage,
@@ -313,7 +306,10 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     )
 
     val json = DotcomFrontsRenderingDataModel.toJson(dataModel)
-    val timeout = getTimeout
+    val timeout = if (Configuration.environment.stage == "DEV")
+      Configuration.rendering.timeout * 5
+    else
+      Configuration.rendering.timeout * 2
     post(ws, json, Configuration.rendering.faciaBaseURL + "/Front", CacheTime.Facia, timeout)
   }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -306,10 +306,11 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     )
 
     val json = DotcomFrontsRenderingDataModel.toJson(dataModel)
-    val timeout = if (Configuration.environment.stage == "DEV")
-      Configuration.rendering.timeout * 5
-    else
-      Configuration.rendering.timeout * 2
+    val timeout =
+      if (Configuration.environment.stage == "DEV")
+        Configuration.rendering.timeout * 5
+      else
+        Configuration.rendering.timeout * 2
     post(ws, json, Configuration.rendering.faciaBaseURL + "/Front", CacheTime.Facia, timeout)
   }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -285,7 +285,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     if (Configuration.environment.stage == "DEV")
       Configuration.rendering.timeout * 5
     else
-      Configuration.rendering.timeout
+      Configuration.rendering.timeout * 2
   }
 
   def getFront(


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR increases the facia timeout from 2 seconds to 4 seconds to allow heavier page requests to complete successfully.

It also introduces a new circuit breaker with a longer timeout that matches the 4 seconds plus 200 milliseconds for [interactives](https://github.com/guardian/frontend/blob/dd69bdff659bd46dfa58c98d2bce9069266e830e/common/app/renderers/DotcomRenderingService.scala#L343) and now facia. 

This change should reduce the current cycle of 504 timeouts (which could also be preventing the cache from updating). We should expect immediate error reduction with further stabilisation expected gradually towards next Wednesday as natural TTL expiry refreshes the remaining content.

