### PR TITLE
Add support for reporter callouts

### DIFF
--- a/common/app/commercial/targeting/CampaignAgent.scala
+++ b/common/app/commercial/targeting/CampaignAgent.scala
@@ -36,6 +36,14 @@ object CampaignAgent extends GuLogging {
     }
   }
 
+  def getCampaignsForIds(ids: Seq[String]): List[Campaign] = {
+    if (Targeting.isSwitchedOn) {
+      agent().campaigns.filter(c => ids.contains(c.id.toString))
+    } else {
+      Nil
+    }
+  }
+
   def getCampaignsForTags(tags: Seq[String]): List[Campaign] = {
     if (Targeting.isSwitchedOn) {
       agent().getCampaignsForTags(tags, stripRules = true)

--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -227,6 +227,9 @@ object CalloutExtraction {
   private case object ReporterCallout extends CalloutType {
     val name = "reporter"
   }
+  private case object UnsupportedCallout extends CalloutType {
+    val name = "unsupported"
+  }
 
   private case class BaseCalloutFields(
       id: String,
@@ -248,7 +251,7 @@ object CalloutExtraction {
       val calloutType = campaignType match {
         case "callout"          => CommunityCallout
         case "reporter-callout" => ReporterCallout
-        case _                  => CommunityCallout
+        case _                  => UnsupportedCallout
       }
       BaseCalloutFields(
         id,
@@ -481,8 +484,9 @@ object CalloutExtraction {
       element <-
         if (baseCalloutFields.calloutType == ReporterCallout) {
           campaignJsObjectToReporterCalloutBlockElement(campaign, baseCalloutFields)
-        } else
+        } else if (baseCalloutFields.calloutType == CommunityCallout) {
           campaignJsObjectToCalloutBlockElementV2(campaign, callout, calloutsUrl, baseCalloutFields)
+        } else None
 
     } yield {
       element

--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -218,6 +218,16 @@ object CalloutExtraction {
     }
   }
 
+  private sealed trait CalloutType {
+    def name: String
+  }
+  private case object CommunityCallout extends CalloutType {
+    val name = "community"
+  }
+  private case object ReporterCallout extends CalloutType {
+    val name = "reporter"
+  }
+
   private case class BaseCalloutFields(
       id: String,
       activeFrom: Option[Long],
@@ -271,7 +281,6 @@ object CalloutExtraction {
         baseCalloutFields.activeFrom,
         baseCalloutFields.activeUntil,
         baseCalloutFields.displayOnSensitive,
-        baseCalloutFields.calloutType,
         title,
         subtitle,
         intro,
@@ -318,7 +327,6 @@ object CalloutExtraction {
         formFields2,
         callout.isNonCollapsible.getOrElse(false),
         contacts,
-        baseCalloutFields.calloutType,
       )
     }
   }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -137,6 +137,16 @@ object BlockquoteBlockElement {
   implicit val BlockquoteBlockElementWrites: Writes[BlockquoteBlockElement] = Json.writes[BlockquoteBlockElement]
 }
 
+sealed trait CalloutType {
+  def name: String
+}
+case object CommunityCallout extends CalloutType {
+  val name = "community"
+}
+case object ReporterCallout extends CalloutType {
+  val name = "reporter"
+}
+
 case class CalloutBlockElement(
     id: String,
     calloutsUrl: Option[String],
@@ -166,10 +176,34 @@ case class CalloutBlockElementV2(
     formFields: List[CalloutFormField],
     isNonCollapsible: Boolean,
     contacts: Option[Seq[Contact]],
+    calloutType: CalloutType,
 ) extends PageElement
 
 object CalloutBlockElementV2 {
+  implicit val CalloutTypeWrites: Writes[CalloutType] = Writes { calloutType =>
+    JsString(calloutType.name)
+  }
   implicit val CalloutBlockElementV2Writes: Writes[CalloutBlockElementV2] = Json.writes[CalloutBlockElementV2]
+}
+
+case class ReporterCalloutBlockElement(
+    id: String,
+    activeFrom: Option[Long],
+    activeUntil: Option[Long],
+    displayOnSensitive: Boolean,
+    title: String,
+    description: String,
+    contacts: Option[Seq[Contact]],
+    calloutType: CalloutType,
+) extends PageElement
+
+object ReporterCalloutBlockElement {
+  implicit val CalloutTypeWrites: Writes[CalloutType] = Writes { calloutType =>
+    JsString(calloutType.name)
+  }
+  implicit val ReporterCalloutBlockElementWrites: Writes[ReporterCalloutBlockElement] =
+    Json.writes[ReporterCalloutBlockElement]
+
 }
 
 case class DcrCartoonVariant(
@@ -953,6 +987,7 @@ object PageElement {
       case _: TimelineBlockElement        => true
       case _: LinkBlockElement            => true
       case _: ProductBlockElement         => true
+      case _: ReporterCalloutBlockElement => true
 
       // TODO we should quick fail here for these rather than pointlessly go to DCR
       case table: TableBlockElement if table.isMandatory.exists(identity) => true

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -191,10 +191,16 @@ case class ReporterCalloutBlockElement(
     activeFrom: Option[Long],
     activeUntil: Option[Long],
     displayOnSensitive: Boolean,
-    title: String,
-    description: String,
-    contacts: Option[Seq[Contact]],
     calloutType: CalloutType,
+    title: String,
+    subtitle: String,
+    intro: String,
+    mainTextHeading: String,
+    mainText: String,
+    emailContact: Option[String],
+    messagingContact: Option[String],
+    securedropContact: Option[String],
+    endNote: Option[String],
 ) extends PageElement
 
 object ReporterCalloutBlockElement {

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -137,16 +137,6 @@ object BlockquoteBlockElement {
   implicit val BlockquoteBlockElementWrites: Writes[BlockquoteBlockElement] = Json.writes[BlockquoteBlockElement]
 }
 
-sealed trait CalloutType {
-  def name: String
-}
-case object CommunityCallout extends CalloutType {
-  val name = "community"
-}
-case object ReporterCallout extends CalloutType {
-  val name = "reporter"
-}
-
 case class CalloutBlockElement(
     id: String,
     calloutsUrl: Option[String],
@@ -176,13 +166,9 @@ case class CalloutBlockElementV2(
     formFields: List[CalloutFormField],
     isNonCollapsible: Boolean,
     contacts: Option[Seq[Contact]],
-    calloutType: CalloutType,
 ) extends PageElement
 
 object CalloutBlockElementV2 {
-  implicit val CalloutTypeWrites: Writes[CalloutType] = Writes { calloutType =>
-    JsString(calloutType.name)
-  }
   implicit val CalloutBlockElementV2Writes: Writes[CalloutBlockElementV2] = Json.writes[CalloutBlockElementV2]
 }
 
@@ -191,7 +177,6 @@ case class ReporterCalloutBlockElement(
     activeFrom: Option[Long],
     activeUntil: Option[Long],
     displayOnSensitive: Boolean,
-    calloutType: CalloutType,
     title: String,
     subtitle: String,
     intro: String,
@@ -204,9 +189,6 @@ case class ReporterCalloutBlockElement(
 ) extends PageElement
 
 object ReporterCalloutBlockElement {
-  implicit val CalloutTypeWrites: Writes[CalloutType] = Writes { calloutType =>
-    JsString(calloutType.name)
-  }
   implicit val ReporterCalloutBlockElementWrites: Writes[ReporterCalloutBlockElement] =
     Json.writes[ReporterCalloutBlockElement]
 

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -53,6 +53,7 @@ case class MapBlockElement(html: Option[String]) extends BlockElement
 case class UnknownBlockElement(html: Option[String]) extends BlockElement
 case class UnsupportedBlockElement(html: Option[String]) extends BlockElement
 case class InteractiveBlockElement(html: Option[String], scriptUrl: Option[String] = None) extends BlockElement
+case class CalloutBlockElement(campaignId: String, calloutType: Option[String]) extends BlockElement
 
 case class MembershipBlockElement(
     originalUrl: Option[String],
@@ -177,13 +178,14 @@ object BlockElement {
       case Form            => Some(FormBlockElement(None))
 
       case EnumUnknownElementType(f) => Some(UnknownBlockElement(None))
-      case Callout                   => Some(UnsupportedBlockElement(None))
-      case Cartoon                   => Some(UnsupportedBlockElement(None))
-      case Recipe                    => Some(UnsupportedBlockElement(None))
-      case ElementType.List          => Some(UnsupportedBlockElement(None))
-      case Timeline                  => Some(UnsupportedBlockElement(None))
-      case Link                      => Some(UnsupportedBlockElement(None))
-      case Product                   => Some(UnsupportedBlockElement(None))
+      case Callout                   =>
+        element.calloutTypeData.flatMap(typeData => typeData.campaignId.map(id => CalloutBlockElement(id, None)))
+      case Cartoon          => Some(UnsupportedBlockElement(None))
+      case Recipe           => Some(UnsupportedBlockElement(None))
+      case ElementType.List => Some(UnsupportedBlockElement(None))
+      case Timeline         => Some(UnsupportedBlockElement(None))
+      case Link             => Some(UnsupportedBlockElement(None))
+      case Product          => Some(UnsupportedBlockElement(None))
     }
   }
 
@@ -222,6 +224,7 @@ object BlockElement {
   implicit val ContentAtomBlockElementWrites: Writes[ContentAtomBlockElement] = Json.writes[ContentAtomBlockElement]
   implicit val PullquoteBlockElementWrites: Writes[PullquoteBlockElement] = Json.writes[PullquoteBlockElement]
   implicit val InteractiveBlockElementWrites: Writes[InteractiveBlockElement] = Json.writes[InteractiveBlockElement]
+  implicit val CalloutBlockElementWrites: Writes[CalloutBlockElement] = Json.writes[CalloutBlockElement]
   implicit val CommentBlockElementWrites: Writes[CommentBlockElement] = Json.writes[CommentBlockElement]
   implicit val TableBlockElementWrites: Writes[TableBlockElement] = Json.writes[TableBlockElement]
   implicit val WitnessBlockElementWrites: Writes[WitnessBlockElement] = Json.writes[WitnessBlockElement]

--- a/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
@@ -154,6 +154,7 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
           Contact("signal", "+4488736683", "http://signal.com", Some("this is the guidance")),
         ),
       ),
+      CommunityCallout,
     )
   }
 

--- a/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
@@ -154,7 +154,6 @@ class CalloutExtractionTest extends AnyFlatSpec with Matchers {
           Contact("signal", "+4488736683", "http://signal.com", Some("this is the guidance")),
         ),
       ),
-      CommunityCallout,
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,7 +86,7 @@ object Dependencies {
     .excludeAll(ExclusionRule("com.fasterxml.jackson.core")) // Avoid conflicts with Play's Jackson dependency
 
   val targetingClient =
-    "com.gu.targeting-client" %% "client-play-json-v30" % "1.2.0-PREVIEW.pm-reporter-callouts.2025-11-11T1328.8c76a2cb"
+    "com.gu.targeting-client" %% "client-play-json-v30" % "1.2.0-PREVIEW.pm-reporter-callouts.2026-01-14T1622.cab4377d"
   val scanamo = "org.scanamo" %% "scanamo" % "2.0.0"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.9.2"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,7 +85,8 @@ object Dependencies {
   val logstash = ("net.logstash.logback" % "logstash-logback-encoder" % "8.0")
     .excludeAll(ExclusionRule("com.fasterxml.jackson.core")) // Avoid conflicts with Play's Jackson dependency
 
-  val targetingClient = "com.gu.targeting-client" %% "client-play-json-v30" % "1.1.9"
+  val targetingClient =
+    "com.gu.targeting-client" %% "client-play-json-v30" % "1.2.0-PREVIEW.pm-reporter-callouts.2025-11-11T1328.8c76a2cb"
   val scanamo = "org.scanamo" %% "scanamo" % "2.0.0"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.9.2"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,8 +85,7 @@ object Dependencies {
   val logstash = ("net.logstash.logback" % "logstash-logback-encoder" % "8.0")
     .excludeAll(ExclusionRule("com.fasterxml.jackson.core")) // Avoid conflicts with Play's Jackson dependency
 
-  val targetingClient =
-    "com.gu.targeting-client" %% "client-play-json-v30" % "1.2.0-PREVIEW.pm-reporter-callouts.2026-01-14T1622.cab4377d"
+  val targetingClient = "com.gu.targeting-client" %% "client-play-json-v30" % "1.2.0"
   val scanamo = "org.scanamo" %% "scanamo" % "2.0.0"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.9.2"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.2.5"


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR contains the frontend changes needed to render 'reporter callouts' in dotcom rendering. For a bit more detail on these callouts, see the associated composer PR: https://github.com/guardian/flexible-content/pull/6004

This PR depends on changes in the targeting tool, as well as a change in dcr for rendering and composer to allow people to add the new reporter callout type. All relevant prs below:

 - https://github.com/guardian/targeting-client/pull/45
 - https://github.com/guardian/targeting-client/pull/48
 - https://github.com/guardian/targeting/pull/203
 - https://github.com/guardian/dotcom-rendering/pull/15082
 - https://github.com/guardian/flexible-content/pull/6004

I've tested this on frontend CODE both with and without the associated DCR change

## Screenshots

Note - this PR doesn't include any rendering code just aiming to give an idea what the goal is. 

<img width="743" height="343" alt="Screenshot 2026-01-19 at 14 07 19" src="https://github.com/user-attachments/assets/fd02d5e1-9b10-42c2-ad5b-df19b6ca96fb" />
<img width="656" height="612" alt="Screenshot 2026-01-19 at 14 07 02" src="https://github.com/user-attachments/assets/f4597119-3b2c-48be-9900-470923793c6a" />


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
