### PR TITLE
UK columnist subnav link

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -100,7 +100,7 @@ object NavLinks {
   val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate, retail))
 
   /* OPINION */
-  val columnists = NavLink("Columnists", "/index/contributors")
+  val columnists = NavLink("Columnists", "/uk/columnists")
   val auColumnists = NavLink("Columnists", "/au/index/contributors")
   val usColumnists = NavLink("Columnists", "/us/columnists")
   val theGuardianView = NavLink("The Guardian view", "/profile/editorial")
@@ -777,6 +777,8 @@ object NavLinks {
     "profile/editorial",
     "au/index/contributors",
     "index/contributors",
+    "us/columnists",
+    "uk/columnists",
     "commentisfree/series/comment-is-free-weekly",
     "sport/rugby-union",
     "sport/cricket",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -388,7 +388,7 @@
 				},
 				{
 					"title": "Columnists",
-					"url": "/index/contributors",
+					"url": "/uk/columnists",
 					"children": [],
 					"classList": []
 				},
@@ -2765,7 +2765,7 @@
 				},
 				{
 					"title": "Columnists",
-					"url": "/index/contributors",
+					"url": "/uk/columnists",
 					"children": [],
 					"classList": []
 				},
@@ -3313,6 +3313,8 @@
 		"profile/editorial",
 		"au/index/contributors",
 		"index/contributors",
+		"us/columnists",
+		"uk/columnists",
 		"commentisfree/series/comment-is-free-weekly",
 		"sport/rugby-union",
 		"sport/cricket",
@@ -3750,7 +3752,7 @@
 				},
 				{
 					"title": "Columnists",
-					"url": "/index/contributors",
+					"url": "/uk/columnists",
 					"children": [],
 					"classList": []
 				},


### PR DESCRIPTION

## What does this change?
Updates the following navigation link:
Columnists → https://www.theguardian.com/uk/columnists

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
