### PR TITLE
Add match-stats json endpoint

### DIFF
--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -3,7 +3,7 @@ package football.model
 import common.{CanonicalLink, Edition, LinkTo}
 import conf.Configuration
 import experiments.ActiveExperiments
-import football.controllers.{CompetitionFilter, FootballPage, MatchDataAnswer, MatchMetadata, MatchPage}
+import football.controllers.{CompetitionFilter, FootballPage, MatchMetadata, MatchPage}
 import model.content.InteractiveAtom
 import model.dotcomrendering.DotcomRenderingUtils.{
   assetURL,
@@ -358,7 +358,7 @@ object DotcomRenderingFootballTablesDataModel {
 
 case class DotcomRenderingFootballMatchSummaryDataModel(
     // this field will need to get renamed to matchStats in upcoming PR
-    footballMatch: MatchDataAnswer,
+    footballMatch: MatchStats,
     matchInfo: FootballMatch,
     group: Option[Group],
     competitionName: String,
@@ -378,7 +378,7 @@ case class DotcomRenderingFootballMatchSummaryDataModel(
 object DotcomRenderingFootballMatchSummaryDataModel {
   def apply(
       page: MatchPage,
-      matchStats: MatchDataAnswer,
+      matchStats: MatchStats,
       matchInfo: FootballMatch,
       group: Option[Group],
       competitionName: String,

--- a/sport/app/football/model/MatchStats.scala
+++ b/sport/app/football/model/MatchStats.scala
@@ -1,0 +1,98 @@
+package football.model
+
+import conf.Configuration
+import model.TeamColours
+import pa.{FootballMatch, LineUp, LineUpTeam, MatchDayTeam}
+import play.api.libs.json.{Json, Writes}
+
+case class PlayerEvent(eventTime: String, eventType: String)
+case class Player(
+    id: String,
+    name: String,
+    position: String,
+    lastName: String,
+    substitute: Boolean,
+    timeOnPitch: String,
+    shirtNumber: String,
+    events: Seq[PlayerEvent],
+)
+case class TeamStats(
+    id: String,
+    name: String,
+    players: Seq[Player],
+    score: Option[Int],
+    scorers: List[String],
+    possession: Int,
+    shotsOn: Int,
+    shotsOff: Int,
+    corners: Int,
+    fouls: Int,
+    colours: String,
+    crest: String,
+    codename: String,
+)
+
+case class MatchStats(
+    id: String,
+    homeTeam: TeamStats,
+    awayTeam: TeamStats,
+    comments: Option[String],
+    status: String,
+)
+
+object MatchStats {
+  val reportedEventTypes = List("booking", "dismissal", "substitution")
+
+  def makePlayers(team: LineUpTeam): Seq[Player] = {
+    team.players.map { player =>
+      val events = player.events.filter(event => MatchStats.reportedEventTypes.contains(event.eventType)).map { event =>
+        PlayerEvent(event.eventTime, event.eventType)
+      }
+      Player(
+        player.id,
+        player.name,
+        player.position,
+        player.lastName,
+        player.substitute,
+        player.timeOnPitch,
+        player.shirtNumber,
+        events,
+      )
+    }
+  }
+
+  def makeTeamAnswer(teamV1: MatchDayTeam, teamV2: LineUpTeam, teamPossession: Int, teamColour: String): TeamStats = {
+    val players = makePlayers(teamV2)
+    TeamStats(
+      teamV1.id,
+      teamV1.name,
+      players = players,
+      score = teamV1.score,
+      scorers = teamV1.scorers.fold(Nil: List[String])(_.split(",").toList),
+      possession = teamPossession,
+      shotsOn = teamV2.shotsOn,
+      shotsOff = teamV2.shotsOff,
+      corners = teamV2.corners,
+      fouls = teamV2.fouls,
+      colours = teamColour,
+      crest = s"${Configuration.staticSport.path}/football/crests/120/${teamV1.id}.png",
+      codename = GuTeamCodes.codeFor(teamV1),
+    )
+  }
+
+  def statsFromFootballMatch(theMatch: FootballMatch, lineUp: LineUp, matchStatus: String): MatchStats = {
+    val teamColours = TeamColours(lineUp.homeTeam, lineUp.awayTeam)
+    MatchStats(
+      theMatch.id,
+      makeTeamAnswer(theMatch.homeTeam, lineUp.homeTeam, lineUp.homeTeamPossession, teamColours.home),
+      makeTeamAnswer(theMatch.awayTeam, lineUp.awayTeam, lineUp.awayTeamPossession, teamColours.away),
+      theMatch.comments,
+      matchStatus,
+    )
+  }
+
+  implicit val PlayerEventWrites: Writes[PlayerEvent] = Json.writes[PlayerEvent]
+  implicit val PlayerWrites: Writes[Player] = Json.writes[Player]
+  implicit val TeamStatsWrites: Writes[TeamStats] = Json.writes[TeamStats]
+  implicit val MatchStatsWrites: Writes[MatchStats] = Json.writes[MatchStats]
+}

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -66,6 +66,7 @@ GET        /football/:competitionTag/wallchart.json                           fo
 
 GET        /football/api/match-nav/:year/:month/:day/:home/:away.json         football.controllers.MoreOnMatchController.matchNavJson(year, month, day, home, away)
 GET        /football/api/match-header/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchHeaderJson(year, month, day, home, away)
+GET        /football/api/match-stats/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchStatsJson(year, month, day, home, away)
 GET        /football/api/match-nav/:year/:month/:day/:home/:away              football.controllers.MoreOnMatchController.matchNav(year, month, day, home, away)
 GET        /football/api/match-nav/:matchId.json                              football.controllers.MoreOnMatchController.moreOnJson(matchId)
 GET        /football/api/match-nav/:matchId                                   football.controllers.MoreOnMatchController.moreOn(matchId)


### PR DESCRIPTION
## What does this change?

This PR introduces a new Sport API route: `/football/api/match-stats/:year/:month/:day/:home/:away.json` This route is to power the **match stats** section on football match report pages.

Previously, these pages relied on: `/football/api/match-nav/:year/:month/:day/:home/:away.json`. However, the `match-nav` route returns a broader data structure than required, as it is designed to support both the header and the stats sections.

The new `match-stats` route provides a more focused response containing only the data needed for the stats component, reducing unnecessary payload size and clearly separating responsibilities between endpoints.

Fixes part of https://github.com/guardian/dotcom-rendering/issues/15174