### PR TITLE
Remove Star Rating Experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,22 +11,12 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      StarRatingRedesign,
       DarkModeWeb,
       GoogleOneTap,
       TagPageStorylines,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
-
-object StarRatingRedesign
-    extends Experiment(
-      name = "star-rating-redesign",
-      description = "Enable the refreshed star ratings design",
-      owners = Seq(Owner.withEmail("fronts.and.curation@theguardian.com")),
-      sellByDate = LocalDate.of(2026, 2, 2),
-      participationGroup = Perc0A,
-    )
 
 object GoogleOneTap
     extends Experiment(


### PR DESCRIPTION
## What does this change?

Removes the Star Ratings experiment. This is now live to 100% of users and unused by DCR since https://github.com/guardian/dotcom-rendering/pull/15182.