### PR TITLE
Stop logging 404 DISCUSSION_NOT_FOUND 

### DIFF
--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -197,17 +197,7 @@ trait DiscussionApiLike extends Http with GuLogging {
   override protected def getJsonOrError(url: String, onError: (WSResponse) => String, headers: (String, String)*)(
       implicit executionContext: ExecutionContext,
   ) = {
-    failIfDisabled().flatMap { _ =>
-      GET(url, (headers :+ guClientHeader): _*).flatMap { response =>
-        val errorCode = scala.util.Try((response.json \ "errorCode").asOpt[String]).getOrElse(None)
-        if (response.status == 404 && errorCode.contains("DISCUSSION_NOT_FOUND")) {
-          log.debug(s"Discussion API: 404 DISCUSSION_NOT_FOUND at $url")
-          Future.failed(NotFoundException(onError(response)))
-        } else {
-          super.getJsonOrError(url, onError, headers :+ guClientHeader: _*)
-        }
-      }
-    }
+    failIfDisabled().flatMap(_ => super.getJsonOrError(url, onError, headers :+ guClientHeader: _*))
   }
 
   private def guClientHeader = ("GU-Client", clientHeaderValue)

--- a/discussion/app/discussion/util/Http.scala
+++ b/discussion/app/discussion/util/Http.scala
@@ -24,10 +24,13 @@ trait Http extends GuLogging {
           val customFields: List[LogField] = List("dapi.response.latency.millis" -> dapiLatency.toInt)
           logDebugWithCustomFields(s"DAPI responded successfully in ${dapiLatency} ms for url: ${url}", customFields)
           response.json
+        case 404 =>
+          val errorMessage = onError(response)
+          throw NotFoundException(errorMessage)
         case otherStatus =>
           val errorMessage = onError(response)
           log.error(errorMessage)
-          throw if (otherStatus == 404) NotFoundException(errorMessage) else OtherException(errorMessage)
+          throw OtherException(errorMessage)
       }
     }
   }


### PR DESCRIPTION
## What is the value of this and can you measure success?
We are seeing large numbers of intermittent [ERROR logs](https://logs.gutools.co.uk/s/dotcom/app/r/s/7I8Gn) for articles where discussions are not found. Upon investigation, these articles do not have comments enabled and are legacy observer content.
Resolves https://github.com/guardian/frontend/issues/28062
## What does this change?
Stop logging 404 DISCUSSION_NOT_FOUND
