### PR TITLE
Enable use of article endpoints for hosted content

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -128,7 +128,6 @@ class ArticleController(
   private def mapModel(path: String, range: BlockRange)(
       render: BlocksOn[ArticlePage] => Future[Result],
   )(implicit request: RequestHeader): Future[Result] = {
-    println(s"hitting map model for article: $path")
     capiLookup
       .lookup(path, Some(range))
       .map(responseToModelOrResult)
@@ -145,16 +144,12 @@ class ArticleController(
     val supportedContent: Option[ContentType] = response.content.map(Content(_))
     val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
 
-    val result = ModelOrResult(supportedContent, response) match {
+    ModelOrResult(supportedContent, response) match {
       case Right(article: Article) =>
         Right(BlocksOn(ArticlePage(article, StoryPackages(article.metadata.id, response)), blocks))
       case Left(r) => Left(r)
       case _       => Left(NotFound)
     }
-    println("result:")
-    println(result.isRight)
-
-    result
   }
 
   def servePressedPage(path: String)(implicit request: RequestHeader): Future[Result] = {

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -33,7 +33,7 @@ class ArticleController(
 
   val capiLookup: CAPILookup = new CAPILookup(contentApiClient)
 
-  private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
+  private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku || c.isHosted
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
   override def renderItem(path: String)(implicit req: RequestHeader): Future[Result] =
     mapAndRender(path, GenericFallback)()
@@ -141,7 +141,7 @@ class ArticleController(
   private def responseToModelOrResult(
       response: ItemResponse,
   )(implicit request: RequestHeader): Either[Result, BlocksOn[ArticlePage]] = {
-    val supportedContent: Option[ContentType] = response.content.map(Content(_))
+    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
 
     ModelOrResult(supportedContent, response) match {

--- a/article/app/services/dotcomrendering/ArticlePicker.scala
+++ b/article/app/services/dotcomrendering/ArticlePicker.scala
@@ -16,7 +16,8 @@ object ArticlePageChecks {
     }
   }
 
-  def isNotAGallery(page: PageWithStoryPackage): Boolean = !page.item.tags.isGallery
+  // Treat all hosted content as non-galleries, at least during migration work
+  def isNotAGallery(page: PageWithStoryPackage): Boolean = !page.item.tags.isGallery || page.item.content.isHosted
 
   def isNotPaidContent(page: PageWithStoryPackage): Boolean = !page.item.tags.isPaidContent
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -434,12 +434,13 @@ object Content {
     val content = make(apiContent)
 
     apiContent match {
-      case _ if apiContent.isLiveBlog || apiContent.isArticle || apiContent.isSudoku => Article.make(content)
-      case _ if apiContent.isGallery                                                 => Gallery.make(content)
-      case _ if apiContent.isVideo                                                   => Video.make(content)
-      case _ if apiContent.isAudio                                                   => Audio.make(content)
-      case _ if apiContent.isImageContent                                            => ImageContent.make(content)
-      case _                                                                         => GenericContent(content)
+      case _ if apiContent.isLiveBlog || apiContent.isArticle || apiContent.isSudoku || apiContent.isHosted =>
+        Article.make(content)
+      case _ if apiContent.isGallery      => Gallery.make(content)
+      case _ if apiContent.isVideo        => Video.make(content)
+      case _ if apiContent.isAudio        => Audio.make(content)
+      case _ if apiContent.isImageContent => ImageContent.make(content)
+      case _                              => GenericContent(content)
     }
   }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -54,6 +54,7 @@ final case class Content(
     starRating: Option[Int],
     allowUserGeneratedContent: Boolean,
     isExpired: Boolean,
+    isHosted: Boolean,
     productionOffice: Option[String],
     tweets: Seq[Tweet],
     showInRelated: Boolean,
@@ -472,6 +473,7 @@ object Content {
       starRating = apifields.flatMap(_.starRating),
       allowUserGeneratedContent = apifields.flatMap(_.allowUgc).getOrElse(false),
       isExpired = apiContent.isExpired.getOrElse(false),
+      isHosted = apiContent.isHosted,
       productionOffice = apifields.flatMap(_.productionOffice.map(_.name)),
       tweets = apiContent.elements.getOrElse(Nil).filter(_.`type`.name == "Tweet").toSeq.map { tweet =>
         val images = tweet.assets
@@ -549,7 +551,7 @@ object Article {
       ("lightboxImages", lightbox.javascriptConfig),
       ("hasMultipleVideosInPage", JsBoolean(content.hasMultipleVideosInPage)),
       ("isImmersive", JsBoolean(content.isImmersive)),
-      ("isHosted", JsBoolean(false)),
+      ("isHosted", JsBoolean(content.isHosted)),
       ("isPhotoEssay", JsBoolean(content.isPhotoEssay)),
       ("isColumn", JsBoolean(content.isColumn)),
       ("isNumberedList", JsBoolean(content.isNumberedList)),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.40.17"
-  val capiVersion = "41.0.0"
+  val capiVersion = "41.1.1"
   val faciaVersion = "29.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
@@ -28,7 +28,7 @@ object Dependencies {
   val commonsLang = "commons-lang" % "commons-lang" % "2.6"
   val commonsIo = "commons-io" % "commons-io" % "2.21.0"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
-  val contentApiClient = "com.gu" %% "content-api-client" % "41.0.1-SNAPSHOT"
+  val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "37.0.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val commonsLang = "commons-lang" % "commons-lang" % "2.6"
   val commonsIo = "commons-io" % "commons-io" % "2.21.0"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
-  val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
+  val contentApiClient = "com.gu" %% "content-api-client" % "41.0.1-SNAPSHOT"
   val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "37.0.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion


### PR DESCRIPTION
## What is the value of this and can you measure success?

This change enables us to access all three kinds of hosted content data- article, video or gallery- via the methods used for articles, as part of the ongoing work to migrate hosted content to DCR. Using the existing article application rather than continuing with an entirely separate rendering path for hosted content enables us to bring patterns for rendering this content more in line with our other content, and enables much greater code re-use within both frontend and DCR.

Currently none of these changes will be usable outside of a local dev environment as the dedicated `/advertiser-content` path will ensure all hosted content is rendered via the existing controller in the commercial application. I'll be working on a follow-up to this PR to enable rendering via the article application via use of a query parameter.