### PR TITLE
Remove deprecated fixed containers from supported collections

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -21,19 +21,6 @@ object FrontChecks {
     */
   val SUPPORTED_COLLECTIONS: Set[String] =
     Set(
-      "fixed/large/slow-XIV",
-      "fixed/medium/fast-XI",
-      "fixed/medium/fast-XII",
-      "fixed/medium/slow-VI",
-      "fixed/medium/slow-VII",
-      "fixed/medium/slow-XII-mpu",
-      "fixed/small/fast-VIII",
-      "fixed/small/slow-I",
-      "fixed/small/slow-III",
-      "fixed/small/slow-IV",
-      "fixed/small/slow-V-half",
-      "fixed/small/slow-V-mpu",
-      "fixed/small/slow-V-third",
       "fixed/thrasher",
       "nav/list",
       "nav/media-list",

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -226,19 +226,6 @@ import layout.slices.EmailLayouts
   it should "Should render supported collections" in {
     val faciaPage = FixtureBuilder.mkPressedPage(
       List(
-        PressedCollectionBuilder.mkPressedCollection("fixed/large/slow-XIV"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/medium/fast-XI"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/medium/fast-XII"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/medium/slow-VI"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/medium/slow-VII"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/medium/slow-XII-mpu"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/small/fast-VIII"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-I"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-III"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-IV"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-V-half"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-V-mpu"),
-        PressedCollectionBuilder.mkPressedCollection("fixed/small/slow-V-third"),
         PressedCollectionBuilder.mkPressedCollection("fixed/thrasher"),
         PressedCollectionBuilder.mkPressedCollection("nav/list"),
         PressedCollectionBuilder.mkPressedCollection("nav/media-list"),


### PR DESCRIPTION
Corresponding [DCR PR](https://github.com/guardian/dotcom-rendering/pull/15500)

## What is the value of this and can you measure success?

All deprecated "fixed" containers have now been removed and can no longer be selected in the fronts tool

## What does this change?

The following containers are no longer supported by DCR:
- fixed/large/slow-XIV
- fixed/medium/fast-XI
- fixed/medium/fast-XII
- fixed/medium/slow-VI
- fixed/medium/slow-VII
- fixed/medium/slow-XII-mpu
- fixed/small/fast-VIII
- fixed/small/slow-I
- fixed/small/slow-III
- fixed/small/slow-IV
- fixed/small/slow-V-half
- fixed/small/slow-V-mpu
- fixed/small/slow-V-third