### PR TITLE
Switch for DCR Admiral Migration added

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -660,4 +660,16 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
+
+  val DCROwnsAdmiral = Switch(
+    group = SwitchGroup.Feature,
+    name = "dcr-owns-admiral",
+    description =
+      "When ON - DCR will run Admiral bootstrap script, when OFF - Commercial will run the script in the usual way. This switch is intended to be ON for a short period of time while we verify that DCR can run the Admiral script without causing any issues, before we remove the script from Commercial and fully hand over control to DCR.",
+    owners = Seq(Owner.withEmail("growth.dev@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?
[Ticket link](https://trello.com/c/WJLFBAjJ/1622-admiral-migration)
## What does this change?
This PR creates a new feature switch exposed to client in order to expliciltly indicate that DCR should run admiral-bootstrap script instead of Commercial.
This switch is used during migration the admiral from Commercial project to DCR and will be removed after migration is over.
DCR PR for migration: https://github.com/guardian/dotcom-rendering/pull/15355
Commercial PR for migration: https://github.com/guardian/commercial/pull/2414
## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
