### PR TITLE
Exclude successful healthcheck requests

### DIFF
--- a/common/app/http/RequestLoggingFilter.scala
+++ b/common/app/http/RequestLoggingFilter.scala
@@ -30,7 +30,10 @@ class RequestLoggingFilter(implicit val mat: Materializer, executionContext: Exe
               }
           }
         // don't log uncacheable POST requests due to the volume of them
-        if (rh.method != "POST") {
+        // don't log healthcheck successes
+        val isHealthcheck = rh.uri == "/_healthcheck"
+        val isHealthcheckSuccess = isHealthcheck && response.header.status == 200
+        if (rh.method != "POST" && !isHealthcheckSuccess) {
           requestLogger.withResponse(response).info(s"${rh.method} ${rh.uri}$additionalInfo")
         }
       case Failure(error) =>


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR updates `RequestLoggingFilter` to stop logging requests to the `/_healthcheck` endpoint, provided they return a successful 200 response.

## What does this change?
By filtering out these successful checks, we estimate this will reduce our log volume by around 5%.

Part of https://github.com/guardian/frontend/issues/28496

Tested on code https://riffraff.gutools.co.uk/deployment/view/058ec2f7-0470-4e33-8e75-ac27665e2544