### PR TITLE
Refactor `PageType` to remove duplicate calls to `JavaScriptPage.getMap()`

### DIFF
--- a/common/app/model/dotcomrendering/PageType.scala
+++ b/common/app/model/dotcomrendering/PageType.scala
@@ -20,16 +20,18 @@ object PageType {
   implicit val writes: OWrites[PageType] = Json.writes[PageType]
 
   def apply(page: Page, request: RequestHeader, context: ApplicationContext): PageType = {
+    val config = getMap(page, Edition(request), false, request) // Only construct config once
+
+    def configFor(key: String): Boolean = config.getOrElse(key, JsBoolean(false)).as[Boolean]
+
     PageType(
-      getMap(page, Edition(request), false, request)
-        .getOrElse("hasShowcaseMainElement", JsBoolean(false))
-        .as[Boolean],
-      getMap(page, Edition(request), false, request).getOrElse("isFront", JsBoolean(false)).as[Boolean],
-      getMap(page, Edition(request), false, request).getOrElse("isLiveBlog", JsBoolean(false)).as[Boolean],
-      getMap(page, Edition(request), false, request).getOrElse("isMinuteArticle", JsBoolean(false)).as[Boolean],
-      getMap(page, Edition(request), false, request).getOrElse("isPaidContent", JsBoolean(false)).as[Boolean],
-      context.isPreview,
-      getMap(page, Edition(request), false, request).getOrElse("isSensitive", JsBoolean(false)).as[Boolean],
+      hasShowcaseMainElement = configFor("hasShowcaseMainElement"),
+      isFront = configFor("isFront"),
+      isLiveblog = configFor("isLiveBlog"),
+      isMinuteArticle = configFor("isMinuteArticle"),
+      isPaidContent = configFor("isPaidContent"),
+      isPreview = context.isPreview,
+      isSensitive = configFor("isSensitive"),
     )
   }
 }


### PR DESCRIPTION
Co-authored-by: @rtyley 

## What is the value of this and can you measure success?
Refactor PageType to remove duplicate calls to getMap. 

[`JavaScriptPage.getMap()`](https://github.com/guardian/frontend/blob/46ada8178ebe97b6f63c9ed86086f8a6788f0d5e/common/app/views/support/JavaScriptPage.scala#L23) produces a lot of data, and is called with almost every page request, so we're preventing 6 duplicate calls to this complicated function, reducing it to just 1 call. 
