### PR TITLE
Remove null fields from the response for football group

### DIFF
--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -375,9 +375,11 @@ object DotcomRenderingFootballMatchSummaryDataModel {
     }
   }
   implicit val groupWrites: Writes[Group] = (group: Group) =>
-    Json.obj(
-      "round" -> group.round,
-      "entries" -> getGroupEntries(group),
+    withoutDeepNull(
+      Json.obj(
+        "round" -> group.round,
+        "entries" -> getGroupEntries(group),
+      ),
     )
 
   implicit def dotcomRenderingFootballMatchSummaryDataModel: Writes[DotcomRenderingFootballMatchSummaryDataModel] =


### PR DESCRIPTION
## What does this change?
This PR removes the field in `Group` that have value null. The Group was added to the `DotcomRenderingFootballMatchSummaryDataModel` data model on this https://github.com/guardian/frontend/pull/28495

Tested this in CODE and locally
