### PR TITLE
Set function jobs to debug

### DIFF
--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -32,7 +32,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -25,12 +25,12 @@ class FunctionJob extends Job with GuLogging {
     if (outstanding.get()(name) > 0) {
       log.warn(s"didn't run scheduled job $name because the previous one is still in progress")
     } else {
-      log.info(s"Running job: $name")
+      log.debug(s"Running job: $name")
       outstanding.send(map => map.updated(name, map(name) + 1))
       f().onComplete {
         case Success(_) =>
           outstanding.send(map => map.updated(name, map(name) - 1))
-          log.info(s"Finished job: $name")
+          log.debug(s"Finished job: $name")
         case Failure(t) =>
           outstanding.send(map => map.updated(name, map(name) - 1))
           log.error(s"An error has occured during job $name", t)
@@ -65,7 +65,7 @@ class JobScheduler(context: ApplicationContext) extends GuLogging {
     // it just results in unexpected data files when you
     // want to check in
     if (context.environment.mode != Test) {
-      log.info(s"Scheduling $name")
+      log.debug(s"Scheduling $name")
       jobs.put(name, () => block)
 
       scheduler.scheduleJob(
@@ -79,7 +79,7 @@ class JobScheduler(context: ApplicationContext) extends GuLogging {
     if (context.environment.mode != Test) {
       val schedule =
         DailyTimeIntervalScheduleBuilder.dailyTimeIntervalSchedule().withIntervalInMinutes(intervalInMinutes)
-      log.info(s"Scheduling $name to run every $intervalInMinutes minutes")
+      log.debug(s"Scheduling $name to run every $intervalInMinutes minutes")
       jobs.put(name, () => block)
 
       scheduler.scheduleJob(
@@ -93,7 +93,7 @@ class JobScheduler(context: ApplicationContext) extends GuLogging {
     if (context.environment.mode != Test) {
       val schedule =
         DailyTimeIntervalScheduleBuilder.dailyTimeIntervalSchedule().withIntervalInSeconds(interval.toSeconds.toInt)
-      log.info(s"Scheduling $name to run every ${interval.toSeconds} seconds")
+      log.debug(s"Scheduling $name to run every ${interval.toSeconds} seconds")
       jobs.put(name, () => block)
 
       scheduler.scheduleJob(
@@ -104,7 +104,7 @@ class JobScheduler(context: ApplicationContext) extends GuLogging {
   }
 
   def deschedule(name: String): Unit = {
-    log.info(s"Descheduling $name")
+    log.debug(s"Descheduling $name")
     jobs.remove(name)
     scheduler.deleteJob(new JobKey(name))
   }

--- a/common/test/resources/logback.xml
+++ b/common/test/resources/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -29,7 +29,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -31,7 +31,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -27,7 +27,7 @@
         <appender-ref ref="LOGFILE"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
 
     <if condition='!property("STAGE").contains("DEV")'>
         <then>


### PR DESCRIPTION
## What is the value of this and can you measure success?
Set function job logs to debug so logs will only be recorded in code environment. 
This should reduce total logs by around 8%
Part of https://github.com/guardian/frontend/issues/28496
