### PR TITLE
Change the way we pass vars to the log conf

### DIFF
--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -19,12 +19,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -36,6 +38,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -24,7 +24,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -36,6 +36,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,7 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
+
 
 </configuration>

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,7 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
-
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -10,28 +10,46 @@ import play.api.mvc.{ControllerComponents, EssentialFilter}
 import play.api.routing.Router
 import play.filters.csrf.CSRFComponents
 import controllers.AssetsComponents
-import play.api.{Application, ApplicationLoader, BuiltInComponents, LoggerConfigurator, OptionalDevContext}
+import play.api.{
+  Application,
+  ApplicationLoader,
+  BuiltInComponents,
+  Configuration,
+  LoggerConfigurator,
+  OptionalDevContext,
+}
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 
 trait FrontendApplicationLoader extends ApplicationLoader {
 
   def buildComponents(context: Context): FrontendComponents
 
-  override def load(context: Context): Application = {
+  /** In here we pre-calculate values that are environment dependent and can't simply be set in the configuration files.
+    * @param configuration
+    *   the original configuration
+    * @return
+    *   a logger specific configuration enriched with environment dependent values
+    */
+  def enrichConfigWithLogging(configuration: Configuration): Configuration = {
     val stage = Environment.stage
+    val accessLogLevel = if (stage != "PROD") "DEBUG" else "INFO"
+    val stdoutLogLevel = if (stage == "DEV") "DEBUG" else "OFF"
 
-    val accessLogLevel = if (stage == "CODE") "DEBUG" else "INFO"
+    val loggerConfiguration = Configuration(
+      "logger.includeConfigProperties" -> true,
+      "logger.stdoutLogLevel" -> stdoutLogLevel,
+      "logger.accessLogLevel" -> accessLogLevel,
+    )
 
-    val stdoutLogLevel = if (stage == "DEV") "OFF" else "TRACE"
+    loggerConfiguration.withFallback(loggerConfiguration)
+  }
 
+  override def load(context: Context): Application = {
     LoggerConfigurator(context.environment.classLoader).foreach {
       _.configure(
         context.environment,
-        context.initialConfiguration,
-        Map(
-          "ACCESS_LOG_LEVEL" -> accessLogLevel,
-          "STDOUT_LOG_LEVEL" -> stdoutLogLevel,
-        ),
+        enrichConfigWithLogging(context.initialConfiguration),
+        Map.empty,
       )
     }
     val components = buildComponents(context)

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -18,12 +18,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -33,6 +35,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -23,7 +23,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -33,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -35,6 +35,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -35,6 +37,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -16,12 +16,14 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>false</includeContext>
+        </encoder>
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${logger.stdoutLogLevel:-OFF}</level>
+            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +33,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
+    <logger name="common" level="${COMMON_PKG_LOG_LEVEL:-DEBUG}"/>
 
 </configuration>

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -21,7 +21,7 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${STDOUT_LOG_LEVEL:-OFF}</level>
+            <level>${logger.stdoutLogLevel:-OFF}</level>
         </filter>
         <appender-ref ref="STDOUT" />
     </appender>
@@ -31,6 +31,6 @@
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
-    <logger name="common" level="${ACCESS_LOG_LEVEL:-DEBUG}"/>
+    <logger name="common.RequestLogger" level="${logger.accessLogLevel:-INFO}"/>
 
 </configuration>


### PR DESCRIPTION
Unfortunately when we decided to pass variables to the logging framework like this:
```
    LoggerConfigurator(context.environment.classLoader).foreach {
      _.configure(
        context.environment,
        context.initialConfiguration,
        Map(
          "ACCESS_LOG_LEVEL" -> accessLogLevel,
          "STDOUT_LOG_LEVEL" -> stdoutLogLevel,
        ),
      )
    }
```
We did not anticipate the default behaviour to also attach these values to every single log line.


~So as a workaround, I'm passing these log levels through the initialConfiguration, hoping there will be no unforseen side effects this time around.~ => this approach had the same issue

~I'm also changing a few things:~
- ~I'm setting the defaults in the configuration file to be production friendly, so if there were any issue with the configuration, production should still behave correctly (RequestLogger is set to INFO by default)~
- ~I'm setting the stdout to be DEBUG in DEV, OFF otherwise. It was currently set to OFF in DEV, meaning we don't see any logs in our terminal when running the app~

The solution I'm using is to disable the automatic inclusion of the log context on every single log line. As far as I can tell, this doesn't seem to have any negative influence on the logs.

Addresses: https://github.com/guardian/frontend/issues/28566