### PR TITLE
Fix sorting of World Cup groups

### DIFF
--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -30,7 +30,7 @@ class CompetitionStage(competitions: Seq[Competition]) {
     sortedStagesWithMatches.flatMap { case (stage, stageMatches) =>
       // work out stage type
       val stageLeagueEntries = competition.leagueTable.filter(_.stageNumber == stage.stageNumber)
-      val rounds = stageMatches.map(_.round).distinct.sortBy(_.roundNumber)
+      val rounds = stageMatches.map(_.round).distinct.sortBy(_.roundNumber.toIntOption.getOrElse(0))
       if (stageLeagueEntries.isEmpty) {
         if (rounds.size > 1) {
           orderings.get(competition.id) match {
@@ -54,7 +54,7 @@ class CompetitionStage(competitions: Seq[Competition]) {
       } else {
         if (rounds.size > 1) {
           // multiple rounds and league table entries is a group stage
-          val groupTables = stageLeagueEntries.groupBy(_.round).toList.sortBy(_._1.roundNumber)
+          val groupTables = stageLeagueEntries.groupBy(_.round).toList.sortBy(_._1.roundNumber.toIntOption.getOrElse(0))
           Some(Groups(competitions, stageMatches, groupTables))
         } else if (rounds.size == 1) {
           // single round with table is league


### PR DESCRIPTION
## What is the value of this and can you measure success?

Fixes sorting of World Cup groups so they appear in the correct order on the [overview page](https://www.theguardian.com/football/world-cup-2026/overview). The incorrect ordering also affects the individual football atoms which fetch markup from the [group embed endpoint](https://www.theguardian.com/football/world-cup-2026/groups/individual/embed/a) and rely on the ordering of the groups to display the correct data. (ie. Group A should be in position 1, Group B in position 2 etc.)

## What does this change?

We use the `roundNumber` field from the PA data to sort the groups. However, this is currently being sorted as a string rather than an integer. This hasn't been an issue in previous competitions where there have been fewer than 10 rounds. Due to the 2026 World Cup's expanded lineup there are now 12 group stage rounds. Sorting as a string results in rounds being shown in the wrong order. ie. 1 (A), 10 (J), 11 (K), 12 (L), 2 (B), 3 (C) etc.

Converting `roundNumber` to an integer before sorting ensures the rounds are sorted into the correct order.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/0b1e051c-c245-42b7-b71a-893a66cb9390
[after]: https://github.com/user-attachments/assets/7e8b6e36-fd3d-4ca0-9aea-90255babbb56