### PR TITLE
Remove any netty ambiguity

### DIFF
--- a/preview/conf/application.conf
+++ b/preview/conf/application.conf
@@ -35,9 +35,6 @@ pekko {
 }
 
 play {
-
-  server.netty.maxHeaderSize = 16384
-
   http {
     # The secret key is used to secure cryptographics functions.
     # If you deploy your application to several instances be sure to use the same key!

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbt.packager.universal.UniversalPlugin
 import sbt._
 import sbt.Keys._
 import com.gu.Dependencies._
-import play.sbt.{PlayPekkoHttpServer, PlayNettyServer, PlayScala}
+import play.sbt.{PlayPekkoHttpServer, PlayScala}
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys.packageName
 import sbtbuildinfo.{BuildInfoKey, BuildInfoOption, BuildInfoPlugin}
@@ -123,8 +123,7 @@ object ProjectSettings {
 
   def library(applicationName: String): Project = {
     Project(applicationName, file(applicationName))
-      .enablePlugins(PlayScala, PlayNettyServer)
-      .disablePlugins(PlayPekkoHttpServer)
+      .enablePlugins(PlayScala)
       .settings(frontendDependencyManagementSettings)
       .settings(frontendCompilationSettings)
       .settings(frontendTestSettings)


### PR DESCRIPTION
We still have traces of netty (which we stopped using in 2017) in our config.

This hopefully clears out any ambiguity about which HTTP framework is handling our incoming traffic.