### PR TITLE
Add apps rendering path for interactive live harnesses

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -75,8 +75,15 @@ class InteractiveController(
 
   def modelAndRenderHtml(response: ItemResponse)(
       modifier: BlocksOn[InteractivePage] => BlocksOn[InteractivePage] = identity,
-  )(implicit req: RequestHeader): Future[Result] =
-    modelAndRender(response)(pageBlocks => renderHtml(modifier(pageBlocks)))
+  )(implicit req: RequestHeader): Future[Result] = {
+    modelAndRender(response)(pageBlocks => {
+      val modifiedBlocks = modifier(pageBlocks)
+      req.getRequestFormat match {
+        case AppsFormat => renderApps(modifiedBlocks)
+        case _          => renderHtml(modifiedBlocks)
+      }
+    })
+  }
 
   def modelAndRender(
       response: ItemResponse,


### PR DESCRIPTION
This addresses an issue where interactive articles in live harnesses were rendering as web pages regardless of whether they had `?dcr=apps` appended or not. This meant interactive devs could never see how a piece would look and behave on the apps. Not good.

@jonathonherbert and I dug into it and found this was we were using the same `renderHtml()` option regardless of the format. Now we go down the `renderApps()` path when appropriate.

Tested locally and looks to be working nicely.