### PR TITLE
Add match info url to match nav

### DIFF
--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -374,7 +374,7 @@ object DotcomRenderingFootballMatchSummaryDataModel {
 
   private def getMatchUrl(theMatch: FootballMatch, page: MatchPage) = {
     val (homeId, awayId) = (theMatch.homeTeam.id, theMatch.awayTeam.id)
-    val localDate = JodaLocalDate.parse(theMatch.date.toLocalDate.toString)
+    val localDate = new JodaLocalDate(theMatch.date.getYear, theMatch.date.getMonthValue, theMatch.date.getDayOfMonth)
     getMatchNavUrl(Configuration.ajax.url, localDate, homeId, awayId, page.metadata.id)
   }
 

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -5,8 +5,8 @@ import conf.Configuration
 import experiments.ActiveExperiments
 import football.controllers.{CompetitionFilter, FootballPage, MatchDataAnswer, MatchPage}
 import model.content.InteractiveAtom
-import model.dotcomrendering.DotcomRenderingUtils.{assetURL, withoutDeepNull, withoutNull}
-import model.dotcomrendering.{Config, PageFooter, PageType, Trail}
+import model.dotcomrendering.DotcomRenderingUtils.{assetURL, getMatchNavUrl, withoutDeepNull, withoutNull}
+import model.dotcomrendering.{Config, PageFooter, PageType}
 import model.{ApplicationContext, Competition, CompetitionSummary, Group, StandalonePage, Table, TeamUrl}
 import navigation.{FooterLinks, Nav}
 import pa.{
@@ -29,9 +29,8 @@ import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.{CamelCase, JavaScriptPage}
 import ab.ABTests
-import football.datetime.DateHelpers
+import org.joda.time.{LocalDate => JodaLocalDate}
 
-import java.net.URLEncoder
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -374,11 +373,9 @@ object DotcomRenderingFootballMatchSummaryDataModel {
   }
 
   private def getMatchUrl(theMatch: FootballMatch, page: MatchPage) = {
-    val pageId = URLEncoder.encode(page.metadata.id, "UTF-8")
     val (homeId, awayId) = (theMatch.homeTeam.id, theMatch.awayTeam.id)
-    val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd").withZone(DateHelpers.defaultFootballZoneId)
-    val datePath = theMatch.date.format(formatter)
-    s"${Configuration.ajax.url}/football/api/match-nav/$datePath/$homeId/$awayId.json?dcr=true&page=$pageId"
+    val localDate = JodaLocalDate.parse(theMatch.date.toLocalDate.toString)
+    getMatchNavUrl(Configuration.ajax.url, localDate, homeId, awayId, page.metadata.id)
   }
 
   import football.model.DotcomRenderingFootballDataModelImplicits._

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -29,7 +29,9 @@ import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.{CamelCase, JavaScriptPage}
 import ab.ABTests
+import football.datetime.DateHelpers
 
+import java.net.URLEncoder
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -327,6 +329,7 @@ case class DotcomRenderingFootballMatchSummaryDataModel(
     matchInfo: FootballMatch,
     group: Option[Group],
     competitionName: String,
+    matchUrl: String,
     nav: Nav,
     editionId: String,
     guardianBaseURL: String,
@@ -357,6 +360,7 @@ object DotcomRenderingFootballMatchSummaryDataModel {
       matchInfo = matchInfo,
       group = group,
       competitionName = competitionName,
+      matchUrl = getMatchUrl(matchInfo, page),
       nav = nav,
       editionId = edition.id,
       guardianBaseURL = Configuration.site.host,
@@ -367,6 +371,14 @@ object DotcomRenderingFootballMatchSummaryDataModel {
       canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
       pageId = page.metadata.id,
     )
+  }
+
+  private def getMatchUrl(theMatch: FootballMatch, page: MatchPage) = {
+    val pageId = URLEncoder.encode(page.metadata.id, "UTF-8")
+    val (homeId, awayId) = (theMatch.homeTeam.id, theMatch.awayTeam.id)
+    val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd").withZone(DateHelpers.defaultFootballZoneId)
+    val datePath = theMatch.date.format(formatter)
+    s"${Configuration.ajax.url}/football/api/match-nav/$datePath/$homeId/$awayId.json?dcr=true&page=$pageId"
   }
 
   import football.model.DotcomRenderingFootballDataModelImplicits._


### PR DESCRIPTION
Thanks to @alexduf for helping me get a better understanding of Scala’s DateTime types.
## What does this change?
This PR does the following:

1. **Add `matchUrl (/football/api/match-nav/:year/:month/:day/:home/:away.json)` to `DotcomRenderingFootballMatchSummaryDataModel`**
   - Used on Match Info pages (e.g., [Udinese v Roma](https://www.theguardian.com/football/match/2026/feb/02/udinese-v-roma))
   - Client calls this URL to fetch match nav data (`reportUrl`, `minByMinUrl`, `matchInfoUrl`) and up-to-date match details (e.g., score)
   - Previously, this wasn’t needed for Match Info pages, but the new design requires **match nav tabs** and live match details
 
**Tested in CODE:**
<img width="1312" height="219" alt="image" src="https://github.com/user-attachments/assets/49e59597-0ada-4c30-ab60-7eed13856db3" />


2. **Add `matchInfoUrl` to the match nav data model**
   - Client calls the match nav API (e.g., `https://api.nextgen.guardianapps.co.uk/football/api/match-nav/2026/02/02/70/39.json?dcr=true&page=football%2F2026%2Ffeb%2F02%2Fsunderland-burnley-premier-league-match-report`)
   - Previously returned only `minByMinUrl` & `reportUrl`; now includes `matchInfoUrl` for the **new tab in the design**

**Tested in CODE:**
<img width="1325" height="343" alt="image" src="https://github.com/user-attachments/assets/d6997094-e187-458b-8489-5195451bde84" />


The DCAR PR relevant to this change: https://github.com/guardian/dotcom-rendering/pull/15293

This PR fixes part of [#15265](https://github.com/guardian/dotcom-rendering/issues/15265)

