### PR TITLE
Support new newsletter signup card

### DIFF
--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -5,6 +5,17 @@ import conf.switches.Owner.group
 
 trait NewslettersSwitches {
 
+  val ShowNewNewsLetterSignupCard = Switch(
+    SwitchGroup.Newsletters,
+    "show-new-newsletter-signup-card",
+    "Feature flag to show new newsletter signup card instead of email signup component",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
   val HideNewsletterSignupComponentForSubscribers = Switch(
     SwitchGroup.Newsletters,
     "hide-newsletter-signup-component-for-subscribers",

--- a/common/app/services/NewsletterService.scala
+++ b/common/app/services/NewsletterService.scala
@@ -80,7 +80,7 @@ class NewsletterService(newsletterSignupAgent: NewsletterSignupAgent) {
       response.group,
       response.mailSuccessDescription.getOrElse("You are subscribed"),
       response.regionFocus,
-      illustrationCard = Option.empty[String],
+      response.illustrationCard,
     )
   }
 


### PR DESCRIPTION
Feature flag to show new newsletter signup card instead of signup component
Return newsletter illustration field in response to show illustration in sign-up card

## What is the value of this and can you measure success?

Enables us to switch on the new NewsletterSignupCard instead of the original EmailSignup component and display the newsletter illustration in the signup card

## What does this change?

Adds the new switch
Adds the illustration field

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
