### PR TITLE
Open page skin line items in new tab/window in commercial admin page

### DIFF
--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -16,7 +16,7 @@
 
 @listItem(sponsorship: PageSkinSponsorship, flagErrors: Boolean = true) = {
   <li class="lineItem">@sponsorship.lineItemName
-    (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
+    (<a href="@DfpLink.lineItem(sponsorship.lineItemId)" target="_blank">@sponsorship.lineItemId</a>)
     @flaggableProperty("Editions", sponsorship.editions.map(_.id), "No edition", flagErrors)
     @flaggableProperty("Countries", sponsorship.countries, "No country", flagErrors)
     <br />


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows line items listed on the page skin admin page to open in a new tab when clicking on the ID anchor tag

## What does this change?

- adds `target=_blank` to anchor tag in pageskins admin page
