### PR TITLE
Update World Cup Competition to refer to World Cup 2026

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -126,14 +126,13 @@ object CompetitionsProvider {
   val allCompetitions: Seq[Competition] = Seq(
     Competition(
       "700",
-      "/football/world-cup-2022",
-      "World Cup 2022",
-      "World Cup 2022",
+      "/football/world-cup-2026",
+      "World Cup 2026",
+      "World Cup 2026",
       "Internationals",
       showInTeamsList = true,
       tableDividers = List(2),
-      startDate = Some(LocalDate.of(2022, 11, 1)),
-      finalMatchSVG = Some("world_cup_2022_badge"),
+      startDate = Some(LocalDate.of(2025, 12, 2)),
     ),
     Competition(
       "423",


### PR DESCRIPTION
## What does this change?
Update World Cup Competition to refer to World Cup 2026 

## Why?
World Cup 2022 is over. World Cup 2026 is the new thing

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1960" height="1202" alt="image" src="https://github.com/user-attachments/assets/2613ee4d-661d-4459-96b7-f5cf68946704" /> | <img width="2072" height="1202" alt="image" src="https://github.com/user-attachments/assets/bfccbedb-5945-4865-bdaf-5d2a49937eb8" /> |


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
