### PR TITLE
Remove 'resp.Vary' field from request logs

### DIFF
--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -24,7 +24,6 @@ case class RequestLoggerFields(request: RequestHeader, response: Option[Result],
       "Fastly-FF",
       "Fastly-SSL",
       "Fastly-Digest",
-      "Accept-Encoding", // TODO remove if seen after 2021/09/03
     )
 
     val allHeadersFields = request.headers.toMap.mapV(_.mkString(","))
@@ -63,7 +62,6 @@ case class RequestLoggerFields(request: RequestHeader, response: Option[Result],
         List[LogField](
           "resp.status" -> r.header.status,
           "resp.dotcomponents" -> r.header.headers.contains("X-GU-Dotcomponents"),
-          "resp.Vary" -> r.header.headers.getOrElse("Vary", ""), // TODO remove if seen after 2021/09/03
         )
       }
       .getOrElse(Nil)


### PR DESCRIPTION
## What is the value of this and can you measure success?

Remove 'resp.Vary' field from request logs introduced here https://github.com/guardian/frontend/pull/24145
