### PR TITLE
INFO log for missing switch state

### DIFF
--- a/common/app/conf/switches/SwitchboardLifecycle.scala
+++ b/common/app/conf/switches/SwitchboardLifecycle.scala
@@ -43,7 +43,11 @@ class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobSchedule
           case Some("on")  => switch.switchOn()
           case Some("off") => switch.switchOff()
           case _           =>
-            log.warn(s"Badly configured switch ${switch.name}, setting to safe state.")
+            log.info(s"""No state has yet been initialised for ${switch.name} in the switchboard,
+                        |which probably means the switchboard has not been updated and/or saved
+                        |since this switch was created. Setting it to its safe state for now."""
+                        .replaceAll("\n", " ")
+                    )
             switch.switchToSafeState()
         }
       }

--- a/common/app/conf/switches/SwitchboardLifecycle.scala
+++ b/common/app/conf/switches/SwitchboardLifecycle.scala
@@ -43,11 +43,9 @@ class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobSchedule
           case Some("on")  => switch.switchOn()
           case Some("off") => switch.switchOff()
           case _           =>
-            log.info(s"""No state has yet been initialised for ${switch.name} in the switchboard,
-                        |which probably means the switchboard has not been updated and/or saved
-                        |since this switch was created. Setting it to its safe state for now."""
-                        .replaceAll("\n", " ")
-                    )
+            log.info(
+              s"No state has yet been initialised for ${switch.name} in the switchboard, which probably means the switchboard has not been updated and/or saved since this switch was created. Setting it to its safe state for now.",
+            )
             switch.switchToSafeState()
         }
       }


### PR DESCRIPTION
At the moment, when a switch's state cannot be retrieved from S3, a warning is logged stating that the switch is badly configured. However, whenever a new switch is created, no state will exist in S3 until the switchboard has been updated and/or saved in the admin tool. This might not happen immediately, so warnings are repeatedly logged, every minute, until it does.

But the switch is not really badly configured, it's just not set yet. This can be confusing for anyone reading the logs, as it appears something is wrong with the switchboard, whereas this is actually expected behaviour. Therefore this change downgrades the log from a WARN to an INFO, and adds a longer explanation to the message.
