### PR TITLE
Add mParticle consent sync configuration and API URL

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -706,6 +706,10 @@ class GuardianConfiguration extends GuLogging {
     lazy val apiKey = configuration.getStringProperty("braze.apikey").getOrElse("")
   }
 
+  object mparticle {
+    lazy val apiUrl = configuration.getStringProperty("mparticle.api.url")
+  }
+
   object newsletterApi {
     lazy val host = configuration.getStringProperty("newsletterApi.host")
     lazy val origin = configuration.getStringProperty("newsletterApi.origin")

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -20,4 +20,15 @@ trait PrivacySwitches {
       "Warning: Requires ExCo sign-off. Disabling this switch will cost £160,000/day in ad-revenue, impact marketing, impact reader revenue...",
     ),
   )
+
+  val MparticleConsentSync = Switch(
+    SwitchGroup.Privacy,
+    "mparticle-consent-sync",
+    "Enables syncing of browser consent state to mParticle for paid media targeting",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
 }

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -25,7 +25,7 @@ trait PrivacySwitches {
     SwitchGroup.Privacy,
     "mparticle-consent-sync",
     "Enables syncing of browser consent state to mParticle for paid media targeting",
-    owners = group(Commercial),
+    owners = Seq(Owner.withEmail("value.dev@guardian.co.uk"), Owner.withEmail("growth.dev@guardian.co.uk")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true,

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -74,6 +74,8 @@ object JavaScriptPage {
     val commercialBundleUrl = Configuration.commercial.overrideCommercialBundleUrl
       .getOrElse(CommercialBundle.bundleUrl)
 
+    val mparticleApiUrl = Configuration.mparticle.apiUrl.map("mparticleApiUrl" -> JsString(_))
+
     javascriptConfig ++ config ++ commercialMetaData ++ journalismMetaData ++ Map(
       ("edition", JsString(edition.id)),
       ("ajaxUrl", JsString(Configuration.ajax.url)),
@@ -96,6 +98,6 @@ object JavaScriptPage {
       ("isAdFree", JsBoolean(isAdFree(request))),
       ("commercialBundleUrl", JsString(commercialBundleUrl)),
       ("stage", JsString(Configuration.environment.stage)),
-    )
+    ) ++ mparticleApiUrl
   }.toMap
 }

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -66,6 +66,9 @@ commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 # Journalism
 journalism.callouts.url=http://www.theguardian.com
 
+# mParticle
+mparticle.api.url=https://mparticle-api-code.support.guardianapis.com
+
 # Headlines AB Test
 headlines.spreadsheet=1aGUa-Prxre5ul4nDc-7b31TOIyHaprCsmy6jkKevGL8
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

This prepares the frontend to support a new mParticle consent sync feature in dotcom-rendering. Without these changes, DCR has no way to know whether the feature is enabled or which API endpoint to call. Success is measured by dotcom-rendering being able to read `window.guardian.config.switches.mparticle-consent-sync` and `window.guardian.config.page.mparticleApiUrl` correctly once the switch is turned on.

## What does this change?

Two small additions, both inert until the switch is explicitly enabled:

1. **New feature switch `mparticle-consent-sync`** (PrivacySwitches.scala)  
   Added to the `Privacy` switch group with `safeState = Off` and `exposeClientSide = true`. This serialises into `window.guardian.config.switches` in the page HTML. The switch defaults to **OFF** and is not enabled in any environment by this PR.

2. **New page config value `mparticleApiUrl`** (configuration.scala, JavaScriptPage.scala)  
   Added an `object mparticle` to `Configuration` that reads `mparticle.api.url` from the parameter store as an `Option[String]`. The value is conditionally emitted into `window.guardian.config.page` only when configured:
   - **PROD:** `https://mparticle-api.support.guardianapis.com`
   - **CODE / DEVINFRA:** `https://mparticle-api-code.support.guardianapis.com`

No existing behaviour is changed.

## Screenshots

N/A — no UI changes.

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)