### PR TITLE
Use correct host for preview football urls

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -310,6 +310,7 @@ class GuardianConfiguration extends GuLogging {
 
   object site {
     lazy val host = configuration.getStringProperty("guardian.page.host").getOrElse("")
+    lazy val viewerProxyBaseUrl = configuration.getStringProperty("viewer.proxy.baseUrl").getOrElse("")
   }
 
   object cookies {

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -634,7 +634,7 @@ object DotcomRenderingDataModel {
       modifiedFormat.design == InteractiveDesign && content.trail.webPublicationDate
         .isBefore(Chronos.javaTimeLocalDateTimeToJodaDateTime(InteractiveSwitchOver.date))
 
-    val matchData = makeMatchData(page, pageType)
+    val matchData = makeMatchData(page, pageType)(request)
 
     def addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks: Boolean, shouldAddDisclaimer: Boolean) = {
       if (shouldAddAffiliateLinks && shouldAddDisclaimer) {

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -634,7 +634,7 @@ object DotcomRenderingDataModel {
       modifiedFormat.design == InteractiveDesign && content.trail.webPublicationDate
         .isBefore(Chronos.javaTimeLocalDateTimeToJodaDateTime(InteractiveSwitchOver.date))
 
-    val matchData = makeMatchData(page, pageType)(request)
+    val matchData = makeMatchData(page, pageType)
 
     def addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks: Boolean, shouldAddDisclaimer: Boolean) = {
       if (shouldAddAffiliateLinks && shouldAddDisclaimer) {

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -63,15 +63,13 @@ trait DCARUrlHelper {
     if (Environment.app == "preview") s"$getPreviewHost$path" else LinkTo(path)
   }
 
-  def getAjaxHost(implicit request: RequestHeader): String = {
+  def getAjaxHost: String = {
     if (Environment.app == "preview") s"$getPreviewHost" else Configuration.ajax.url
   }
 }
 
 object DotcomRenderingUtils extends DCARUrlHelper {
-  def makeMatchData(articlePage: ContentPage, pageType: PageType)(implicit
-      request: RequestHeader,
-  ): Option[DotcomRenderingMatchData] = {
+  def makeMatchData(articlePage: ContentPage, pageType: PageType): Option[DotcomRenderingMatchData] = {
     makeFootballMatch(articlePage, pageType).orElse(makeCricketMatch(articlePage))
   }
 
@@ -112,9 +110,7 @@ object DotcomRenderingUtils extends DCARUrlHelper {
     s"$host/football/api/${endpoint.urlSegment}/$datePath/$team1/$team2.json"
   }
 
-  def makeFootballMatch(articlePage: ContentPage, pageType: PageType)(implicit
-      request: RequestHeader,
-  ): Option[DotcomRenderingMatchData] = {
+  def makeFootballMatch(articlePage: ContentPage, pageType: PageType): Option[DotcomRenderingMatchData] = {
 
     def extraction1(references: JsValue): Option[IndexedSeq[JsValue]] = {
       val sequence = references match {

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -4,7 +4,7 @@ import com.github.nscala_time.time.Imports.DateTime
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, LiveBlogDesign}
 import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
-import common.Edition
+import common.{Edition, Environment, LinkTo}
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import model.content.Atom
@@ -54,8 +54,20 @@ case object MatchHeaderEndpoint extends MatchEndpoint { val urlSegment = "match-
 case object MatchStatsEndpoint extends MatchEndpoint { val urlSegment = "match-stats" }
 case object MatchStatsSummaryEndpoint extends MatchEndpoint { val urlSegment = "match-stats-summary" }
 
-object DotcomRenderingUtils {
-  def makeMatchData(articlePage: ContentPage, pageType: PageType): Option[DotcomRenderingMatchData] = {
+trait DCARUrlHelper {
+  def getPageUrl(path: String)(implicit request: RequestHeader): String = {
+    if (Environment.app == "preview") s"https://${request.host}$path" else LinkTo(path)
+  }
+
+  def getAjaxHost(implicit request: RequestHeader): String = {
+    if (Environment.app == "preview") s"https://${request.host}" else Configuration.ajax.url
+  }
+}
+
+object DotcomRenderingUtils extends DCARUrlHelper {
+  def makeMatchData(articlePage: ContentPage, pageType: PageType)(implicit
+      request: RequestHeader,
+  ): Option[DotcomRenderingMatchData] = {
     makeFootballMatch(articlePage, pageType).orElse(makeCricketMatch(articlePage))
   }
 
@@ -96,7 +108,9 @@ object DotcomRenderingUtils {
     s"$host/football/api/${endpoint.urlSegment}/$datePath/$team1/$team2.json"
   }
 
-  def makeFootballMatch(articlePage: ContentPage, pageType: PageType): Option[DotcomRenderingMatchData] = {
+  def makeFootballMatch(articlePage: ContentPage, pageType: PageType)(implicit
+      request: RequestHeader,
+  ): Option[DotcomRenderingMatchData] = {
 
     def extraction1(references: JsValue): Option[IndexedSeq[JsValue]] = {
       val sequence = references match {
@@ -138,9 +152,9 @@ object DotcomRenderingUtils {
           val statsUrlSegment: MatchEndpoint =
             if (pageType.isLiveblog) MatchStatsSummaryEndpoint else MatchStatsEndpoint
           val localDate = articlePage.item.trail.webPublicationDate.toLocalDate
-          val navUrl = getMatchNavUrl(Configuration.ajax.url, localDate, e1._2, e2._2, articlePage.metadata.id)
-          val headerUrl = getMatchUrl(Configuration.ajax.url, localDate, e1._2, e2._2, MatchHeaderEndpoint)
-          val statsUrl = getMatchUrl(Configuration.ajax.url, localDate, e1._2, e2._2, statsUrlSegment)
+          val navUrl = getMatchNavUrl(getAjaxHost, localDate, e1._2, e2._2, articlePage.metadata.id)
+          val headerUrl = getMatchUrl(getAjaxHost, localDate, e1._2, e2._2, MatchHeaderEndpoint)
+          val statsUrl = getMatchUrl(getAjaxHost, localDate, e1._2, e2._2, statsUrlSegment)
           Some(
             DotcomRenderingMatchData(
               matchUrl = navUrl,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -55,12 +55,16 @@ case object MatchStatsEndpoint extends MatchEndpoint { val urlSegment = "match-s
 case object MatchStatsSummaryEndpoint extends MatchEndpoint { val urlSegment = "match-stats-summary" }
 
 trait DCARUrlHelper {
+  def getPreviewHost = {
+    if (Environment.stage == "PROD") "https://viewer.gutools.co.uk/proxy/preview"
+    else s"https://viewer.code.dev-gutools.co.uk/proxy/preview"
+  }
   def getPageUrl(path: String)(implicit request: RequestHeader): String = {
-    if (Environment.app == "preview") s"https://${request.host}$path" else LinkTo(path)
+    if (Environment.app == "preview") s"$getPreviewHost$path" else LinkTo(path)
   }
 
   def getAjaxHost(implicit request: RequestHeader): String = {
-    if (Environment.app == "preview") s"https://${request.host}" else Configuration.ajax.url
+    if (Environment.app == "preview") s"$getPreviewHost" else Configuration.ajax.url
   }
 }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -55,16 +55,12 @@ case object MatchStatsEndpoint extends MatchEndpoint { val urlSegment = "match-s
 case object MatchStatsSummaryEndpoint extends MatchEndpoint { val urlSegment = "match-stats-summary" }
 
 trait DCARUrlHelper {
-  def getPreviewHost = {
-    if (Environment.stage == "PROD") "https://viewer.gutools.co.uk/proxy/preview"
-    else s"https://viewer.code.dev-gutools.co.uk/proxy/preview"
-  }
   def getPageUrl(path: String)(implicit request: RequestHeader): String = {
-    if (Environment.app == "preview") s"$getPreviewHost$path" else LinkTo(path)
+    if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}$path" else LinkTo(path)
   }
 
   def getAjaxHost: String = {
-    if (Environment.app == "preview") s"$getPreviewHost" else Configuration.ajax.url
+    if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.ajax.url
   }
 }
 

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -6,7 +6,7 @@ import experiments.ActiveExperiments
 import football.controllers.{CompetitionFilter, FootballPage, MatchMetadata, MatchPage}
 import model.content.InteractiveAtom
 import model.dotcomrendering.DotcomRenderingUtils.{assetURL, getMatchNavUrl, getMatchUrl, withoutDeepNull, withoutNull}
-import model.dotcomrendering.{Config, MatchHeaderEndpoint, PageFooter, PageType}
+import model.dotcomrendering.{Config, DCARUrlHelper, MatchHeaderEndpoint, PageFooter, PageType}
 import model.{ApplicationContext, Competition, CompetitionSummary, ContentType, Group, StandalonePage, Table, TeamUrl}
 import navigation.{FooterLinks, Nav}
 import pa.{
@@ -50,16 +50,6 @@ trait DotcomRenderingFootballDataModel {
   def contributionsServiceUrl: String
   def canonicalUrl: String
   def pageId: String
-}
-
-sealed trait DCARUrlHelper {
-  def getPageUrl(path: String)(implicit request: RequestHeader): String = {
-    if (Environment.app == "preview") s"https://${request.host}$path" else LinkTo(path)
-  }
-
-  def getAjaxHost(implicit request: RequestHeader): String = {
-    if (Environment.app == "preview") s"https://${request.host}" else Configuration.ajax.url
-  }
 }
 
 object DotcomRenderingFootballDataModel {

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -409,7 +409,7 @@ object DotcomRenderingFootballMatchSummaryDataModel extends DCARUrlHelper {
     getMatchNavUrl(Configuration.ajax.url, localDate, homeId, awayId, page.metadata.id)
   }
 
-  private def matchHeaderUrl(theMatch: FootballMatch)(implicit request: RequestHeader): String = {
+  private def matchHeaderUrl(theMatch: FootballMatch): String = {
     val (homeId, awayId) = (theMatch.homeTeam.id, theMatch.awayTeam.id)
     val localDate = new JodaLocalDate(theMatch.date.getYear, theMatch.date.getMonthValue, theMatch.date.getDayOfMonth)
     getMatchUrl(getAjaxHost, localDate, homeId, awayId, MatchHeaderEndpoint)


### PR DESCRIPTION
## What does this change?
In a previous PR (https://github.com/guardian/frontend/pull/28694), I updated the fields sending URLs to DCAR to ensure full URLs were used in preview. This was needed because the preview host was an empty string, so only the path (without a host) was being sent and DCAR would expect a full URL.

Initially, I derived the host from the request header. However, this turned out to be incorrect. The viewer app used in composer only accepts URLs from the same domain. As part of this PR the viewer base url was added to the SSM field `viewer.proxy.baseUrl` for both CODE & PROD.

Using request.host (which resolves to the preview URL) appeared to work at first, but it actually caused the page to be treated as a non-Guardian page (as indicated by the red flag below).
<img width="615" height="399" alt="image" src="https://github.com/user-attachments/assets/90bc1474-7f9f-45e0-af10-ec3394a55b27" />

**Now all the linking works with the new changes:**


https://github.com/user-attachments/assets/59ddf260-3ee4-40fc-92ea-82740bb422f4


Fixes https://github.com/guardian/dotcom-rendering/issues/15611
