### PR TITLE
Add The Filter US link to US news subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -322,6 +322,7 @@ object NavLinks {
       usTech,
       science,
       newsletters,
+      theFilterUs,
       usWellness,
     ),
   )

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1192,6 +1192,12 @@
 					"classList": []
 				},
 				{
+					"title": "The Filter",
+					"url": "/thefilter-us",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Wellness",
 					"url": "/us/wellness",
 					"children": [],


### PR DESCRIPTION
Requested by digital editors.

On click it directs the user to `/thefilter-us`.

<img width="1309" height="236" alt="Screenshot 2026-02-03 at 16 50 15" src="https://github.com/user-attachments/assets/bd3f521f-6f96-4b61-b52f-a296a9b9a2aa" />
