### PR TITLE
Fix comment in `.jvmopts`

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,7 @@
 -Xmx8G
 -XX:ReservedCodeCacheSize=128m
 -XX:NewRatio=4
--Duser.timezone=Australia/Sydney # because it is too easy for devs to forget about timezones, see https://github.com/guardian/frontend/pull/4713
+# because it is too easy for devs to forget about timezones, see https://github.com/guardian/frontend/pull/4713
+-Duser.timezone=Australia/Sydney
 -DSTAGE=DEV
 -DAPP_SECRET=this_is_not_a_real_secret_just_for_tests


### PR DESCRIPTION
Recent versions of `sbt` do not accept comments at the end of lines in a `.jvmopts` file. Attempting to launch `sbt` results in a crash with variations of the following error:

```
Error: Could not find or load main class #
Caused by: java.lang.ClassNotFoundException: #
```

This appears to affect at least some versions of `sbt` 1.12.x; it has been reproduced on 1.12.3 and 1.12.4 so far. It does not appear to affect earlier versions; 1.11.2, for example, runs fine with these kinds of comments.

Comments that are on their own line, i.e. with the comment character at the start of the line, do still work. Therefore the fix for now is to move the comment in our `.jvmopts` file onto its own line.

Credit to @adamnfish @johnduffell and @alexduf for investigating and figuring this out.

It looks like this was the reason for the issue mentioned in #28625.
