### PR TITLE
Update security.txt

### DIFF
--- a/facia/public/security.txt
+++ b/facia/public/security.txt
@@ -1,5 +1,3 @@
 Contact: mailto:appsec@theguardian.com
-Encryption: https://www.theguardian.com/pgp/PublicKeys/Guardian%20Application-Security.pub.txt
 Canonical: https://www.theguardian.com/.well-known/security.txt
-Hiring: https://workforus.theguardian.com/index.php/search-jobs-and-apply/?search_paths%5B%5D=&query=information+security&submit=Search+Jobs
-Signature: https://www.theguardian.com/.well-known/security.txt.asc
+Hiring: https://workwithus.theguardian.com/job-search?role=Technology


### PR DESCRIPTION
## What is the value of this and can you measure success?

Our security.txt file provides a route for security researchers to report vulnerabilities to us. It shows that we take security seriously, and that we have a process for evaluating security reports. Currently, it isn't working properly, which reduces reporter confidence in our process.

## What does this change?

A few fields in the security.txt file are not working. They are all optional according to the [RFC](https://www.rfc-editor.org/rfc/rfc9116#name-field-definitions). I've updated `Hiring`, which is easy to fix.

`Encryption` should point to a public key. Currently, that key is inaccessible. `Signature` points to a digital signature that is only verifiable using the public key. As this key is inaccessible, it's not possible to verify the signature, and this field is not usable.

I've removed both of these fields temporarily so we can fix forward, without creating a frustrating experience for researchers.

N.B. There is a little more work to make the security.txt file valid according to the RFC. This PR does not intend to do that. The goal is that all the fields that do exist should work correctly.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

This is a plaintext file, the git diff is the complete change

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
