### PR TITLE
Bump @guardian/libs to 31.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
-		"@guardian/libs": "30.1.1",
+		"@guardian/libs": "31.0.0",
 		"@guardian/prettier": "^8.0.1",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "16.0.0",

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.ts
@@ -90,6 +90,7 @@ const canTargetUSNAT = (canTarget: boolean): ConsentState => ({
 const canTargetAUS = (canTarget: boolean): ConsentState => ({
 	aus: {
 		personalisedAdvertising: canTarget,
+		signalStatus: 'ready',
 	},
 	canTarget,
 	framework: 'aus',
@@ -200,7 +201,7 @@ describe('Get Host (no-cookie)', () => {
 	test('`youtube-nocookie.com` with an ad-free', () => {
 		const host = youtubePlayer.getHost({
 			consentState: {
-				aus: { personalisedAdvertising: true },
+				aus: { personalisedAdvertising: true, signalStatus: 'ready' },
 				canTarget: true,
 				framework: 'aus',
 			},
@@ -214,7 +215,7 @@ describe('Get Host (no-cookie)', () => {
 	test('`youtube-nocookie.com` with for other than youtube-media-atom__iframe', () => {
 		const host = youtubePlayer.getHost({
 			consentState: {
-				aus: { personalisedAdvertising: true },
+				aus: { personalisedAdvertising: true, signalStatus: 'ready' },
 				canTarget: true,
 				framework: 'aus',
 			},
@@ -228,7 +229,7 @@ describe('Get Host (no-cookie)', () => {
 	test('`youtube.com` when all three conditions met', () => {
 		const host = youtubePlayer.getHost({
 			consentState: {
-				aus: { personalisedAdvertising: true },
+				aus: { personalisedAdvertising: true, signalStatus: 'ready' },
 				canTarget: true,
 				framework: 'aus',
 			},

--- a/static/src/javascripts/projects/common/modules/commercial/braze/hasRequiredConsents.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/braze/hasRequiredConsents.spec.ts
@@ -98,6 +98,7 @@ describe('hasRequiredConsents', () => {
 			mockOnConsentChangeResult = {
 				aus: {
 					personalisedAdvertising: true,
+					signalStatus: 'ready'
 				},
 				canTarget: true,
 				framework: 'aus',
@@ -112,6 +113,7 @@ describe('hasRequiredConsents', () => {
 			mockOnConsentChangeResult = {
 				aus: {
 					personalisedAdvertising: false,
+					signalStatus: 'ready'
 				},
 				canTarget: false,
 				framework: 'aus',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,7 +2846,7 @@ __metadata:
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/identity-auth": "npm:6.0.1"
     "@guardian/identity-auth-frontend": "npm:8.1.0"
-    "@guardian/libs": "npm:30.1.1"
+    "@guardian/libs": "npm:31.0.0"
     "@guardian/prettier": "npm:^8.0.1"
     "@guardian/shimport": "npm:^1.0.2"
     "@guardian/source-foundations": "npm:16.0.0"
@@ -3000,9 +3000,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/libs@npm:30.1.1":
-  version: 30.1.1
-  resolution: "@guardian/libs@npm:30.1.1"
+"@guardian/libs@npm:31.0.0":
+  version: 31.0.0
+  resolution: "@guardian/libs@npm:31.0.0"
   dependencies:
     "@guardian/ophan-tracker-js": "npm:2.8.0"
   peerDependencies:
@@ -3012,7 +3012,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/d1cbe8ab1729af541eec3b937f4443f1205a79e9efe667b374ac2a4f084238d340652aa2a74cec5558f17cbfd324f4549ffbbea8c89cbcb565c8877103e81414
+  checksum: 10c0/d2193235241c49a0a7622f1034b540fb8df0057e217bf498898a4355675953cf3a26e5442d21736f67398edbb955de0af900adbf2ab3a1d309f7bb07fc9ca47e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this change?
This PR bumps guardian/libs to the latest version which includes a migration of the Australian framework from deprecated ccpa to Global Enterprise framework
## Why?
CCPA is no longer maintained by Sourcepoint.
