### PR TITLE
Winter olympics nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -142,6 +142,7 @@ object NavLinks {
       footballClubs,
     ),
   )
+  val winterOlympics = NavLink("Winter Olympics", "/sport/winter-olympics-2026")
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
   val rugbyUnion = NavLink("Rugby union", "/sport/rugby-union")
@@ -416,6 +417,7 @@ object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
+      winterOlympics,
       football,
       cricket,
       rugbyUnion,

--- a/common/test/navigation/NavigationDataTest.scala
+++ b/common/test/navigation/NavigationDataTest.scala
@@ -25,6 +25,8 @@ class NavigationDataTest extends AnyFlatSpec with Matchers {
         |If this is intentional (eg you're adding a new Section or Edition):
         |* Please update the test resource file 'reference-navigation.json' by copying over the new version from
         |  $tempFile
+        |  Unfortunately this file is space indented but reference-navigation.json is tab indented, so you might try
+        |  running `cat $tempFile | jq --tab > common/test/resources/reference-navigation.json` to convert spaces to tabs.
         |
         |If this is unintentional:
         |* Please check that you're not breaking the data used by DCR! See

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -420,6 +420,12 @@
 			"iconName": "home",
 			"children": [
 				{
+					"title": "Winter Olympics",
+					"url": "/sport/winter-olympics-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Football",
 					"url": "/football",
 					"children": [


### PR DESCRIPTION
## What is the value of this and can you measure success?

Fulfils an editorial request

## What does this change?

Adds winter olympics to the UK Sports subnav

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/531ac46f-b5e0-44ef-81ea-c973dd1b1772
[after]: https://github.com/user-attachments/assets/25413746-cdbd-4694-b768-79ada3742c07

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
