### PR TITLE
Replace org.lz4 with at.yawk.lz4 1.10.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,10 @@ https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-proj
  */
 ThisBuild / asciiGraphWidth := 999999999
 
+// Exclude vulnerable org.lz4:lz4-java and use at.yawk.lz4:lz4-java see https://github.com/advisories/GHSA-cmp6-m4wj-q63q
+ThisBuild / excludeDependencies += "org.lz4" % "lz4-java"
+ThisBuild / libraryDependencies += "at.yawk.lz4" % "lz4-java" % "1.10.2"
+
 val common = library("common")
   .settings(
     Test / javaOptions += "-Dconfig.file=common/conf/test.conf",


### PR DESCRIPTION
## What does this change?
Switches to the maintained `at.yawk` fork to resolve upstream security advisories regarding the LZ4 implementation.
## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
