### PR TITLE
Update work for us to work with us

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -37,7 +37,7 @@ object FooterLinks {
       "js-tech-feedback-report",
     )
   def workForUs(edition: String): FooterLink =
-    FooterLink("Work for us", "https://workforus.theguardian.com", s"${edition} : footer : work for us")
+    FooterLink("Work with us", "https://workwithus.theguardian.com/", s"${edition} : footer : work with us")
   def allTopics(edition: String): FooterLink =
     FooterLink("All topics", "/index/subjects/a", s"${edition} : footer : all topics")
   def allWriters(edition: String): FooterLink =


### PR DESCRIPTION
## What does this change?

As https://workforus.theguardian.com/ now redirects to https://workwithus.theguardian.com/, this updates the link and text from "Work for us" to "Work with us" on the back of a request from the recruitment team. 



## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]:https://github.com/user-attachments/assets/adc206f5-c54e-48a4-ac9f-d5c217917604
[after]:https://github.com/user-attachments/assets/e57f2443-98f7-433a-a967-b254c6b4aa75



## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
