### PR TITLE
Add comment explaining unusual choice of `Australia/Sydney` as default timezone

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,6 @@
 -Xmx8G
 -XX:ReservedCodeCacheSize=128m
 -XX:NewRatio=4
--Duser.timezone=Australia/Sydney
+-Duser.timezone=Australia/Sydney # because it is too easy for devs to forget about timezones, see https://github.com/guardian/frontend/pull/4713
 -DSTAGE=DEV
 -DAPP_SECRET=this_is_not_a_real_secret_just_for_tests


### PR DESCRIPTION
Grant Klopper first made this change to the Frontend codebase in June 2014 with https://github.com/guardian/frontend/pull/4713 - he explained:

> "dev machines will now run in a far away timezone so it is more obvious when you get a timezone wrong"

With the wonderful work to drop the custom `sbt` script in https://github.com/guardian/frontend/pull/28599 in January 2026, we weren't sure (https://github.com/guardian/frontend/pull/28599#discussion_r2803304897) if we could keep the helpful comment explaining why the timezone was used - can the `.jvmopts` file, where the setting now lives, accept comments!?

## How does `sbt` parse `.jvmopts`?

It turns out `sbt` takes the input from `.jvmopts` [here](https://github.com/sbt/sbt/blob/v1.12.2/sbt#L869), calling `$(loadConfigFile .jvmopts)` - the [`loadConfigFile()` function](https://github.com/sbt/sbt/blob/v1.12.2/sbt#L771) reads in each line of the file, and crucially calls `eval` on it:

```
eval echo $line
```

[`eval`](https://www.geeksforgeeks.org/linux-unix/eval-command-in-linux-with-examples/) is a built-in Linux command:

> "The eval utility shall construct a command by concatenating arguments together, separating each with a `<space>`. The constructed command shall be read and executed by the shell."

The upshot is that this line of input:

```
-Duser.timezone=Australia/Sydney # because it is too easy for devs
```

...becomes the shell evaluation of:

```
echo -Duser.timezone=Australia/Sydney # because it is too easy for devs
```

...which as far as the shell is concerned, is just:

```
echo -Duser.timezone=Australia/Sydney
```

...so we _are_ allowed comments! (**Update**: not end-of-line comments, starting with sbt v.1.12.3 😢  - see https://github.com/guardian/frontend/pull/28633)

This behaviour was added to the sbt launcher script with [this commit](https://github.com/sbt/sbt/commit/18352254e0dfe93987c0dde1d8aa450b144fb723) in June 2013, as part of https://github.com/sbt/sbt/pull/6458.

We can double-check it works by running `sbt -v` to see the arguments the launcher script passed to Java:

```
% sbt -v
[sbt_options] declare -a sbt_options='()'
[process_args] java_version = '11'
[copyRt] java9_rt = '/Users/roberto_tyley/.sbt/1.0/java9-rt-ext-amazon_com_inc__11_0_22/rt.jar'
# Executing command line:
java
-Xmx8G
-XX:ReservedCodeCacheSize=128m
-XX:NewRatio=4
-Duser.timezone=Australia/Sydney
-DSTAGE=DEV
-DAPP_SECRET=this_is_not_a_real_secret_just_for_tests
-Dsbt.script=/opt/homebrew/Cellar/sbt/1.12.0/libexec/bin/sbt
-Dscala.ext.dirs=/Users/roberto_tyley/.sbt/1.0/java9-rt-ext-amazon_com_inc__11_0_22
-jar
/opt/homebrew/Cellar/sbt/1.12.0/libexec/bin/sbt-launch.jar

[info] welcome to sbt 1.12.2 (Amazon.com Inc. Java 11.0.22)
```
