### PR TITLE
Fix SBT install in sbt graph workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -3,26 +3,20 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: 
+  workflow_dispatch:
+
 jobs:
   dependency-graph:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
         id: checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
-      - name: Install Java
-        id: java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: corretto
-          java-version: 17
+        uses: actions/checkout@v6
       - name: Install sbt
-        id: sbt
-        uses: sbt/setup-sbt@06192244f17880c9bf69ccd8de5b2e8785822be5 # v1.1.17
+        uses: guardian/setup-scala@v1
       - name: Submit dependencies
         id: submit
-        uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
+        uses: scalacenter/sbt-dependency-submission@v3
       - name: Log snapshot for user validation
         id: validate
         run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq

--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -11,12 +11,12 @@ jobs:
     steps:
       - name: Checkout branch
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f265659d3bb64ab1440b03b12f4d47a24320917 # v6
       - name: Install sbt
-        uses: guardian/setup-scala@v1
+        uses: guardian/setup-scala@f8b37d4380d93ee5c37739fd8aea97f7c580034a # v1.1.0
       - name: Submit dependencies
         id: submit
-        uses: scalacenter/sbt-dependency-submission@v3
+        uses: scalacenter/sbt-dependency-submission@0e494e20a396dac25645a0134cd6749cc581bbb5 # v3.2.1
       - name: Log snapshot for user validation
         id: validate
         run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq


### PR DESCRIPTION
Our dependency tree upload broke recently, it's unclear as to why, but SBT wasn't being installed properly.

This uses latest departmental best-practices to install sbt and, conveniently, was enough to get the action to successfully run.

Successful run here: https://github.com/guardian/frontend/actions/runs/22359623074