### PR TITLE
Bump netty-codec-http

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ val common = library("common")
       pekkoSlf4j,
       pekkoSerializationJackson,
       pekkoActorTyped,
-    ) ++ jackson,
+    ) ++ jackson ++ netty,
   )
 
 val commonWithTests = withTests(common)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -103,6 +103,12 @@ object Dependencies {
   val epoch = "org.webjars.npm" % "epoch-charting" % "0.8.4"
   val d3 = "org.webjars.npm" % "d3" % "7.9.0"
 
+  val nettyVersion = "4.1.132.Final"
+  val netty = Seq(
+    "io.netty" % "netty-codec-http" % nettyVersion,
+    "io.netty" % "netty-codec-http2" % nettyVersion,
+  )
+
   /*
     The versions are currently set as they are because of:
     https://github.com/orgs/playframework/discussions/11222


### PR DESCRIPTION
## What is the value of this and can you measure success?
Bump netty-codec-http and Bump netty-codec-http2. This has to be pinned as it is a transitive dependency of the aws-sdk which has yet to be updated.
## What does this change?
Keeping dependencies up to date
