### PR TITLE
Add priority field to Link element

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -517,6 +517,9 @@ object LinkBlockElement {
   implicit val LinkTypeWrites: Writes[LinkType] = Writes { linkType =>
     JsString(linkType.name)
   }
+  implicit val PriorityWrites: Writes[Priority] = Writes { priority =>
+    JsString(priority.name)
+  }
   implicit val LinkBlockElementWrites: Writes[LinkBlockElement] = Json.writes[LinkBlockElement]
 }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -6,15 +6,16 @@ import com.gu.contentapi.client.model.v1.EmbedTracksType.DoesNotTrack
 import com.gu.contentapi.client.model.v1.{
   EmbedTracking,
   LinkType,
+  Priority,
   ProductDisplayType,
   ProductElementFields,
-  ProductCTA => ApiProductCta,
-  ProductCustomAttribute => ApiProductCustomAttribute,
-  ProductImage => ApiProductImage,
   SponsorshipType,
   TimelineElementFields,
   WitnessElementFields,
   BlockElement => ApiBlockElement,
+  ProductCTA => ApiProductCta,
+  ProductCustomAttribute => ApiProductCustomAttribute,
+  ProductImage => ApiProductImage,
   Sponsorship => ApiSponsorship,
 }
 import common.{Chronos, Edition}
@@ -510,6 +511,7 @@ case class LinkBlockElement(
     url: Option[String],
     label: Option[String],
     linkType: LinkType,
+    priority: Option[Priority],
 ) extends PageElement
 object LinkBlockElement {
   implicit val LinkTypeWrites: Writes[LinkType] = Writes { linkType =>
@@ -1463,6 +1465,7 @@ object PageElement {
               AffiliateLinksCleaner.replaceUrlInLink(d.url, pageUrl, addAffiliateLinks, isUSProductionOffice),
               d.label,
               d.linkType.getOrElse(LinkType.ProductButton),
+              d.priority,
             ),
           )
           .toList


### PR DESCRIPTION
## What does this change?

Adds the new 'priority' field to the Link element, available upstream.

## What is the value of this and can you measure success?

Necessary to support the design decisions for the 'standard button' type, defined in [this doc](https://docs.google.com/document/d/1EJsFItFlNwsZk7ByOJx-XkKQv5B4zwTwYqHb8dZKrOc/edit?tab=t.oodgd98nkgrq#heading=h.58irgiyxmtkv).

## Screenshots

N/A

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering (well, it will permit elements that are not yet support by DCR, but they are not available in an editorial context yet)
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
