### PR TITLE
Delete `update-ami-for-legacy-stacks` 

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,6 @@ templates:
       warmupGrace: 60
     dependencies:
     - frontend-static
-    - update-ami-for-legacy-stacks
     - update-ami-for-admin
     - update-ami-for-discussion
     - update-ami-for-sport
@@ -62,16 +61,6 @@ deployments:
       cacheControl: public, max-age=315360000, immutable
       prefixStack: false
       publicReadAcl: false
-  update-ami-for-legacy-stacks:
-    type: ami-cloudformation-parameter
-    parameters:
-      cloudFormationStackByTags: false
-      prependStackToCloudFormationStackName: false
-      cloudFormationStackName: frontend
-      amiParametersToTags:
-        AMI:
-          Recipe: ubuntu-jammy-frontend-base-ARM-java11-cdk-base
-          AmigoStage: PROD
   # Riff-Raff identifies the GuCDK stacks using tag-based lookups
   update-ami-for-admin:
     app: admin


### PR DESCRIPTION
## What is the value of this and can you measure success?
Deletes the `update-ami-for-legacy-stacks` deployment and dependency subsequent to the completion of migrating all apps to GuCDK
Part of https://github.com/guardian/platform/issues/2068
