### PR TITLE
Send browserId to `/consent-signup` endpoint in IDAPI

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -38,6 +38,7 @@ case class EmailForm(
     referrer: Option[String],
     ref: Option[String],
     refViewId: Option[String],
+    browserId: Option[String],
     campaignCode: Option[String],
     googleRecaptchaResponse: Option[String],
     name: Option[String],
@@ -68,6 +69,7 @@ class EmailFormService(wsClient: WSClient, emailEmbedAgent: NewsletterSignupAgen
           "set-lists" -> List(form.listName),
           "set-consents" -> form.marketing.filter(_ == true).map(_ => List("similar_guardian_products")),
           "unset-consents" -> form.marketing.filter(_ == false).map(_ => List("similar_guardian_products")),
+          "browser-id" -> form.browserId,
         )
         .fields,
     )
@@ -149,6 +151,7 @@ class EmailSignupController(
       "referrer" -> optional[String](of[String]),
       "ref" -> optional[String](of[String]),
       "refViewId" -> optional[String](of[String]),
+      "browserId" -> optional[String](of[String]),
       "campaignCode" -> optional[String](of[String]),
       "g-recaptcha-response" -> optional[String](of[String]),
       "name" -> optional[String](of[String]),


### PR DESCRIPTION
## What does this change?
This PR passes the browserId from DCR to IDAPI when the user subscribes to a single newsletter. This flow does not require email confirmation and gets triggered in:
* Article sign-ups, e.g. https://www.theguardian.com/tv-and-radio/2026/feb/17/look-mum-no-computer-uk-entry-eurovision-2026
* Distinct article pages for each individual newsletter, e.g. https://www.theguardian.com/global/2022/sep/20/sign-up-for-the-first-edition-newsletter-our-free-news-email

## Why?
Supporter Revenue have made a request to send them the user id, the newsletter id, the browser id and the timestamp when a user subscribes to a newsletter. Browser id is the only info we currently don't have.

* https://github.com/guardian/identity/pull/2882
* https://github.com/guardian/dotcom-rendering/pull/15377

## Screenshots

BrowserId is undefined in CODE so we will have to merge this to see whether we actually send it.

| Before      | After      |
|-------------|------------|
| <img width="676" height="139" alt="image" src="https://github.com/user-attachments/assets/bd55f903-6d8e-4775-ab06-4bbebc616340" /> | <img width="917" height="139" alt="image" src="https://github.com/user-attachments/assets/87df3358-8f0f-42cc-bf63-bff35a6cf2af" /> |


## Checklist

- [x] Tested on CODE
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
