### PR TITLE
Add maxLength for renderLiveHarness

### DIFF
--- a/preview/app/controllers/LiveHarnessController.scala
+++ b/preview/app/controllers/LiveHarnessController.scala
@@ -45,7 +45,11 @@ class LiveHarnessController(
       renderingService,
     )
 
-  def renderLiveHarness(path: String): Action[JsValue] = Action.async(parse.json) { implicit request =>
+  def renderLiveHarness(path: String): Action[JsValue] = Action.async(
+    // We allow a larger payload here to accommodate server-side rendered atoms, which can be larger than
+    // the Play default of 100kb - see https://www.playframework.com/documentation/3.0.x/ScalaBodyParsers#Max-content-length
+    parse.json(maxLength = 2048 * 1024),
+  ) { implicit request =>
     request.body.validate[List[LiveHarnessInteractiveAtom]] match {
       case JsSuccess(atoms, _) =>
         capiLookup.lookup(path, Some(ArticleBlocks)).flatMap { response =>


### PR DESCRIPTION
## What is the value of this and can you measure success?

Extends the `maxLength` property of the body parser for the `renderLiveHarness` controller action, to permit payloads that are larger than the default in-memory setting (100k — [docs.](https://www.playframework.com/documentation/3.0.x/ScalaBodyParsers#Max-content-length))

## Screenshots
 
|Before|After|
|-|-|
|<img width="1186" height="514" alt="Screenshot 2026-03-18 at 20 13 18" src="https://github.com/user-attachments/assets/49df1d04-cd4f-4e17-bfbd-38c82715e120" />|<img width="1186" height="514" alt="Screenshot 2026-03-18 at 20 12 58" src="https://github.com/user-attachments/assets/23fd62b6-42ec-4ca5-b2e6-0deac84fbc67" />|

Tested locally with https://github.com/guardian/interactive-local-elex-2026.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
