### PR TITLE
Remove ASG migration parameter from `identity` deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -47,8 +47,6 @@ deployments:
     template: frontend
   identity:
     template: frontend
-    parameters:
-      asgMigrationInProgress: true
   onward:
     template: frontend
   preview:


### PR DESCRIPTION
Closes https://github.com/guardian/platform/issues/2072

This should be merged immediately following removal of the legacy `identity` infrastructure:
* https://github.com/guardian/platform/pull/2137

Once that has been done we will no longer be dual-stacking `identity` and have a single ASG again. We need to remove the ASG migration parameter so that Riff-Raff is no longer trying to update two ASGs which would break `dotcom:frontend-all` deployments.