### PR TITLE
Allow Remote Render (DCR) for Hosted Content

### DIFF
--- a/article/conf/routes
+++ b/article/conf/routes
@@ -21,9 +21,6 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogContr
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], filterKeyEvents: Option[Boolean])
 
-# Commercial Hosted Content (under migration)
-GET     /advertiser-content/:campaignName/:pageName.json  controllers.ArticleController.renderHosted(campaignName, pageName)
-
 # articles, finished liveblogs
 
 GET     /*path.json                     controllers.ArticleController.renderJson(path)

--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -38,12 +38,14 @@ trait CommercialServices {
 
   lazy val capiAgent = wire[CapiAgent]
   lazy val admiralAgent = wire[AdmiralAgent]
+
 }
 
 trait AppComponents extends FrontendComponents with CommercialControllers with CommercialServices {
 
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val healthCheck = wire[HealthCheck]
+  lazy val remoteRender = wire[renderers.DotcomRenderingService]
 
   override lazy val lifecycleComponents = List(
     wire[DfpAgentLifecycle],

--- a/commercial/app/controllers/CommercialControllers.scala
+++ b/commercial/app/controllers/CommercialControllers.scala
@@ -5,13 +5,18 @@ import com.softwaremill.macwire._
 import commercial.model.capi.CapiAgent
 import contentapi.ContentApiClient
 import model.ApplicationContext
+import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
+import renderers.DotcomRenderingService
 
 trait CommercialControllers {
   def contentApiClient: ContentApiClient
   def capiAgent: CapiAgent
   def controllerComponents: ControllerComponents
   def admiralAgent: AdmiralAgent
+  def wsClient: WSClient
+  def remoteRender: DotcomRenderingService
+
   implicit def appContext: ApplicationContext
   lazy val contentApiOffersController = wire[ContentApiOffersController]
   lazy val hostedContentController = wire[HostedContentController]

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -98,7 +98,8 @@ class HostedContentController(
       .showAtoms("all")
       .showBlocks("all")
 
-  private def lookup(
+  /** Legacy lookup for frontend-rendered pages */
+  private def lookupLegacy(
       campaignName: String,
       pageName: String,
   )(implicit request: Request[AnyContent]): Future[Option[CapiContent]] = {
@@ -118,7 +119,7 @@ class HostedContentController(
       }
   }
 
-  private def lookupNew(
+  private def lookup(
       campaignName: String,
       pageName: String,
   )(implicit request: Request[AnyContent]): Future[Either[Result, BlocksOn[ArticlePage]]] = {
@@ -144,7 +145,7 @@ class HostedContentController(
       tier match {
         // Migration of Hosted Content pages to DCR
         case RemoteRender =>
-          lookupNew(campaignName, pageName) flatMap {
+          lookup(campaignName, pageName) flatMap {
             case Right(articleBlocks) if request.isJson && request.forceDCR =>
               Future.successful(
                 common.renderJson(getDCRJson(articleBlocks), articleBlocks.page).as("application/json"),
@@ -155,7 +156,7 @@ class HostedContentController(
           }
 
         case LocalRender =>
-          lookup(campaignName, pageName) flatMap {
+          lookupLegacy(campaignName, pageName) flatMap {
             case Some(content) =>
               localRender(Future.successful(HostedPage.fromContent(content)))
             case None =>

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -7,15 +7,7 @@ import com.gu.contentapi.client.model.v1.{Blocks, Content => CapiContent}
 import commercial.model.hosted.HostedTrails
 import common.`package`.convertApiExceptions
 import common.commercial.hosted._
-import common.{
-  Edition,
-  GuLogging,
-  ImplicitControllerExecutionContext,
-  InternalRedirect,
-  JsonComponent,
-  JsonNotFound,
-  ModelOrResult,
-}
+import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent, JsonNotFound, ModelOrResult}
 import contentapi.ContentApiClient
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{
@@ -96,7 +88,6 @@ class HostedContentController(
       .showFields("all")
       .showTags("all")
       .showAtoms("all")
-      .showBlocks("all")
 
   /** Legacy lookup for frontend-rendered pages */
   private def lookupLegacy(

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -3,20 +3,44 @@ package commercial.controllers
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.ItemQuery
 import com.gu.contentapi.client.model.v1.ContentType.Video
-import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.v1.{Blocks, Content => CapiContent}
 import commercial.model.hosted.HostedTrails
+import common.`package`.convertApiExceptions
 import common.commercial.hosted._
-import common.{Edition, GuLogging, ImplicitControllerExecutionContext, InternalRedirect, JsonComponent, JsonNotFound}
+import common.{
+  Edition,
+  GuLogging,
+  ImplicitControllerExecutionContext,
+  InternalRedirect,
+  JsonComponent,
+  JsonNotFound,
+  ModelOrResult,
+}
 import contentapi.ContentApiClient
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model.{ApplicationContext, Cached, DotcomRenderingHostedContentModel, NoCache}
-import play.api.libs.json.{JsArray, Json}
+import model.{
+  ApplicationContext,
+  Article,
+  ArticleBlocks,
+  ArticlePage,
+  Cached,
+  Content,
+  NoCache,
+  PageWithStoryPackage,
+  StoryPackages,
+}
+import play.api.libs.json.{JsArray, JsValue, Json}
 import play.api.mvc._
 import play.twirl.api.Html
 import views.html.commercialExpired
 import views.html.hosted._
-import implicits.JsonFormat
-import services.dotcomrendering.{HostedContentPicker, RemoteRender}
+import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
+import model.meta.BlocksOn
+import play.api.libs.ws.WSClient
+import renderers.DotcomRenderingService
+import services.CAPILookup
+import services.dotcomrendering.{HostedContentPicker, LocalRender, RemoteRender}
+import views.support.RenderOtherStatus
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -24,6 +48,8 @@ import scala.util.control.NonFatal
 class HostedContentController(
     contentApiClient: ContentApiClient,
     val controllerComponents: ControllerComponents,
+    wsClient: WSClient,
+    remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
 )(implicit context: ApplicationContext)
     extends BaseController
     with ImplicitControllerExecutionContext
@@ -31,8 +57,9 @@ class HostedContentController(
     with implicits.Requests {
 
   private def cacheDuration: Int = 60
+  val capiLookup: CAPILookup = new CAPILookup(contentApiClient)
 
-  private def renderPage(
+  private def localRender(
       hostedPage: Future[Option[HostedPage]],
   )(implicit request: Request[AnyContent]): Future[Result] = {
     def cached(html: Html) = Cached(cacheDuration)(RevalidatableResult.Ok(html))
@@ -69,11 +96,12 @@ class HostedContentController(
       .showFields("all")
       .showTags("all")
       .showAtoms("all")
+      .showBlocks("all")
 
   private def lookup(
       campaignName: String,
       pageName: String,
-  )(implicit request: Request[AnyContent]): Future[Option[Content]] = {
+  )(implicit request: Request[AnyContent]): Future[Option[CapiContent]] = {
     val itemId = s"advertiser-content/$campaignName/$pageName"
     contentApiClient
       .getResponse(baseQuery(itemId))
@@ -90,56 +118,70 @@ class HostedContentController(
       }
   }
 
-  def renderHostedPage(campaignName: String, pageName: String): Action[AnyContent] =
-    Action.async { implicit request =>
-      // Migration of Hosted Content pages to DCR
-      if (HostedContentPicker.getTier() == RemoteRender) {
-        // Redirect to article application for further processing
-        Future.successful(
-          InternalRedirect.internalRedirect(
-            "type/article",
-            s"advertiser-content/$campaignName/$pageName",
-            request.rawQueryStringOption.map("?" + _),
-          ),
-        )
-      } else {
-        lookup(campaignName, pageName).flatMap {
-          case Some(content) if request.getRequestFormat == JsonFormat =>
-            renderJsonResponse(content)
-          case Some(content) =>
-            renderPage(Future.successful(HostedPage.fromContent(content)))
-          case None =>
-            Future.successful(NotFound)
+  private def lookupNew(
+      campaignName: String,
+      pageName: String,
+  )(implicit request: Request[AnyContent]): Future[Either[Result, BlocksOn[ArticlePage]]] = {
+    val itemId = s"advertiser-content/$campaignName/$pageName"
+    capiLookup
+      .lookup(itemId, Some(ArticleBlocks))
+      .map { response =>
+        val content = response.content.map(Content(_))
+        val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
+        ModelOrResult(content, response) match {
+          case Right(article: Article) =>
+            Right(BlocksOn(ArticlePage(article, StoryPackages(article.metadata.id, response)), blocks))
+          case Left(r) => Left(r)
+          case _       => Left(NotFound)
         }
       }
-    }
+      .recover(convertApiExceptions)
+  }
 
-  def renderJson(campaignName: String, pageName: String): Action[AnyContent] =
+  def renderHostedPage(campaignName: String, pageName: String): Action[AnyContent] =
     Action.async { implicit request =>
-      // Migration of Hosted Content pages to DCR
-      if (HostedContentPicker.getTier() == RemoteRender) {
-        // Redirect to article application for further processing
-        Future.successful(
-          InternalRedirect.internalRedirect(
-            "type/article",
-            s"advertiser-content/$campaignName/$pageName",
-            request.rawQueryStringOption.map("?" + _),
-          ),
-        )
-      }
-      lookup(campaignName, pageName).flatMap {
-        case Some(content) => renderJsonResponse(content)
-        case None          => Future.successful(NotFound)
+      val tier = HostedContentPicker.getTier()
+      tier match {
+        // Migration of Hosted Content pages to DCR
+        case RemoteRender =>
+          lookupNew(campaignName, pageName) flatMap {
+            case Right(articleBlocks) if request.isJson && request.forceDCR =>
+              Future.successful(
+                common.renderJson(getDCRJson(articleBlocks), articleBlocks.page).as("application/json"),
+              )
+            case Right(articleBlocks) =>
+              remoteRender(articleBlocks)
+            case Left(other) => Future.successful(RenderOtherStatus(other))
+          }
+
+        case LocalRender =>
+          lookup(campaignName, pageName) flatMap {
+            case Some(content) =>
+              localRender(Future.successful(HostedPage.fromContent(content)))
+            case None =>
+              Future.successful(NotFound)
+          }
       }
     }
 
-  private def renderJsonResponse(content: Content): Future[Result] =
-    DotcomRenderingHostedContentModel.get(content) match {
-      case Some(model) =>
-        Future.successful(Ok(DotcomRenderingHostedContentModel.toJson(model)).as("application/json"))
-      case None =>
-        Future.successful(NotFound)
+  private def getDCRJson(
+      pageBlocks: BlocksOn[ArticlePage],
+  )(implicit request: RequestHeader): JsValue = {
+    val pageType: PageType = PageType(pageBlocks.page, request, context)
+    DotcomRenderingDataModel.toJson(DotcomRenderingDataModel.forArticle(pageBlocks, request, pageType, None))
+  }
+
+  private def remoteRender(
+      pageBlocks: BlocksOn[PageWithStoryPackage],
+  )(implicit request: RequestHeader): Future[Result] = {
+    val pageType = PageType(pageBlocks.page, request, context)
+
+    if (request.isApps) {
+      remoteRenderer.getAppsHostedArticle(wsClient, pageBlocks, pageType)
+    } else {
+      remoteRenderer.getHostedArticle(wsClient, pageBlocks, pageType)
     }
+  }
 
   def renderOnwardComponent(campaignName: String, pageName: String, contentType: String): Action[AnyContent] =
     Action.async { implicit request =>

--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -1,6 +1,5 @@
 package services.dotcomrendering
 
-import ab.ABTests.isUserInTestGroup
 import common.GuLogging
 import implicits.Requests._
 import play.api.mvc.RequestHeader

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -20,7 +20,7 @@ GET         /commercial/api/capi-multiple.json                              comm
 GET         /commercial/anx/anxresize.js                                    commercial.controllers.PiggybackPixelController.resize()
 
 # Hosted content
-GET         /advertiser-content/:campaignName/:pageName.json                commercial.controllers.HostedContentController.renderJson(campaignName, pageName)
+GET         /advertiser-content/:campaignName/:pageName.json                commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName                     commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json  commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET         /advertiser-content/:campaignName/:pageName/autoplay.json       commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -519,6 +519,51 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       CacheTime.Component,
     )
   }
+
+  def getHostedArticle(
+      ws: WSClient,
+      pageBlocks: BlocksOn[PageWithStoryPackage],
+      pageType: PageType,
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = DotcomRenderingDataModel.forArticle(pageBlocks, request, pageType, None)
+    val json = DotcomRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/HostedContent", pageBlocks.page.metadata.cacheTime)
+  }
+
+  def getAppsHostedArticle(
+      ws: WSClient,
+      pageBlocks: BlocksOn[PageWithStoryPackage],
+      pageType: PageType,
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = DotcomRenderingDataModel.forArticle(pageBlocks, request, pageType, None)
+    val json = DotcomRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsHostedContent", pageBlocks.page.metadata.cacheTime)
+  }
+
+  def getHostedGallery(
+      ws: WSClient,
+      gallery: GalleryPage,
+      pageType: PageType,
+      blocks: Blocks,
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = DotcomRenderingDataModel.forGallery(gallery, request, pageType, blocks)
+
+    val json = DotcomRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/HostedContent", gallery.metadata.cacheTime)
+  }
+
+  def getHostedAppsGallery(
+      ws: WSClient,
+      gallery: GalleryPage,
+      pageType: PageType,
+      blocks: Blocks,
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = DotcomRenderingDataModel.forGallery(gallery, request, pageType, blocks)
+
+    val json = DotcomRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsHostedContent", gallery.metadata.cacheTime)
+  }
+
 }
 
 object DotcomRenderingService {

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -539,31 +539,6 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val json = DotcomRenderingDataModel.toJson(dataModel)
     post(ws, json, Configuration.rendering.articleBaseURL + "/AppsHostedContent", pageBlocks.page.metadata.cacheTime)
   }
-
-  def getHostedGallery(
-      ws: WSClient,
-      gallery: GalleryPage,
-      pageType: PageType,
-      blocks: Blocks,
-  )(implicit request: RequestHeader): Future[Result] = {
-    val dataModel = DotcomRenderingDataModel.forGallery(gallery, request, pageType, blocks)
-
-    val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.articleBaseURL + "/HostedContent", gallery.metadata.cacheTime)
-  }
-
-  def getHostedAppsGallery(
-      ws: WSClient,
-      gallery: GalleryPage,
-      pageType: PageType,
-      blocks: Blocks,
-  )(implicit request: RequestHeader): Future[Result] = {
-    val dataModel = DotcomRenderingDataModel.forGallery(gallery, request, pageType, blocks)
-
-    val json = DotcomRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.articleBaseURL + "/AppsHostedContent", gallery.metadata.cacheTime)
-  }
-
 }
 
 object DotcomRenderingService {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -232,8 +232,8 @@ GET            /admin/football/api/squad/:teamId                                
 GET            /commercial/api/capi-single.json                                                                                  commercial.controllers.ContentApiOffersController.nativeJson
 GET            /commercial/api/capi-multiple.json                                                                                commercial.controllers.ContentApiOffersController.nativeJsonMulti
 GET            /$path<commercial-containers>                                                                                     controllers.FaciaController.renderFront(path)
-# Hosted content migration - JSON request is handled by article controller in dev
-GET            /advertiser-content/:campaignName/:pageName.json                                                                  controllers.ArticleController.renderHosted(campaignName, pageName)
+# Hosted content migration
+GET            /advertiser-content/:campaignName/:pageName.json                                                                  commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName                                                                       commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json                                                    commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET            /advertiser-content/:campaignName/:pageName/autoplay.json                                                         commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows the Commercial frontend application to render pages in DCR without needing to redirect to the Article app.

We use the `tier` from the `HostedContentPicker` to decide whether to send to DCR or not.

This also implements the `.json?dcr` route which allows us to work with DCR locally more easily as well as showing the underlying data behind the requests.

Continuing to render these pages using the commercial application gives us more control over the logic.

> [!NOTE]
> This does not explicitly cover gallery pages yet as this is slightly more complicated

## What does this change?

- Removes the redirect process from the previous attempt to do this
- Wires wsClient and remoteRenderer into the commercial AppLoader and through to the Commercial controllers layer to allow it to send requests to dotcom-rendering
- Updates the `.json` route controller method in the commercial app since we now use one render function and split on the request type within that (this is similar to articles)
- Adds `getHostedArticle` and `getAppsHostedArticle` methods to the `DotcomRenderingService` to format the DCR requests in a specific way for hosted content pages
- Uses a process more similar to general articles and galleries for hosted content data:
  - Adds a new `lookup` function and marks the previous lookup as "legacy". We need the lookup to return a slightly different shape in the new form compared with the previous. It is probably possible to tidy this up to work in both ways but given that we expect to deprecate frontend-rendering, it isn't worth spending much time on this

