### PR TITLE
docs: fix typos across developer documentation

### DIFF
--- a/docs/01-start-here/05-testing-tips.md
+++ b/docs/01-start-here/05-testing-tips.md
@@ -93,8 +93,8 @@ A list of useful information on device testing follows:
 
 -   Chrome and Firefox on windows 10 - Windows10 is slowly overtaking Windows7 as our users most popular desktop OS. When Windows 10 originally came out, firefox had some rendering issues and Chrome and firefox periodically show rendering issues there - especially with things like fonts.
 
--   Older devices - A common source of problems comes from older devices. Where the device is running the latest operating system, it will attempt to run all the latest features and give the fullest experience. This can be catastrophic if the device just doesnt have the memory or processing power to cope.
-    This is especially important if your feature is very resource heavy. For reasons unknown, but possibly connected to the way safari manages memory, iOS devices have proved more susceptable. Good examples of old devices to test on are: iPhone 4S, iPad3 (both known to be prone to crashes) and the Samsung Galaxy S3.
+-   Older devices - A common source of problems comes from older devices. Where the device is running the latest operating system, it will attempt to run all the latest features and give the fullest experience. This can be catastrophic if the device just doesn't have the memory or processing power to cope.
+    This is especially important if your feature is very resource heavy. For reasons unknown, but possibly connected to the way safari manages memory, iOS devices have proved more susceptible. Good examples of old devices to test on are: iPhone 4S, iPad3 (both known to be prone to crashes) and the Samsung Galaxy S3.
     [Interesting page talking about iOS crashes](http://stackoverflow.com/questions/22039534/ios-browser-crashes-due-to-low-memory). As a result of a large number of crashes on iPads, it has been necessary to limit all iPads to only showing the non-enhanced version of network and section fronts.
 
 -   non-enhanced pages - features should either be hidden or have a way of displaying on non-enhanced versions of pages. To see the non-enhanced version of a page use the links [here](https://www.theguardian.com/info/2015/sep/22/making-theguardiancom-work-best-for-you).

--- a/docs/03-dev-howtos/06-repressing.md
+++ b/docs/03-dev-howtos/06-repressing.md
@@ -19,7 +19,7 @@ Tests are failing because of mis pressed data committed. In the Teamcity PR buil
 
 * Check your `facia.stage` property in your `frontend.conf` file is pointing at DEV (*not* PROD!)
 * Check you are using your own switches file and not the `PROD` or `CODE` one.
-	* To do this, create your own properties file in the the S3 bucket named `aws-frontend-store`. Add it to your `frontend.conf` like this: `switches.key=DEV/config/switches-nbaltazar.properties`
+	* To do this, create your own properties file in the S3 bucket named `aws-frontend-store`. Add it to your `frontend.conf` like this: `switches.key=DEV/config/switches-nbaltazar.properties`
 * Ensure you have the test AWS SQS queues in your `frontend.conf` properties
 	* Add two properties: `frontpress.sqs.tool_queue_url` and `frontpress.sqs.cron_queue_url`
 	* Set _both_ properties to the value `"https://sqs.eu-west-1.amazonaws.com/<id-here>/Frontend-TEST-page-presser-queue"`

--- a/docs/05-commercial/03-commercial-javascript.md
+++ b/docs/05-commercial/03-commercial-javascript.md
@@ -6,7 +6,7 @@ In frontend, commercial logic is intertwined with the rest of the JS code,
 being loaded as one of the “bootstraps” in [boot.js][frontend]. This means
 chunks and conditional loading is all handled by Webpack.
 
-With the introduction of `dotcom-rendering`, commercial scripts needed to to be
+With the introduction of `dotcom-rendering`, commercial scripts needed to be
 executed in different contexts, and a new remote bundle was introduced:
 `webpack.config.dcr.js`. The standalone bundle uses the same behaviour in every
 context, being loaded via a `<script>` tag injection.


### PR DESCRIPTION
## What does this PR change?

Fixes four typos across three docs.

**docs/03-dev-howtos/06-repressing.md**
Before: > create your own properties file in the the S3 bucket
After:  > create your own properties file in the S3 bucket

**docs/05-commercial/03-commercial-javascript.md**
Before: > commercial scripts needed to to be
After:  > commercial scripts needed to be

**docs/01-start-here/05-testing-tips.md**
Before: > the device just doesnt have the memory
After:  > the device just doesn't have the memory

Before: > iOS devices have proved more susceptable
After:  > iOS devices have proved more susceptible
