### PR TITLE
Add interactive article to list of pressed content

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -134,6 +134,7 @@ object PressedContent {
     "/uk-news/ng-interactive/2017/feb/20/what-the-eu27-want-brexit-red-lines-from-the-other-side-of-the-table",
     "/sport/ng-interactive/2017/aug/02/usain-bolt-fastest-man-ever-lived",
     "/world/ng-interactive/2017/mar/01/who-are-europes-newcomers",
+    "/us-news/ng-interactive/2017/dec/20/bussed-out-america-moves-homeless-people-country-study",
     // 2018
     "/lifeandstyle/ng-interactive/2018/feb/25/the-ofm-50-everything-we-love-in-the-world-of-food-right-now",
     "/world/ng-interactive/2018/mar/05/italian-elections-2018-full-results-renzi-berlusconi",


### PR DESCRIPTION
## What is the value of this and can you measure success?

This article works when rendered by frontend, but not DCAR:

https://www.theguardian.com/us-news/ng-interactive/2017/dec/20/bussed-out-america-moves-homeless-people-country-study

Looks like the JavaScript expects the `<figure class="interactive-atom">` to be structured in a certain way, which is no longer the case in DCAR. 

## What does this change?

The content was pressed to archive back in 2021. This PR ensures frontend serves the pressed version of the article instead of asking DCAR to render it. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e7b57f35-c3fe-4016-a19b-ec4852999062
[after]: https://github.com/user-attachments/assets/85524a95-de0a-49af-82ef-0a24563936af
