### PR TITLE
feature flag added for signup newsletter component

### DIFF
--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -5,6 +5,17 @@ import conf.switches.Owner.group
 
 trait NewslettersSwitches {
 
+  val HideNewsletterForSubscribers = Switch(
+    SwitchGroup.Newsletters,
+    "hide-newsletter-for-subscribers",
+    "Feature flag to enable/disable newsletter subscription check",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
   val EmailSignupRecaptcha = Switch(
     SwitchGroup.Newsletters,
     "email-signup-recaptcha",

--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -5,7 +5,7 @@ import conf.switches.Owner.group
 
 trait NewslettersSwitches {
 
-  val HideNewsletterForSubscribers = Switch(
+  val HideNewsletterSignupComponentForSubscribers = Switch(
     SwitchGroup.Newsletters,
     "hide-newsletter-for-subscribers",
     "Feature flag to enable/disable newsletter subscription check",

--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -7,7 +7,7 @@ trait NewslettersSwitches {
 
   val HideNewsletterSignupComponentForSubscribers = Switch(
     SwitchGroup.Newsletters,
-    "hide-newsletter-for-subscribers",
+    "hide-newsletter-signup-component-for-subscribers",
     "Feature flag to enable/disable newsletter subscription check",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = On,

--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -12,7 +12,7 @@ trait NewslettersSwitches {
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = On,
     sellByDate = never,
-    exposeClientSide = true,
+    exposeClientSide = false,
     highImpact = false,
   )
 

--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -12,7 +12,7 @@ trait NewslettersSwitches {
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = On,
     sellByDate = never,
-    exposeClientSide = false,
+    exposeClientSide = true,
     highImpact = false,
   )
 


### PR DESCRIPTION

## What does this change?
I've added a feature flag for newsletter signup component

We will look to add a feature flag to toggle to identity api call.

Work in: https://github.com/guardian/dotcom-rendering/pull/15027
ticket link: https://github.com/orgs/guardian/projects/131/views/1?pane=issue&itemId=145082334&issue=guardian%7Cnewsletters-nx%7C442

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
