### PR TITLE
Add support for Really Simple Licensing (RSL)

### DIFF
--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -13,6 +13,8 @@ GET        /_agentcontents                                                      
 
 GET        /humans.txt                                                              controllers.Assets.at(path="/public", file="humans.txt")
 
+GET        /license.xml                                                             controllers.Assets.at(path="/public", file="license.xml")
+
 GET        /.well-known/security.txt                                                controllers.Assets.at(path="/public", file="security.txt")
 GET        /.well-known/security.txt.asc                                            controllers.Assets.at(path="/public", file="security.txt.asc")
 

--- a/facia/public/license.xml
+++ b/facia/public/license.xml
@@ -1,0 +1,13 @@
+<rsl xmlns="https://rslstandard.org/rsl">
+  <content url="/">
+    <license>
+      <permits type="usage">ai-train ai-input</permits>
+    
+      <payment type="subscription">
+        <custom>https://licensing.theguardian.com/</custom>
+      </payment>
+    
+      <prohibits type="usage">all</prohibits>
+    </license>
+  </content>
+</rsl>


### PR DESCRIPTION
CoAuthored-by: @Jakeii 

## What is the value of this and can you measure success?
This adds support for [RSL](https://rslstandard.org/).

This will be the first of two changes. 
First to add a license.xml, and then to link to it from our robots.txt (https://github.com/guardian/platform/pull/2106)