### PR TITLE
Limit getting storylines content to specific tags for test

### DIFF
--- a/common/app/model/StorylinesContent.scala
+++ b/common/app/model/StorylinesContent.scala
@@ -142,8 +142,21 @@ object StorylinesContent extends GuLogging {
   implicit val storylinesContentEncoder: Encoder[StorylinesContent] = deriveEncoder
   implicit val storylinesWrites: Writes[StorylinesContent] = Json.writes[StorylinesContent]
 
+  private val allowedTags: Set[String] = Set(
+    "world/americas",
+    "us-news/trump-administration",
+    "environment/wildlife",
+    "business/retail",
+    "technology/artificialintelligenceai",
+    "world/china",
+    "politics/labour",
+    "australia-news/indigenous-australians",
+    "sport/formulaone",
+    "football/liverpool",
+  )
+
   def getContent(tag: String)(implicit rh: RequestHeader): Option[StorylinesContent] = {
-    if (ABTests.isInVariant(rh, "fronts-and-curation-tag-page-storylines", "variant")) {
+    if (allowedTags.contains(tag) && ABTests.isInVariant(rh, "fronts-and-curation-tag-page-storylines", "variant")) {
       lazy val stage: String = Configuration.facia.stage.toUpperCase
       val encodedTag = java.net.URLEncoder.encode(tag, "UTF-8")
       val location = s"$stage/tag-page-ai-data/$encodedTag.json"


### PR DESCRIPTION
## What is the value of this and can you measure success?

We only want to run this test on select tag pages:
[Americas](https://www.theguardian.com/world/americas)
[Trump administration](https://www.theguardian.com/us-news/trump-administration)
[Wildlife](https://www.theguardian.com/environment/wildlife)
[Retail](https://www.theguardian.com/business/retail)
[AI](https://www.theguardian.com/technology/artificialintelligenceai)
[China](https://www.theguardian.com/world/china)
[Labour](https://www.theguardian.com/politics/labour)
[Indigenous Australians](https://www.theguardian.com/australia-news/indigenous-australians)
[F1](https://www.theguardian.com/sport/formulaone)
[Liverpool FC](https://www.theguardian.com/football/liverpool)

## Testing

On code we don't currently have generated content for each of these (although you're welcome to try generating some). 

But this behaviour can be verified by opting in to the test on code, visiting one of the pages above (e.g. f1, AI or Liverpool FC) and checking the content appears, and in contrast visiting the `football/mls` tag and checking the content there doesn't appear (despite it existing in the frontend bucket). 



<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
