### PR TITLE
Add UK daily highlights email front dependency on UK front

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -106,11 +106,12 @@ case class EmailFrontPath(path: String, edition: String)
 object EmailFrontPath {
   def fromPath(path: String): Option[EmailFrontPath] =
     path match {
-      case "email/uk/daily"     => Some(EmailFrontPath(path, "uk"))
-      case "email/us/daily"     => Some(EmailFrontPath(path, "us"))
-      case "email/au/daily"     => Some(EmailFrontPath(path, "au"))
-      case "email/europe/daily" => Some(EmailFrontPath(path, "europe"))
-      case _                    => None
+      case "email/uk/daily"                 => Some(EmailFrontPath(path, "uk"))
+      case "email/uk/daily-with-highlights" => Some(EmailFrontPath(path, "uk"))
+      case "email/us/daily"                 => Some(EmailFrontPath(path, "us"))
+      case "email/au/daily"                 => Some(EmailFrontPath(path, "au"))
+      case "email/europe/daily"             => Some(EmailFrontPath(path, "europe"))
+      case _                                => None
     }
 }
 
@@ -198,7 +199,7 @@ trait EmailFrontPress extends GuLogging {
 trait FapiFrontPress extends EmailFrontPress with GuLogging {
 
   val dependentFrontPaths: Map[String, Seq[String]] = Map(
-    "uk" -> Seq("email/uk/daily"),
+    "uk" -> Seq("email/uk/daily", "email/uk/daily-with-highlights"),
     "us" -> Seq("email/us/daily"),
     "au" -> Seq("email/au/daily"),
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

This change supports an A/B test for the UK daily email newsletter, allowing a new variant (`email/uk/daily-with-highlights`) to pull in the breaking UK section as the `email/uk/daily` one does. 

Success can be measured by comparing open/click-through rates between the control group (`email/uk/daily`) and the highlights variant (`email/uk/daily-with-highlights`).

## What does this change?

Adds support for a new email front path `email/uk/daily-with-highlights` in `FapiFrontPress`:

- **Routes the new path**: `email/uk/daily-with-highlights` is now recognised in mapped to the `uk` front config.
- **Ensures the new email front is re-pressed when the UK front changes**: `email/uk/daily-with-highlights` has been added to the `dependentFrontPaths` map under `"uk"`, so it will be re-pressed whenever the main UK front is pressed — meaning that a breaking news section will appear in this email front when the UK front is pressed.

## Screenshots

N/A — backend-only change, no UI impact.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
