### PR TITLE
Replace percent log sampling with rate limiting

### DIFF
--- a/common/app/http/TooManyHeadersFilter.scala
+++ b/common/app/http/TooManyHeadersFilter.scala
@@ -6,7 +6,6 @@ import play.api.Logger
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.Future
-import scala.util.Random
 
 class TooManyHeadersFilter(implicit val mat: Materializer) extends Filter {
   private val MAX_HEADERS = 64

--- a/common/app/http/TooManyHeadersFilter.scala
+++ b/common/app/http/TooManyHeadersFilter.scala
@@ -1,5 +1,6 @@
 package http
 
+import com.google.common.util.concurrent.RateLimiter
 import org.apache.pekko.stream.Materializer
 import play.api.Logger
 import play.api.mvc.{Filter, RequestHeader, Result}
@@ -11,10 +12,11 @@ class TooManyHeadersFilter(implicit val mat: Materializer) extends Filter {
   private val MAX_HEADERS = 64
 
   private val logging: Logger = Logger(this.getClass)
+  private val rateLimiter = RateLimiter.create(0.1) // 1 permit per 10 seconds
 
   override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
-    // Log a warning for requests with an excessive number of headers, sampling at ~1%
-    if (rh.headers.keys.size > MAX_HEADERS && Random.nextInt(100) == 0) {
+    // Log a warning for requests with an excessive number of headers, sampling with rate limiter at 1 permit in 10 seconds
+    if (rh.headers.keys.size > MAX_HEADERS && rateLimiter.tryAcquire()) {
       logging.warn(
         s"Request with too many headers: ${rh.headers.keys.size} headers: ${rh.headers.keys.mkString(",")}",
       )


### PR DESCRIPTION
Paired with 
Co-authored-by: Ioanna Kokkini <ioannakok@hotmail.com>
Co-authored-by: Roberto Tyley <52038+rtyley@users.noreply.github.com>

## What does this change?
Replacing the percentage method for sampling logs by RateLimiter which can use a bucket to add permits per seconds and check on each log if it can be permitted or not. More details about the RateLimiter can be found in this [documentation](https://guava.dev/releases/19.0/api/docs/index.html?com/google/common/util/concurrent/RateLimiter.html)

## Why
This rate limiter ensures that we will always retain a minimum number of logs, even if log events occur infrequently. This is specially useful in CODE environment where we don't have that many logs

## Test
We tested this in CODE. We made multiple requests with too many headers within 10 seconds and only one log appeared in kibanna. After 10 second, we made another request and a new log also appeared