### PR TITLE
Add illustration square to newsletter response model

### DIFF
--- a/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
@@ -119,6 +119,7 @@ object DotcomNewslettersPageRenderingDataModel {
       response.mailSuccessDescription.getOrElse("You are subscribed"),
       response.regionFocus,
       response.illustrationCard,
+      response.illustrationSquare,
     )
   }
 }

--- a/common/app/services/NewsletterService.scala
+++ b/common/app/services/NewsletterService.scala
@@ -20,6 +20,7 @@ case class NewsletterData(
     successDescription: String,
     regionFocus: Option[String],
     illustrationCard: Option[String],
+    illustrationSquare: Option[String],
 )
 
 object NewsletterData {
@@ -81,6 +82,7 @@ class NewsletterService(newsletterSignupAgent: NewsletterSignupAgent) {
       response.mailSuccessDescription.getOrElse("You are subscribed"),
       response.regionFocus,
       response.illustrationCard,
+      response.illustrationSquare,
     )
   }
 

--- a/common/app/services/newsletters/model/NewsletterResponse.scala
+++ b/common/app/services/newsletters/model/NewsletterResponse.scala
@@ -49,6 +49,7 @@ case class NewsletterResponseV2(
     regionFocus: Option[String], // edition Id
     illustrationCard: Option[String],
     illustrationCircle: Option[String],
+    illustrationSquare: Option[String],
     seriesTag: Option[String],
     signupPage: Option[String],
     exampleUrl: Option[String],


### PR DESCRIPTION
## What is the value of this and can you measure success?

Enables the square newsletter illustration to be displayed on the newsletter sign up card

## What does this change?

adds illustrationSquare to the newsletter data - this is a field that is already in the newsletters tool

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
