### PR TITLE
Customise atom placement in live harnesses

### DIFF
--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -5,6 +5,7 @@ import model.content.InteractiveAtom
 import model.meta.BlocksOn
 import model.{ArticlePage, Content, ContentPage, InteractivePage}
 import play.api.libs.json.{Json, Reads}
+import scala.xml.XML
 
 case class LiveHarnessInteractiveAtom(
     id: String,
@@ -51,7 +52,10 @@ object LiveHarness {
   implicit val iu: PageUpdater[InteractivePage] = (ip, nc) => ip.copy(interactive = ip.item.copy(content = nc))
   implicit val au: PageUpdater[ArticlePage] = (ap, nc) => ap.copy(article = ap.item.copy(content = nc))
 
-  private val tagPattern = """(?s)(<\w[^>]*>.*?</\w+>)""".r
+  private def splitIntoTags(html: String): List[String] = {
+    val xml = XML.loadString(s"<root>$html</root>")
+    xml.child.toList.map(_.toString).filter(_.trim.nonEmpty)
+  }
 
   def inject[P <: ContentPage](harnessAtoms: Seq[LiveHarnessInteractiveAtom])(implicit
       updater: PageUpdater[P],
@@ -68,7 +72,7 @@ object LiveHarness {
           // Each unit is Either[String (text chunk), BlockElement (non-text)]
           val visualUnits: List[Either[String, BlockElement]] = block.elements.toList.flatMap {
             case el if el.`type` == ElementType.Text =>
-              tagPattern.findAllIn(el.textTypeData.flatMap(_.html).getOrElse("")).toList.map(Left(_))
+              splitIntoTags(el.textTypeData.flatMap(_.html).getOrElse("")).map(Left(_))
             case el =>
               List(Right(el))
           }
@@ -81,22 +85,17 @@ object LiveHarness {
           }
 
           // Repack: merge adjacent text chunks back into Text BlockElements
-          val repacked: List[BlockElement] = withAtoms.foldRight(List.empty[BlockElement]) { (unit, acc) =>
-            unit match {
-              case Left(chunk) =>
-                acc match {
-                  case head :: tail if head.`type` == ElementType.Text =>
-                    val existingHtml = head.textTypeData.flatMap(_.html).getOrElse("")
-                    head.copy(textTypeData = Some(TextElementFields(html = Some(chunk + "\n" + existingHtml)))) :: tail
-                  case _ =>
-                    BlockElement(
-                      `type` = ElementType.Text,
-                      assets = Seq.empty,
-                      textTypeData = Some(TextElementFields(html = Some(chunk))),
-                    ) :: acc
-                }
-              case Right(el) => el :: acc
-            }
+          val repacked: List[BlockElement] = withAtoms.foldRight(List.empty[BlockElement]) {
+            case (Left(chunk), head :: tail) if head.`type` == ElementType.Text =>
+              val existingHtml = head.textTypeData.flatMap(_.html).getOrElse("")
+              head.copy(textTypeData = Some(TextElementFields(html = Some(chunk + "\n" + existingHtml)))) :: tail
+            case (Left(chunk), acc) =>
+              BlockElement(
+                `type` = ElementType.Text,
+                assets = Seq.empty,
+                textTypeData = Some(TextElementFields(html = Some(chunk))),
+              ) :: acc
+            case (Right(el), acc) => el :: acc
           }
 
           block.copy(elements = repacked.toIndexedSeq)

--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -1,6 +1,6 @@
 package utils
 
-import com.gu.contentapi.client.model.v1.{BlockElement, ContentAtomElementFields, ElementType}
+import com.gu.contentapi.client.model.v1.{BlockElement, ContentAtomElementFields, ElementType, TextElementFields}
 import model.content.InteractiveAtom
 import model.meta.BlocksOn
 import model.{ArticlePage, Content, ContentPage, InteractivePage}
@@ -13,6 +13,7 @@ case class LiveHarnessInteractiveAtom(
     html: String,
     js: String,
     weighting: String,
+    position: Option[Int] = None, // 1-based visual index; defaults to 1 (before everything)
 ) {
   val atom = InteractiveAtom(
     id = id,
@@ -50,6 +51,8 @@ object LiveHarness {
   implicit val iu: PageUpdater[InteractivePage] = (ip, nc) => ip.copy(interactive = ip.item.copy(content = nc))
   implicit val au: PageUpdater[ArticlePage] = (ap, nc) => ap.copy(article = ap.item.copy(content = nc))
 
+  private val tagPattern = """(?s)(<\w[^>]*>.*?</\w+>)""".r
+
   def inject[P <: ContentPage](harnessAtoms: Seq[LiveHarnessInteractiveAtom])(implicit
       updater: PageUpdater[P],
   ): BlocksOn[P] => BlocksOn[P] = _.mapBoth(
@@ -59,10 +62,45 @@ object LiveHarness {
     },
     blocks =>
       blocks.copy(body = blocks.body.map { bodyBlocks =>
-        val (headBlockOpt, tailBlocks) = bodyBlocks.splitAt(1)
-        headBlockOpt.map { headBlock =>
-          headBlock.copy(elements = harnessAtoms.map(_.blockElement) ++ headBlock.elements)
-        } ++ tailBlocks
+        bodyBlocks.map { block =>
+          // Flatten elements into visual units: Text elements are split into
+          // individual tags, all other elements count as one unit each.
+          // Each unit is Either[String (text chunk), BlockElement (non-text)]
+          val visualUnits: List[Either[String, BlockElement]] = block.elements.toList.flatMap {
+            case el if el.`type` == ElementType.Text =>
+              tagPattern.findAllIn(el.textTypeData.flatMap(_.html).getOrElse("")).toList.map(Left(_))
+            case el =>
+              List(Right(el))
+          }
+
+          // Insert each harness atom at its requested visual position
+          val withAtoms = harnessAtoms.foldLeft(visualUnits) { (units, harnessAtom) =>
+            val insertAt = (harnessAtom.position.getOrElse(1) - 1).max(0).min(units.length)
+            val (before, after) = units.splitAt(insertAt)
+            before ::: List(Right(harnessAtom.blockElement)) ::: after
+          }
+
+          // Repack: merge adjacent text chunks back into Text BlockElements
+          val repacked: List[BlockElement] = withAtoms.foldRight(List.empty[BlockElement]) { (unit, acc) =>
+            unit match {
+              case Left(chunk) =>
+                acc match {
+                  case head :: tail if head.`type` == ElementType.Text =>
+                    val existingHtml = head.textTypeData.flatMap(_.html).getOrElse("")
+                    head.copy(textTypeData = Some(TextElementFields(html = Some(chunk + "\n" + existingHtml)))) :: tail
+                  case _ =>
+                    BlockElement(
+                      `type` = ElementType.Text,
+                      assets = Seq.empty,
+                      textTypeData = Some(TextElementFields(html = Some(chunk))),
+                    ) :: acc
+                }
+              case Right(el) => el :: acc
+            }
+          }
+
+          block.copy(elements = repacked.toIndexedSeq)
+        }
       }),
   )
 }

--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -52,11 +52,6 @@ object LiveHarness {
   implicit val iu: PageUpdater[InteractivePage] = (ip, nc) => ip.copy(interactive = ip.item.copy(content = nc))
   implicit val au: PageUpdater[ArticlePage] = (ap, nc) => ap.copy(article = ap.item.copy(content = nc))
 
-  private def splitIntoTags(html: String): List[String] = {
-    val xml = XML.loadString(s"<root>$html</root>")
-    xml.child.toList.map(_.toString).filter(_.trim.nonEmpty)
-  }
-
   def inject[P <: ContentPage](harnessAtoms: Seq[LiveHarnessInteractiveAtom])(implicit
       updater: PageUpdater[P],
   ): BlocksOn[P] => BlocksOn[P] = _.mapBoth(
@@ -67,39 +62,51 @@ object LiveHarness {
     blocks =>
       blocks.copy(body = blocks.body.map { bodyBlocks =>
         bodyBlocks.map { block =>
-          // Flatten elements into visual units: Text elements are split into
-          // individual tags, all other elements count as one unit each.
-          // Each unit is Either[String (text chunk), BlockElement (non-text)]
-          val visualUnits: List[Either[String, BlockElement]] = block.elements.toList.flatMap {
-            case el if el.`type` == ElementType.Text =>
-              splitIntoTags(el.textTypeData.flatMap(_.html).getOrElse("")).map(Left(_))
-            case el =>
-              List(Right(el))
-          }
-
-          // Insert each harness atom at its requested visual position
-          val withAtoms = harnessAtoms.foldLeft(visualUnits) { (units, harnessAtom) =>
-            val insertAt = (harnessAtom.position.getOrElse(1) - 1).max(0).min(units.length)
-            val (before, after) = units.splitAt(insertAt)
-            before ::: List(Right(harnessAtom.blockElement)) ::: after
-          }
-
-          // Repack: merge adjacent text chunks back into Text BlockElements
-          val repacked: List[BlockElement] = withAtoms.foldRight(List.empty[BlockElement]) {
-            case (Left(chunk), head :: tail) if head.`type` == ElementType.Text =>
-              val existingHtml = head.textTypeData.flatMap(_.html).getOrElse("")
-              head.copy(textTypeData = Some(TextElementFields(html = Some(chunk + "\n" + existingHtml)))) :: tail
-            case (Left(chunk), acc) =>
-              BlockElement(
-                `type` = ElementType.Text,
-                assets = Seq.empty,
-                textTypeData = Some(TextElementFields(html = Some(chunk))),
-              ) :: acc
-            case (Right(el), acc) => el :: acc
-          }
-
-          block.copy(elements = repacked.toIndexedSeq)
+          block.copy(elements = insertAtomsAtNthPoints(block.elements.toSeq, harnessAtoms))
         }
       }),
   )
+
+  private[utils] def splitIntoTags(html: String): List[String] = {
+    val xml = XML.loadString(s"<root>$html</root>")
+    xml.child.toList.map(_.toString).filter(_.trim.nonEmpty)
+  }
+
+  private[utils] def insertAtomsAtNthPoints(
+      elements: Seq[BlockElement],
+      harnessAtoms: Seq[LiveHarnessInteractiveAtom],
+  ) = {
+    // Flatten elements into visual units: Text elements are split into
+    // individual tags, all other elements count as one unit each.
+    // Each unit is Either[String (text chunk), BlockElement (non-text)]
+    val visualUnits: List[Either[String, BlockElement]] = elements.toList.flatMap {
+      case el if el.`type` == ElementType.Text =>
+        splitIntoTags(el.textTypeData.flatMap(_.html).getOrElse("")).map(Left(_))
+      case el =>
+        List(Right(el))
+    }
+
+    // Insert each harness atom at its requested visual position
+    val withAtoms = harnessAtoms.foldLeft(visualUnits) { (units, harnessAtom) =>
+      val insertAt = (harnessAtom.position.getOrElse(1) - 1).max(0).min(units.length)
+      val (before, after) = units.splitAt(insertAt)
+      before ::: List(Right(harnessAtom.blockElement)) ::: after
+    }
+
+    // Repack: merge adjacent text chunks back into Text BlockElements
+    val repacked: List[BlockElement] = withAtoms.foldRight(List.empty[BlockElement]) {
+      case (Left(chunk), head :: tail) if head.`type` == ElementType.Text =>
+        val existingHtml = head.textTypeData.flatMap(_.html).getOrElse("")
+        head.copy(textTypeData = Some(TextElementFields(html = Some(chunk + "\n" + existingHtml)))) :: tail
+      case (Left(chunk), acc) =>
+        BlockElement(
+          `type` = ElementType.Text,
+          assets = Seq.empty,
+          textTypeData = Some(TextElementFields(html = Some(chunk))),
+        ) :: acc
+      case (Right(el), acc) => el :: acc
+    }
+
+    repacked.toIndexedSeq
+  }
 }

--- a/preview/test/utils/LiveHarnessTest.scala
+++ b/preview/test/utils/LiveHarnessTest.scala
@@ -1,0 +1,56 @@
+package utils
+
+import com.gu.contentapi.client.model.v1.{BlockElement, ElementType, TextElementFields}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LiveHarnessTest extends AnyFlatSpec with Matchers {
+
+  "insertAtomsAtNthPoints" should "place atoms at the appropriate positions in the body" in {
+    val elements = Seq(
+      BlockElement(
+        `type` = ElementType.Text,
+        textTypeData = Some(TextElementFields(html = Some("<p>First</p><p>Second</p><h2>A heading</h2>"))),
+      ),
+    )
+    val liveHarnessAtom =
+      LiveHarnessInteractiveAtom(
+        id = "/interactive/my-atom",
+        title = "My Atom",
+        css = "p { color: red };",
+        html = "<div><h1>Hello, world!</h1><p>I am an interactive atom.</p></div>",
+        js = "",
+        weighting = "inline",
+        position = Some(2),
+      )
+    LiveHarness.insertAtomsAtNthPoints(elements, Seq(liveHarnessAtom)) shouldEqual IndexedSeq(
+      BlockElement(
+        `type` = ElementType.Text,
+        textTypeData = Some(TextElementFields(html = Some("<p>First</p>"))),
+      ),
+      liveHarnessAtom.blockElement,
+      BlockElement(
+        `type` = ElementType.Text,
+        textTypeData = Some(TextElementFields(html = Some("<p>Second</p>\n<h2>A heading</h2>"))),
+      ),
+    )
+  }
+
+  "splitIntoTags" should "split a multi-paragraph html blob into individual tags" in {
+    val html = "<p>First</p>\n<p>Second</p>\n<h2>A heading</h2>"
+    LiveHarness.splitIntoTags(html) shouldEqual List(
+      "<p>First</p>",
+      "<p>Second</p>",
+      "<h2>A heading</h2>",
+    )
+  }
+
+  it should "filter out whitespace-only nodes" in {
+    val html = "<p>First</p>\n\n   \n<p>Second</p>"
+    LiveHarness.splitIntoTags(html) should have length 2
+  }
+
+  it should "handle an empty string" in {
+    LiveHarness.splitIntoTags("") shouldEqual List.empty
+  }
+}


### PR DESCRIPTION
The goal: Allow interactive devs to control where their interactive atoms sit in the live harness. At the moment they're put at the start by default.

With this change if the local dev config includes a `position` value, the atom will be placed in that spot of the body. A bit like this:

<img width="673" height="867" alt="image" src="https://github.com/user-attachments/assets/7b8ff649-f653-4ff2-a2d7-6efa12b8e64c" />

If there is no position set the live harness just puts it at the start.

The rub: This was tricky to implement. Content blocks aren't structured as you (read: I) might expect. Rather than being an array of paragraphs, headings, figures, etc., sometimes they're nested. E.g.:

```
Block[0] id=6762e8d28f081f8d963d524a elements=5
    [0] Text | <p>Donald Trump will come in to power with a “trifecta” of governmental control after his Republican party won the House of Representatives, the Senate and the presidency in the 2024 US election.</p> 
<p>Control of both chambers of Congress is not uncommon for US presidents. Trump achieved a trifecta in his first term, as did Joe Biden, Barack Obama and Bill Clinton.</p> 
<p>But Trump has an unusual edge over his predecessors: six of the nine members of the US supreme court are appointees of Republican presidents.</p> 
<p>Since the second world war, only two other presidents have assumed office with overall control of both houses as well as a supreme court “super majority” of two-thirds or more.</p> 
<p>Supreme court justices owe no official loyalty to a party or president, but a majority of conservative-leaning justices will work to Trump’s advantage.</p> 
<p>Here’s how these government majorities compare historically. Use the “Show party distributions” checkbox to reveal the exact proportions of control.</p>
    [1] Contentatom | -
    [2] Text | <h2>What will be the impact of the supreme court’s conservative majority?</h2> 
<p>William Galston, the Ezra K Zilkha chair in governance studies at the Brookings Institution, said: “On the face of it, the president-elect will enjoy substantial freedom of action despite a very narrow majority in the House of Representatives.”</p> 
<p>But, he added: “In the past, many presidents have made the mistake of assuming that the supreme court is on their side.”</p> 
<p>Earlier in the 20th century, Scotus appointments tended to be somewhat less partisan. For example, Dwight D Eisenhower, a Republican, appointed justices who would go on to lead a liberal era on the court. “I have made two mistakes, and they are both sitting on the supreme court,” he purportedly said after his presidency.</p> 
<p>Also in 1952, at a time when all nine supreme court justices were appointed by Democratic presidents, Democrat Harry Truman was blindsided by a ruling that called his attempt to commandeer the US steel industry unconstitutional.</p> 
<p>Several rulings on the rights of prisoners during Republican George W Bush’s war on terror also imposed limits on presidential authority, such as <a href="https://www.theguardian.com/world/2004/jun/29/guantanamo.politics">Rasul v Bush and Hamdi v Rumsfeld</a>.</p> 
<p>However in recent years experts have warned of an increasingly partisan supreme court. Data from the supreme court database reveals a 50-point gap between Republican and Democratic appointees in how often they voted for liberal results in 2023. In 2004, this was 25 points, and in 1984 it was 13 points.</p>
    [3] Interactive | -
    [4] Text | <p>“This supreme court is further to the right than anything seen before,” said Galston.</p> 
<p>Recent landmark rulings on abortion rights, expanding second amendment rights and presidential immunity were all ideologically divided: six conservative justices voting one way; three liberal justices voting the other.</p> 
<p>The supreme court’s decision on presidential immunity also highlights its attitude towards the scope of the president’s executive powers.</p> 
<p>“We already know the current majority holds a very expansive view of executive authority. With this ruling, one wonders what fences the supreme court could put up against assertions of executive power,” said Ed Fallone, a professor at Marquette University Law School in Wisconsin.</p> 
<h2>How might the balance of power change?</h2> 
<p>Trump’s use of these extraordinary executive freedoms will face their first public judgment in the 2026 midterm elections.</p> 
<p>Recent history shows that presidents typically lose at least some control over government in the midterms. Of the last five presidents, all but George W Bush lost one or both branches of Congress to the opposition in their first midterms.</p> 
<p>It remains to be seen whether Trump will buck this trend, but his ambitious and controversial agenda, and an already tenuous majority in the House, will be factors when the elections come.</p> 
<p>In the supreme court, if any of the current justices retire in the next few years, Trump will get to appoint their replacement.</p> 
<p>He will be able to preserve the conservative super majority if he is able to replace the two oldest Republican appointees: Samuel Alito, who is 76, or Clarence Thomas, 74.</p> 
<p>Sonia Sotomayor, 70, is the oldest of the liberal bloc. Her retirement would let Trump further boost the super majority to seven out of nine.</p>
```
To my mind the intuitive experience here would be to set position to 2 and expect the atom to appear after the first paragraph, so that's what I've tried to provide. It feels a little gnarly but given it's inside the live harness bubble it feels fairly low stakes.