### PR TITLE
Use empty string instead of false for empty thumbnail value 

### DIFF
--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -117,7 +117,7 @@ final case class Trail(
   def javascriptConfig: Map[String, JsValue] =
     Map(
       ("sectionName", JsString(sectionName)),
-      ("thumbnail", thumbnailPath.map(JsString.apply).getOrElse(JsBoolean(false))),
+      ("thumbnail", JsString(thumbnailPath.getOrElse(""))),
       ("isLive", JsBoolean(fields.isLive)),
       ("webPublicationDate", Json.toJson(webPublicationDate)),
       ("headline", JsString(headline)),


### PR DESCRIPTION
## What is the value of this and can you measure success?

The DCR PR https://github.com/guardian/dotcom-rendering/pull/15767 had to be rolled back due to errors in PROD. 

The errors looked like the following, because the DCR schema was updated to specify _all_ frontend fields being sent to DCR, which included setting the thumbnail as a string type. 

```
TypeError: Unable to validate request body for url <URL>
[ 
  { 
    "instancePath": "/config/thumbnail", 
    "schemaPath": "#/properties/thumbnail/type", 
    "keyword": "type", 
    "params": { "type": "string" }, 
    "message": "must be string" 
  } 
] at validateAsFEArticle (/home/dotcom-rendering/article-rendering/dist/server.js:127337:1199)
```

When a thumbnail is missing for a piece of content, it is instead represented by the boolean value `false` which fails the validation

## What does this change?

Instead of representing empty values of thumbnail as `false`, this uses empty string to represent it instead


## Screenshots

| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |

[before]:https://github.com/user-attachments/assets/310eb6e5-47af-4d8f-ac0a-ef4e094ea463
[after]:https://github.com/user-attachments/assets/1c6f4ad0-7833-4894-ba69-a2c627ec11b5

