### PR TITLE
Use internal redirect for Hosted Content

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -46,6 +46,9 @@ class ArticleController(
   def renderArticle(path: String): Action[AnyContent] = Action.async(mapAndRender(path, ArticleBlocks)()(_))
   def renderJson(path: String): Action[AnyContent] = renderArticle(path)
   def renderEmail(path: String): Action[AnyContent] = renderArticle(path)
+  def renderHosted(campaignName: String, pageName: String): Action[AnyContent] = renderArticle(
+    s"advertiser-content/$campaignName/$pageName",
+  )
 
   def renderHeadline(path: String): Action[AnyContent] =
     Action.async { implicit request =>

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -21,13 +21,17 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogContr
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], filterKeyEvents: Option[Boolean])
 
+# Hosted content (under migration)
+
+GET     /advertiser-content/:campaignName/:pageName.json  controllers.ArticleController.renderHosted(campaignName, pageName)
+
 # articles, finished liveblogs
 
-GET     /*path.json                 controllers.ArticleController.renderJson(path)
-GET     /*path/email                controllers.ArticleController.renderEmail(path)
-GET     /*path/email/headline.txt   controllers.ArticleController.renderHeadline(path)
-GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
-GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
+GET     /*path.json                     controllers.ArticleController.renderJson(path)
+GET     /*path/email                    controllers.ArticleController.renderEmail(path)
+GET     /*path/email/headline.txt       controllers.ArticleController.renderHeadline(path)
+GET     /*path/email.emailjson          controllers.ArticleController.renderEmail(path)
+GET     /*path/email.emailtxt           controllers.ArticleController.renderEmail(path)
 
 # Newspaper pages paths
 # gallery format (?)

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -21,8 +21,7 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogContr
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], filterKeyEvents: Option[Boolean])
 
-# Hosted content (under migration)
-
+# Commercial Hosted Content (under migration)
 GET     /advertiser-content/:campaignName/:pageName.json  controllers.ArticleController.renderHosted(campaignName, pageName)
 
 # articles, finished liveblogs

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -1,12 +1,14 @@
 package commercial.controllers
 
+import ab.ABTests.isUserInTestGroup
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.ItemQuery
-import com.gu.contentapi.client.model.v1.ContentType.{Article, Gallery, Video}
+import com.gu.contentapi.client.model.v1.ContentType.Video
 import com.gu.contentapi.client.model.v1.Content
 import commercial.model.hosted.HostedTrails
 import common.commercial.hosted._
-import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent, JsonNotFound}
+import common.{Edition, GuLogging, ImplicitControllerExecutionContext, InternalRedirect, JsonComponent, JsonNotFound}
+import conf.switches.Switches.DCRHostedContent
 import contentapi.ContentApiClient
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{ApplicationContext, Cached, DotcomRenderingHostedContentModel, NoCache}
@@ -74,7 +76,6 @@ class HostedContentController(
       pageName: String,
   )(implicit request: Request[AnyContent]): Future[Option[Content]] = {
     val itemId = s"advertiser-content/$campaignName/$pageName"
-
     contentApiClient
       .getResponse(baseQuery(itemId))
       .map(_.content)
@@ -92,13 +93,27 @@ class HostedContentController(
 
   def renderHostedPage(campaignName: String, pageName: String): Action[AnyContent] =
     Action.async { implicit request =>
-      lookup(campaignName, pageName).flatMap {
-        case Some(content) if request.getRequestFormat == JsonFormat =>
-          renderJsonResponse(content)
-        case Some(content) =>
-          renderPage(Future.successful(HostedPage.fromContent(content)))
-        case None =>
-          Future.successful(NotFound)
+      log.info(s"[Render Hosted Page] is DCRHostedContent switch on? ${DCRHostedContent.isSwitchedOn}")
+      log.info(
+        s"[Render Hosted Page] isUserInTestGroup commercial-hosted-content:preview? ${isUserInTestGroup("commercial-hosted-content", "preview")}",
+      )
+      if (DCRHostedContent.isSwitchedOn && isUserInTestGroup("commercial-hosted-content", "preview")) {
+        Future.successful(
+          InternalRedirect.internalRedirect(
+            "type/article",
+            s"/$campaignName/$pageName",
+            request.rawQueryStringOption.map("?" + _),
+          ),
+        )
+      } else {
+        lookup(campaignName, pageName).flatMap {
+          case Some(content) if request.getRequestFormat == JsonFormat =>
+            renderJsonResponse(content)
+          case Some(content) =>
+            renderPage(Future.successful(HostedPage.fromContent(content)))
+          case None =>
+            Future.successful(NotFound)
+        }
       }
     }
 

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -1,6 +1,5 @@
 package commercial.controllers
 
-import ab.ABTests.isUserInTestGroup
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.ItemQuery
 import com.gu.contentapi.client.model.v1.ContentType.Video
@@ -8,7 +7,6 @@ import com.gu.contentapi.client.model.v1.Content
 import commercial.model.hosted.HostedTrails
 import common.commercial.hosted._
 import common.{Edition, GuLogging, ImplicitControllerExecutionContext, InternalRedirect, JsonComponent, JsonNotFound}
-import conf.switches.Switches.DCRHostedContent
 import contentapi.ContentApiClient
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{ApplicationContext, Cached, DotcomRenderingHostedContentModel, NoCache}
@@ -96,12 +94,11 @@ class HostedContentController(
     Action.async { implicit request =>
       // Migration of Hosted Content pages to DCR
       if (HostedContentPicker.getTier() == RemoteRender) {
-        val itemId = s"advertiser-content/$campaignName/$pageName"
         // Redirect to article application for further processing
         Future.successful(
           InternalRedirect.internalRedirect(
             "type/article",
-            itemId,
+            s"advertiser-content/$campaignName/$pageName",
             request.rawQueryStringOption.map("?" + _),
           ),
         )
@@ -119,6 +116,17 @@ class HostedContentController(
 
   def renderJson(campaignName: String, pageName: String): Action[AnyContent] =
     Action.async { implicit request =>
+      // Migration of Hosted Content pages to DCR
+      if (HostedContentPicker.getTier() == RemoteRender) {
+        // Redirect to article application for further processing
+        Future.successful(
+          InternalRedirect.internalRedirect(
+            "type/article",
+            s"advertiser-content/$campaignName/$pageName",
+            request.rawQueryStringOption.map("?" + _),
+          ),
+        )
+      }
       lookup(campaignName, pageName).flatMap {
         case Some(content) => renderJsonResponse(content)
         case None          => Future.successful(NotFound)

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -98,10 +98,11 @@ class HostedContentController(
         s"[Render Hosted Page] isUserInTestGroup commercial-hosted-content:preview? ${isUserInTestGroup("commercial-hosted-content", "preview")}",
       )
       if (DCRHostedContent.isSwitchedOn && isUserInTestGroup("commercial-hosted-content", "preview")) {
+        val itemId = s"advertiser-content/$campaignName/$pageName"
         Future.successful(
           InternalRedirect.internalRedirect(
             "type/article",
-            s"/$campaignName/$pageName",
+            itemId,
             request.rawQueryStringOption.map("?" + _),
           ),
         )

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -18,6 +18,7 @@ import play.twirl.api.Html
 import views.html.commercialExpired
 import views.html.hosted._
 import implicits.JsonFormat
+import services.dotcomrendering.{HostedContentPicker, RemoteRender}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -93,12 +94,10 @@ class HostedContentController(
 
   def renderHostedPage(campaignName: String, pageName: String): Action[AnyContent] =
     Action.async { implicit request =>
-      log.info(s"[Render Hosted Page] is DCRHostedContent switch on? ${DCRHostedContent.isSwitchedOn}")
-      log.info(
-        s"[Render Hosted Page] isUserInTestGroup commercial-hosted-content:preview? ${isUserInTestGroup("commercial-hosted-content", "preview")}",
-      )
-      if (DCRHostedContent.isSwitchedOn && isUserInTestGroup("commercial-hosted-content", "preview")) {
+      // Migration of Hosted Content pages to DCR
+      if (HostedContentPicker.getTier() == RemoteRender) {
         val itemId = s"advertiser-content/$campaignName/$pageName"
+        // Redirect to article application for further processing
         Future.successful(
           InternalRedirect.internalRedirect(
             "type/article",

--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -29,7 +29,7 @@ object HostedContentPicker extends GuLogging {
   ): RenderType = {
     if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
     else if (request.forceDCROff) LocalRender
-    else if (request.forceDCR && isUserInTestGroup("commercial-hosted-content", "preview")) RemoteRender
+    else if (request.forceDCR) RemoteRender
     else LocalRender
   }
 }

--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -1,88 +1,35 @@
 package services.dotcomrendering
 
-import com.madgag.scala.collection.decorators.MapDecorator
-import common.commercial.hosted.{HostedArticlePage, HostedGalleryPage, HostedVideoPage}
+import ab.ABTests.isUserInTestGroup
+import common.GuLogging
 import implicits.Requests._
-import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
-import utils.DotcomponentsLogger
 import implicits.AppsFormat
 import conf.switches.Switches
 
-object HostedContentPageChecks {
-
-  def isSupportedType(page: PageWithStoryPackage): Boolean = {
-    page match {
-      case a: HostedArticlePage => false
-      case v: HostedVideoPage   => false
-      case g: HostedGalleryPage => false
-      case _                    => false
-    }
-  }
-}
-
-object HostedContentPicker {
-
-  def dcrChecks(page: PageWithStoryPackage): Map[String, Boolean] = {
-    Map(
-      ("isSupportedType", HostedContentPageChecks.isSupportedType(page)),
-    )
-  }
-
-  private[this] def dcr100PercentPage(page: PageWithStoryPackage): Boolean = {
-    val allowListFeatures = dcrChecks(page)
-    val hostedPage100PercentFeatures = allowListFeatures.view.filterKeys(
-      Set(
-        "isSupportedType",
-      ),
-    )
-
-    hostedPage100PercentFeatures.forall({ case (_, isMet) => isMet })
-  }
-
-  def getTier(page: PageWithStoryPackage)(implicit
+object HostedContentPicker extends GuLogging {
+  def getTier()(implicit
       request: RequestHeader,
   ): RenderType = {
-    val checks = dcrChecks(page)
-    val dcrCanRender = checks.values.forall(identity)
-
-    val tier: RenderType = decideTier(dcrCanRender)
-
-    // include features that we wish to log but not allow-list against
-    val features = checks.mapV(_.toString) +
-      ("dcrCouldRender" -> dcrCanRender.toString)
-
-    if (tier == RemoteRender) {
-      if (request.getRequestFormat == AppsFormat)
-        DotcomponentsLogger.logger.logRequest(
-          s"[HostedContentRendering] path executing in dotcom rendering for apps (DCAR)",
-          features,
-          page.article,
-        )
-      else
-        DotcomponentsLogger.logger.logRequest(
-          s"[HostedContentRendering] path executing in dotcomponents",
-          features,
-          page.article,
-        )
-    } else {
-      DotcomponentsLogger.logger.logRequest(
-        s"[HostedContentRendering] path executing in web (frontend)",
-        features,
-        page.article,
-      )
+    val tier: RenderType = decideTier()
+    tier match {
+      case RemoteRender =>
+        if (request.getRequestFormat == AppsFormat)
+          log.info(s"[HostedContentRendering] path executing in dotcom rendering for apps (DCAR)")
+        else
+          log.info(s"[HostedContentRendering] path executing in dotcomponents")
+      case LocalRender =>
+        log.info(s"[HostedContentRendering] path executing in web (frontend)")
     }
-
     tier
   }
 
-  def decideTier(dcrCanRender: Boolean)(implicit
+  def decideTier()(implicit
       request: RequestHeader,
   ): RenderType = {
     if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
     else if (request.forceDCROff) LocalRender
-    else if (request.forceDCR) LocalRender // Prevent RemoteRender (DCR) for now
-    else if (dcrCanRender) LocalRender // Prevent RemoteRender (DCR) for now
+    else if (request.forceDCR && isUserInTestGroup("commercial-hosted-content", "preview")) RemoteRender
     else LocalRender
   }
 }

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -20,6 +20,7 @@ GET         /commercial/api/capi-multiple.json                              comm
 GET         /commercial/anx/anxresize.js                                    commercial.controllers.PiggybackPixelController.resize()
 
 # Hosted content
+GET         /advertiser-content/:campaignName/:pageName.json                commercial.controllers.HostedContentController.renderJson(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName                     commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json  commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET         /advertiser-content/:campaignName/:pageName/autoplay.json       commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -20,7 +20,6 @@ GET         /commercial/api/capi-multiple.json                              comm
 GET         /commercial/anx/anxresize.js                                    commercial.controllers.PiggybackPixelController.resize()
 
 # Hosted content
-GET         /advertiser-content/:campaignName/:pageName.json                commercial.controllers.HostedContentController.renderJson(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName                     commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json  commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET         /advertiser-content/:campaignName/:pageName/autoplay.json       commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)

--- a/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
+++ b/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
@@ -7,35 +7,27 @@ import services.dotcomrendering.{LocalRender, RemoteRender}
 import test.TestRequest
 
 @DoNotDiscover class HostedContentPickerTest extends AnyFlatSpec with Matchers {
-  // All tests should return LocalRender initially
-
-  "Hosted Content Picker decideTier" should "return LocalRender if forceDCROff and dcr cannot render" in {
+  "Hosted Content Picker decideTier" should "return LocalRender if forceDCROff" in {
     val testRequest = TestRequest("hosted-content-path?dcr=false")
-    val tier = HostedContentPicker.decideTier(false)(testRequest)
+    val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
 
-  it should "return LocalRender if forceDCROff and dcrCanRender" in {
-    val testRequest = TestRequest("hosted-content-path?dcr=false")
-    val tier = HostedContentPicker.decideTier(false)(testRequest)
+  it should "return RemoteRender if force DCR and in the test group commercial-hosted-content:preview" in {
+    val testRequest = TestRequest("hosted-content-path?dcr=true&ab-commercial-hosted-content:preview")
+    val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
 
-  it should "return LocalRender if force DCR" in {
+  it should "return LocalRender if force DCR and NOT in the test group commercial-hosted-content:preview" in {
     val testRequest = TestRequest("hosted-content-path?dcr=true")
-    val tier = HostedContentPicker.decideTier(false)(testRequest)
-    tier should be(LocalRender)
-  }
-
-  it should "return LocalRender if force DCR and content should be served pressed" in {
-    val testRequest = TestRequest("hosted-content-path?dcr=true")
-    val tier = HostedContentPicker.decideTier(true)(testRequest)
+    val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
 
   it should "return LocalRender otherwise" in {
     val testRequest = TestRequest("hosted-content-path")
-    val tier = HostedContentPicker.decideTier(false)(testRequest)
+    val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
 }

--- a/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
+++ b/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
@@ -13,13 +13,7 @@ import test.TestRequest
     tier should be(LocalRender)
   }
 
-  it should "return RemoteRender if force DCR and in the test group commercial-hosted-content:preview" in {
-    val testRequest = TestRequest("hosted-content-path?dcr=true&ab-commercial-hosted-content:preview")
-    val tier = HostedContentPicker.decideTier()(testRequest)
-    tier should be(LocalRender)
-  }
-
-  it should "return LocalRender if force DCR and NOT in the test group commercial-hosted-content:preview" in {
+  it should "return RemoteRender if force DCR" in {
     val testRequest = TestRequest("hosted-content-path?dcr=true")
     val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -102,7 +102,8 @@ class DevParametersHttpRequestHandler(
         "/commercial/anx/anxresize.js",
       ) // this is used by commercial for advert resizing, served through api.nextgen
     ) {
-      val illegalParams = request.queryString.keySet.filterNot(allowedParams.contains(_))
+      val illegalParams =
+        request.queryString.keySet.filterNot(param => allowedParams.contains(param) || param.startsWith("ab-"))
       if (illegalParams.nonEmpty) {
         // it is pretty hard to spot what is happening in tests without this println
         println(s"\n\nILLEGAL PARAMETER(S) FOUND : ${illegalParams.mkString(",")}\n\n")

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -232,6 +232,7 @@ GET            /admin/football/api/squad/:teamId                                
 GET            /commercial/api/capi-single.json                                                                                  commercial.controllers.ContentApiOffersController.nativeJson
 GET            /commercial/api/capi-multiple.json                                                                                commercial.controllers.ContentApiOffersController.nativeJsonMulti
 GET            /$path<commercial-containers>                                                                                     controllers.FaciaController.renderFront(path)
+GET             /advertiser-content/:campaignName/:pageName.json                                                                    controllers.ArticleController.renderHosted(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName                                                                       commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json                                                    commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET            /advertiser-content/:campaignName/:pageName/autoplay.json                                                         commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -232,7 +232,8 @@ GET            /admin/football/api/squad/:teamId                                
 GET            /commercial/api/capi-single.json                                                                                  commercial.controllers.ContentApiOffersController.nativeJson
 GET            /commercial/api/capi-multiple.json                                                                                commercial.controllers.ContentApiOffersController.nativeJsonMulti
 GET            /$path<commercial-containers>                                                                                     controllers.FaciaController.renderFront(path)
-GET             /advertiser-content/:campaignName/:pageName.json                                                                    controllers.ArticleController.renderHosted(campaignName, pageName)
+# Hosted content migration - JSON request is handled by article controller in dev
+GET            /advertiser-content/:campaignName/:pageName.json                                                                  controllers.ArticleController.renderHosted(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName                                                                       commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json                                                    commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET            /advertiser-content/:campaignName/:pageName/autoplay.json                                                         commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)


### PR DESCRIPTION
## What is the value of this and can you measure success?

Supports previewing dcr rendered Hosted Content articles in production and in the CODE environment whilst these pages are being developed 

## What does this change?

Internally redirect requests for Hosted Content from the `commercial` app to the `article` app when all of the following are true:
- the feature switch (`DCRHostedContent`) is **on** 
- the user is in the test group `commercial-hosted-content:preview`
- DCR rendering has been forced using the query parameter (`?dcr=true`)

Also simplifies the `HostedContentPicker` logic to remove any handling of page specific parts 


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
