### PR TITLE
Remove Google One Tap

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,20 +12,10 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       DarkModeWeb,
-      GoogleOneTap,
       TagPageStorylines,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
-
-object GoogleOneTap
-    extends Experiment(
-      name = "google-one-tap",
-      description = "Signing into the Guardian with Google One Tap",
-      owners = Seq(Owner.withEmail("identity.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2026, 2, 2),
-      participationGroup = Perc0B,
-    )
 
 object DarkModeWeb
     extends Experiment(


### PR DESCRIPTION
## What does this change?
This PR removes an expiring Google One Tap AB test.