### PR TITLE
Remove HLS switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -649,15 +649,4 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  val EnableHlsWeb = Switch(
-    group = SwitchGroup.Feature,
-    name = "enable-hls-web",
-    description = "Enable HLS web streaming on web",
-    owners = Seq(Owner.withEmail("fronts.and.curation@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }


### PR DESCRIPTION
## What does this change?

Removes a switch.

The logic was removed in this [DCR PR](https://github.com/guardian/dotcom-rendering/pull/15136).