### PR TITLE
Fix stale competition filters

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -30,19 +30,19 @@ trait Competitions extends implicits.Football {
 
   def competitionsWithId(compId: String): Option[Competition] = competitions.find(_.id == compId)
 
-  lazy val competitionsWithTodaysMatchesAndFutureFixtures = Competitions(
+  def competitionsWithTodaysMatchesAndFutureFixtures = Competitions(
     competitions
       .map(c => c.copy(matches = c.matches.filter(m => m.isFixture || m.isOn(LocalDate.now()))))
       .filter(_.hasMatches),
   )
 
-  lazy val competitionsWithTodaysMatchesAndPastResults = Competitions(
+  def competitionsWithTodaysMatchesAndPastResults = Competitions(
     competitions
       .map(c => c.copy(matches = c.matches.filter(m => m.isResult || m.isOn(LocalDate.now()))))
       .filter(_.hasMatches),
   )
 
-  lazy val withTodaysMatches = Competitions(
+  def withTodaysMatches = Competitions(
     competitions.map(c => c.copy(matches = c.matches.filter(_.isOn(LocalDate.now())))).filter(_.hasMatches),
   )
 


### PR DESCRIPTION
## What does this change?
Fix stale competition filters by recomputing the filters data on access

Convert competitionsWithTodaysMatchesAndFutureFixtures, competitionsWithTodaysMatchesAndPastResults & withTodaysMatches from lazy val to def so it reflects latest competition data and current date. Previously the value was cached on first access, leading to outdated filters.

## Screenshots
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/cb8418ad-cb73-4849-b006-37a154226530"
             controls
             width="300">
      </video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/1d9d0fce-8040-4c0b-a8c7-e543c33cc670" width="300"></video>
    </td>
  </tr>
</table>
