### PR TITLE
Add match header/stats URLs to DCAR data model 

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -634,7 +634,7 @@ object DotcomRenderingDataModel {
       modifiedFormat.design == InteractiveDesign && content.trail.webPublicationDate
         .isBefore(Chronos.javaTimeLocalDateTimeToJodaDateTime(InteractiveSwitchOver.date))
 
-    val matchData = makeMatchData(page)
+    val matchData = makeMatchData(page, pageType)
 
     def addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks: Boolean, shouldAddDisclaimer: Boolean) = {
       if (shouldAddAffiliateLinks && shouldAddDisclaimer) {

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -106,6 +106,8 @@ case class DotcomRenderingDataModel(
     contributionsServiceUrl: String,
     badge: Option[DCRBadge],
     matchUrl: Option[String], // Optional url used for match data
+    matchHeaderUrl: Option[String],
+    matchStatsUrl: Option[String],
     matchType: Option[DotcomRenderingMatchType],
     isSpecialReport: Boolean, // Indicates whether the page is a special report.
     promotedNewsletter: Option[NewsletterData],
@@ -185,6 +187,8 @@ object DotcomRenderingDataModel {
         "contributionsServiceUrl" -> model.contributionsServiceUrl,
         "badge" -> model.badge,
         "matchUrl" -> model.matchUrl,
+        "matchHeaderUrl" -> model.matchHeaderUrl,
+        "matchStatsUrl" -> model.matchStatsUrl,
         "matchType" -> model.matchType,
         "isSpecialReport" -> model.isSpecialReport,
         "promotedNewsletter" -> model.promotedNewsletter,
@@ -675,6 +679,8 @@ object DotcomRenderingDataModel {
       main = content.fields.main,
       mainMediaElements = mainMediaElements,
       matchUrl = matchData.map(_.matchUrl),
+      matchHeaderUrl = matchData.flatMap(_.matchHeaderUrl),
+      matchStatsUrl = matchData.flatMap(_.matchStatsUrl),
       matchType = matchData.map(_.matchType),
       nav = Nav(page, edition),
       openGraphData = page.getOpenGraphProperties,

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -5,14 +5,8 @@ import conf.Configuration
 import experiments.ActiveExperiments
 import football.controllers.{CompetitionFilter, FootballPage, MatchMetadata, MatchPage}
 import model.content.InteractiveAtom
-import model.dotcomrendering.DotcomRenderingUtils.{
-  assetURL,
-  getMatchHeaderUrl,
-  getMatchNavUrl,
-  withoutDeepNull,
-  withoutNull,
-}
-import model.dotcomrendering.{Config, PageFooter, PageType}
+import model.dotcomrendering.DotcomRenderingUtils.{assetURL, getMatchNavUrl, getMatchUrl, withoutDeepNull, withoutNull}
+import model.dotcomrendering.{Config, MatchHeaderEndpoint, PageFooter, PageType}
 import model.{ApplicationContext, Competition, CompetitionSummary, ContentType, Group, StandalonePage, Table, TeamUrl}
 import navigation.{FooterLinks, Nav}
 import pa.{
@@ -419,7 +413,7 @@ object DotcomRenderingFootballMatchSummaryDataModel {
     val (homeId, awayId) = (theMatch.homeTeam.id, theMatch.awayTeam.id)
     val localDate = new JodaLocalDate(theMatch.date.getYear, theMatch.date.getMonthValue, theMatch.date.getDayOfMonth)
 
-    getMatchHeaderUrl(Configuration.ajax.url, localDate, homeId, awayId)
+    getMatchUrl(Configuration.ajax.url, localDate, homeId, awayId, MatchHeaderEndpoint)
   }
 
   import football.model.DotcomRenderingFootballDataModelImplicits._

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -66,7 +66,8 @@ GET        /football/:competitionTag/wallchart.json                           fo
 
 GET        /football/api/match-nav/:year/:month/:day/:home/:away.json         football.controllers.MoreOnMatchController.matchNavJson(year, month, day, home, away)
 GET        /football/api/match-header/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchHeaderJson(year, month, day, home, away)
-GET        /football/api/match-stats/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchStatsJson(year, month, day, home, away)
+GET        /football/api/match-stats/:year/:month/:day/:home/:away.json       football.controllers.MoreOnMatchController.matchStatsJson(year, month, day, home, away)
+GET        /football/api/match-stats-summary/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchStatsSummaryJson(year, month, day, home, away)
 GET        /football/api/match-nav/:year/:month/:day/:home/:away              football.controllers.MoreOnMatchController.matchNav(year, month, day, home, away)
 GET        /football/api/match-nav/:matchId.json                              football.controllers.MoreOnMatchController.moreOnJson(matchId)
 GET        /football/api/match-nav/:matchId                                   football.controllers.MoreOnMatchController.moreOn(matchId)


### PR DESCRIPTION
## What does this change?
This PR:

- Adds a new Sport API route for **match-stats-summary**:
`/football/api/match-stats-summary/:year/:month/:day/:home/:away.json`
This endpoint returns a summary of match stats and will be used for the match stats section on football live/dead blog pages.
- Extends the DCAR article data model (match reports and live/dead blogs) to include:
  - `matchHeaderUrl` 
  - `matchStatsUrl`
- Updates URL selection logic based on pageType:
  - live/dead blog -> `match-stats-summary`
  - none blog article -> `match-stats`

 ### NOTE: 
The existing field in DCAR data model `matchUrl` will be deprecated and removed after the migration
## Screenshots

### DCAR data model for articles:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3ffbb410-3f37-4604-8c47-c0a049fd4244
[after]: https://github.com/user-attachments/assets/8abde432-e34c-4455-8b12-3cebf059acd4


### Data model for `match-stats-summary` endpoint:
<img width="721" height="413" alt="image" src="https://github.com/user-attachments/assets/ceee7c45-a387-4b30-8bd8-516cc7b75c43" />


Fixes part of https://github.com/guardian/dotcom-rendering/issues/15174