### PR TITLE
Use new ab test framework for tag page storylines

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,7 +12,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
       DarkModeWeb,
-      TagPageStorylines,
     )
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
@@ -24,13 +23,4 @@ object DarkModeWeb
       owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
       sellByDate = LocalDate.of(2027, 1, 26),
       participationGroup = Perc0D,
-    )
-
-object TagPageStorylines
-    extends Experiment(
-      name = "tag-page-storylines",
-      description = "Enable AI storylines content on web tag pages",
-      owners = Seq(Owner.withEmail("ai.dev@theguardian.com")),
-      sellByDate = LocalDate.of(2026, 2, 27),
-      participationGroup = Perc0E,
     )

--- a/common/app/model/StorylinesContent.scala
+++ b/common/app/model/StorylinesContent.scala
@@ -1,5 +1,6 @@
 package model
 
+import ab.ABTests
 import common.GuLogging
 import conf.Configuration
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
@@ -8,8 +9,7 @@ import play.api.libs.json.{Json, Writes}
 import services.S3
 
 import java.time.Instant
-import experiments.{TagPageStorylines, ActiveExperiments}
-import play.api.mvc.{Filter, RequestHeader}
+import play.api.mvc.RequestHeader
 
 // this mirrors the structure in the tool generating the content
 // https://github.com/guardian/tag-page-supercharger/blob/main/app/models/FrontendContent.scala#L18
@@ -143,7 +143,7 @@ object StorylinesContent extends GuLogging {
   implicit val storylinesWrites: Writes[StorylinesContent] = Json.writes[StorylinesContent]
 
   def getContent(tag: String)(implicit rh: RequestHeader): Option[StorylinesContent] = {
-    if (ActiveExperiments.isParticipating(TagPageStorylines)) {
+    if (ABTests.isParticipating(rh, "fronts-and-curation-tag-page-storylines")) {
       lazy val stage: String = Configuration.facia.stage.toUpperCase
       val encodedTag = java.net.URLEncoder.encode(tag, "UTF-8")
       val location = s"$stage/tag-page-ai-data/$encodedTag.json"

--- a/common/app/model/StorylinesContent.scala
+++ b/common/app/model/StorylinesContent.scala
@@ -143,7 +143,7 @@ object StorylinesContent extends GuLogging {
   implicit val storylinesWrites: Writes[StorylinesContent] = Json.writes[StorylinesContent]
 
   def getContent(tag: String)(implicit rh: RequestHeader): Option[StorylinesContent] = {
-    if (ABTests.isParticipating(rh, "fronts-and-curation-tag-page-storylines")) {
+    if (ABTests.isInVariant(rh, "fronts-and-curation-tag-page-storylines", "variant")) {
       lazy val stage: String = Configuration.facia.stage.toUpperCase
       val encodedTag = java.net.URLEncoder.encode(tag, "UTF-8")
       val location = s"$stage/tag-page-ai-data/$encodedTag.json"


### PR DESCRIPTION
## What does this change?

Uses the new ab testing framework to support this test. Dependent on this [DCR PR](https://github.com/guardian/dotcom-rendering/pull/15425)

## Testing

- Deploy this branch to code
- Verify that the current tag pages test is no longer active (https://m.code.dev-theguardian.com/opt/in/tag-page-storylines should give a 404, the test shouldn't appear in the frontend console anymore)
- Deploy the DCR branch to code (including the ab testing project)
- Check that tag pages are showing as normal without being included in the test
- Opting in to the test should then display storylines content on selected page (for example, sport/formulaone)

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
