### PR TITLE
Update 'Ops metrics' configuration for migrated Router stack

### DIFF
--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -21,7 +21,12 @@ case class LoadBalancer(
 object LoadBalancer extends GuLogging {
 
   private val loadBalancers = Seq(
-    LoadBalancer("frontend-PROD-router-ELB", "Router", "frontend-router"),
+    LoadBalancer(
+      "app/fronte-LoadB-Qs4j1NIlqHHR/42b2a4e0e0528b70",
+      "Router",
+      "frontend-router",
+      targetGroup = Some("targetgroup/fronte-Targe-EJKJLKK5DKUZ/262ab39748d9c310"),
+    ),
     LoadBalancer(
       "app/fronte-LoadB-xXnA5yhOxB7G/cf797b52302fc833",
       "Article",


### PR DESCRIPTION
See [this for context which adds the functionality for discussion](https://github.com/guardian/frontend/pull/27865)
Part of https://github.com/guardian/platform/issues/2065