### PR TITLE
Remove unused `babel-jest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"any-observable": "^0.2.0",
 		"autoprefixer": "^10.3.7",
 		"babel-core": "^7.0.0-bridge.0",
-		"babel-jest": "29.7.0",
 		"babel-loader": "^8.1.0",
 		"babel-plugin-dynamic-import-node": "^2.3.3",
 		"bean": "~1.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,7 +2860,6 @@ __metadata:
     any-observable: "npm:^0.2.0"
     autoprefixer: "npm:^10.3.7"
     babel-core: "npm:^7.0.0-bridge.0"
-    babel-jest: "npm:29.7.0"
     babel-loader: "npm:^8.1.0"
     babel-plugin-dynamic-import-node: "npm:^2.3.3"
     bean: "npm:~1.0.14"
@@ -5184,7 +5183,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:29.7.0, babel-jest@npm:^29.7.0":
+"babel-jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "babel-jest@npm:29.7.0"
   dependencies:


### PR DESCRIPTION
## What does this change?

Remove unused direct dependency `babel-jest` .

This does not appear to be used and I presume was superseded by [ts-jest](https://github.com/guardian/frontend/blob/e62e6a865a1484a4d8af5c8595f96d17a31b4ee5/package.json#L144-L151)
