### PR TITLE
Move Liveramp switch to the Prebid group from the Commercial switch group

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -406,7 +406,7 @@ trait PrebidSwitches {
   )
 
   val prebidLiveramp: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-liveramp",
     description = "When ON, the Liveramp ID integration is enabled for user sync in Prebid",
     owners = group(Commercial),


### PR DESCRIPTION
## What is the value of this and can you measure success?

Keeping switches organised in the admin tool

## What does this change?

Organises the Liveramp switch in the correct place in the admin tool - next to the other Prebid switches