### PR TITLE
Replace header `x-gu-xid` with `x-request-id`

### DIFF
--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -73,7 +73,7 @@ trait GuLogging {
   }
 
   private def getRequestIdField(implicit request: RequestHeader) = {
-    customFieldMarkers(List("requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided")))
+    customFieldMarkers(List("requestId" -> request.headers.get("x-request-id").getOrElse("request-id-not-provided")))
   }
 }
 

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -36,16 +36,16 @@ case class RequestLoggerFields(request: RequestHeader, response: Option[Result],
 
     val guardianSpecificHeaders = allHeadersFields.view.filterKeys(_.toUpperCase.startsWith("X-GU-")).toMap
 
-    // Extract x-gu-xid case-insensitively and assign default if missing
+    // Extract x-request-id case-insensitively and assign default if missing
     val requestId = allHeadersFields
       .collectFirst {
-        case (key, value) if key.equalsIgnoreCase("x-gu-xid") => value
+        case (key, value) if key.equalsIgnoreCase("x-request-id") => value
       }
       .getOrElse("request-id-not-provided")
 
-    // Convert remaining headers to LogField format, ensuring x-gu-xid is not duplicated
+    // Convert remaining headers to LogField format, ensuring x-request-id is not duplicated
     val headerFields = (allowListedHeaders ++ guardianSpecificHeaders).toList.collect {
-      case (headerName, headerValue) if !headerName.equalsIgnoreCase("x-gu-xid") =>
+      case (headerName, headerValue) if !headerName.equalsIgnoreCase("x-request-id") =>
         LogFieldString(s"req.header.$headerName", headerValue)
     }
 

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -43,7 +43,7 @@ object `package`
       context: ApplicationContext,
       log: Logger,
   ): PartialFunction[Throwable, Result] = {
-    val requestId = request.headers.get("x-gu-xid").getOrElse("request-id-not-provided")
+    val requestId = request.headers.get("x-request-id").getOrElse("request-id-not-provided")
     val customFieldMarker: LogstashMarker = {
       append("requestId", requestId)
     }

--- a/common/app/http/RequestIdFilter.scala
+++ b/common/app/http/RequestIdFilter.scala
@@ -12,7 +12,7 @@ class RequestIdFilter(implicit val mat: Materializer, executionContext: Executio
     with GuLogging {
 
   override def apply(next: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
-    val headerKey = "x-gu-xid"
+    val headerKey = "x-request-id"
     // Play Framework's Headers.get(key) does a case-insensitive lookup
     val updatedRequest =
       if (rh.headers.get(headerKey).isEmpty) {

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -80,7 +80,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       .addHttpHeaders("Content-Type" -> "application/json")
 
     val resp = requestId match {
-      case Some(id) => request.addHttpHeaders("x-gu-xid" -> id).post(payload)
+      case Some(id) => request.addHttpHeaders("x-request-id" -> id).post(payload)
       case None     => request.post(payload)
     }
 
@@ -113,7 +113,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       cacheTime: CacheTime,
       timeout: Duration = Configuration.rendering.timeout,
   )(implicit request: RequestHeader): Future[Result] = {
-    val requestId = request.headers.get("x-gu-xid")
+    val requestId = request.headers.get("x-request-id")
     def handler(response: WSResponse): Result = {
       response.status match {
         case 200 =>
@@ -253,7 +253,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[String] = {
     val dataModel = DotcomBlocksRenderingDataModel(page, request, blocks)
     val json = DotcomBlocksRenderingDataModel.toJson(dataModel)
-    val requestId = request.headers.get("x-gu-xid")
+    val requestId = request.headers.get("x-request-id")
 
     postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/Blocks", requestId)
       .flatMap(response => {
@@ -275,7 +275,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   )(implicit request: RequestHeader): Future[String] = {
     val dataModel = DotcomBlocksRenderingDataModel(page, request, blocks)
     val json = DotcomBlocksRenderingDataModel.toJson(dataModel)
-    val requestId = request.headers.get("x-gu-xid")
+    val requestId = request.headers.get("x-request-id")
 
     postWithoutHandler(ws, json, Configuration.rendering.articleBaseURL + "/AppsBlocks", requestId)
       .flatMap(response => {

--- a/common/app/services/dotcomrendering/DotcomFrontsLogger.scala
+++ b/common/app/services/dotcomrendering/DotcomFrontsLogger.scala
@@ -14,7 +14,7 @@ case class DotcomFrontsLogger() extends GuLogging {
       "req.method" -> request.method,
       "req.url" -> request.uri,
       "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString,
-      "requestId" -> request.headers.get("x-gu-xid").getOrElse("request-id-not-provided"),
+      "requestId" -> request.headers.get("x-request-id").getOrElse("request-id-not-provided"),
     )
   }
 

--- a/common/app/utils/DotcomponentsLogger.scala
+++ b/common/app/utils/DotcomponentsLogger.scala
@@ -18,7 +18,7 @@ case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
           "req.method" -> r.method,
           "req.url" -> r.uri,
           "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString,
-          "requestId" -> r.headers.get("x-gu-xid").getOrElse("request-id-not-provided"),
+          "requestId" -> r.headers.get("x-request-id").getOrElse("request-id-not-provided"),
         )
       }
       .getOrElse(Nil)

--- a/onward/app/controllers/OnwardContentCardController.scala
+++ b/onward/app/controllers/OnwardContentCardController.scala
@@ -28,7 +28,7 @@ abstract class OnwardContentCardController(
   protected def lookup(path: String, fields: String)(implicit request: RequestHeader): Future[ItemResponse] = {
     val edition = Edition(request)
 
-    val requestId = request.headers.get("x-gu-xid").getOrElse("request-id-not-provided")
+    val requestId = request.headers.get("x-request-id").getOrElse("request-id-not-provided")
     val customFieldMarker = append("requestId", requestId)
 
     log.logger.info(customFieldMarker, s"Fetching article: $path for edition: ${edition.id}:")


### PR DESCRIPTION
## What does this change?

Replace header `x-gu-xid` with `x-request-id`

`x-request-id` is a standard header name for request tracing.

The value is currently duplicated into `x-gu-xid` and `x-request-id` by the VCL layer.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
