### PR TITLE
Allow Riff-Raff to update `identity` AMI and both ASGs during migration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,6 +26,7 @@ templates:
     - update-ami-for-article
     - update-ami-for-preview
     - update-ami-for-commercial
+    - update-ami-for-identity
 
 deployments:
   admin:
@@ -168,5 +169,13 @@ deployments:
     parameters:
       amiParametersToTags:
         AMICommercial:
+          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
+          AmigoStage: PROD
+  update-ami-for-identity:
+    app: identity
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AMIIdentity:
           Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
           AmigoStage: PROD

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -46,6 +46,8 @@ deployments:
     template: frontend
   identity:
     template: frontend
+    parameters:
+      asgMigrationInProgress: true
   onward:
     template: frontend
   preview:


### PR DESCRIPTION
## What does this change?

We are [dual-stacking](https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md) `identity` as we migrate to GuCDK. This means all infrastructure components (load balancer, autoscaling group etc.) are temporarily duplicated.

Riff-Raff normally expects to find exactly one matching autoscaling group for a set of tags. When deploying it will update the application code for that autoscaling group only. If Riff-Raff finds more than one autoscaling group with the same set of tags the deployment will fail.

This change adds the `asgMigrationInProgress` parameter to `identity` to allow Riff-Raff to update both autoscaling groups when deploying.

This also adds config to allow `dotcom:frontend-all` deployments (including scheduled deployments) to automatically update the identity AMI.

This relies on 
* https://github.com/guardian/platform/pull/2115 being applied first.


[Validated with Riff-Raff](https://riffraff.gutools.co.uk/configuration/validation)

<img width="1177" height="363" alt="image" src="https://github.com/user-attachments/assets/c31caa78-04e6-4a8c-b7dc-c606978c96dc" />


## Testing

Both ASGs are getting [deployed](https://riffraff.gutools.co.uk/deployment/view/a4001f43-2b94-4fae-90dd-4d8aaa07e873)

<img width="1219" height="812" alt="image" src="https://github.com/user-attachments/assets/fa8dc545-c470-4f1f-90e5-630bca02bec9" />


