### PR TITLE
Create 0% onwards journey AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -26,4 +26,15 @@ trait ABTestSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  Switch(
+    ABTests,
+    "ab-onward-journeys",
+    "Testing the new gallery Onward Journey component on all articles",
+    owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2026, 7, 23)),
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { auxiaSignInGate } from './tests/auxia-sign-in-gate';
+import { onwardJourneys } from './tests/onward-jouneys';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -11,4 +12,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
 	auxiaSignInGate,
+	onwardJourneys,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-jouneys.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-jouneys.js
@@ -1,0 +1,23 @@
+export const onwardJourneys = {
+	id: 'OnwardJourneys',
+	start: '2025-12-11',
+	expiry: '2026-07-23',
+	author: 'fronts.and.curation@guardian.co.uk',
+	description: 'Testing the new Onward Journey component on all articles',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	successMeasure: 'Higher click-through rate',
+	audienceCriteria: 'All articles on web (excludes apps)',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: () => {},
+		},
+		{
+			id: 'variant',
+			test: () => {},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?

Creates a 0% AB test for testing the new onwards journey component in all articles. Adds a feature switch as recommended [in the docs](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/development/ab-testing-in-dcr.md#quick-start).