### PR TITLE
Add cricket match-header endpoint and update match data model

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -328,7 +328,9 @@ final case class Content(
   }
 
   def cricketMatchDate: Option[String] = {
-    if (tags.isCricketLiveBlog && conf.switches.Switches.CricketScoresSwitch.isSwitchedOn) {
+    if (
+      (tags.isCricketLiveBlog || tags.isCricketMatchReport) && conf.switches.Switches.CricketScoresSwitch.isSwitchedOn
+    ) {
       Some(trail.webPublicationDate.withZone(DateTimeZone.UTC).toString("yyyy-MM-dd"))
     } else None
   }

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -79,7 +79,7 @@ object DotcomRenderingUtils extends DCARUrlHelper {
         Some(
           DotcomRenderingMatchData(
             matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
-            matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
+            matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/api/match-header/$date/$team.json"),
             matchStatsUrl = None,
             matchType = CricketMatchType,
           ),

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -79,7 +79,7 @@ object DotcomRenderingUtils extends DCARUrlHelper {
         Some(
           DotcomRenderingMatchData(
             matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
-            matchHeaderUrl = None,
+            matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
             matchStatsUrl = None,
             matchType = CricketMatchType,
           ),

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -859,6 +859,11 @@ final case class Tags(tags: List[Tag]) {
     tags.map(_.id).exists(tagId => CricketTeams.teamTagIds.contains(tagId)) &&
     tags.map(_.id).contains("sport/over-by-over-reports")
 
+  lazy val isCricketMatchReport: Boolean =
+    isCricketSport && isMatchReport && tags.map(_.id).exists(tagId => CricketTeams.teamTagIds.contains(tagId))
+
+  lazy val isCricketSport: Boolean = tags.exists(t => t.id == "sport/cricket")
+
   lazy val isRugbyMatch: Boolean = (isMatchReport || isLiveBlog) &&
     tags.exists(t => t.id == "sport/rugby-union")
 

--- a/sport/app/cricket/controllers/CricketControllers.scala
+++ b/sport/app/cricket/controllers/CricketControllers.scala
@@ -1,6 +1,7 @@
 package cricket.controllers
 
 import com.softwaremill.macwire._
+import contentapi.ContentApiClient
 import jobs.CricketStatsJob
 import model.ApplicationContext
 import play.api.libs.ws.WSClient
@@ -10,6 +11,7 @@ trait CricketControllers {
   def cricketStatsJob: CricketStatsJob
   def controllerComponents: ControllerComponents
   def wsClient: WSClient
+  def contentApiClient: ContentApiClient
   implicit def appContext: ApplicationContext
   lazy val cricketMatchController: CricketMatchController = wire[CricketMatchController]
 }

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -5,6 +5,7 @@ import conf.Configuration
 import conf.cricketPa.{CricketTeam, CricketTeams, PaFeed}
 import contentapi.ContentApiClient
 import cricketModel.{Match, MatchHeader}
+import football.datetime.DateHelpers
 import football.model.{CricketScoreBoardDataModel, DotcomRenderingCricketDataModel}
 import implicits.{HtmlFormat, JsonFormat}
 import jobs.CricketStatsJob
@@ -118,8 +119,8 @@ class CricketMatchController(
   }
 
   private def relatedContents(theMatch: Match, date: ZonedDateTime): Future[List[ContentType]] = {
-    val startOfDateRange = date.minusDays(1)
-    val endOfDateRange = date.plusDays(1)
+    val startOfDateRange = DateHelpers.startOfDay(date)
+    val endOfDateRange = DateHelpers.startOfDay(date.plusDays(1))
     val tagIds = theMatch.teams.flatMap(_.teamTagId).mkString(",")
 
     contentApiClient

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future.successful
 
 case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam) extends StandalonePage {
   override val metadata = MetaData.make(
-    id = s"sport/cricket/match/$matchId/${team.wordsForUrl}",
+    id = s"/sport/cricket/match/$matchId/${team.wordsForUrl}",
     section = Some(SectionId.fromId("cricket")),
     webTitle = s"${theMatch.competitionName}, ${theMatch.venueName}",
   )

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -81,7 +81,7 @@ class CricketMatchController(
             val page = CricketMatchPage(matchData, date, team)
             val requestedDate: ZonedDateTime =
               LocalDate.parse(date, PaFeed.dateFormat).atStartOfDay(ZoneId.of("Europe/London"))
-            val related: Future[Seq[ContentType]] = loadMoreOn(matchData, requestedDate)
+            val related: Future[Seq[ContentType]] = relatedContents(matchData, requestedDate)
             related.map { relatedContents =>
               val model = MatchHeader(page, relatedContents, requestedDate)
               Cached(CacheTime.Cricket)(JsonComponent.fromWritable(model))
@@ -117,7 +117,7 @@ class CricketMatchController(
     }
   }
 
-  private def loadMoreOn(theMatch: Match, date: ZonedDateTime): Future[List[ContentType]] = {
+  private def relatedContents(theMatch: Match, date: ZonedDateTime): Future[List[ContentType]] = {
     val startOfDateRange = date.minusDays(1)
     val endOfDateRange = date.plusDays(1)
     val tagIds = theMatch.teams.flatMap(_.teamTagId).mkString(",")

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -2,19 +2,20 @@ package cricket.controllers
 
 import common._
 import conf.Configuration
-import cricketModel.Match
-import conf.cricketPa.{CricketTeam, CricketTeams}
+import conf.cricketPa.{CricketTeam, CricketTeams, PaFeed}
+import contentapi.ContentApiClient
+import cricketModel.{Match, MatchHeader}
 import football.model.{CricketScoreBoardDataModel, DotcomRenderingCricketDataModel}
 import implicits.{HtmlFormat, JsonFormat}
 import jobs.CricketStatsJob
 import model.Cached.RevalidatableResult
 import model._
-import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
-import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents, RequestHeader, Result}
+import play.api.mvc._
 import renderers.DotcomRenderingService
 import services.dotcomrendering.{CricketPagePicker, RemoteRender}
 
+import java.time.{LocalDate, ZoneId, ZonedDateTime}
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
 
@@ -30,6 +31,7 @@ class CricketMatchController(
     cricketStatsJob: CricketStatsJob,
     val controllerComponents: ControllerComponents,
     val wsClient: WSClient,
+    contentApiClient: ContentApiClient,
 )(implicit
     context: ApplicationContext,
 ) extends BaseController
@@ -70,6 +72,25 @@ class CricketMatchController(
         .getOrElse(successful(NoCache(NotFound)))
     }
 
+  def matchHeaderJson(date: String, teamId: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      CricketTeams
+        .byWordsForUrl(teamId)
+        .flatMap { team =>
+          cricketStatsJob.findMatch(team, date).map { matchData =>
+            val page = CricketMatchPage(matchData, date, team)
+            val requestedDate: ZonedDateTime =
+              LocalDate.parse(date, PaFeed.dateFormat).atStartOfDay(ZoneId.of("Europe/London"))
+            val related: Future[Seq[ContentType]] = loadMoreOn(matchData, requestedDate)
+            related.map { relatedContents =>
+              val model = MatchHeader(page.theMatch, relatedContents, requestedDate)
+              Cached(CacheTime.Cricket)(JsonComponent.fromWritable(model))
+            }
+          }
+        }
+        .getOrElse(successful(NoCache(NotFound)))
+    }
+
   private def renderMatch(
       page: CricketMatchPage,
   )(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
@@ -95,4 +116,32 @@ class CricketMatchController(
         })
     }
   }
+
+  private def loadMoreOn(theMatch: Match, date: ZonedDateTime): Future[List[ContentType]] = {
+    val startOfDateRange = date.minusDays(1)
+    val endOfDateRange = date.plusDays(1)
+    val tagIds = theMatch.teams.flatMap(_.teamTagId).mkString(",")
+
+    contentApiClient
+      .getResponse(
+        contentApiClient
+          .search()
+          .section("sport")
+          .tag(
+            s"sport/cricket,$tagIds",
+          )
+          .fromDate(startOfDateRange.toInstant)
+          .toDate(endOfDateRange.toInstant),
+      )
+      .map { response =>
+        response.results
+          .map(Content(_))
+          .toList
+          .filter(c => hasExactlyTwoTeams(c))
+      }
+  }
+
+  private def hasExactlyTwoTeams(content: ContentType): Boolean = content.tags.tags.count(tag => {
+    tag.id.endsWith("-cricket-team") || tag.id.endsWith("cricketteam")
+  }) == 2
 }

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future.successful
 
 case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam) extends StandalonePage {
   override val metadata = MetaData.make(
-    id = s"/sport/cricket/match/$matchId/${team.wordsForUrl}",
+    id = s"sport/cricket/match/$matchId/${team.wordsForUrl}",
     section = Some(SectionId.fromId("cricket")),
     webTitle = s"${theMatch.competitionName}, ${theMatch.venueName}",
   )
@@ -83,7 +83,7 @@ class CricketMatchController(
               LocalDate.parse(date, PaFeed.dateFormat).atStartOfDay(ZoneId.of("Europe/London"))
             val related: Future[Seq[ContentType]] = loadMoreOn(matchData, requestedDate)
             related.map { relatedContents =>
-              val model = MatchHeader(page.theMatch, relatedContents, requestedDate)
+              val model = MatchHeader(page, relatedContents, requestedDate)
               Cached(CacheTime.Cricket)(JsonComponent.fromWritable(model))
             }
           }

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -117,7 +117,7 @@ object Match {
 
 case class MatchHeader(
     cricketMatch: Match,
-    competitionName: String, // e.g., "Ashes 2025-26"
+//    competitionName: String, TODO: we currently don't have this but need to retrieve it e.g., "Ashes 2025-26"
     liveURL: Option[String],
     reportURL: Option[String],
     infoURL: String,
@@ -136,9 +136,14 @@ object MatchHeader extends DCARUrlHelper {
       .orElse {
         related.find { content =>
           content.isArticleType &&
+          content.isMatchReport &&
           !content.isLiveCricket &&
-          (content.webPublicationDate.toLocalDate == date.toLocalDate ||
-            content.webPublicationDate.isAfter(DateHelpers.startOfDay(date)))
+          (content.webPublicationDate.toLocalDate == date.toLocalDate &&
+            content.webPublicationDate.isAfter(
+              DateHelpers.startOfDay(
+                page.theMatch.gameDate.atZone(ZoneId.of("Europe/London")),
+              ), // match report always happens after the match
+            ))
         }
       }
       .map(content => getPageUrl(content.metadata.url))
@@ -148,12 +153,11 @@ object MatchHeader extends DCARUrlHelper {
       .orElse {
         related.find { content =>
           content.isLiveCricket &&
-          (content.webPublicationDate.toLocalDate == date.toLocalDate ||
-            content.webPublicationDate.isAfter(page.theMatch.gameDate.atZone(ZoneId.of("Europe/London"))))
+          (content.webPublicationDate.toLocalDate == date.toLocalDate)
         }
       }
       .map(content => getPageUrl(content.metadata.url))
 
-    MatchHeader(page.theMatch, "", liveBlog, matchReport, s"$getAjaxHost${page.metadata.id}")
+    MatchHeader(page.theMatch, liveBlog, matchReport, s"$getAjaxHost${page.metadata.id}")
   }
 }

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -1,9 +1,17 @@
 package cricketModel
 
+import com.github.nscala_time.time.Imports.DateTimeZone
+import football.datetime.DateHelpers
+import cricket.implicits.Cricket._
+import model.ContentType
+import model.Cors.RichRequestHeader
+import model.dotcomrendering.DotcomRenderingUtils.getPageUrl
 import play.api.libs.json._
-import java.time.LocalDateTime
+import play.api.mvc.RequestHeader
 
-case class Team(name: String, id: String, home: Boolean, lineup: List[String])
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
+
+case class Team(name: String, id: String, home: Boolean, lineup: List[String], teamTagId: Option[String])
 
 object Team {
   implicit val writes: OWrites[Team] = Json.writes[Team]
@@ -44,6 +52,7 @@ case class Innings(
     order: Int,
     battingTeam: String,
     runsScored: Int,
+    wickets: Int,
     overs: String,
     declared: Boolean,
     forfeited: Boolean,
@@ -61,7 +70,6 @@ case class Innings(
   implicit val writes: OWrites[Innings] = Json.writes[Innings]
   lazy val closed = declared || forfeited || allOut
   lazy val allOut = wickets == 10
-  lazy val wickets = fallOfWicket.length
 
   lazy val firstIn: Option[InningsBatter] = batters.find(_.notOut)
   lazy val secondIn: Option[InningsBatter] = {
@@ -83,6 +91,8 @@ case class Match(
     competitionName: String,
     venueName: String,
     result: String,
+    currentDay: Int,
+    totalDays: Int,
     gameDate: LocalDateTime,
     officials: List[String],
     matchId: String,
@@ -103,4 +113,53 @@ case class Match(
 
 object Match {
   implicit val writes: OWrites[Match] = Json.writes[Match]
+}
+
+case class MatchHeader(
+    cricketMatch: Match,
+    competitionName: String, // e.g., "Ashes 2025-26"
+    liveURL: Option[String],
+    reportURL: Option[String],
+)
+
+object MatchHeader {
+  implicit val writes: OWrites[MatchHeader] = Json.writes[MatchHeader]
+
+  def apply(theMatch: Match, related: Seq[ContentType], date: ZonedDateTime)(implicit
+      request: RequestHeader,
+  ): MatchHeader = {
+    val currentPage = request.getParameter("page").getOrElse("")
+
+    val matchReport = related
+      .find(c => c.isArticleType && c.isPage(currentPage))
+      .orElse {
+        related.find { content =>
+          val webPublicationDate =
+            DateHelpers.asZonedDateTime(content.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")))
+
+          content.isArticleType &&
+          !content.isLiveCricket &&
+          (webPublicationDate.toLocalDate == date.toLocalDate ||
+            webPublicationDate.isAfter(DateHelpers.startOfDay(date)))
+        }
+      }
+      .map(content => getPageUrl(content.metadata.url))
+
+    val liveBlog = related
+      .find(c => c.isLiveCricket && c.isPage(currentPage))
+      .orElse {
+        related
+          .find { c =>
+            val webPublicationDate =
+              DateHelpers.asZonedDateTime(c.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")))
+
+            c.isLiveCricket &&
+            (webPublicationDate.toLocalDate == date.toLocalDate ||
+              webPublicationDate.isAfter(theMatch.gameDate.atZone(ZoneId.of("Europe/London"))))
+          }
+      }
+      .map(content => getPageUrl(content.metadata.url))
+
+    MatchHeader(theMatch, "", liveBlog, matchReport)
+  }
 }

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -1,12 +1,11 @@
 package cricketModel
 
-import com.github.nscala_time.time.Imports.DateTimeZone
 import cricket.controllers.CricketMatchPage
-import football.datetime.DateHelpers
 import cricket.implicits.Cricket._
+import football.datetime.DateHelpers
 import model.ContentType
 import model.Cors.RichRequestHeader
-import model.dotcomrendering.DotcomRenderingUtils.getPageUrl
+import model.dotcomrendering.DCARUrlHelper
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 
@@ -124,7 +123,7 @@ case class MatchHeader(
     infoURL: String,
 )
 
-object MatchHeader {
+object MatchHeader extends DCARUrlHelper {
   implicit val writes: OWrites[MatchHeader] = Json.writes[MatchHeader]
 
   def apply(page: CricketMatchPage, related: Seq[ContentType], date: ZonedDateTime)(implicit
@@ -155,6 +154,6 @@ object MatchHeader {
       }
       .map(content => getPageUrl(content.metadata.url))
 
-    MatchHeader(page.theMatch, "", liveBlog, matchReport, page.metadata.webUrl)
+    MatchHeader(page.theMatch, "", liveBlog, matchReport, s"$getAjaxHost${page.metadata.id}")
   }
 }

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -131,24 +131,27 @@ object MatchHeader extends DCARUrlHelper {
   ): MatchHeader = {
     val currentPage = request.getParameter("page").getOrElse("")
 
-    val matchReport = related
+    val matchReportUrl = related
       .find(c => c.isArticleType && c.isPage(currentPage))
       .orElse {
-        related.find { content =>
-          content.isArticleType &&
-          content.isMatchReport &&
-          !content.isLiveCricket &&
-          (content.webPublicationDate.toLocalDate == date.toLocalDate &&
-            content.webPublicationDate.isAfter(
-              DateHelpers.startOfDay(
-                page.theMatch.gameDate.atZone(ZoneId.of("Europe/London")),
-              ), // match report always happens after the match
-            ))
-        }
+
+        related
+          .filter { content =>
+            content.isArticleType &&
+            content.isMatchReport &&
+            !content.isLiveCricket
+          }
+          .find(content => {
+            val matchStart = DateHelpers.startOfDay(
+              page.theMatch.gameDate.atZone(ZoneId.of("Europe/London")),
+            )
+            content.webPublicationDate.toLocalDate == date.toLocalDate &&
+            content.webPublicationDate.isAfter(matchStart) // match report always happens after the match starts
+          })
       }
       .map(content => getPageUrl(content.metadata.url))
 
-    val liveBlog = related
+    val liveBlogUrl = related
       .find(c => c.isLiveCricket && c.isPage(currentPage))
       .orElse {
         related.find { content =>
@@ -158,6 +161,6 @@ object MatchHeader extends DCARUrlHelper {
       }
       .map(content => getPageUrl(content.metadata.url))
 
-    MatchHeader(page.theMatch, liveBlog, matchReport, s"$getAjaxHost${page.metadata.id}")
+    MatchHeader(page.theMatch, liveBlogUrl, matchReportUrl, s"$getAjaxHost${page.metadata.id}")
   }
 }

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -1,6 +1,7 @@
 package cricketModel
 
 import com.github.nscala_time.time.Imports.DateTimeZone
+import cricket.controllers.CricketMatchPage
 import football.datetime.DateHelpers
 import cricket.implicits.Cricket._
 import model.ContentType
@@ -120,12 +121,13 @@ case class MatchHeader(
     competitionName: String, // e.g., "Ashes 2025-26"
     liveURL: Option[String],
     reportURL: Option[String],
+    infoURL: String,
 )
 
 object MatchHeader {
   implicit val writes: OWrites[MatchHeader] = Json.writes[MatchHeader]
 
-  def apply(theMatch: Match, related: Seq[ContentType], date: ZonedDateTime)(implicit
+  def apply(page: CricketMatchPage, related: Seq[ContentType], date: ZonedDateTime)(implicit
       request: RequestHeader,
   ): MatchHeader = {
     val currentPage = request.getParameter("page").getOrElse("")
@@ -155,11 +157,11 @@ object MatchHeader {
 
             c.isLiveCricket &&
             (webPublicationDate.toLocalDate == date.toLocalDate ||
-              webPublicationDate.isAfter(theMatch.gameDate.atZone(ZoneId.of("Europe/London"))))
+              webPublicationDate.isAfter(page.theMatch.gameDate.atZone(ZoneId.of("Europe/London"))))
           }
       }
       .map(content => getPageUrl(content.metadata.url))
 
-    MatchHeader(theMatch, "", liveBlog, matchReport)
+    MatchHeader(page.theMatch, "", liveBlog, matchReport, page.metadata.webUrl)
   }
 }

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -161,6 +161,11 @@ object MatchHeader extends DCARUrlHelper {
       }
       .map(content => getPageUrl(content.metadata.url))
 
-    MatchHeader(page.theMatch, liveBlogUrl, matchReportUrl, getPageUrl(page.metadata.id))
+    MatchHeader(
+      cricketMatch = page.theMatch,
+      liveURL = liveBlogUrl,
+      reportURL = matchReportUrl,
+      infoURL = getPageUrl(page.metadata.id),
+    )
   }
 }

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -136,13 +136,10 @@ object MatchHeader {
       .find(c => c.isArticleType && c.isPage(currentPage))
       .orElse {
         related.find { content =>
-          val webPublicationDate =
-            DateHelpers.asZonedDateTime(content.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")))
-
           content.isArticleType &&
           !content.isLiveCricket &&
-          (webPublicationDate.toLocalDate == date.toLocalDate ||
-            webPublicationDate.isAfter(DateHelpers.startOfDay(date)))
+          (content.webPublicationDate.toLocalDate == date.toLocalDate ||
+            content.webPublicationDate.isAfter(DateHelpers.startOfDay(date)))
         }
       }
       .map(content => getPageUrl(content.metadata.url))
@@ -150,15 +147,11 @@ object MatchHeader {
     val liveBlog = related
       .find(c => c.isLiveCricket && c.isPage(currentPage))
       .orElse {
-        related
-          .find { c =>
-            val webPublicationDate =
-              DateHelpers.asZonedDateTime(c.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")))
-
-            c.isLiveCricket &&
-            (webPublicationDate.toLocalDate == date.toLocalDate ||
-              webPublicationDate.isAfter(page.theMatch.gameDate.atZone(ZoneId.of("Europe/London"))))
-          }
+        related.find { content =>
+          content.isLiveCricket &&
+          (content.webPublicationDate.toLocalDate == date.toLocalDate ||
+            content.webPublicationDate.isAfter(page.theMatch.gameDate.atZone(ZoneId.of("Europe/London"))))
+        }
       }
       .map(content => getPageUrl(content.metadata.url))
 

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -161,6 +161,6 @@ object MatchHeader extends DCARUrlHelper {
       }
       .map(content => getPageUrl(content.metadata.url))
 
-    MatchHeader(page.theMatch, liveBlogUrl, matchReportUrl, s"$getAjaxHost${page.metadata.id}")
+    MatchHeader(page.theMatch, liveBlogUrl, matchReportUrl, getPageUrl(page.metadata.id))
   }
 }

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -12,21 +12,22 @@ import java.util.TimeZone
 object Parser {
 
   def parseMatch(scorecard: String, detail: String, lineups: String, matchId: String): Match = {
-
     val matchData = XML.loadString(detail) \ "match"
     val matchDetail = parseMatchDetail(matchData)
     val lineupData = XML.loadString(lineups)
     val scorecardData = XML.loadString(scorecard)
 
     Match(
-      parseTeams(lineupData \ "match" \ "team"),
-      parseInnings(scorecardData \ "match" \ "innings"),
-      matchDetail.competitionName,
-      matchDetail.venueName,
-      matchDetail.result,
-      matchDetail.gameDate,
-      matchDetail.officials,
-      matchId,
+      teams = parseTeams(lineupData \ "match" \ "team"),
+      innings = parseInnings(scorecardData \ "match" \ "innings"),
+      competitionName = matchDetail.competitionName,
+      venueName = matchDetail.venueName,
+      result = matchDetail.result,
+      currentDay = matchDetail.currentDay,
+      totalDays = matchDetail.totalDays,
+      gameDate = matchDetail.gameDate,
+      officials = matchDetail.officials,
+      matchId = matchId,
     )
   }
 
@@ -34,6 +35,8 @@ object Parser {
       competitionName: String,
       venueName: String,
       result: String,
+      currentDay: Int,
+      totalDays: Int,
       gameDate: LocalDateTime,
       officials: List[String],
   )
@@ -55,16 +58,26 @@ object Parser {
 
   private def parseMatchDetail(matchDetail: NodeSeq): MatchDetail =
     MatchDetail(
-      matchDetail \ "stage" text,
-      matchDetail \ "venue" \ "name" text,
-      matchDetail \ "status" text,
-      Date(matchDetail \ "dateTime" text),
-      parseOfficials(matchDetail \ "official"),
+      competitionName = matchDetail \ "stage" text,
+      venueName = matchDetail \ "venue" \ "name" text,
+      result = matchDetail \ "status" text,
+      currentDay = (matchDetail \ "currentDay").text.toInt,
+      totalDays = (matchDetail \ "totalDays").text.toInt,
+      gameDate = Date(matchDetail \ "dateTime" text),
+      officials = parseOfficials(matchDetail \ "official"),
     )
 
   private def parseTeams(teams: NodeSeq): List[Team] =
     teams.map { team =>
-      Team((team \ "name").text, (team \ "@id").text, (team \ "home").text == "true", parseTeamLineup(team \ "player"))
+      val teamId = (team \ "@id").text
+      val teamTagId = CricketTeams.teams.find(_.paId == teamId).map(_.tagId)
+      Team(
+        (team \ "name").text,
+        (team \ "@id").text,
+        (team \ "home").text == "true",
+        parseTeamLineup(team \ "player"),
+        teamTagId,
+      )
 
     }.toList
 
@@ -80,22 +93,23 @@ object Parser {
         val inningsOrder = (singleInnings \ "@order").text.toInt
         val battingTeam = (singleInnings \ "batting" \ "team" \ "name").text
         Innings(
-          inningsOrder,
-          battingTeam,
-          getStatistic(singleInnings, "runs-scored").toInt,
-          getStatistic(singleInnings, "overs"),
-          getStatistic(singleInnings, "declared") == "true",
-          getStatistic(singleInnings, "forefeited") == "true",
-          inningsDescription(inningsOrder, battingTeam),
-          parseInningsBatters(singleInnings \ "batting" \ "batter"),
-          parseInningsBowlers(singleInnings \ "bowling" \ "bowler"),
-          parseInningsWickets(singleInnings \ "fallenWicket"),
-          getStatistic(singleInnings, "extra-byes").toInt,
-          getStatistic(singleInnings, "extra-leg-byes").toInt,
-          getStatistic(singleInnings, "extra-no-balls").toInt,
-          getStatistic(singleInnings, "extra-penalties").toInt,
-          getStatistic(singleInnings, "extra-wides").toInt,
-          getStatistic(singleInnings, "extra-total").toInt,
+          order = inningsOrder,
+          battingTeam = battingTeam,
+          runsScored = getStatistic(singleInnings, "runs-scored").toInt,
+          wickets = getStatistic(singleInnings, "wickets").toInt,
+          overs = getStatistic(singleInnings, "overs"),
+          declared = getStatistic(singleInnings, "declared") == "true",
+          forfeited = getStatistic(singleInnings, "forefeited") == "true",
+          description = inningsDescription(inningsOrder, battingTeam),
+          batters = parseInningsBatters(singleInnings \ "batting" \ "batter"),
+          bowlers = parseInningsBowlers(singleInnings \ "bowling" \ "bowler"),
+          fallOfWicket = parseInningsWickets(singleInnings \ "fallenWicket"),
+          byes = getStatistic(singleInnings, "extra-byes").toInt,
+          legByes = getStatistic(singleInnings, "extra-leg-byes").toInt,
+          noBalls = getStatistic(singleInnings, "extra-no-balls").toInt,
+          penalties = getStatistic(singleInnings, "extra-penalties").toInt,
+          wides = getStatistic(singleInnings, "extra-wides").toInt,
+          extras = getStatistic(singleInnings, "extra-total").toInt,
         )
       }
       .toList

--- a/sport/app/cricket/implicits/Cricket.scala
+++ b/sport/app/cricket/implicits/Cricket.scala
@@ -1,0 +1,20 @@
+package cricket.implicits
+
+import model.ContentType
+import scala.language.implicitConversions
+
+object Cricket {
+  implicit class ContentHelper(c: ContentType) {
+    lazy val matchReport = c.tags.tags.exists(_.id == "tone/matchreports")
+
+    lazy val isLiveCricket =
+      c.tags.tags.exists(_.id == "tone/minutebyminute") && c.tags.tags.exists(
+        _.id == "sport/over-by-over-reports",
+      ) && c.isLiveBlogType
+
+    lazy val isArticleType = c.metadata.contentType.exists(_.name == "Article")
+    lazy val isLiveBlogType = c.metadata.contentType.exists(_.name == "LiveBlog")
+
+    def isPage(currentPage: String): Boolean = c.metadata.id == currentPage
+  }
+}

--- a/sport/app/cricket/implicits/Cricket.scala
+++ b/sport/app/cricket/implicits/Cricket.scala
@@ -7,7 +7,7 @@ import scala.language.implicitConversions
 
 object Cricket {
   implicit class ContentHelper(c: ContentType) {
-    lazy val matchReport = c.tags.tags.exists(_.id == "tone/matchreports")
+    lazy val isMatchReport = c.tags.tags.exists(_.id == "tone/matchreports")
 
     lazy val isLiveCricket =
       c.tags.tags.exists(_.id == "tone/minutebyminute") && c.tags.tags.exists(

--- a/sport/app/cricket/implicits/Cricket.scala
+++ b/sport/app/cricket/implicits/Cricket.scala
@@ -1,5 +1,7 @@
 package cricket.implicits
 
+import com.github.nscala_time.time.Imports.DateTimeZone
+import football.datetime.DateHelpers
 import model.ContentType
 import scala.language.implicitConversions
 
@@ -14,6 +16,9 @@ object Cricket {
 
     lazy val isArticleType = c.metadata.contentType.exists(_.name == "Article")
     lazy val isLiveBlogType = c.metadata.contentType.exists(_.name == "LiveBlog")
+
+    lazy val webPublicationDate =
+      DateHelpers.asZonedDateTime(c.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")))
 
     def isPage(currentPage: String): Boolean = c.metadata.id == currentPage
   }

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -13,7 +13,7 @@ GET        /football/wallchart/:competitionTag                                  
 GET        /sport/cricket/match/:matchDate/:teamId.json                                        cricket.controllers.CricketMatchController.renderMatchIdJson(matchDate, teamId)
 GET        /sport/cricket/match/:matchDate/:teamId                                             cricket.controllers.CricketMatchController.renderMatchId(matchDate, teamId)
 GET        /sport/cricket/match-scoreboard/:matchDate/:teamId.json                             cricket.controllers.CricketMatchController.renderMatchScoreboardJson(matchDate, teamId)
-GET        /sport/cricket/api/match-header/:matchDate/:teamId.json                              cricket.controllers.CricketMatchController.matchHeaderJson(matchDate, teamId)
+GET        /sport/cricket/match-header/:matchDate/:teamId.json                              cricket.controllers.CricketMatchController.matchHeaderJson(matchDate, teamId)
 
 GET        /football/fixtures/more/:year/:month/:day.json                                      football.controllers.FixturesController.moreFixturesForJson(year, month, day)
 GET        /football/fixtures/:year/:month/:day.json                                           football.controllers.FixturesController.allFixturesForJson(year, month, day)

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -13,6 +13,7 @@ GET        /football/wallchart/:competitionTag                                  
 GET        /sport/cricket/match/:matchDate/:teamId.json                                        cricket.controllers.CricketMatchController.renderMatchIdJson(matchDate, teamId)
 GET        /sport/cricket/match/:matchDate/:teamId                                             cricket.controllers.CricketMatchController.renderMatchId(matchDate, teamId)
 GET        /sport/cricket/match-scoreboard/:matchDate/:teamId.json                             cricket.controllers.CricketMatchController.renderMatchScoreboardJson(matchDate, teamId)
+GET        /sport/cricket/api/match-header/:matchDate/:teamId.json                              cricket.controllers.CricketMatchController.matchHeaderJson(matchDate, teamId)
 
 GET        /football/fixtures/more/:year/:month/:day.json                                      football.controllers.FixturesController.moreFixturesForJson(year, month, day)
 GET        /football/fixtures/:year/:month/:day.json                                           football.controllers.FixturesController.allFixturesForJson(year, month, day)


### PR DESCRIPTION
## What does this change?
This PR adds a new endpoint in sport api `/sport/cricket/match-header/:matchDate/:teamId.json` which will be used for the header section of the cricket match pages (match info, live feed & match report)

For this new endpoint to work, we need to add the new route in the nginx setup. This was done in https://github.com/guardian/platform/pull/2243


### Changes: 
- Added **matchHeaderUrl** field to the Cricket blogs & reports 
This is only added if the cricket team tags that we support exist in the article. 
matchUrl was already being added to the live blogs, this field will be deperecated after we complete the redesign for the cricket match pages. In this change, to avoid , complexity the matchUrl is also added to the Cricket reports, but this is not going to cause any issue client side, since the Standard layout won't use the matchUrl for cricket reports. 

- For matchHeaderUrl, the publication date and the team tag is used, and also a page parameter is provided to inform the endpoint what's the current page that's needing the header. 
This is because if the love blog requests header, header shouldn't give any other live blog url, also the same for reports. 

- The new endpoint `/sport/cricket/match-header/:matchDate/:teamId.json` queries CAPI based on the team tag and also the provided date. 
Then there's a filtering on the capi response to choose the right live blog and report urls. 

Fixes part of https://github.com/guardian/dotcom-rendering/issues/15978