### PR TITLE
Update US Columnists subnav link

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -102,6 +102,7 @@ object NavLinks {
   /* OPINION */
   val columnists = NavLink("Columnists", "/index/contributors")
   val auColumnists = NavLink("Columnists", "/au/index/contributors")
+  val usColumnists = NavLink("Columnists", "/us/columnists")
   val theGuardianView = NavLink("The Guardian view", "/profile/editorial")
   val cartoons = NavLink("Cartoons", "/tone/cartoons")
   val opinionVideos = NavLink("Opinion videos", "/type/video+tone/comment")
@@ -384,7 +385,7 @@ object NavLinks {
   val usOpinionPillar = ukOpinionPillar.copy(
     children = List(
       theGuardianView,
-      columnists,
+      usColumnists,
       letters,
       opinionVideos,
       cartoons,

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -39,12 +39,12 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
   }
 
   "On `/index/contributors`, the parent" should "be Opinion" in {
-    val edition = Us
+    val edition = Uk
     val root = NavMenu.navRoot(edition)
     val maybeNavLink = NavMenu.findDescendantByUrl("/index/contributors", edition, root.children, root.otherLinks)
     val maybeParent = maybeNavLink.flatMap(link => NavMenu.findParent(link, edition, root.children, root.otherLinks))
 
-    maybeParent.map(p => p should be(usOpinionPillar))
+    maybeParent.map(p => p should be(ukOpinionPillar))
   }
 
   "On `/football`, the parent" should "be Sport" in {

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -1220,7 +1220,7 @@
 				},
 				{
 					"title": "Columnists",
-					"url": "/index/contributors",
+					"url": "/us/columnists",
 					"children": [],
 					"classList": []
 				},


### PR DESCRIPTION
## What is the value of this and can you measure success?
Fullfils editorial need.

## What does this change?
Editionises the columnist link of the US opinion sub nav (https://www.theguardian.com/us/columnists)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/49864cd2-b88c-49aa-95ac-ccd75fe7fd37
[after]: https://github.com/user-attachments/assets/d1229cc4-d34f-4ae0-899d-795ac73c092e

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
