### PR TITLE
Allow previewing Hosted Content pages without switch being turned on

### DIFF
--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -1,5 +1,6 @@
 package services.dotcomrendering
 
+import ab.ABTests.isUserInTestGroup
 import common.GuLogging
 import implicits.Requests._
 import play.api.mvc.RequestHeader
@@ -7,7 +8,7 @@ import implicits.AppsFormat
 import conf.switches.Switches
 
 object HostedContentPicker extends GuLogging {
-  def getTier(isGallery: Boolean)(implicit
+  def getTier(isGallery: Boolean = false)(implicit
       request: RequestHeader,
   ): RenderType = {
     val tier: RenderType = decideTier(isGallery)
@@ -23,10 +24,11 @@ object HostedContentPicker extends GuLogging {
     tier
   }
 
-  def decideTier(isGallery: Boolean)(implicit
+  def decideTier(isGallery: Boolean = false)(implicit
       request: RequestHeader,
   ): RenderType = {
-    if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
+    if (Switches.DCRHostedContent.isSwitchedOff && !isUserInTestGroup("commercial-hosted-content", "preview"))
+      LocalRender
     // Gallery pages are not supported in DCR yet
     else if (isGallery) LocalRender
     else if (request.forceDCROff) LocalRender

--- a/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
+++ b/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
@@ -9,7 +9,7 @@ import test.TestRequest
 @DoNotDiscover class HostedContentPickerTest extends AnyFlatSpec with Matchers {
   "Hosted Content Picker decideTier" should "return LocalRender if forceDCROff" in {
     val testRequest = TestRequest("hosted-content-path?dcr=false")
-    val tier = HostedContentPicker.decideTier(isGallery = false)(testRequest)
+    val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
 
@@ -19,15 +19,23 @@ import test.TestRequest
     tier should be(LocalRender)
   }
 
-  it should "return RemoteRender if force DCR" in {
+  it should "return RemoteRender if force DCR and in the test group" in {
+    val testRequest = TestRequest("hosted-content-path?dcr=true").withHeaders(
+      "X-GU-Server-AB-Tests" -> "commercial-hosted-content:preview",
+    )
+    val tier = HostedContentPicker.decideTier()(testRequest)
+    tier should be(LocalRender)
+  }
+
+  it should "return LocalRender if force DCR and not in the test group" in {
     val testRequest = TestRequest("hosted-content-path?dcr=true")
-    val tier = HostedContentPicker.decideTier(isGallery = false)(testRequest)
+    val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
 
   it should "return LocalRender otherwise" in {
     val testRequest = TestRequest("hosted-content-path")
-    val tier = HostedContentPicker.decideTier(isGallery = false)(testRequest)
+    val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

During the final stages of the Hosted Content page migration, we want to be able to preview the content in a live and stable environment to check that things look and behave as expected before releasing to the public.

The CODE environment is very unstable and is becoming unsuitable for this purpose. This PR allows anyone opted into the `preview` group of the `commercial-hosted-content` AB test (currently opt-in only/0% of the audience) to be able to see hosted content pages in PROD with the `?dcr` query parameter, despite the feature flag being turned off in this environment.

## What does this change?

Adds an extra condition to the `HostedContentPicker` to allow participation in the AB test to override the feature switch condition

Updates the `HostedContentPickerTest` to cover this scenario
