### PR TITLE
Add logging to non-discussion routes

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -22,6 +22,7 @@ class EmailVerificationController(
 
   def completeRegistration: Action[AnyContent] =
     Action.async { implicit request =>
+      logger.info(s"Request path is: ${request.path}")
       val page = IdentityPage("/complete-registration", "Complete Signup", isFlow = true)
       val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
 
@@ -41,10 +42,15 @@ class EmailVerificationController(
           logger.error("No encryptedEmail parameter present on complete registration page request")
           Future.successful(errorPage(verifiedReturnUrlAsOpt, page))
         })
+        .map { result =>
+          logger.info(s"Response for ${request.path} is: ${result.header.status}")
+          result
+        }
     }
 
   def resendValidationEmail: Action[AnyContent] =
     Action.async { implicit request =>
+      logger.info(s"Request path is: ${request.path}")
       val page = IdentityPage("/complete-registration", "Complete Signup", isFlow = true)
       val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
       val email = request.session.get("email")
@@ -66,6 +72,10 @@ class EmailVerificationController(
           )
           Future.successful(errorPage(verifiedReturnUrlAsOpt, page))
         })
+        .map { result =>
+          logger.info(s"Response for ${request.path} is: ${result.header.status}")
+          result
+        }
     }
 
   private def successPage(

--- a/identity/app/controllers/FormstackController.scala
+++ b/identity/app/controllers/FormstackController.scala
@@ -20,11 +20,17 @@ class FormstackController(
 
   def formstackForm(formReference: String): Action[AnyContent] =
     Action { implicit request =>
-      NotFound(views.html.formstack.formstackFormNotFound(page))
+      logger.info(s"Request path is: ${request.path}")
+      val result = NotFound(views.html.formstack.formstackFormNotFound(page))
+      logger.info(s"Response for ${request.path} is: ${result.header.status}")
+      result
     }
 
   def complete: Action[AnyContent] =
     Action { implicit request =>
-      Ok(views.html.formstack.formstackComplete(page))
+      logger.info(s"Request path is: ${request.path}")
+      val result = Ok(views.html.formstack.formstackComplete(page))
+      logger.info(s"Response for ${request.path} is: ${result.header.status}")
+      result
     }
 }

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -36,6 +36,7 @@ trait ConsentsJourney extends EditProfileControllerComponents {
   def completeConsents: Action[AnyContent] =
     csrfCheck {
       consentAuthWithIdapiUserAction.async { implicit request =>
+        logger.info(s"Request path is: ${request.path}")
         val returnUrlForm = Form(single("returnUrl" -> nonEmptyText))
         returnUrlForm
           .bindFromRequest()
@@ -67,20 +68,27 @@ trait ConsentsJourney extends EditProfileControllerComponents {
                 }
             },
           )
+          .map { result =>
+            logger.info(s"Response for ${request.path} is: ${result.header.status}")
+            result
+          }
       }
     }
 
   private def displayConsentJourneyForm(page: ConsentJourneyPage, consentHint: Option[String]): Action[AnyContent] =
     csrfAddToken {
       consentAuthWithIdapiUserWithEmailValidation.async { implicit request =>
+        logger.info(s"Request path is: ${request.path}")
         consentJourneyView(
           page = page,
           journey = page.journey,
           forms = ProfileForms(userWithOrderedConsents(request.user, consentHint), PublicEditProfilePage),
           request.user,
           consentHint,
-        )
-
+        ).map { result =>
+          logger.info(s"Response for ${request.path} is: ${result.header.status}")
+          result
+        }
       }
     }
 
@@ -90,6 +98,7 @@ trait ConsentsJourney extends EditProfileControllerComponents {
   ): Action[AnyContent] =
     csrfAddToken {
       consentAuthWithIdapiUserWithEmailValidation.async { implicit request =>
+        logger.info(s"Request path is: ${request.path}")
         val returnUrl = returnUrlVerifier.getVerifiedReturnUrl(request) match {
           case Some(url) => if (url contains "/consents") returnUrlVerifier.defaultReturnUrl else url
           case _         => returnUrlVerifier.defaultReturnUrl
@@ -99,7 +108,10 @@ trait ConsentsJourney extends EditProfileControllerComponents {
           page,
           request.user,
           returnUrl,
-        )
+        ).map { result =>
+          logger.info(s"Response for ${request.path} is: ${result.header.status}")
+          result
+        }
       }
     }
 

--- a/identity/app/controllers/editprofile/tabs/EmailsTab.scala
+++ b/identity/app/controllers/editprofile/tabs/EmailsTab.scala
@@ -7,7 +7,10 @@ import play.api.mvc.{Action, AnyContent}
 trait EmailsTab extends EditProfileControllerComponents {
   private def redirectToManage(path: String): Action[AnyContent] =
     Action { implicit request =>
-      Redirect(url = s"${Configuration.id.mmaUrl}/${path}", MOVED_PERMANENTLY)
+      logger.info(s"Request path is: ${request.path}")
+      val result = Redirect(url = s"${Configuration.id.mmaUrl}/${path}", MOVED_PERMANENTLY)
+      logger.info(s"Response for ${request.path} is: ${result.header.status}")
+      result
     }
 
   /** GET /email-prefs */

--- a/identity/app/controllers/editprofile/tabs/PublicTab.scala
+++ b/identity/app/controllers/editprofile/tabs/PublicTab.scala
@@ -8,7 +8,10 @@ trait PublicTab extends EditProfileControllerComponents {
 
   private def redirectToManage(path: String): Action[AnyContent] =
     Action { implicit request =>
-      Redirect(url = s"${Configuration.id.mmaUrl}/${path}", MOVED_PERMANENTLY)
+      logger.info(s"Request path is: ${request.path}")
+      val result = Redirect(url = s"${Configuration.id.mmaUrl}/${path}", MOVED_PERMANENTLY)
+      logger.info(s"Response for ${request.path} is: ${result.header.status}")
+      result
     }
 
   /** GET /public/edit */


### PR DESCRIPTION
## What does this change?
Adds logging to non-discussion routes

## Why?
We would like to check which ones are still visited. As part of the CDK migration of the identity service, we will only test the discussion routes because we know they are still used. We are not sure about the rest so we're adding logging so if CDK breaks any of these flows, we will know.

