### PR TITLE
Add matchInfo and competitionName to match summary page data model

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -5,7 +5,7 @@ import com.github.nscala_time.time.Imports._
 import common._
 import conf.FootballClient
 import football.controllers.Interval
-import model.{Competition, Table, TeamFixture, TeamNameBuilder}
+import model.{Competition, CompetitionSummary, Table, TeamFixture, TeamNameBuilder}
 import org.joda.time.DateTimeComparator
 import pa.{FootballMatch, _}
 
@@ -69,7 +69,7 @@ trait Competitions extends implicits.Football {
     matchDates.reverse.filter(_ <= date).take(numDays)
 
   def findMatch(id: String): Option[FootballMatch] = matches.find(_.id == id)
-  def findCompetitionMatch(id: String): Option[(String, FootballMatch)] =
+  def findCompetitionMatch(id: String): Option[(CompetitionSummary, FootballMatch)] =
     matchesWithCompetition.find { case (_, m) => m.id == id }
 
   def competitionForMatch(matchId: String): Option[Competition] =
@@ -100,7 +100,11 @@ trait Competitions extends implicits.Football {
   }
 
   // note team1 & team2 are the home and away team, but we do NOT know their order
-  def competitionMatchFor(interval: Interval, team1: String, team2: String): Option[(String, FootballMatch)] =
+  def competitionMatchFor(
+      interval: Interval,
+      team1: String,
+      team2: String,
+  ): Option[(CompetitionSummary, FootballMatch)] =
     matchesWithCompetition
       .find { case (_, m) =>
         interval.contains(m.date) && m.hasTeam(team1) && m.hasTeam(team2)
@@ -112,8 +116,8 @@ trait Competitions extends implicits.Football {
 
   // Returns a lazy view of all matches paired with their competition ID.
   // WARNING: Only use this for single-pass lookups.
-  def matchesWithCompetition: View[(String, FootballMatch)] =
-    competitions.view.flatMap(comp => comp.matches.map(m => (comp.id, m)))
+  def matchesWithCompetition: View[(CompetitionSummary, FootballMatch)] =
+    competitions.view.flatMap(comp => comp.matches.map(m => (comp, m)))
 
   def isMatchLiveOrAboutToStart(matches: Seq[FootballMatch], clock: Clock): Boolean =
     matches.exists(game => {

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -322,8 +322,11 @@ object DotcomRenderingFootballTablesDataModel {
 }
 
 case class DotcomRenderingFootballMatchSummaryDataModel(
+    // this field will need to get renamed to matchStats in upcoming PR
     footballMatch: MatchDataAnswer,
+    matchInfo: FootballMatch,
     group: Option[Group],
+    competitionName: String,
     nav: Nav,
     editionId: String,
     guardianBaseURL: String,
@@ -338,8 +341,10 @@ case class DotcomRenderingFootballMatchSummaryDataModel(
 object DotcomRenderingFootballMatchSummaryDataModel {
   def apply(
       page: MatchPage,
-      footballMatch: MatchDataAnswer,
+      matchStats: MatchDataAnswer,
+      matchInfo: FootballMatch,
       group: Option[Group],
+      competitionName: String,
   )(implicit
       request: RequestHeader,
       context: ApplicationContext,
@@ -348,8 +353,10 @@ object DotcomRenderingFootballMatchSummaryDataModel {
     val nav = Nav(page, edition)
     val combinedConfig: JsObject = DotcomRenderingFootballDataModel.getConfig(page)
     DotcomRenderingFootballMatchSummaryDataModel(
-      footballMatch = footballMatch,
+      footballMatch = matchStats,
+      matchInfo = matchInfo,
       group = group,
+      competitionName = competitionName,
       nav = nav,
       editionId = edition.id,
       guardianBaseURL = Configuration.site.host,


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?
This PR updates the data model for the match summary pages which are served via the following api endpoints:
- `/football/match/:year/:month/:day/$home<[\w\d-\.]+>-v-$away<[\w\d-\.]+>`
- `/football/match/:matchId`

The data added to these endpoints are:
- competitionName
- matchInfo which is returning the type FootballMatch 
This is the PA match info that holds information about a match such as venue, type (result, fixture, etc.), date, etc. This is the type that is used for football match list pages and will also be used for the football page headers. 

The existing data model for the match summary page includes the field `footballMatch`. This field holds lineups & stats information about a match. We will probably need too rename this field to `matchStats` but that will need a more careful release strategy since renaming the field will also need to be done in DCAR data model. So, this will be done seperately in upcoming PR. 

The example new json data returned by this endpoint for https://www.theguardian.com/football/match/2026/jan/26/norwichcity-v-coventry.json?dcr looks like below:

<img width="491" height="905" alt="image" src="https://github.com/user-attachments/assets/49c5728a-774a-4d19-bba8-1c38aeda457e" />

Fixes part of [#15219](https://github.com/guardian/dotcom-rendering/issues/15219)