### PR TITLE
additional fields for newsletter preview

### DIFF
--- a/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
@@ -119,6 +119,8 @@ object DotcomNewslettersPageRenderingDataModel {
       response.mailSuccessDescription.getOrElse("You are subscribed"),
       response.regionFocus,
       response.illustrationCard,
+      response.exampleUrl,
+      response.category,
     )
   }
 }

--- a/common/app/services/NewsletterService.scala
+++ b/common/app/services/NewsletterService.scala
@@ -20,6 +20,7 @@ case class NewsletterData(
     successDescription: String,
     regionFocus: Option[String],
     illustrationCard: Option[String],
+    illustrationSquare: Option[String],
     exampleUrl: Option[String],
     category: String,
 )
@@ -82,9 +83,10 @@ class NewsletterService(newsletterSignupAgent: NewsletterSignupAgent) {
       response.group,
       response.mailSuccessDescription.getOrElse("You are subscribed"),
       response.regionFocus,
-      illustrationCard = Option.empty[String],
-      exampleUrl = response.exampleUrl,
-      category = response.category,
+      response.illustrationCard,
+      response.illustrationSquare,
+      response.exampleUrl,
+      response.category,
     )
   }
 

--- a/common/app/services/NewsletterService.scala
+++ b/common/app/services/NewsletterService.scala
@@ -20,6 +20,8 @@ case class NewsletterData(
     successDescription: String,
     regionFocus: Option[String],
     illustrationCard: Option[String],
+    renderUrl: Option[String],
+    category: String,
 )
 
 object NewsletterData {
@@ -81,6 +83,8 @@ class NewsletterService(newsletterSignupAgent: NewsletterSignupAgent) {
       response.mailSuccessDescription.getOrElse("You are subscribed"),
       response.regionFocus,
       illustrationCard = Option.empty[String],
+      renderUrl = response.exampleUrl,
+      category = response.category,
     )
   }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
