### PR TITLE
Labs Redesign: Remove 0% experiment and feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -617,17 +617,6 @@ trait FeatureSwitches {
     highImpact = false,
   )
 
-  val GuardianLabsRedesign = Switch(
-    SwitchGroup.Feature,
-    "guardian-labs-redesign",
-    "Shows the new style labs containers and cards",
-    owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
-    sellByDate = Some(LocalDate.of(2025, 12, 16)),
-    safeState = Off,
-    exposeClientSide = true,
-    highImpact = false,
-  )
-
   val ProductLeftColCards = Switch(
     SwitchGroup.Feature,
     "product-left-col-cards",

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -13,7 +13,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     Set(
       DarkModeWeb,
       GoogleOneTap,
-      LabsRedesign,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -25,15 +24,6 @@ object GoogleOneTap
       owners = Seq(Owner.withEmail("identity.dev@theguardian.com")),
       sellByDate = LocalDate.of(2026, 2, 2),
       participationGroup = Perc0B,
-    )
-
-object LabsRedesign
-    extends Experiment(
-      name = "labs-redesign",
-      description = "Allows opting in to preview the Guardian Labs redesign work",
-      owners = Seq(Owner.withEmail("commercial.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2025, 12, 16),
-      participationGroup = Perc0C,
     )
 
 object DarkModeWeb


### PR DESCRIPTION
## What is the value of this and can you measure success?

Now that the Labs Redesign work is live, we can remove the test and experiment that was set up to test and control the launch of it

## What does this change?

- Removes the feature switch `GuardianLabsRedesign`
- Removes the experiment (server-side AB test) `LabsRedesign`


> [!WARNING]
> The DCR PR to migrate over to the new designs permanently must be merged first https://github.com/guardian/dotcom-rendering/pull/15007
