### PR TITLE
Apply new Filter UK/US overlays to Filter UK/US content

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -86,7 +86,8 @@ final case class Content(
   lazy val isImmersive =
     fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists { tag => tag.id == "tone/advertisement-features" }
-  lazy val isTheFilter: Boolean = tags.tags.exists { tag => tag.id == "thefilter/series/the-filter" }
+  lazy val isTheFilterUk: Boolean = tags.tags.exists { tag => tag.id == "thefilter/series/the-filter" }
+  lazy val isTheFilterUs: Boolean = tags.tags.exists { tag => tag.id == "thefilter-us/series/thefilter-us" }
   lazy val isUSProductionOffice: Boolean = productionOffice.exists(_.toLowerCase == "us")
   lazy val campaigns: List[Campaign] =
     _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
@@ -102,7 +103,7 @@ final case class Content(
         // Some Labs pages have quiz atoms but are not tagged as quizzes
         val hasQuizAtoms: Boolean = atoms.exists(a => a.quizzes.nonEmpty)
 
-        AmpArticleSwitch.isSwitchedOn && hasBodyBlocks && !tags.isQuiz && !hasQuizAtoms && !isTheFilter
+        AmpArticleSwitch.isSwitchedOn && hasBodyBlocks && !tags.isQuiz && !hasQuizAtoms && !isTheFilterUk
       } else {
         false
       }
@@ -163,7 +164,9 @@ final case class Content(
       trail.webPublicationDate.isBefore(DateTime.now().minusYears(1))
 
     () match {
-      case paid if isPaidContent => Paid
+      case paid if isPaidContent     => Paid
+      case filterUk if isTheFilterUk => FilterUk
+      case filterUs if isTheFilterUs => FilterUs
       case oldcommentObserver if isOldOpinion && isFromTheObserver =>
         CommentObserverOldContent(trail.webPublicationDate.getYear)
       case oldComment if isOldOpinion => CommentGuardianOldContent(trail.webPublicationDate.getYear)

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -225,7 +225,7 @@ object OpenGraphImage extends OverlayBase64 {
       case ObserverStarRating(rating)      => starRatingObserver(rating, shouldIncludeOverlay, shouldUpscale)
       case GuardianStarRating(rating)      => starRating(rating, shouldIncludeOverlay, shouldUpscale)
       case Paid                            => Item700
-      case FilterUk =>
+      case FilterUk                        =>
         new ShareImage(s"overlay-base64=${overlayUrlBase64("filter-uk.png")}", shouldIncludeOverlay, shouldUpscale)
       case FilterUs =>
         new ShareImage(s"overlay-base64=${overlayUrlBase64("filter-us.png")}", shouldIncludeOverlay, shouldUpscale)

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -193,6 +193,8 @@ case class GuardianOldContent(publicationYear: Int) extends ShareImageCategory
 case class ObserverStarRating(rating: Int) extends ShareImageCategory
 case class GuardianStarRating(rating: Int) extends ShareImageCategory
 case object Paid extends ShareImageCategory
+case object FilterUk extends ShareImageCategory
+case object FilterUs extends ShareImageCategory
 
 trait OverlayBase64 {
   def overlayUrlBase64(overlay: String): String =
@@ -223,6 +225,10 @@ object OpenGraphImage extends OverlayBase64 {
       case ObserverStarRating(rating)      => starRatingObserver(rating, shouldIncludeOverlay, shouldUpscale)
       case GuardianStarRating(rating)      => starRating(rating, shouldIncludeOverlay, shouldUpscale)
       case Paid                            => Item700
+      case FilterUk =>
+        new ShareImage(s"overlay-base64=${overlayUrlBase64("filter-uk.png")}", shouldIncludeOverlay, shouldUpscale)
+      case FilterUs =>
+        new ShareImage(s"overlay-base64=${overlayUrlBase64("filter-us.png")}", shouldIncludeOverlay, shouldUpscale)
     }
   }
 

--- a/docs/03-dev-howtos/20-update-overlay-images.md
+++ b/docs/03-dev-howtos/20-update-overlay-images.md
@@ -4,7 +4,7 @@ Updating Social Media Overlay Images
 We use the [overlay capability of Fastly IO](https://docs.fastly.com/api/imageopto/overlay) to generate images for social
 media - [here](https://i.guim.co.uk/img/media/a16462a73520e333b6b0f84cc487dc5c1cde68a3/0_173_5184_3110/master/5184.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctb3BpbmlvbnMucG5n&s=63e3b63a91b42000daefd4811f513ada)
 is an example with the guardian logo overlayed on it. The code that generates the urls for these images exists in 
-`Profile.scala`.
+`ImageProfile.scala`.
 
 Overlay images are currently all hosted from the frontend static S3 bucket, so to update the images you'll need access to
 S3. It's recommended you add any new overlay images under `overlays/`. You can check that your new image has been properly
@@ -18,7 +18,7 @@ If you've updated an image you'll need to clear the cache for that image using t
 image, for example `https://i.guim.co.uk/img/static/overlays/tg-default.png` - note that this URL isn't signed so will return
 a 403, but will still work in the cache clearing tool.
 
-You can then reference the image in a url either by using the existing logic in `Profile.scala` or like this:
+You can then reference the image in a url either by using the existing logic in `ImageProfile.scala` or like this:
 `https://i.guim.co.uk/img/media/abc123/master/1234.jpg?overlay-base64=<base64encode(/img/static/overlays/logo.png)`
 
 See the fastly docs referenced above, or if you're feeling brave the [fastly image service vcl](https://github.com/guardian/fastly-image-service)


### PR DESCRIPTION
## What does this change?
Use new overlay images for the Filter UK and Filter US content. This is to help readers differentiate Filter content when links are sent or posted on social media. These overlay images have been uploaded to S3 so that the links being added in this code work properly.

I've tested this on CODE, and have checked the links being added to the metadata in the page html. Screenshots of the images added there are below.

## Images
|  | Before      | After     |
| ------------- | ------------- | ------------- |
| Filter UK | <img width="600" alt="Screenshot 2025-12-15 at 09 48 39" src="https://github.com/user-attachments/assets/3c1d889e-1baf-4f4a-90ba-ca2fc472264b" /> | <img width="600" alt="Screenshot 2025-12-15 at 09 51 55" src="https://github.com/user-attachments/assets/5c4f6fa8-dd82-4207-848d-0801fe39319b" /> |
| Filter US | <img width="600" alt="Screenshot 2025-12-15 at 09 51 20" src="https://github.com/user-attachments/assets/33b53714-20ee-41fe-ab9b-18580ba1a800" /> | <img width="600" alt="Screenshot 2025-12-15 at 09 52 34" src="https://github.com/user-attachments/assets/13ed9548-f727-46b0-b56c-a04d9dbd9ff4" /> |