### PR TITLE
Remove Janino dependency by replacing conditional Logback logic with filters

### DIFF
--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -23,6 +23,9 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
@@ -30,16 +33,9 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,6 @@ val common = library("common")
       pekkoSlf4j,
       pekkoSerializationJackson,
       pekkoActorTyped,
-      janino,
     ) ++ jackson,
   )
 

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -20,21 +20,18 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="STDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -22,11 +22,16 @@ trait FrontendApplicationLoader extends ApplicationLoader {
 
     val accessLogLevel = if (stage == "CODE") "DEBUG" else "INFO"
 
+    val stdoutLogLevel = if (stage == "DEV") "OFF" else "TRACE"
+
     LoggerConfigurator(context.environment.classLoader).foreach {
       _.configure(
         context.environment,
         context.initialConfiguration,
-        Map("ACCESS_LOG_LEVEL" -> accessLogLevel),
+        Map(
+          "ACCESS_LOG_LEVEL" -> accessLogLevel,
+          "STDOUT_LOG_LEVEL" -> stdoutLogLevel,
+        ),
       )
     }
     val components = buildComponents(context)

--- a/common/test/resources/logback.xml
+++ b/common/test/resources/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -22,21 +22,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -20,6 +20,9 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
@@ -29,16 +32,9 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,7 +84,6 @@ object Dependencies {
 
   val logstash = ("net.logstash.logback" % "logstash-logback-encoder" % "8.0")
     .excludeAll(ExclusionRule("com.fasterxml.jackson.core")) // Avoid conflicts with Play's Jackson dependency
-  val janino = "org.codehaus.janino" % "janino" % "3.1.12"
 
   val targetingClient = "com.gu.targeting-client" %% "client-play-json-v30" % "1.1.9"
   val scanamo = "org.scanamo" %% "scanamo" % "2.0.0"

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -20,21 +20,17 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+        </filter>
         <appender-ref ref="STDOUT" />
     </appender>
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
     <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
-    <if condition='!property("STAGE").contains("DEV")'>
-        <then>
-            <root level="INFO">
-                <appender-ref ref="ASYNCSTDOUT"/>
-            </root>
-        </then>
-    </if>
 
 </configuration>


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR removes the dependency on janino and refactors how logging to STDOUT is configured across the application.

Previously, logback.xml used the `<if>` conditional tag to determine whether to attach the `ASYNCSTDOUT` appender based on the `STAGE` property (specifically checking if it was not DEV). This conditional logic required the janino library to compile expressions at runtime.

The new approach moves this logic into `FrontendApplicationLoader`:

1. The loader now calculates a `STDOUT_LOG_LEVEL`. If the stage is `DEV`, the level is set to `OFF`; otherwise, it is set to `TRACE`.

2. The logback.xml files now attach the `ASYNCSTDOUT` appender but apply a ThresholdFilter using the `${STDOUT_LOG_LEVEL}` property.

Conditional configuration using Janino has been deprecated and will be removed in 2027. [See note here ](https://logback.qos.ch/manual/configuration.html#conditional)

