### PR TITLE
Extract DCR config creation to DotcomRenderingConfig and removal list for legacy config properties

### DIFF
--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -4,15 +4,10 @@ import common.{CanonicalLink, Edition}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import conf.Configuration
-import com.gu.contentapi.client.model.v1.Content
-import experiments.ActiveExperiments
-import layout.ContentCard
 import model.{PressedPage, RelatedContentItem}
 import navigation.{FooterLinks, Nav}
 import play.api.libs.json.{JsObject, JsValue, Json, OWrites}
 import play.api.mvc.RequestHeader
-import views.support.{CamelCase, JavaScriptPage}
-import ab.ABTests
 
 case class DotcomFrontsRenderingDataModel(
     pressedPage: PressedPage,
@@ -47,27 +42,11 @@ object DotcomFrontsRenderingDataModel {
     val edition = Edition.edition(request)
     val nav = Nav(page, edition)
 
-    val switches: Map[String, Boolean] = conf.switches.Switches.all
-      .filter(_.exposeClientSide)
-      .foldLeft(Map.empty[String, Boolean])((acc, switch) => {
-        acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
-      })
-
-    val config = Config(
-      switches = switches,
-      abTests = ActiveExperiments.getJsMap(request),
-      serverSideABTests = ABTests.getParticipations(request),
-      ampIframeUrl = DotcomRenderingUtils.assetURL("data/vendor/amp-iframe.html"),
-      googletagUrl = Configuration.googletag.jsLocation,
-      stage = common.Environment.stage,
-      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
+    val combinedConfig = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = pageType.isPreview,
     )
-
-    val combinedConfig: JsObject = {
-      val jsPageConfig: Map[String, JsValue] =
-        JavaScriptPage.getMap(page, Edition(request), pageType.isPreview, request)
-      Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
-    }
 
     val commercialProperties = page.metadata.commercial
       .map { _.perEdition.mapKeys(_.id) }

--- a/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
@@ -50,27 +50,11 @@ object DotcomNewslettersPageRenderingDataModel {
     val edition = Edition.edition(request)
     val nav = Nav(page, edition)
 
-    val switches: Map[String, Boolean] = conf.switches.Switches.all
-      .filter(_.exposeClientSide)
-      .foldLeft(Map.empty[String, Boolean])((acc, switch) => {
-        acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
-      })
-
-    val config = Config(
-      switches = switches,
-      abTests = ActiveExperiments.getJsMap(request),
-      serverSideABTests = ABTests.getParticipations(request),
-      ampIframeUrl = DotcomRenderingUtils.assetURL("data/vendor/amp-iframe.html"),
-      googletagUrl = Configuration.googletag.jsLocation,
-      stage = common.Environment.stage,
-      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
+    val combinedConfig = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = false,
     )
-
-    val combinedConfig: JsObject = {
-      val jsPageConfig: Map[String, JsValue] =
-        JavaScriptPage.getMap(page, Edition(request), isPreview = false, request)
-      Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
-    }
 
     val commercialProperties = page.metadata.commercial
       .map { _.perEdition.mapKeys(_.id) }

--- a/common/app/model/dotcomrendering/DotcomRenderingConfig.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingConfig.scala
@@ -11,6 +11,8 @@ import play.api.mvc.RequestHeader
 import views.support.{CamelCase, JavaScriptPage}
 
 object DotcomRenderingConfig {
+  val removeProperties: Seq[String] = Seq("thumbnail")
+
   def apply(
       page: Page,
       request: RequestHeader,
@@ -35,6 +37,15 @@ object DotcomRenderingConfig {
     val jsPageConfig: Map[String, JsValue] =
       JavaScriptPage.getMap(page, Edition(request), isPreview, request)
 
-    Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
+    val combinedConfig = Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
+
+    /** Remove legacy config not used by DCR
+      *
+      * See: https://github.com/guardian/dotcom-rendering/pull/15767
+      *
+      * Properties removed here should also be deleted from the LegacyConfig type in DCR
+      * https://github.com/guardian/dotcom-rendering/blob/7f862e949d50bf98a4505995121502cfbd8daaf6/dotcom-rendering/src/types/config.ts#L94-L100
+      */
+    JsObject(combinedConfig.fields.filterNot { case (key, _) => removeProperties.contains(key) })
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingConfig.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingConfig.scala
@@ -1,0 +1,40 @@
+package model.dotcomrendering
+
+import ab.ABTests
+import common.Edition
+import conf.Configuration
+import experiments.ActiveExperiments
+import model.Page
+import model.dotcomrendering.DotcomRenderingUtils.assetURL
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.mvc.RequestHeader
+import views.support.{CamelCase, JavaScriptPage}
+
+object DotcomRenderingConfig {
+  def apply(
+      page: Page,
+      request: RequestHeader,
+      isPreview: Boolean,
+  ): JsObject = {
+    val switches: Map[String, Boolean] = conf.switches.Switches.all
+      .filter(_.exposeClientSide)
+      .foldLeft(Map.empty[String, Boolean])((acc, switch) => {
+        acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
+      })
+
+    val config = Config(
+      switches = switches,
+      abTests = ActiveExperiments.getJsMap(request),
+      serverSideABTests = ABTests.getParticipations(request),
+      ampIframeUrl = assetURL("data/vendor/amp-iframe.html"),
+      googletagUrl = Configuration.googletag.jsLocation,
+      stage = common.Environment.stage,
+      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
+    )
+
+    val jsPageConfig: Map[String, JsValue] =
+      JavaScriptPage.getMap(page, Edition(request), isPreview, request)
+
+    Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
+  }
+}

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -1,6 +1,5 @@
 package model.dotcomrendering
 
-import ab.ABTests
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, Blocks => APIBlocks}
 import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
@@ -9,7 +8,6 @@ import common.commercial.EditionCommercialProperties
 import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
 import crosswords.CrosswordPageWithContent
-import experiments.ActiveExperiments
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements._
 import model.meta.BlocksOn
@@ -36,7 +34,7 @@ import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import services.NewsletterData
-import views.support.{CamelCase, ContentLayout, JavaScriptPage}
+import views.support.ContentLayout
 
 // -----------------------------------------------------------------
 // DCR DataModel
@@ -492,27 +490,11 @@ object DotcomRenderingDataModel {
       lastModificationDate = content.fields.lastModified,
     )
 
-    val switches: Map[String, Boolean] = conf.switches.Switches.all
-      .filter(_.exposeClientSide)
-      .foldLeft(Map.empty[String, Boolean])((acc, switch) => {
-        acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
-      })
-
-    val config = Config(
-      switches = switches,
-      abTests = ActiveExperiments.getJsMap(request),
-      serverSideABTests = ABTests.getParticipations(request),
-      ampIframeUrl = assetURL("data/vendor/amp-iframe.html"),
-      googletagUrl = Configuration.googletag.jsLocation,
-      stage = common.Environment.stage,
-      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
+    val combinedConfig = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = pageType.isPreview,
     )
-
-    val combinedConfig: JsObject = {
-      val jsPageConfig: Map[String, JsValue] =
-        JavaScriptPage.getMap(page, Edition(request), pageType.isPreview, request)
-      Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
-    }
 
     val calloutsUrl: Option[String] = combinedConfig.fields.toList
       .find(_._1 == "calloutsUrl")

--- a/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
@@ -79,27 +79,11 @@ object DotcomTagPagesRenderingDataModel {
     val edition = Edition.edition(request)
     val nav = Nav(page, edition)
 
-    val switches: Map[String, Boolean] = conf.switches.Switches.all
-      .filter(_.exposeClientSide)
-      .foldLeft(Map.empty[String, Boolean])((acc, switch) => {
-        acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
-      })
-
-    val config = Config(
-      switches = switches,
-      abTests = ActiveExperiments.getJsMap(request),
-      serverSideABTests = ABTests.getParticipations(request),
-      ampIframeUrl = DotcomRenderingUtils.assetURL("data/vendor/amp-iframe.html"),
-      googletagUrl = Configuration.googletag.jsLocation,
-      stage = common.Environment.stage,
-      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
+    val combinedConfig = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = pageType.isPreview,
     )
-
-    val combinedConfig: JsObject = {
-      val jsPageConfig: Map[String, JsValue] =
-        JavaScriptPage.getMap(page, Edition(request), pageType.isPreview, request)
-      Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
-    }
 
     val commercialProperties = page.metadata.commercial
       .map {

--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -3,16 +3,13 @@ package football.model
 import common.{CanonicalLink, Edition}
 import conf.Configuration
 import cricket.controllers.CricketMatchPage
-import cricketModel.{Innings, InningsBatter, InningsBowler, InningsWicket, Match, Team}
-import experiments.ActiveExperiments
+import cricketModel.{Innings, InningsWicket, Match, Team}
 import model.ApplicationContext
-import model.dotcomrendering.DotcomRenderingUtils.{assetURL, withoutNull}
-import model.dotcomrendering.{Config, PageFooter, PageType}
+import model.dotcomrendering.DotcomRenderingUtils.withoutNull
+import model.dotcomrendering.{DotcomRenderingConfig, PageFooter, PageType}
 import navigation.{FooterLinks, Nav}
 import play.api.libs.json.{JsObject, JsValue, Json, Writes}
 import play.api.mvc.RequestHeader
-import views.support.{CamelCase, JavaScriptPage}
-import ab.ABTests
 
 case class DotcomRenderingCricketDataModel(
     cricketMatch: Match,
@@ -40,27 +37,11 @@ object DotcomRenderingCricketDataModel {
 
     val pageType: PageType = PageType(page, request, context)
 
-    val switches: Map[String, Boolean] = conf.switches.Switches.all
-      .filter(_.exposeClientSide)
-      .foldLeft(Map.empty[String, Boolean])((acc, switch) => {
-        acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
-      })
-
-    val config = Config(
-      switches = switches,
-      abTests = ActiveExperiments.getJsMap(request),
-      serverSideABTests = ABTests.getParticipations,
-      ampIframeUrl = assetURL("data/vendor/amp-iframe.html"),
-      googletagUrl = Configuration.googletag.jsLocation,
-      stage = common.Environment.stage,
-      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
+    val combinedConfig = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = pageType.isPreview,
     )
-
-    val combinedConfig: JsObject = {
-      val jsPageConfig: Map[String, JsValue] =
-        JavaScriptPage.getMap(page, Edition(request), pageType.isPreview, request)
-      Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
-    }
 
     DotcomRenderingCricketDataModel(
       page.theMatch,

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -1,13 +1,12 @@
 package football.model
 
-import common.{CanonicalLink, Edition, Environment, LinkTo}
+import common.{CanonicalLink, Edition}
 import conf.Configuration
-import experiments.ActiveExperiments
 import football.controllers.{CompetitionFilter, FootballPage, MatchMetadata, MatchPage}
 import model.content.InteractiveAtom
-import model.dotcomrendering.DotcomRenderingUtils.{assetURL, getMatchNavUrl, getMatchUrl, withoutDeepNull, withoutNull}
-import model.dotcomrendering.{Config, DCARUrlHelper, MatchHeaderEndpoint, PageFooter, PageType}
-import model.{ApplicationContext, Competition, CompetitionSummary, ContentType, Group, StandalonePage, Table, TeamUrl}
+import model.dotcomrendering.DotcomRenderingUtils.{getMatchNavUrl, getMatchUrl, withoutDeepNull, withoutNull}
+import model.dotcomrendering.{DCARUrlHelper, DotcomRenderingConfig, MatchHeaderEndpoint, PageFooter, PageType}
+import model.{ApplicationContext, Competition, CompetitionSummary, ContentType, Group, Table, TeamUrl}
 import navigation.{FooterLinks, Nav}
 import pa.{
   Fixture,
@@ -27,8 +26,6 @@ import pa.{
 }
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.support.{CamelCase, JavaScriptPage}
-import ab.ABTests
 import org.joda.time.{LocalDate => JodaLocalDate}
 
 import java.time.LocalDate
@@ -50,38 +47,6 @@ trait DotcomRenderingFootballDataModel {
   def contributionsServiceUrl: String
   def canonicalUrl: String
   def pageId: String
-}
-
-object DotcomRenderingFootballDataModel {
-  def getConfig(page: StandalonePage)(implicit
-      request: RequestHeader,
-      context: ApplicationContext,
-  ): JsObject = {
-    val pageType: PageType = PageType(page, request, context)
-
-    val switches: Map[String, Boolean] = conf.switches.Switches.all
-      .filter(_.exposeClientSide)
-      .foldLeft(Map.empty[String, Boolean])((acc, switch) => {
-        acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
-      })
-
-    val config = Config(
-      switches = switches,
-      abTests = ActiveExperiments.getJsMap(request),
-      serverSideABTests = ABTests.getParticipations,
-      ampIframeUrl = assetURL("data/vendor/amp-iframe.html"),
-      googletagUrl = Configuration.googletag.jsLocation,
-      stage = common.Environment.stage,
-      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
-    )
-
-    val combinedConfig: JsObject = {
-      val jsPageConfig: Map[String, JsValue] =
-        JavaScriptPage.getMap(page, Edition(request), pageType.isPreview, request)
-      Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
-    }
-    combinedConfig
-  }
 }
 
 private object DotcomRenderingFootballDataModelImplicits {
@@ -176,7 +141,11 @@ object DotcomRenderingFootballMatchListDataModel {
   ): DotcomRenderingFootballMatchListDataModel = {
     val edition = Edition(request)
     val nav = Nav(page, edition)
-    val combinedConfig: JsObject = DotcomRenderingFootballDataModel.getConfig(page)
+    val combinedConfig = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = PageType(page, request, context).isPreview,
+    )
 
     val matches =
       getMatchesList(matchesList.matchesGroupedByDateAndCompetition)
@@ -282,7 +251,11 @@ object DotcomRenderingFootballTablesDataModel {
   ): DotcomRenderingFootballTablesDataModel = {
     val edition = Edition(request)
     val nav = Nav(page, edition)
-    val combinedConfig: JsObject = DotcomRenderingFootballDataModel.getConfig(page)
+    val combinedConfig = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = PageType(page, request, context).isPreview,
+    )
 
     DotcomRenderingFootballTablesDataModel(
       tables = tables,
@@ -382,7 +355,11 @@ object DotcomRenderingFootballMatchSummaryDataModel extends DCARUrlHelper {
   ): DotcomRenderingFootballMatchSummaryDataModel = {
     val edition = Edition(request)
     val nav = Nav(page, edition)
-    val combinedConfig: JsObject = DotcomRenderingFootballDataModel.getConfig(page)
+    val combinedConfig = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = PageType(page, request, context).isPreview,
+    )
     DotcomRenderingFootballMatchSummaryDataModel(
       footballMatch = matchStats,
       matchInfo = matchInfo,

--- a/sport/app/football/model/DotcomRenderingWallchartDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingWallchartDataModel.scala
@@ -6,7 +6,7 @@ import football.controllers.FootballPage
 import football.model.DotcomRenderingFootballDataModelImplicits._
 import model.{ApplicationContext, Competition, CompetitionSummary}
 import model.dotcomrendering.DotcomRenderingUtils.withoutNull
-import model.dotcomrendering.PageFooter
+import model.dotcomrendering.{DotcomRenderingConfig, PageFooter, PageType}
 import navigation.{FooterLinks, Nav}
 import pa.{FootballMatch, Round}
 import play.api.libs.json.{JsObject, JsString, JsValue, Json, Writes}
@@ -41,7 +41,11 @@ object DotcomRenderingWallchartDataModel {
   ): DotcomRenderingWallchartDataModel = {
     val edition = Edition(request)
     val nav = Nav(page, edition)
-    val combinedConfig: JsObject = DotcomRenderingFootballDataModel.getConfig(page)
+    val combinedConfig: JsObject = DotcomRenderingConfig(
+      page = page,
+      request = request,
+      isPreview = PageType(page, request, context).isPreview,
+    )
     DotcomRenderingWallchartDataModel(
       competitionStages = competitionStages,
       competition = competition,


### PR DESCRIPTION
## What does this change?

Following: https://github.com/guardian/dotcom-rendering/pull/15767

We are in a position to start removing legacy config that is passed from Frontend to DCR , but not actually used by DCR.

This PR:

- extracts the replicated DCR config creation in multiple locations to a single implementation in `DotcomRenderingConfig`
- adds a config property removal list

We can now progressively add to the removal list to remove legacy config sent to DCR.

All legacy config properties (once the type is reinstated in DCR) are optional so removing them from the config object should not causes issues for DCR.

## Screenshots

<img width="1211" height="90" alt="Screenshot 2026-05-07 at 16 09 55" src="https://github.com/user-attachments/assets/1695c20e-0546-4af7-9674-3cb9f0c99848" />


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
