### PR TITLE
Test wc subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -143,6 +143,25 @@ object NavLinks {
       footballClubs,
     ),
   )
+
+  val matchCentre = NavLink("Match centre", "")
+  val playerGuide = NavLink("Player guide", "")
+  val bracketology = NavLink("Bracketology", "")
+  val goldenBoot = NavLink("Golden boot", "")
+  val moreFootball = NavLink("More football", "")
+
+  val worldCup2026 = NavLink(
+    "World Cup",
+    "/football/world-cup-2026",
+    children = List(
+      matchCentre,
+      playerGuide,
+      bracketology,
+      goldenBoot,
+      moreFootball,
+    ),
+  )
+
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
   val rugbyUnion = NavLink("Rugby union", "/sport/rugby-union")
@@ -418,6 +437,7 @@ object NavLinks {
     iconName = Some("home"),
     List(
       football,
+      worldCup2026,
       cricket,
       rugbyUnion,
       tennis,


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
