### PR TITLE
Set implicit arguments in secondary argument list in ABTests methods

### DIFF
--- a/common/app/ab/ABTests.scala
+++ b/common/app/ab/ABTests.scala
@@ -16,7 +16,7 @@ object ABTests {
   /** Decorates the request with the AB tests defined in the request header. The header should be in the format:
     * "testName1:variant1,testName2:variant2,..."
     */
-  def decorateRequest(implicit request: RequestHeader, abTestHeader: String): RequestHeader = {
+  def decorateRequest(abTestHeader: String)(implicit request: RequestHeader): RequestHeader = {
     val tests = request.headers.get(abTestHeader).fold(Map.empty[String, String]) { tests =>
       tests
         .split(",")
@@ -39,7 +39,7 @@ object ABTests {
     * @return
     *   true if the request is participating in the test, false otherwise.
     */
-  def isUserInTest(implicit request: RequestHeader, testName: String): Boolean = {
+  def isUserInTest(testName: String)(implicit request: RequestHeader): Boolean = {
     request.attrs.get(attrKey).exists(_.asScala.keys.exists { case (name, _) => name == testName })
   }
 
@@ -51,7 +51,7 @@ object ABTests {
     * @return
     *   true if the request is in the specified variant, false otherwise.
     */
-  def isUserInTestGroup(implicit request: RequestHeader, testName: String, variant: String): Boolean = {
+  def isUserInTestGroup(testName: String, variant: String)(implicit request: RequestHeader): Boolean = {
     request.attrs.get(attrKey).exists(_.containsKey((testName, variant)))
   }
 

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -115,11 +115,11 @@ class ExperimentsFilter(implicit val mat: Materializer, executionContext: Execut
 class ABTestingFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
   private val abTestHeader = "X-GU-Server-AB-Tests"
 
-  override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
+  override def apply(nextFilter: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
     if (EnableNewServerSideABTestsHeader.isSwitchedOff) {
       nextFilter(request)
     } else {
-      val r = ABTests.decorateRequest(request, abTestHeader)
+      val r = ABTests.decorateRequest(abTestHeader)(request)
       nextFilter(r).map { result =>
         val varyHeaderValues = result.header.headers.get("Vary").toSeq ++ Seq(abTestHeader)
         val abTestHeaderValue = request.headers.get(abTestHeader).getOrElse("")

--- a/common/app/model/StorylinesContent.scala
+++ b/common/app/model/StorylinesContent.scala
@@ -156,9 +156,7 @@ object StorylinesContent extends GuLogging {
   )
 
   def getContent(tag: String)(implicit rh: RequestHeader): Option[StorylinesContent] = {
-    if (
-      allowedTags.contains(tag) && ABTests.isUserInTestGroup(rh, "fronts-and-curation-tag-page-storylines", "variant")
-    ) {
+    if (allowedTags.contains(tag) && ABTests.isUserInTestGroup("fronts-and-curation-tag-page-storylines", "variant")) {
       lazy val stage: String = Configuration.facia.stage.toUpperCase
       val encodedTag = java.net.URLEncoder.encode(tag, "UTF-8")
       val location = s"$stage/tag-page-ai-data/$encodedTag.json"

--- a/common/test/ab/ABTestsTest.scala
+++ b/common/test/ab/ABTestsTest.scala
@@ -12,7 +12,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   "ABTests.decorateRequest" should "parse AB test header correctly" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test1" -> "variant1",
@@ -22,14 +22,14 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "handle empty header" in {
     val request = FakeRequest()
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should be(empty)
   }
 
   it should "handle malformed test entries" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,malformed,test2:variant2:extra")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test1" -> "variant1",
@@ -38,7 +38,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "handle test entries with missing variant" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test2" -> "variant2",
@@ -47,7 +47,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "handle test entries with colons in values" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant:with:colons,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test2" -> "variant2",
@@ -56,78 +56,78 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "handle empty string header" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should be(empty)
   }
 
   "ABTests.isUserInTest" should "return true when test exists" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
-    ABTests.isUserInTest(enrichedRequest, "test1") should be(true)
-    ABTests.isUserInTest(enrichedRequest, "test2") should be(true)
+    ABTests.isUserInTest("test1")(enrichedRequest) should be(true)
+    ABTests.isUserInTest("test2")(enrichedRequest) should be(true)
   }
 
   it should "return false when test does not exist" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
-    ABTests.isUserInTest(enrichedRequest, "test3") should be(false)
+    ABTests.isUserInTest("test3")(enrichedRequest) should be(false)
   }
 
   it should "return false for empty request" in {
     val request = FakeRequest()
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
-    ABTests.isUserInTest(enrichedRequest, "test1") should be(false)
+    ABTests.isUserInTest("test1")(enrichedRequest) should be(false)
   }
 
   it should "return false when request has no AB test attributes" in {
     val request = FakeRequest()
 
-    ABTests.isUserInTest(request, "test1") should be(false)
+    ABTests.isUserInTest("test1")(request) should be(false)
   }
 
   "ABTests.isUserInTestGroup" should "return true when test and variant match" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
-    ABTests.isUserInTestGroup(enrichedRequest, "test1", "variant1") should be(true)
-    ABTests.isUserInTestGroup(enrichedRequest, "test2", "variant2") should be(true)
+    ABTests.isUserInTestGroup("test1", "variant1")(enrichedRequest) should be(true)
+    ABTests.isUserInTestGroup("test2", "variant2")(enrichedRequest) should be(true)
   }
 
   it should "return false when test exists but variant does not match" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
-    ABTests.isUserInTestGroup(enrichedRequest, "test1", "variant2") should be(false)
-    ABTests.isUserInTestGroup(enrichedRequest, "test2", "variant1") should be(false)
+    ABTests.isUserInTestGroup("test1", "variant2")(enrichedRequest) should be(false)
+    ABTests.isUserInTestGroup("test2", "variant1")(enrichedRequest) should be(false)
   }
 
   it should "return false when test does not exist" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
-    ABTests.isUserInTestGroup(enrichedRequest, "test3", "variant1") should be(false)
+    ABTests.isUserInTestGroup("test3", "variant1")(enrichedRequest) should be(false)
   }
 
   it should "return false for empty request" in {
     val request = FakeRequest()
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
-    ABTests.isUserInTestGroup(enrichedRequest, "test1", "variant1") should be(false)
+    ABTests.isUserInTestGroup("test1", "variant1")(enrichedRequest) should be(false)
   }
 
   it should "return false when request has no AB test attributes" in {
     val request = FakeRequest()
 
-    ABTests.isUserInTestGroup(request, "test1", "variant1") should be(false)
+    ABTests.isUserInTestGroup("test1", "variant1")(request) should be(false)
   }
 
   "ABTests.getParticipations" should "return all parsed tests" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2,test3:control")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test1" -> "variant1",
@@ -138,7 +138,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "return empty map for request without AB tests" in {
     val request = FakeRequest()
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should be(empty)
   }
@@ -151,7 +151,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   "ABTests.getJavascriptConfig" should "return properly formatted JavaScript config" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     val jsConfig = ABTests.getJavascriptConfig(enrichedRequest)
 
@@ -162,14 +162,14 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "return empty string for request without AB tests" in {
     val request = FakeRequest()
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getJavascriptConfig(enrichedRequest) should be("")
   }
 
   it should "handle single test" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getJavascriptConfig(enrichedRequest) should be(""""test1":"variant1"""")
   }
@@ -182,7 +182,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   "ABTests header parsing" should "handle whitespace around test entries" in {
     val request = FakeRequest().withHeaders(abTestHeader -> " test1:variant1 , test2:variant2 ")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test1" -> "variant1",
@@ -192,7 +192,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "handle trailing commas" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,test2:variant2,")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test1" -> "variant1",
@@ -202,7 +202,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "handle leading commas" in {
     val request = FakeRequest().withHeaders(abTestHeader -> ",test1:variant1,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test1" -> "variant1",
@@ -212,7 +212,7 @@ class ABTestsTest extends AnyFlatSpec with Matchers {
 
   it should "handle multiple consecutive commas" in {
     val request = FakeRequest().withHeaders(abTestHeader -> "test1:variant1,,test2:variant2")
-    val enrichedRequest = ABTests.decorateRequest(request, abTestHeader)
+    val enrichedRequest = ABTests.decorateRequest(abTestHeader)(request)
 
     ABTests.getParticipations(enrichedRequest) should contain theSameElementsAs Map(
       "test1" -> "variant1",


### PR DESCRIPTION
## What is the value of this and can you measure success?

`request` is often passed around frontend methods implicitly - it has been declared in scope then is omitted in sub methods.

The new AB testing framework methods had the implicit `request` argument as the first parameter meaning that it cannot act truly implicitly as it must be declared each time.

## What does this change?

This PR moves the implicit `request` argument to a secondary argument list to allow a `request` variable in scope to be automatically included when methods are called

You can still specify the `request` argument in these methods but this now goes in a secondary argument list
