### PR TITLE
Update competition name for Conference League

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -351,8 +351,8 @@ object CompetitionsProvider {
     Competition(
       "516",
       "/football/europa-conference-league",
-      "Europa Conference League",
-      "Europa Conference League",
+      "Conference League",
+      "Conference League",
       "European",
       showInTeamsList = true,
       tableDividers = List(2),


### PR DESCRIPTION
## What does this change?
Update competition name for `Conference League`