### PR TITLE
Add missing football routes to preview

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -32,21 +32,6 @@ trait LinkTo extends GuLogging {
 
   case class ProcessedUrl(url: String, shouldNoFollow: Boolean = false)
 
-  def getAbsoluteUrlOnRequestDomain(url: String, prefix: Option[String] = None)(implicit
-      request: RequestHeader,
-  ): String = {
-    val processedUrl = processUrl(url, Edition(request))
-    val resolvedHost = Option(host).filter(_.nonEmpty) match {
-      case Some(value) => value
-      case None        => s"https://${request.host}/"
-    }
-
-    prefix match {
-      case Some(p) => s"$resolvedHost$p${processedUrl.url}"
-      case None    => s"$resolvedHost${processedUrl.url}"
-    }
-  }
-
   def processUrl(url: String, edition: Edition): ProcessedUrl =
     url match {
       case `url` if url.startsWith("//") => ProcessedUrl(url)

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters._
  */
 trait LinkTo extends GuLogging {
 
-  lazy val host = "" // Configuration.site.host
+  lazy val host = Configuration.site.host
 
   private val GuardianUrl = "^(http[s]?://www.theguardian.com)?(/.*)?$".r
   private val RssPath = "^(/.+)?(/rss)".r
@@ -32,7 +32,9 @@ trait LinkTo extends GuLogging {
 
   case class ProcessedUrl(url: String, shouldNoFollow: Boolean = false)
 
-  def getFullPath(url: String, prefix: Option[String] = None)(implicit request: RequestHeader): String = {
+  def getAbsoluteUrlOnRequestDomain(url: String, prefix: Option[String] = None)(implicit
+      request: RequestHeader,
+  ): String = {
     val processedUrl = processUrl(url, Edition(request))
     val resolvedHost = Option(host).filter(_.nonEmpty) match {
       case Some(value) => value

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters._
  */
 trait LinkTo extends GuLogging {
 
-  lazy val host = Configuration.site.host
+  lazy val host = "" // Configuration.site.host
 
   private val GuardianUrl = "^(http[s]?://www.theguardian.com)?(/.*)?$".r
   private val RssPath = "^(/.+)?(/rss)".r
@@ -31,6 +31,19 @@ trait LinkTo extends GuLogging {
     faciaCard.header.url.get(request)
 
   case class ProcessedUrl(url: String, shouldNoFollow: Boolean = false)
+
+  def getFullPath(url: String, prefix: Option[String] = None)(implicit request: RequestHeader): String = {
+    val processedUrl = processUrl(url, Edition(request))
+    val resolvedHost = Option(host).filter(_.nonEmpty) match {
+      case Some(value) => value
+      case None        => s"https://${request.host}/"
+    }
+
+    prefix match {
+      case Some(p) => s"$resolvedHost$p${processedUrl.url}"
+      case None    => s"$resolvedHost${processedUrl.url}"
+    }
+  }
 
   def processUrl(url: String, edition: Edition): ProcessedUrl =
     url match {

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -94,6 +94,9 @@ GET        /football/:competitionTag/groups/embed                            foo
 GET        /football/:competitionTag/spider/embed                            football.controllers.WallchartController.renderSpiderEmbed(competitionTag)
 
 GET        /football/api/match-nav/:year/:month/:day/:home/:away.json        football.controllers.MoreOnMatchController.matchNavJson(year, month, day, home, away)
+GET        /football/api/match-header/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchHeaderJson(year, month, day, home, away)
+GET        /football/api/match-stats/:year/:month/:day/:home/:away.json       football.controllers.MoreOnMatchController.matchStatsJson(year, month, day, home, away)
+GET        /football/api/match-stats-summary/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchStatsSummaryJson(year, month, day, home, away)
 GET        /football/api/match-nav/:year/:month/:day/:home/:away             football.controllers.MoreOnMatchController.matchNav(year, month, day, home, away)
 GET        /football/api/match-nav/:matchId.json                             football.controllers.MoreOnMatchController.moreOnJson(matchId)
 GET        /football/api/match-nav/:matchId                                  football.controllers.MoreOnMatchController.moreOn(matchId)

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -1,6 +1,6 @@
 package football.model
 
-import common.{CanonicalLink, Edition, LinkTo}
+import common.{CanonicalLink, Edition, Environment, LinkTo}
 import conf.Configuration
 import experiments.ActiveExperiments
 import football.controllers.{CompetitionFilter, FootballPage, MatchMetadata, MatchPage}
@@ -242,13 +242,25 @@ object DotcomRenderingFootballHeaderDataModel {
       request: RequestHeader,
   ): DotcomRenderingFootballHeaderDataModel = {
     val (maybeMatchReport, maybeMinByMin, _, matchInfo) = MatchMetadata.fetchRelatedMatchContent(theMatch, related)
-    DotcomRenderingFootballHeaderDataModel(
-      footballMatch = theMatch,
-      competitionName = competitionSummary.fullName,
-      liveURL = maybeMinByMin.map(x => LinkTo(x.url)),
-      reportURL = maybeMatchReport.map(x => LinkTo(x.url)),
-      infoURL = LinkTo(matchInfo.url),
-    )
+
+    if (Environment.app == "preview") {
+      val prefix = Some("proxy/preview")
+      DotcomRenderingFootballHeaderDataModel(
+        footballMatch = theMatch,
+        competitionName = competitionSummary.fullName,
+        liveURL = maybeMinByMin.map(x => LinkTo.getFullPath(x.url, prefix)),
+        reportURL = maybeMatchReport.map(x => LinkTo.getFullPath(x.url, prefix)),
+        infoURL = LinkTo.getFullPath(matchInfo.url, prefix),
+      )
+    } else {
+      DotcomRenderingFootballHeaderDataModel(
+        footballMatch = theMatch,
+        competitionName = competitionSummary.fullName,
+        liveURL = maybeMinByMin.map(x => LinkTo(x.url)),
+        reportURL = maybeMatchReport.map(x => LinkTo(x.url)),
+        infoURL = LinkTo(matchInfo.url),
+      )
+    }
   }
 
   implicit def DotcomRenderingFootballHeaderDataModelWrites: Writes[DotcomRenderingFootballHeaderDataModel] =

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -52,6 +52,16 @@ trait DotcomRenderingFootballDataModel {
   def pageId: String
 }
 
+sealed trait DCARUrlHelper {
+  def getPageUrl(path: String)(implicit request: RequestHeader): String = {
+    if (Environment.app == "preview") s"https://${request.host}$path" else LinkTo(path)
+  }
+
+  def getAjaxHost(implicit request: RequestHeader): String = {
+    if (Environment.app == "preview") s"https://${request.host}" else Configuration.ajax.url
+  }
+}
+
 object DotcomRenderingFootballDataModel {
   def getConfig(page: StandalonePage)(implicit
       request: RequestHeader,
@@ -235,31 +245,20 @@ case class DotcomRenderingFootballHeaderDataModel(
     infoURL: String,
 )
 
-object DotcomRenderingFootballHeaderDataModel {
+object DotcomRenderingFootballHeaderDataModel extends DCARUrlHelper {
   import football.model.DotcomRenderingFootballDataModelImplicits._
 
   def apply(theMatch: FootballMatch, competitionSummary: CompetitionSummary, related: Seq[ContentType])(implicit
       request: RequestHeader,
   ): DotcomRenderingFootballHeaderDataModel = {
     val (maybeMatchReport, maybeMinByMin, _, matchInfo) = MatchMetadata.fetchRelatedMatchContent(theMatch, related)
-
-    if (Environment.app == "preview") {
-      DotcomRenderingFootballHeaderDataModel(
-        footballMatch = theMatch,
-        competitionName = competitionSummary.fullName,
-        liveURL = maybeMinByMin.map(x => s"https://${request.host}${x.url}"),
-        reportURL = maybeMatchReport.map(x => s"https://${request.host}${x.url}"),
-        infoURL = s"https://${request.host}${matchInfo.url}",
-      )
-    } else {
-      DotcomRenderingFootballHeaderDataModel(
-        footballMatch = theMatch,
-        competitionName = competitionSummary.fullName,
-        liveURL = maybeMinByMin.map(x => LinkTo(x.url)),
-        reportURL = maybeMatchReport.map(x => LinkTo(x.url)),
-        infoURL = LinkTo(matchInfo.url),
-      )
-    }
+    DotcomRenderingFootballHeaderDataModel(
+      footballMatch = theMatch,
+      competitionName = competitionSummary.fullName,
+      liveURL = maybeMinByMin.map(x => getPageUrl(x.url)),
+      reportURL = maybeMatchReport.map(x => getPageUrl(x.url)),
+      infoURL = getPageUrl(matchInfo.url),
+    )
   }
 
   implicit def DotcomRenderingFootballHeaderDataModelWrites: Writes[DotcomRenderingFootballHeaderDataModel] =
@@ -380,7 +379,7 @@ case class DotcomRenderingFootballMatchSummaryDataModel(
     pageId: String,
 ) extends DotcomRenderingFootballDataModel
 
-object DotcomRenderingFootballMatchSummaryDataModel {
+object DotcomRenderingFootballMatchSummaryDataModel extends DCARUrlHelper {
   def apply(
       page: MatchPage,
       matchStats: MatchStats,
@@ -423,8 +422,7 @@ object DotcomRenderingFootballMatchSummaryDataModel {
   private def matchHeaderUrl(theMatch: FootballMatch)(implicit request: RequestHeader): String = {
     val (homeId, awayId) = (theMatch.homeTeam.id, theMatch.awayTeam.id)
     val localDate = new JodaLocalDate(theMatch.date.getYear, theMatch.date.getMonthValue, theMatch.date.getDayOfMonth)
-    val host = if (Environment.app == "preview") s"https://${request.host}" else Configuration.ajax.url
-    getMatchUrl(host, localDate, homeId, awayId, MatchHeaderEndpoint)
+    getMatchUrl(getAjaxHost, localDate, homeId, awayId, MatchHeaderEndpoint)
   }
 
   import football.model.DotcomRenderingFootballDataModelImplicits._

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -244,13 +244,12 @@ object DotcomRenderingFootballHeaderDataModel {
     val (maybeMatchReport, maybeMinByMin, _, matchInfo) = MatchMetadata.fetchRelatedMatchContent(theMatch, related)
 
     if (Environment.app == "preview") {
-      val prefix = Some("proxy/preview")
       DotcomRenderingFootballHeaderDataModel(
         footballMatch = theMatch,
         competitionName = competitionSummary.fullName,
-        liveURL = maybeMinByMin.map(x => LinkTo.getFullPath(x.url, prefix)),
-        reportURL = maybeMatchReport.map(x => LinkTo.getFullPath(x.url, prefix)),
-        infoURL = LinkTo.getFullPath(matchInfo.url, prefix),
+        liveURL = maybeMinByMin.map(x => s"https://${request.host}${x.url}"),
+        reportURL = maybeMatchReport.map(x => s"https://${request.host}${x.url}"),
+        infoURL = s"https://${request.host}${matchInfo.url}",
       )
     } else {
       DotcomRenderingFootballHeaderDataModel(
@@ -401,7 +400,7 @@ object DotcomRenderingFootballMatchSummaryDataModel {
       group = group,
       competitionName = competitionName,
       matchUrl = matchUrl(matchInfo, page),
-      matchHeaderUrl = matchHeaderUrl(matchInfo, page),
+      matchHeaderUrl = matchHeaderUrl(matchInfo),
       nav = nav,
       editionId = edition.id,
       guardianBaseURL = Configuration.site.host,
@@ -421,11 +420,11 @@ object DotcomRenderingFootballMatchSummaryDataModel {
     getMatchNavUrl(Configuration.ajax.url, localDate, homeId, awayId, page.metadata.id)
   }
 
-  private def matchHeaderUrl(theMatch: FootballMatch, page: MatchPage) = {
+  private def matchHeaderUrl(theMatch: FootballMatch)(implicit request: RequestHeader): String = {
     val (homeId, awayId) = (theMatch.homeTeam.id, theMatch.awayTeam.id)
     val localDate = new JodaLocalDate(theMatch.date.getYear, theMatch.date.getMonthValue, theMatch.date.getDayOfMonth)
-
-    getMatchUrl(Configuration.ajax.url, localDate, homeId, awayId, MatchHeaderEndpoint)
+    val host = if (Environment.app == "preview") s"https://${request.host}" else Configuration.ajax.url
+    getMatchUrl(host, localDate, homeId, awayId, MatchHeaderEndpoint)
   }
 
   import football.model.DotcomRenderingFootballDataModelImplicits._


### PR DESCRIPTION
## What does this change?
Adding the missing football routes to preview. This is needed so that the editorial can have an accurate view of the football liveblog before it's published.

<img width="1795" height="799" alt="image" src="https://github.com/user-attachments/assets/3e9fbc24-866e-4fc1-aec7-29ee5e0ca8f0" />


Fixes https://github.com/guardian/dotcom-rendering/issues/15611