### PR TITLE
Add AppsFormat for match info page route

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -494,6 +494,13 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     post(ws, json, Configuration.rendering.articleBaseURL + "/FootballMatchSummaryPage", CacheTime.FootballMatch)
   }
 
+  def getAppsFootballMatchSummaryPage(
+      ws: WSClient,
+      json: JsValue,
+  )(implicit request: RequestHeader): Future[Result] = {
+    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsFootballMatchSummaryPage", CacheTime.FootballMatch)
+  }
+
   def getCricketPage(
       ws: WSClient,
       json: JsValue,

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -2,7 +2,7 @@ package football.controllers
 
 import common._
 import feed.CompetitionsService
-import implicits.{Football, HtmlFormat, JsonFormat, Requests}
+import implicits.{AppsFormat, Football, HtmlFormat, JsonFormat, Requests}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.TeamMap.findTeamIdByUrlName
 import football.datetime.DateHelpers
@@ -122,6 +122,19 @@ class MatchController(
                   competitionName = competitionSummary.fullName,
                 )
                 remoteRenderer.getFootballMatchSummaryPage(
+                  wsClient,
+                  DotcomRenderingFootballMatchSummaryDataModel.toJson(model),
+                )
+
+              case AppsFormat if tier == RemoteRender =>
+                val model = DotcomRenderingFootballMatchSummaryDataModel(
+                  page = page,
+                  matchStats = matchStats,
+                  matchInfo = theMatch,
+                  group = group,
+                  competitionName = competitionSummary.fullName,
+                )
+                remoteRenderer.getAppsFootballMatchSummaryPage(
                   wsClient,
                   DotcomRenderingFootballMatchSummaryDataModel.toJson(model),
                 )


### PR DESCRIPTION
## What does this change?
This PR adds support for rendering the match info page in the Apps 

### Release NOTE:
This PR can only be merged after the DCAR part is released: https://github.com/guardian/dotcom-rendering/pull/15501

Fixes part of https://github.com/guardian/dotcom-rendering/issues/15502