### PR TITLE
Add world cup 2026 to navbar

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -116,8 +116,8 @@ object NavLinks {
   private val footballResults = NavLink("Results", "/football/results", Some("football/results"))
   private val footballCompetitions = NavLink("Competitions", "/football/competitions", Some("football/competitions"))
   private val footballClubs = NavLink("Clubs", "/football/teams", Some("football/teams"))
-
   private val soccerSchedules = footballFixtures.copy(title = "Schedules")
+  private val footballWorldCup2026 = NavLink("World Cup 2026", "/football/world-cup-2026")
 
   val football = NavLink(
     "Football",
@@ -127,6 +127,7 @@ object NavLinks {
       footballTables,
       footballFixtures,
       footballResults,
+      footballWorldCup2026,
       footballCompetitions,
       footballClubs,
     ),
@@ -139,6 +140,7 @@ object NavLinks {
       footballTables,
       soccerSchedules,
       footballResults,
+      footballWorldCup2026,
       footballCompetitions,
       footballClubs,
     ),
@@ -432,6 +434,7 @@ object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
+      footballWorldCup2026,
       football,
       AFL,
       NRL,
@@ -445,6 +448,7 @@ object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
+      footballWorldCup2026,
       usSoccer,
       NFL,
       tennis,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -208,6 +208,12 @@
 							"classList": []
 						},
 						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Competitions",
 							"url": "/football/competitions",
 							"longTitle": "football/competitions",
@@ -448,6 +454,12 @@
 							"title": "Results",
 							"url": "/football/results",
 							"longTitle": "football/results",
+							"children": [],
+							"classList": []
+						},
+						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
 							"children": [],
 							"classList": []
 						},
@@ -1089,6 +1101,12 @@
 							"classList": []
 						},
 						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Competitions",
 							"url": "/football/competitions",
 							"longTitle": "football/competitions",
@@ -1252,6 +1270,12 @@
 			"iconName": "home",
 			"children": [
 				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Soccer",
 					"url": "/us/soccer",
 					"children": [
@@ -1280,6 +1304,12 @@
 							"title": "Results",
 							"url": "/football/results",
 							"longTitle": "football/results",
+							"children": [],
+							"classList": []
+						},
+						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
 							"children": [],
 							"classList": []
 						},
@@ -1994,6 +2024,12 @@
 			"iconName": "home",
 			"children": [
 				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -2022,6 +2058,12 @@
 							"title": "Results",
 							"url": "/football/results",
 							"longTitle": "football/results",
+							"children": [],
+							"classList": []
+						},
+						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
 							"children": [],
 							"classList": []
 						},
@@ -2640,6 +2682,12 @@
 							"classList": []
 						},
 						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Competitions",
 							"url": "/football/competitions",
 							"longTitle": "football/competitions",
@@ -2825,6 +2873,12 @@
 							"title": "Results",
 							"url": "/football/results",
 							"longTitle": "football/results",
+							"children": [],
+							"classList": []
+						},
+						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
 							"children": [],
 							"classList": []
 						},
@@ -3627,6 +3681,12 @@
 							"classList": []
 						},
 						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
+							"children": [],
+							"classList": []
+						},
+						{
 							"title": "Competitions",
 							"url": "/football/competitions",
 							"longTitle": "football/competitions",
@@ -3812,6 +3872,12 @@
 							"title": "Results",
 							"url": "/football/results",
 							"longTitle": "football/results",
+							"children": [],
+							"classList": []
+						},
+						{
+							"title": "World Cup 2026",
+							"url": "/football/world-cup-2026",
 							"children": [],
 							"classList": []
 						},


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

Adds the 2026 world cup to the football, us/soccer, au/sport and us/sport navbars.

## Screenshots



On /football and /us/soccer:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/acd097ee-e482-4e10-909f-e81f21782748
[after]:https://github.com/user-attachments/assets/13bcd900-95d9-4cc4-a2c9-f78c75fb66ab


On /au/sport and us/sport:

<img width="802" height="147" alt="image" src="https://github.com/user-attachments/assets/d687924e-03e0-4e8d-8211-c286f48d2ddb" />



## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
