### PR TITLE
Log 400s and log too many headers

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -9,7 +9,7 @@ import conf.switches.SwitchboardLifecycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient, SectionsLookUp, SectionsLookUpLifecycle}
 import controllers._
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
-import http.{CommonFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, FrontendDefaultHttpErrorHandler}
 import jobs.{SiteMapJob, SiteMapLifecycle}
 import model.ApplicationIdentity
 import services.ophan.SurgingContentAgentLifecycle
@@ -86,7 +86,7 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
   )
 
   val frontendBuildInfo: FrontendBuildInfo = frontend.applications.BuildInfo
-  override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+  override lazy val httpErrorHandler: HttpErrorHandler = wire[FrontendDefaultHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
-import http.{CommonFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, FrontendDefaultHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
@@ -42,7 +42,7 @@ trait AppComponents extends FrontendComponents {
   lazy val appIdentity = ApplicationIdentity("archive")
 
   val frontendBuildInfo: FrontendBuildInfo = frontend.archive.BuildInfo
-  override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+  override lazy val httpErrorHandler: HttpErrorHandler = wire[FrontendDefaultHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
   def pekkoActorSystem: PekkoActorSystem

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -8,7 +8,7 @@ import conf.switches.SwitchboardLifecycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import controllers.{ArticleControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
-import http.{CommonFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, FrontendDefaultHttpErrorHandler}
 import jobs.StoreNavigationLifecycleComponent
 import model.ApplicationIdentity
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
@@ -67,7 +67,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
   )
 
   val frontendBuildInfo: FrontendBuildInfo = frontend.article.BuildInfo
-  override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+  override lazy val httpErrorHandler: HttpErrorHandler = wire[FrontendDefaultHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 

--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -10,7 +10,7 @@ import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
-import http.{CommonFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, FrontendDefaultHttpErrorHandler}
 import jobs.AdmiralLifecycle
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
@@ -58,7 +58,7 @@ trait AppComponents extends FrontendComponents with CommercialControllers with C
   lazy val appIdentity = ApplicationIdentity("commercial")
 
   val frontendBuildInfo: FrontendBuildInfo = frontend.commercial.BuildInfo
-  override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+  override lazy val httpErrorHandler: HttpErrorHandler = wire[FrontendDefaultHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -162,6 +162,7 @@ object Filters {
       new BackendHeaderFilter(frontendBuildInfo),
       new SurrogateKeyFilter,
       new AmpFilter,
+      new TooManyHeadersFilter,
     )
 
   def preload(implicit

--- a/common/app/http/TooManyHeadersFilter.scala
+++ b/common/app/http/TooManyHeadersFilter.scala
@@ -1,0 +1,24 @@
+package http
+
+import org.apache.pekko.stream.Materializer
+import play.api.Logger
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import scala.concurrent.Future
+import scala.util.Random
+
+class TooManyHeadersFilter(implicit val mat: Materializer) extends Filter {
+  private val MAX_HEADERS = 64
+
+  private val logging: Logger = Logger(this.getClass)
+
+  override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
+    // Log a warning for requests with an excessive number of headers, sampling at ~1%
+    if (rh.headers.keys.size > MAX_HEADERS && Random.nextInt(100) == 0) {
+      logging.warn(
+        s"Request with too many headers: ${rh.headers.keys.size} headers: ${rh.headers.keys.mkString(",")}",
+      )
+    }
+    f(rh)
+  }
+}

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -15,7 +15,7 @@ import cricket.controllers.CricketControllers
 import dev.DevAssetsController
 import feed._
 import football.controllers._
-import http.{CorsHttpErrorHandler, DevBuildParametersHttpRequestHandler, DevFilters}
+import http.{FrontendDefaultHttpErrorHandler, DevBuildParametersHttpRequestHandler, DevFilters}
 import model.{AdminLifecycle, ApplicationIdentity}
 import play.api.ApplicationLoader.Context
 import play.api._
@@ -103,5 +103,5 @@ trait AppComponents
 
   override lazy val httpFilters = wire[DevFilters].filters
   override lazy val httpRequestHandler = wire[DevBuildParametersHttpRequestHandler]
-  override lazy val httpErrorHandler = wire[CorsHttpErrorHandler]
+  override lazy val httpErrorHandler = wire[FrontendDefaultHttpErrorHandler]
 }

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -1,6 +1,6 @@
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import dev.DevAssetsController
-import http.{CommonFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, FrontendDefaultHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
@@ -44,7 +44,7 @@ trait AppComponents extends FrontendComponents with DiscussionControllers with D
   lazy val appIdentity = ApplicationIdentity("discussion")
 
   val frontendBuildInfo: FrontendBuildInfo = frontend.discussion.BuildInfo
-  override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+  override lazy val httpErrorHandler: HttpErrorHandler = wire[FrontendDefaultHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   def pekkoActorSystem: PekkoActorSystem
 }

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -1,5 +1,5 @@
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
-import http.{CommonFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, FrontendDefaultHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendBuildInfo, FrontendComponents}
 import business.{StocksData, StocksDataLifecycle}
 import com.softwaremill.macwire._
@@ -79,7 +79,7 @@ trait AppComponents extends FrontendComponents with OnwardControllers with Onwar
   val frontendBuildInfo: FrontendBuildInfo = frontend.onward.BuildInfo
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
-  override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+  override lazy val httpErrorHandler: HttpErrorHandler = wire[FrontendDefaultHttpErrorHandler]
 
   def pekkoActorSystem: PekkoActorSystem
 }

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -11,7 +11,7 @@ import cricket.controllers.CricketControllers
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import feed.{CompetitionsProvider, CompetitionsService}
 import football.controllers.{FootballControllers, HealthCheck}
-import http.{CommonFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, FrontendDefaultHttpErrorHandler}
 import jobs.CricketStatsJob
 import model.ApplicationIdentity
 import org.apache.pekko.stream.{Materializer => PekkoMaterializer}
@@ -85,6 +85,6 @@ trait AppComponents
   val frontendBuildInfo: FrontendBuildInfo = frontend.sport.BuildInfo
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
-  override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+  override lazy val httpErrorHandler: HttpErrorHandler = wire[FrontendDefaultHttpErrorHandler]
   def pekkoActorSystem: PekkoActorSystem
 }


### PR DESCRIPTION
In this PR I implement two logging cases:
- when there's a 400 (sampled down to 1%)
- when there are too many headers (sampled down, once again, to 1%)

I've also renamed the `CorsHttpErrorHandler` to `FrontendDefaultHttpErrorHandler` because in my opinion it does more than just dealing with CORS. (it's CORS in relation to the CDN, plus logging). It turned out I'm the author of that file so I'm to blame anyway!

Relates to https://github.com/guardian/frontend/issues/28545