### PR TITLE
Add aspect ratio to media asset images

### DIFF
--- a/common/app/model/content/Atom.scala
+++ b/common/app/model/content/Atom.scala
@@ -327,6 +327,7 @@ object MediaAtom extends common.GuLogging {
         "width" -> mediaImage.dimensions.map(_.width).map(_.toString),
         "caption" -> Some(caption),
         "altText" -> Some(caption),
+        "aspectRatio" -> mediaImage.aspectRatio,
       ).collect { case (k, Some(v)) => (k, v) },
     )
   }


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows DCR to include the aspect ratio of a poster image in a Fastly request to obtain an optimised image. Useful for self-hosted video.

## What does this change?

Add aspect ratio to media asset images.

## Screenshots
<img width="1418" height="822" alt="Screenshot 2026-04-30 at 17 04 57" src="https://github.com/user-attachments/assets/fc4473b0-3b0d-4329-a227-5f5e37def9f6" />


## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)