### PR TITLE
reorder nav to match request

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -221,6 +221,7 @@ object NavLinks {
       NavLink("Blog", "/crosswords/crossword-blog"),
       NavLink("Quick", "/crosswords/series/quick"),
       NavLink("Sunday quick", "/crosswords/series/sunday-quick"),
+      NavLink("Mini", "/crosswords/series/mini-crossword"),
       NavLink("Quick cryptic", "/crosswords/series/quick-cryptic"),
       NavLink("Quiptic", "/crosswords/series/quiptic"),
       NavLink("Cryptic", "/crosswords/series/cryptic"),
@@ -228,7 +229,6 @@ object NavLinks {
       NavLink("Genius", "/crosswords/series/genius"),
       NavLink("Weekend", "/crosswords/series/weekend-crossword"),
       NavLink("Special", "/crosswords/series/special"),
-      NavLink("Mini", "/crosswords/series/mini-crossword"),
     ),
   )
   val wordiply = NavLink(

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -822,6 +822,12 @@
 						"classList": []
 					},
 					{
+						"title": "Mini",
+						"url": "/crosswords/series/mini-crossword",
+						"children": [],
+						"classList": []
+					},
+					{
 						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
@@ -860,12 +866,6 @@
 					{
 						"title": "Special",
 						"url": "/crosswords/series/special",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Mini",
-						"url": "/crosswords/series/mini-crossword",
 						"children": [],
 						"classList": []
 					}
@@ -1593,6 +1593,12 @@
 						"classList": []
 					},
 					{
+						"title": "Mini",
+						"url": "/crosswords/series/mini-crossword",
+						"children": [],
+						"classList": []
+					},
+					{
 						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
@@ -1631,12 +1637,6 @@
 					{
 						"title": "Special",
 						"url": "/crosswords/series/special",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Mini",
-						"url": "/crosswords/series/mini-crossword",
 						"children": [],
 						"classList": []
 					}
@@ -2298,6 +2298,12 @@
 						"classList": []
 					},
 					{
+						"title": "Mini",
+						"url": "/crosswords/series/mini-crossword",
+						"children": [],
+						"classList": []
+					},
+					{
 						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
@@ -2336,12 +2342,6 @@
 					{
 						"title": "Special",
 						"url": "/crosswords/series/special",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Mini",
-						"url": "/crosswords/series/mini-crossword",
 						"children": [],
 						"classList": []
 					}
@@ -3163,6 +3163,12 @@
 						"classList": []
 					},
 					{
+						"title": "Mini",
+						"url": "/crosswords/series/mini-crossword",
+						"children": [],
+						"classList": []
+					},
+					{
 						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
@@ -3201,12 +3207,6 @@
 					{
 						"title": "Special",
 						"url": "/crosswords/series/special",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Mini",
-						"url": "/crosswords/series/mini-crossword",
 						"children": [],
 						"classList": []
 					}
@@ -4148,6 +4148,12 @@
 						"classList": []
 					},
 					{
+						"title": "Mini",
+						"url": "/crosswords/series/mini-crossword",
+						"children": [],
+						"classList": []
+					},
+					{
 						"title": "Quick cryptic",
 						"url": "/crosswords/series/quick-cryptic",
 						"children": [],
@@ -4186,12 +4192,6 @@
 					{
 						"title": "Special",
 						"url": "/crosswords/series/special",
-						"children": [],
-						"classList": []
-					},
-					{
-						"title": "Mini",
-						"url": "/crosswords/series/mini-crossword",
 						"children": [],
 						"classList": []
 					}


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

Reorders the crossword nav to match request for new series "Mini" - to keep the nav (roughly!) in order of complexity

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
