### PR TITLE
Delete dark mode web test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,17 +10,6 @@ import java.time.LocalDate
  */
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
-    Set(
-      DarkModeWeb,
-    )
+    Set()
   implicit val canCheckExperiment: CanCheckExperiment = new CanCheckExperiment(this)
 }
-
-object DarkModeWeb
-    extends Experiment(
-      name = "dark-mode-web",
-      description = "Enable dark mode on web",
-      owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-      sellByDate = LocalDate.of(2027, 1, 26),
-      participationGroup = Perc0D,
-    )


### PR DESCRIPTION
## What does this change?
Delete the dark mode web server side test, as of https://github.com/guardian/dotcom-rendering/pull/15299 it's been migrated to the new framework!