### PR TITLE
Remove redundant scala-steward config

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,6 +1,0 @@
-# This extends the main config found here: https://github.com/guardian/scala-steward-public-repos/blob/main/scala-steward.conf
-
-# Overrides the grouping rules from the main config.
-pullRequests.grouping = [
-  { name = "jackson", "title" = "chore(deps): Jackson dependency updates", "filter" = [{"group" = "com.fasterxml.jackson.*"}] }
-]


### PR DESCRIPTION
We're proposing to group Jackson dependency update PRs centrally in https://github.com/guardian/scala-steward-public-repos/pull/110
as discussed in last week's @guardian/scala-guild meeting.
