### PR TITLE
Bump facia version to 28.0.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.38.9"
   val capiVersion = "40.0.0"
-  val faciaVersion = "27.0.0"
+  val faciaVersion = "28.0.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?

Bumps the `fapiClient` dependency to v28.0.1.

Diff: https://github.com/guardian/facia-scala-client/compare/v27.0.0...v28.0.1

Individual PRs
- https://github.com/guardian/facia-scala-client/pull/385
- https://github.com/guardian/facia-scala-client/pull/386

## Testing
- [x] Tested locally
- [x] Tested on CODE