### PR TITLE
Log 5xx errors and 4xx

### DIFF
--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -54,7 +54,10 @@ trait GuLogging {
     log.logger.warn(customFieldMarkers(customFields), message, error)
   }
   def logErrorWithCustomFields(message: String, error: Throwable, customFields: List[LogField]): Unit = {
-    log.logger.error(customFieldMarkers(customFields), message, error)
+    Option(error) match {
+      case Some(e) => log.logger.error(customFieldMarkers(customFields), message, e)
+      case None    => log.logger.error(customFieldMarkers(customFields), message)
+    }
   }
 
   // Transparent error logging on exceptions: log context and exception on error, and pass on the exception

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -53,8 +53,14 @@ trait GuLogging {
   def logWarningWithCustomFields(message: String, error: Throwable, customFields: List[LogField]): Unit = {
     log.logger.warn(customFieldMarkers(customFields), message, error)
   }
+  def logWarningWithCustomFields(message: String, customFields: List[LogField]): Unit = {
+    log.logger.warn(customFieldMarkers(customFields), message)
+  }
   def logErrorWithCustomFields(message: String, error: Throwable, customFields: List[LogField]): Unit = {
     log.logger.error(customFieldMarkers(customFields), message, error)
+  }
+  def logErrorWithCustomFields(message: String, customFields: List[LogField]): Unit = {
+    log.logger.error(customFieldMarkers(customFields), message)
   }
 
   // Transparent error logging on exceptions: log context and exception on error, and pass on the exception

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -54,10 +54,7 @@ trait GuLogging {
     log.logger.warn(customFieldMarkers(customFields), message, error)
   }
   def logErrorWithCustomFields(message: String, error: Throwable, customFields: List[LogField]): Unit = {
-    Option(error) match {
-      case Some(e) => log.logger.error(customFieldMarkers(customFields), message, e)
-      case None    => log.logger.error(customFieldMarkers(customFields), message)
-    }
+    log.logger.error(customFieldMarkers(customFields), message, error)
   }
 
   // Transparent error logging on exceptions: log context and exception on error, and pass on the exception

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -108,7 +108,13 @@ case class RequestLogger(request: RequestHeader, response: Option[Result], stopW
   def warn(message: String, error: Throwable): Unit = {
     logWarningWithCustomFields(message, error, allFields)
   }
+  def warn(message: String): Unit = {
+    logWarningWithCustomFields(message, error, allFields)
+  }
   def error(message: String, error: Throwable = null): Unit = {
+    logErrorWithCustomFields(message, error, allFields)
+  }
+  def error(message: String): Unit = {
     logErrorWithCustomFields(message, error, allFields)
   }
 }

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -111,7 +111,7 @@ case class RequestLogger(request: RequestHeader, response: Option[Result], stopW
   def warn(message: String): Unit = {
     logWarningWithCustomFields(message, allFields)
   }
-  def error(message: String, error: Throwable = null): Unit = {
+  def error(message: String, error: Throwable): Unit = {
     logErrorWithCustomFields(message, error, allFields)
   }
   def error(message: String): Unit = {

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -108,7 +108,7 @@ case class RequestLogger(request: RequestHeader, response: Option[Result], stopW
   def warn(message: String, error: Throwable): Unit = {
     logWarningWithCustomFields(message, error, allFields)
   }
-  def error(message: String, error: Throwable): Unit = {
+  def error(message: String, error: Throwable = null): Unit = {
     logErrorWithCustomFields(message, error, allFields)
   }
 }

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -109,12 +109,12 @@ case class RequestLogger(request: RequestHeader, response: Option[Result], stopW
     logWarningWithCustomFields(message, error, allFields)
   }
   def warn(message: String): Unit = {
-    logWarningWithCustomFields(message, error, allFields)
+    logWarningWithCustomFields(message, allFields)
   }
   def error(message: String, error: Throwable = null): Unit = {
     logErrorWithCustomFields(message, error, allFields)
   }
   def error(message: String): Unit = {
-    logErrorWithCustomFields(message, error, allFields)
+    logErrorWithCustomFields(message, allFields)
   }
 }

--- a/common/app/http/RequestLoggingFilter.scala
+++ b/common/app/http/RequestLoggingFilter.scala
@@ -34,7 +34,15 @@ class RequestLoggingFilter(implicit val mat: Materializer, executionContext: Exe
         val isHealthcheck = rh.uri == "/_healthcheck"
         val isHealthcheckSuccess = isHealthcheck && response.header.status == 200
         if (rh.method != "POST" && !isHealthcheckSuccess) {
-          requestLogger.withResponse(response).debug(s"${rh.method} ${rh.uri}$additionalInfo")
+          val status = response.header.status
+          val logMessage = s"${rh.method} ${rh.uri}$additionalInfo"
+          val logger = requestLogger.withResponse(response)
+          val isErrorStatus = (status >= 400 && status != 404)
+          if (isErrorStatus) {
+            logger.info(logMessage)
+          } else {
+            logger.debug(logMessage)
+          }
         }
       case Failure(error) =>
         requestLogger.warn(s"${rh.method} ${rh.uri} failed", error)

--- a/common/app/http/RequestLoggingFilter.scala
+++ b/common/app/http/RequestLoggingFilter.scala
@@ -40,7 +40,7 @@ class RequestLoggingFilter(implicit val mat: Materializer, executionContext: Exe
           if (status >= 500) {
             logger.error(logMessage)
           } else if (status >= 400 && status != 404) {
-            logger.info(logMessage)
+            logger.warn(logMessage)
           } else {
             logger.debug(logMessage)
           }

--- a/common/app/http/RequestLoggingFilter.scala
+++ b/common/app/http/RequestLoggingFilter.scala
@@ -37,8 +37,9 @@ class RequestLoggingFilter(implicit val mat: Materializer, executionContext: Exe
           val status = response.header.status
           val logMessage = s"${rh.method} ${rh.uri}$additionalInfo"
           val logger = requestLogger.withResponse(response)
-          val isErrorStatus = (status >= 400 && status != 404)
-          if (isErrorStatus) {
+          if (status >= 500) {
+            logger.error(logMessage)
+          } else if (status >= 400 && status != 404) {
             logger.info(logMessage)
           } else {
             logger.debug(logMessage)


### PR DESCRIPTION
## What is the value of this and can you measure success?
Updates `RequestLoggingFilter` to log 5xx at ERROR level and 4xx at WARN but not logging 404, while maintaining DEBUG level for all other logged requests.
Resolves 
https://github.com/guardian/frontend/issues/28567