### PR TITLE
Test: Set cache header stale-if-error to 3 days rather than 10

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -39,6 +39,7 @@ object Cached extends implicits.Dates {
   private val cacheableStatusCodes = Seq(200, 404)
 
   private val tenDaysInSeconds = 864000
+  private val threeDaysInSeconds = 259200
 
   case class Hash(string: String)
 
@@ -98,7 +99,7 @@ object Cached extends implicits.Dates {
 
   private def cacheControl(maxAge: Int) = {
     val staleWhileRevalidateSeconds = max(maxAge / 10, 1)
-    s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds"
+    s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$threeDaysInSeconds"
   }
   /*
     NOTE, if you change these headers make sure they are compatible with our Edge Cache

--- a/common/test/model/CachedTest.scala
+++ b/common/test/model/CachedTest.scala
@@ -24,7 +24,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(liveContent.metadata.cacheTime, WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("max-age=5, stale-while-revalidate=1, stale-if-error=864000")
+    headers("Cache-Control") should be("max-age=5, stale-while-revalidate=1, stale-if-error=259200")
   }
 
   it should "cache content less than 1 hour old for 60 seconds" in {
@@ -38,7 +38,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(liveContent.metadata.cacheTime, WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=259200")
   }
 
   it should "cache older content for 1 minute" in {
@@ -52,7 +52,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(liveContent.metadata.cacheTime, WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=259200")
   }
 
   it should "cache other things for 1 minute" in {
@@ -65,7 +65,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(page.metadata.cacheTime, WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=259200")
   }
 
   it should "have at least 1 second stale-while-revalidate" in {
@@ -74,7 +74,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(CacheTime(5), WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("max-age=5, stale-while-revalidate=1, stale-if-error=864000")
+    headers("Cache-Control") should be("max-age=5, stale-while-revalidate=1, stale-if-error=259200")
   }
 
   it should "set Surrogate-Control the same as Cache-Control" in {
@@ -83,7 +83,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(CacheTime(60, Some(120)), WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=259200")
     headers("Cache-Control") should equal(headers("Surrogate-Control"))
   }
 
@@ -98,7 +98,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(liveContent.metadata.cacheTime, WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Surrogate-Control") should be("max-age=3800, stale-while-revalidate=380, stale-if-error=864000")
+    headers("Surrogate-Control") should be("max-age=3800, stale-while-revalidate=380, stale-if-error=259200")
   }
 
   it should "apply longer SurrogateControl cache time for live content" in {
@@ -112,7 +112,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(liveContent.metadata.cacheTime, WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Surrogate-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    headers("Surrogate-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=259200")
   }
 
   it should "use the cacheSeconds for browser max-age" in {
@@ -127,7 +127,7 @@ class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.D
     val result = Cached(liveContent.metadata.cacheTime, WithoutRevalidationResult(Ok("foo")), None)
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    headers("Cache-Control") should be("max-age=60, stale-while-revalidate=6, stale-if-error=259200")
   }
 
   "ETags" should "should be added" in {


### PR DESCRIPTION
TEST

## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
