### PR TITLE
Bump guardian/libs to 30.1.1 and use getConsentDetailsForOphan

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
-		"@guardian/libs": "26.1.0",
+		"@guardian/libs": "30.1.1",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "16.0.0",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -7,7 +7,7 @@ import config from 'lib/config';
 import { markTime } from 'lib/user-timing';
 import { captureOphanInfo } from 'lib/capture-ophan-info';
 import { reportError } from 'lib/report-error';
-import { cmp, getLocale, loadScript, onConsentChange } from '@guardian/libs';
+import { cmp, getConsentDetailsForOphan, getLocale, loadScript, onConsentChange } from '@guardian/libs';
 import { getCookie } from 'lib/cookies';
 import { init as detectAdBlockers } from 'commercial/detect-adblock';
 import ophan from 'ophan/ng';
@@ -86,44 +86,8 @@ const go = () => {
 
                 if (!consentState) return;
 
-                const consentDetails = () => {
-                    if (consentState.tcfv2) {
-                        return {
-                            consentJurisdiction: 'TCF',
-                            consentUUID: getCookie({ name: 'consentUUID' }) ?? '',
-                            consent: consentState.tcfv2.tcString,
-                        };
-                    }
-                    if (consentState.usnat) {
-
-                        const consentUUID =
-                            getCookie({ name: 'usnatUUID' }) ??
-                            getCookie({ name: 'ccpaUUID' });
-
-                        return {
-                            consentJurisdiction: 'USNAT',
-                            consentUUID: consentUUID ?? '',
-                            consent: consentState.usnat.doNotSell ? 'false' : 'true',
-                        };
-                    }
-                    if (consentState.aus) {
-                        return {
-                            consentJurisdiction: 'AUS',
-                            consentUUID: getCookie({ name: 'ccpaUUID' }) ?? '',
-                            consent: consentState.aus.personalisedAdvertising
-                                ? 'true'
-                                : 'false',
-                        };
-                    }
-                    return {
-                        consentJurisdiction: 'OTHER',
-                        consentUUID: '',
-                        consent: '',
-                    };
-                };
-
                 // Register changes in consent state with Ophan
-                ophan.record(consentDetails());
+                ophan.record(getConsentDetailsForOphan(consentState));
 
                 // ------------------------------------------------------
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,7 +2935,7 @@ __metadata:
     "@guardian/eslint-config-typescript": "npm:9.0.1"
     "@guardian/identity-auth": "npm:6.0.1"
     "@guardian/identity-auth-frontend": "npm:8.1.0"
-    "@guardian/libs": "npm:26.1.0"
+    "@guardian/libs": "npm:30.1.1"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
     "@guardian/source-foundations": "npm:16.0.0"
@@ -3102,19 +3102,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/libs@npm:26.1.0":
-  version: 26.1.0
-  resolution: "@guardian/libs@npm:26.1.0"
+"@guardian/libs@npm:30.1.1":
+  version: 30.1.1
+  resolution: "@guardian/libs@npm:30.1.1"
   dependencies:
-    "@guardian/ophan-tracker-js": "npm:2.2.10"
+    "@guardian/ophan-tracker-js": "npm:2.8.0"
   peerDependencies:
     "@guardian/ophan-tracker-js": ^2.2.10
-    tslib: ^2.6.2
-    typescript: ~5.5.2
+    tslib: ^2.8.1
+    typescript: ~5.9.3
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/1735ceb60a5c82ec85eaac2327bc85a875a6372d3d53ffc59c3983b479426892659831df3f8dbb82ca40cd50092744e8ed586a5b2c2642fac0b4716dfaa483da
+  checksum: 10c0/d1cbe8ab1729af541eec3b937f4443f1205a79e9efe667b374ac2a4f084238d340652aa2a74cec5558f17cbfd324f4549ffbbea8c89cbcb565c8877103e81414
   languageName: node
   linkType: hard
 
@@ -3124,6 +3124,15 @@ __metadata:
   dependencies:
     "@guardian/tsconfig": "npm:^1.0.0"
   checksum: 10c0/e43f520953d0ff18ddb398694f05061f36621a1246720ccce6960de7ed380a7ab4283fdba681f24142418405fec33bece25e6cf198ae0719bee51a37dbfe7cc4
+  languageName: node
+  linkType: hard
+
+"@guardian/ophan-tracker-js@npm:2.8.0":
+  version: 2.8.0
+  resolution: "@guardian/ophan-tracker-js@npm:2.8.0"
+  dependencies:
+    "@guardian/tsconfig": "npm:^1.0.0"
+  checksum: 10c0/72f7c374385254b46df671702e26a9d7bcfec0bfdaf084dcc29f810a269a4dd86db8caad835408b9c322c376f13fb87fa85396d39b9e924cc8c339ae0e923c83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?
This PR bumps the version of guardian/libs to 30.1.1.

It also utilises a new function `getConsentDetailsForOphan` to get the consent details.


## Why?
This is to standardise the consent object sent to Ophan and make it easier to update.
