### PR TITLE
Add match-header json route to sport api

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -70,11 +70,10 @@ object DotcomRenderingUtils {
     s"$host/football/api/match-nav/$datePath/$team1/$team2.json?dcr=true&page=$encodedPageId"
   }
 
-  def getMatchHeaderUrl(host: String, date: LocalDate, team1: String, team2: String, pageId: String): String = {
+  def getMatchHeaderUrl(host: String, date: LocalDate, team1: String, team2: String): String = {
     val formatter = DateTimeFormat.forPattern("yyyy/MM/dd")
     val datePath = formatter.print(date)
-    val encodedPageId = URLEncoder.encode(pageId, "UTF-8")
-    s"$host/football/api/match-header/$datePath/$team1/$team2.json?dcr=true&page=$encodedPageId"
+    s"$host/football/api/match-header/$datePath/$team1/$team2.json"
   }
 
   def makeFootballMatch(articlePage: ContentPage): Option[DotcomRenderingMatchData] = {

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -70,6 +70,13 @@ object DotcomRenderingUtils {
     s"$host/football/api/match-nav/$datePath/$team1/$team2.json?dcr=true&page=$encodedPageId"
   }
 
+  def getMatchHeaderUrl(host: String, date: LocalDate, team1: String, team2: String, pageId: String): String = {
+    val formatter = DateTimeFormat.forPattern("yyyy/MM/dd")
+    val datePath = formatter.print(date)
+    val encodedPageId = URLEncoder.encode(pageId, "UTF-8")
+    s"$host/football/api/match-header/$datePath/$team1/$team2.json?dcr=true&page=$encodedPageId"
+  }
+
   def makeFootballMatch(articlePage: ContentPage): Option[DotcomRenderingMatchData] = {
 
     def extraction1(references: JsValue): Option[IndexedSeq[JsValue]] = {

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -419,7 +419,7 @@ object DotcomRenderingFootballMatchSummaryDataModel {
     val (homeId, awayId) = (theMatch.homeTeam.id, theMatch.awayTeam.id)
     val localDate = new JodaLocalDate(theMatch.date.getYear, theMatch.date.getMonthValue, theMatch.date.getDayOfMonth)
 
-    getMatchHeaderUrl(Configuration.ajax.url, localDate, homeId, awayId, page.metadata.id)
+    getMatchHeaderUrl(Configuration.ajax.url, localDate, homeId, awayId)
   }
 
   import football.model.DotcomRenderingFootballDataModelImplicits._

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -236,9 +236,9 @@ object DotcomRenderingFootballMatchListDataModel {
 case class DotcomRenderingFootballHeaderDataModel(
     footballMatch: FootballMatch,
     competitionName: String,
-    minByMinUrl: Option[String],
-    reportUrl: Option[String],
-    matchInfoUrl: String,
+    liveURL: Option[String],
+    reportURL: Option[String],
+    infoURL: String,
 )
 
 object DotcomRenderingFootballHeaderDataModel {
@@ -249,11 +249,11 @@ object DotcomRenderingFootballHeaderDataModel {
   ): DotcomRenderingFootballHeaderDataModel = {
     val (maybeMatchReport, maybeMinByMin, _, matchInfo) = MatchMetadata.fetchRelatedMatchContent(theMatch, related)
     DotcomRenderingFootballHeaderDataModel(
-      theMatch,
-      competitionSummary.fullName,
-      maybeMinByMin.map(x => LinkTo(x.url)),
-      maybeMatchReport.map(x => LinkTo(x.url)),
-      LinkTo(matchInfo.url),
+      footballMatch = theMatch,
+      competitionName = competitionSummary.fullName,
+      liveURL = maybeMinByMin.map(x => LinkTo(x.url)),
+      reportURL = maybeMatchReport.map(x => LinkTo(x.url)),
+      infoURL = LinkTo(matchInfo.url),
     )
   }
 

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -65,6 +65,7 @@ GET        /football/:competitionTag/overview.json                            fo
 GET        /football/:competitionTag/wallchart.json                           football.controllers.WallchartController.renderWallchartJson(competitionTag)
 
 GET        /football/api/match-nav/:year/:month/:day/:home/:away.json         football.controllers.MoreOnMatchController.matchNavJson(year, month, day, home, away)
+GET        /football/api/match-header/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchHeaderJson(year, month, day, home, away)
 GET        /football/api/match-nav/:year/:month/:day/:home/:away              football.controllers.MoreOnMatchController.matchNav(year, month, day, home, away)
 GET        /football/api/match-nav/:matchId.json                              football.controllers.MoreOnMatchController.moreOnJson(matchId)
 GET        /football/api/match-nav/:matchId                                   football.controllers.MoreOnMatchController.moreOn(matchId)


### PR DESCRIPTION
## What does this change?
This PR introduces a new Sport API route: `/football/api/match-header/:year/:month/:day/:home/:away.json` and also the `matchHeaderUrl` field is added to the match info page json data model. 

The new route is to be used to power the match header across football pages, including the `match report`, `football blog`, and `match info` pages.

Previously, these pages relied on the match-nav route: `/football/api/match-nav/:year/:month/:day/:home/:away.json`

However, that route returns a custom data type derived from the FootballMatch PA type. As part of an effort to reduce complexity and consolidate data models, this PR introduces a route that exposes FootballMatch directly.

This aligns with existing DCAR parsers, avoids introducing additional parsers, and simplifies the overall data flow.

## Screenshots
**The response for match-header url:**
<img width="936" height="812" alt="image" src="https://github.com/user-attachments/assets/03103011-5eae-4cfc-935c-51a9ca076eab" />


This PR fixes part of https://github.com/guardian/dotcom-rendering/issues/15284
