### PR TITLE
Bump CAPI & FAPI to include new media atom fields

### DIFF
--- a/common/app/model/content/Atom.scala
+++ b/common/app/model/content/Atom.scala
@@ -212,6 +212,8 @@ final case class MediaAsset(
     assetType: MediaAssetType,
     dimensions: Option[AssetDimensions],
     aspectRatio: Option[String],
+    duration: Option[Long],
+    hasAudio: Option[Boolean],
 )
 
 sealed trait VideoPlayerFormat extends EnumEntry
@@ -314,6 +316,8 @@ object MediaAtom extends common.GuLogging {
       assetType = MediaAssetType.withName(mediaAsset.assetType.name),
       dimensions = mediaAsset.dimensions.map(dim => AssetDimensions(dim.width, dim.height)),
       aspectRatio = mediaAsset.aspectRatio,
+      duration = mediaAsset.duration,
+      hasAudio = mediaAsset.hasAudio,
     )
   }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -459,12 +459,21 @@ case class MediaAtomBlockElementMediaAsset(
     mimeType: Option[String],
     dimensions: Option[AssetDimensions],
     aspectRatio: Option[String],
+    duration: Option[Long],
+    hasAudio: Option[Boolean],
 )
 object MediaAtomBlockElementMediaAsset {
   implicit val MediaAtomBlockElementMediaAssetWrites: Writes[MediaAtomBlockElementMediaAsset] =
     Json.writes[MediaAtomBlockElementMediaAsset]
   def fromMediaAsset(asset: MediaAsset): MediaAtomBlockElementMediaAsset = {
-    MediaAtomBlockElementMediaAsset(asset.id, asset.mimeType, asset.dimensions, asset.aspectRatio)
+    MediaAtomBlockElementMediaAsset(
+      asset.id,
+      asset.mimeType,
+      asset.dimensions,
+      asset.aspectRatio,
+      asset.duration,
+      asset.hasAudio,
+    )
   }
 }
 case class MediaAtomBlockElement(

--- a/common/test/views/fragments/atoms/YoutubeSpec.scala
+++ b/common/test/views/fragments/atoms/YoutubeSpec.scala
@@ -23,6 +23,8 @@ class YoutubeSpec extends MixedPlaySpec {
             assetType = Video,
             dimensions = None,
             aspectRatio = None,
+            duration = None,
+            hasAudio = None,
           ),
         ),
         title = "",

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -36,6 +36,8 @@ class AtomCleanerTest extends AnyFlatSpec with Matchers with WithTestApplication
       assetType = Video,
       dimensions = None,
       aspectRatio = None,
+      duration = None,
+      hasAudio = None,
     )
 
   val youTubeAtom = Some(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.42.19"
-  val capiVersion = "41.1.1"
-  val faciaVersion = "29.0.0"
+  val capiVersion = "42.0.1"
+  val faciaVersion = "30.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -29,7 +29,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.21.0"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "37.0.0"
+  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "38.0.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 


### PR DESCRIPTION
## What does this change?
Bumps CAPI and FAPI versions. This allows frontend to access the new asset fields duration and hasAudio.

## How to test
1. Deploy this branch to `dotcom:frontend-all` CODE 
2. Create or find a collection on a front that has a videos with and without audio (eg https://m.code.dev-theguardian.com/anna)
3. Hit the json endpoint for front containing your collection to see the frontend json response (eg https://m.code.dev-theguardian.com/uk.json?dcr)
4. Validate that the atoms added in step 2 are showing the correct `hasAudio` field

## Screenshots

<img width="641" height="813" alt="Screenshot 2026-04-27 at 12 57 12" src="https://github.com/user-attachments/assets/b3fba946-179a-42f6-aec7-6d75d70f4eb3" />


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
