### PR TITLE
Add Europa Conference league place to Premier League table

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -159,7 +159,7 @@ object CompetitionsProvider {
       "Premier League",
       "English",
       showInTeamsList = true,
-      tableDividers = List(4, 5, 17),
+      tableDividers = List(4, 5, 6, 17),
     ),
     Competition(
       "625",


### PR DESCRIPTION
## What does this change?

Add a dotted line below the Europa Conference league spot in the Premier League.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/ab0face7-8151-4a52-8b48-d1775ac70db3
[after]: https://github.com/user-attachments/assets/4cc80133-5cee-4dbf-a851-f807f9ae34ce