### PR TITLE
Increase `pekko.http.parsing.max-header-count` from 64 to 128 to reduce 400 errors

### DIFF
--- a/admin/conf/application.conf
+++ b/admin/conf/application.conf
@@ -23,12 +23,16 @@ pekko {
       }
     }
   }
-
   blocking-operations {
     executor = "thread-pool-executor"
     throughput = 10
     thread-pool-executor {
       fixed-pool-size = 128
+    }
+  }
+  http {
+    parsing {
+      max-header-count = 128
     }
   }
 }

--- a/applications/conf/application.conf
+++ b/applications/conf/application.conf
@@ -16,6 +16,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/archive/conf/application.conf
+++ b/archive/conf/application.conf
@@ -16,6 +16,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/article/conf/application.conf
+++ b/article/conf/application.conf
@@ -16,6 +16,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/commercial/conf/application.conf
+++ b/commercial/conf/application.conf
@@ -28,6 +28,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/common/conf/application.conf
+++ b/common/conf/application.conf
@@ -6,5 +6,10 @@ pekko {
       fixed-pool-size = 128
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 

--- a/discussion/conf/application.conf
+++ b/discussion/conf/application.conf
@@ -16,6 +16,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/facia-press/conf/application.conf
+++ b/facia-press/conf/application.conf
@@ -22,6 +22,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/facia/conf/application.conf
+++ b/facia/conf/application.conf
@@ -26,6 +26,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -15,6 +15,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 application.langs = "en"

--- a/onward/conf/application.conf
+++ b/onward/conf/application.conf
@@ -16,6 +16,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/preview/conf/application.conf
+++ b/preview/conf/application.conf
@@ -27,6 +27,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/rss/conf/application.conf
+++ b/rss/conf/application.conf
@@ -16,6 +16,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {

--- a/sport/conf/application.conf
+++ b/sport/conf/application.conf
@@ -16,6 +16,11 @@ pekko {
       }
     }
   }
+  http {
+    parsing {
+      max-header-count = 128
+    }
+  }
 }
 
 play {


### PR DESCRIPTION
Co-authored-by: Marjan Kalanaki <marjan.kalanaki@guardian.co.uk>

## What does this change?

@marjisound  noticed we are returning 400s for requests with > 64 headers which is the default maximum number of headers allowed by pekko http.

https://pekko.apache.org/docs/pekko-http/current/configuration.html#:~:text=max%2Dheader%2Dcount%20%20%20%20%20%20%20%20%20%20%20%3D%2064

Increasing the configuration setting `pekko.http.parsing.max-header-count` should allow requests with > 64 headers to be processed normally.

Logs from origin:

<img width="1330" height="471" alt="Screenshot 2026-01-19 at 11 32 19" src="https://github.com/user-attachments/assets/a2bf53e2-291a-446e-9af8-de3cdc50a996" />

Corresponds with 400 errors in the Fastly logs:

<img width="1525" height="765" alt="Screenshot 2026-01-19 at 12 26 10" src="https://github.com/user-attachments/assets/a9018494-c217-4b2a-a6f7-1a28c4051090" />

## Screenshots

Before
<img width="2006" height="482" alt="Screenshot 2026-01-20 at 17 48 08" src="https://github.com/user-attachments/assets/5d954c3b-28c2-4e88-80cc-e9cb86321813" />

After

<img width="1972" height="477" alt="Screenshot 2026-01-20 at 18 19 59" src="https://github.com/user-attachments/assets/b5449d78-190e-4304-afa7-17089c160037" />

## Next steps

- Roll out this change to minimise impact to users who are experiencing 400s
- Log requests with headers > 64 so we can determine what the problematic headers are (VCL, ab-testing, debug headers?)
- Decide on which http server backend we want to use for Play - see below [comment](https://github.com/guardian/frontend/pull/28525#issuecomment-3777141153)
- Add code to the application to assert the server backend is the one we expect

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
