### PR TITLE
Extend DCR hosted content switch expiry by two months

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -634,7 +634,7 @@ trait FeatureSwitches {
     description = "Render hosted content pages with DCR",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2026, 4, 15)),
+    sellByDate = Some(LocalDate.of(2026, 6, 17)),
     exposeClientSide = false,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

Prevents the feature switch to allow hosted content to render via DCR from expiring too early

## What does this change?

Extends the expiry of the DCR hosted content switch until mid June
