### PR TITLE
Revert "Update nav for paralympics"

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -109,6 +109,7 @@ object NavLinks {
   val letters = NavLink("Letters", "/tone/letters")
 
   /* SPORT */
+
   private val footballScores = NavLink("Live scores", "/football/live", Some("football/live"))
   private val footballTables = NavLink("Tables", "/football/tables", Some("football/tables"))
   private val footballFixtures = NavLink("Fixtures", "/football/fixtures", Some("football/fixtures"))
@@ -142,7 +143,6 @@ object NavLinks {
       footballClubs,
     ),
   )
-  val winterParalympics = NavLink("Winter Paralympics", "/sport/winter-paralympics")
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
   val rugbyUnion = NavLink("Rugby union", "/sport/rugby-union")
@@ -417,7 +417,6 @@ object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
-      winterParalympics,
       football,
       cricket,
       rugbyUnion,
@@ -460,7 +459,6 @@ object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
-      winterParalympics,
       football,
       cricket,
       rugbyUnion,
@@ -473,7 +471,6 @@ object NavLinks {
   )
   val eurSportPillar = ukSportPillar.copy(
     children = List(
-      winterParalympics,
       football,
       cricket,
       rugbyUnion,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -420,12 +420,6 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Winter Paralympics",
-					"url": "/sport/winter-paralympics",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -2803,12 +2797,6 @@
 			"iconName": "home",
 			"children": [
 				{
-					"title": "Winter Paralympics",
-					"url": "/sport/winter-paralympics",
-					"children": [],
-					"classList": []
-				},
-				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -3793,12 +3781,6 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
-				{
-					"title": "Winter Paralympics",
-					"url": "/sport/winter-paralympics",
-					"children": [],
-					"classList": []
-				},
 				{
 					"title": "Football",
 					"url": "/football",


### PR DESCRIPTION
Reverts guardian/frontend#28657

The Paralympics has finished and we have received are a request to remove this from the nav bar