### PR TITLE
Add a switch for football redesign

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -649,15 +649,4 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  val footballRedesign = Switch(
-    group = SwitchGroup.Feature,
-    name = "football-redesign",
-    description = "Enable football redesign ",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -649,4 +649,15 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val footballRedesign = Switch(
+    group = SwitchGroup.Feature,
+    name = "football-redesign",
+    description = "Enable football redesign ",
+    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,6 +15,7 @@ object ActiveExperiments extends ExperimentsDefinition {
       DarkModeWeb,
       GoogleOneTap,
       TagPageStorylines,
+      FootballRedesign,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -53,4 +54,13 @@ object TagPageStorylines
       owners = Seq(Owner.withEmail("ai.dev@theguardian.com")),
       sellByDate = LocalDate.of(2026, 1, 30),
       participationGroup = Perc0E,
+    )
+
+object FootballRedesign
+    extends Experiment(
+      name = "football-redesign",
+      description = "Enable redesigned football pages",
+      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
+      sellByDate = LocalDate.of(2026, 2, 28),
+      participationGroup = Perc0C,
     )


### PR DESCRIPTION
## What is the value of this and can you measure success?
Adding a 0% AB test for football redesign. We don't need to do. AB testing for the redesign, but using AB testing facilitate us with opting in and testing the changes in production

Fixes part of [#14907](https://github.com/guardian/dotcom-rendering/issues/14907)