### PR TITLE
Add league tables data to the football match info endpoints

### DIFF
--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -163,7 +163,7 @@ class MatchController(
   val remoteRenderer: DotcomRenderingService = DotcomRenderingService()
 
   def renderMatchIdJson(matchId: String): Action[AnyContent] = renderMatchId(matchId)
-  def renderMatchId(matchId: String): Action[AnyContent] = render(competitionsService.findMatch(matchId))
+  def renderMatchId(matchId: String): Action[AnyContent] = render(competitionsService.findCompetitionMatch(matchId))
 
   def renderMatchJson(year: String, month: String, day: String, home: String, away: String): Action[AnyContent] =
     renderMatch(year, month, day, home, away)
@@ -174,14 +174,16 @@ class MatchController(
         val date = LocalDate.parse(s"$year${month.capitalize}$day", formatter)
         val startOfDay = date.atStartOfDay(DateHelpers.defaultFootballZoneId)
         val startOfTomorrow = startOfDay.plusDays(1)
-        render(competitionsService.matchFor(Interval(startOfDay, startOfTomorrow), homeId, awayId))
+        render(competitionsService.competitionMatchFor(Interval(startOfDay, startOfTomorrow), homeId, awayId))
       case _ => render(None)
     }
 
-  private def render(maybeMatch: Option[FootballMatch]): Action[AnyContent] =
+  private def render(maybeMatch: Option[(String, FootballMatch)]): Action[AnyContent] =
     Action.async { implicit request =>
       maybeMatch match {
-        case Some(theMatch) =>
+        case Some((competitionId, theMatch)) =>
+          val table =
+            competitionsService.competitions.find(_.id == competitionId).filter(_.hasLeagueTable).map(Table(_))
           val lineup: Future[LineUp] = competitionsService.getLineup(theMatch)
           val page: Future[MatchPage] = lineup.map(MatchPage(theMatch, _))
           val tier = FootballSummaryPagePicker.getTier()
@@ -194,6 +196,7 @@ class MatchController(
                 val model = DotcomRenderingFootballMatchSummaryDataModel(
                   page = page,
                   footballMatch = footballMatch,
+                  table = table,
                 )
                 Future.successful(Cached(CacheTime.FootballMatch)(JsonComponent.fromWritable(model)))
 
@@ -206,6 +209,7 @@ class MatchController(
                 val model = DotcomRenderingFootballMatchSummaryDataModel(
                   page = page,
                   footballMatch = footballMatch,
+                  table = table,
                 )
                 remoteRenderer.getFootballMatchSummaryPage(
                   wsClient,

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -56,7 +56,9 @@ case class Competition(
   }
 }
 
-case class Group(round: Round, entries: Seq[LeagueTableEntry])
+case class Group(round: Round, entries: Seq[LeagueTableEntry]) {
+  def hasTeam(teamId: String): Boolean = entries.exists(_.team.id == teamId)
+}
 
 case class Table(competition: Competition, groups: Seq[Group], hasGroups: Boolean = false) {
   lazy val multiGroup = hasGroups || groups.size > 1


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR updates the data model for `dotcomRenderingFootballMatchSummaryDataModel` with the league table group the match is in. This data model affects the following endpoints:
- /football/match/:year/:month/:day/$home<[\w\d-\.]+>-v-$away<[\w\d-\.]+> e.g. https://www.theguardian.com/football/match/2025/nov/23/arsenal-v-tottenham-hotspur.json?dcr
- /football/match/:matchId e.g. https://www.theguardian.com/football/match/4530503.json?dcr

**Why not include the whole league table:**
The DCAR match summary page only requires the context of the specific group the teams are in, not the entire league table.

- For competitions with multiple groups (e.g. World Cup, Champions League), the full league table data payload can become very large. Sending only the relevant group prevents unnecessary performance degradation.

- Detailed team results within the group entries are not required for these summary pages, so they have been excluded to further reduce payload size.

The DCAR PR for this https://github.com/guardian/dotcom-rendering/pull/15079

The result look like this:
<img width="364" height="801" alt="image" src="https://github.com/user-attachments/assets/4e7b968e-9860-4caf-a0be-812d31a43863" />


This PR fixes part of [#14904](https://github.com/guardian/dotcom-rendering/issues/14904)