### PR TITLE
Allow rendering hosted content with DCR locally

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -46,6 +46,9 @@ class ArticleController(
   def renderArticle(path: String): Action[AnyContent] = Action.async(mapAndRender(path, ArticleBlocks)()(_))
   def renderJson(path: String): Action[AnyContent] = renderArticle(path)
   def renderEmail(path: String): Action[AnyContent] = renderArticle(path)
+  def renderHosted(campaignName: String, pageName: String): Action[AnyContent] = renderArticle(
+    s"advertiser-content/$campaignName/$pageName",
+  )
 
   def renderHeadline(path: String): Action[AnyContent] =
     Action.async { implicit request =>

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -21,13 +21,17 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogContr
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], filterKeyEvents: Option[Boolean])
 
+# Hosted content (under migration)
+
+GET     /advertiser-content/:campaignName/:pageName.json  controllers.ArticleController.renderHosted(campaignName, pageName)
+
 # articles, finished liveblogs
 
-GET     /*path.json                 controllers.ArticleController.renderJson(path)
-GET     /*path/email                controllers.ArticleController.renderEmail(path)
-GET     /*path/email/headline.txt   controllers.ArticleController.renderHeadline(path)
-GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
-GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
+GET     /*path.json                     controllers.ArticleController.renderJson(path)
+GET     /*path/email                    controllers.ArticleController.renderEmail(path)
+GET     /*path/email/headline.txt       controllers.ArticleController.renderHeadline(path)
+GET     /*path/email.emailjson          controllers.ArticleController.renderEmail(path)
+GET     /*path/email.emailtxt           controllers.ArticleController.renderEmail(path)
 
 # Newspaper pages paths
 # gallery format (?)

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -21,8 +21,7 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogContr
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], filterKeyEvents: Option[Boolean])
 
-# Hosted content (under migration)
-
+# Commercial Hosted Content (under migration)
 GET     /advertiser-content/:campaignName/:pageName.json  controllers.ArticleController.renderHosted(campaignName, pageName)
 
 # articles, finished liveblogs

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -20,6 +20,7 @@ GET         /commercial/api/capi-multiple.json                              comm
 GET         /commercial/anx/anxresize.js                                    commercial.controllers.PiggybackPixelController.resize()
 
 # Hosted content
+GET         /advertiser-content/:campaignName/:pageName.json                commercial.controllers.HostedContentController.renderJson(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName                     commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json  commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET         /advertiser-content/:campaignName/:pageName/autoplay.json       commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -20,7 +20,6 @@ GET         /commercial/api/capi-multiple.json                              comm
 GET         /commercial/anx/anxresize.js                                    commercial.controllers.PiggybackPixelController.resize()
 
 # Hosted content
-GET         /advertiser-content/:campaignName/:pageName.json                commercial.controllers.HostedContentController.renderJson(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName                     commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json  commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET         /advertiser-content/:campaignName/:pageName/autoplay.json       commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -102,7 +102,8 @@ class DevParametersHttpRequestHandler(
         "/commercial/anx/anxresize.js",
       ) // this is used by commercial for advert resizing, served through api.nextgen
     ) {
-      val illegalParams = request.queryString.keySet.filterNot(allowedParams.contains(_))
+      val illegalParams =
+        request.queryString.keySet.filterNot(param => allowedParams.contains(param) || param.startsWith("ab-"))
       if (illegalParams.nonEmpty) {
         // it is pretty hard to spot what is happening in tests without this println
         println(s"\n\nILLEGAL PARAMETER(S) FOUND : ${illegalParams.mkString(",")}\n\n")

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -232,6 +232,7 @@ GET            /admin/football/api/squad/:teamId                                
 GET            /commercial/api/capi-single.json                                                                                  commercial.controllers.ContentApiOffersController.nativeJson
 GET            /commercial/api/capi-multiple.json                                                                                commercial.controllers.ContentApiOffersController.nativeJsonMulti
 GET            /$path<commercial-containers>                                                                                     controllers.FaciaController.renderFront(path)
+GET             /advertiser-content/:campaignName/:pageName.json                                                                    controllers.ArticleController.renderHosted(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName                                                                       commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json                                                    commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET            /advertiser-content/:campaignName/:pageName/autoplay.json                                                         commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -232,7 +232,8 @@ GET            /admin/football/api/squad/:teamId                                
 GET            /commercial/api/capi-single.json                                                                                  commercial.controllers.ContentApiOffersController.nativeJson
 GET            /commercial/api/capi-multiple.json                                                                                commercial.controllers.ContentApiOffersController.nativeJsonMulti
 GET            /$path<commercial-containers>                                                                                     controllers.FaciaController.renderFront(path)
-GET             /advertiser-content/:campaignName/:pageName.json                                                                    controllers.ArticleController.renderHosted(campaignName, pageName)
+# Hosted content migration - JSON request is handled by article controller in dev
+GET            /advertiser-content/:campaignName/:pageName.json                                                                  controllers.ArticleController.renderHosted(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName                                                                       commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json                                                    commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET            /advertiser-content/:campaignName/:pageName/autoplay.json                                                         commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)


### PR DESCRIPTION
## What is the value of this and can you measure success?

We're in the process of migrating the Hosted Content pages from being rendered in frontend to being rendered using dotcom-rendering

We are using the `article` app to do this so in order to run this locally, we need to run frontend and DCR together. This is quite cumbersome over time and it would be nice to be able to:
1) use the devBuild frontend app to render these pages since this is the normal route for developers using frontend
2) be able to render Hosted Content pages _without_ having to run frontend locally at all. Ideally we would be able to run DCR and point to a CODE or PROD url to see a dotcom-rendering version of the page

## What does this change?

Allows rendering Hosted Content pages via dotcom-rendering by running the `devBuild` app

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
