### PR TITLE
Add UsNewsletterHideMarketingToggle feature switch

### DIFF
--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -82,6 +82,17 @@ trait NewslettersSwitches {
     highImpact = false,
   )
 
+  val UsNewsletterSignupHideMarketingToggle = Switch(
+    SwitchGroup.Newsletters,
+    "us-signup-hide-marketing-toggle",
+    "When ON, hides the marketing opt-in toggle for sign-ups and silently enrolls users in similar_guardian_products",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+    highImpact = false,
+  )
+
   val UseDcrNewslettersPage = Switch(
     SwitchGroup.Newsletters,
     "use-dcr-newsletters-page",


### PR DESCRIPTION
## Overview

Add the client-exposed feature switch used to control whether the marketing toggle is hidden for eligible US newsletter sign-ups.

Switch details:
- Name: `us-newsletter-hide-marketing-toggle`
- Scala val: `UsNewsletterHideMarketingToggle`

This work is implemented / in progress via PR and is no longer the primary blocker for the overall feature.

## Acceptance Criteria

- [x] Add to `NewslettersSwitches.scala` (or `FeatureSwitches.scala`):
  - [x] Name: `us-newsletter-hide-marketing-toggle`
  - [x] Scala val: `UsNewsletterHideMarketingToggle`
  - [x] `exposeClientSide = true`
  - [x] `safeState = Off`
  - [x] `sellByDate = never`
- [x] Visible and toggleable in the Switchboard at `/dev/switchboard`

## Status

- DCR can now read the switch client-side and apply the toggle-hiding logic
- No further functional work should be required here beyond merge/deploy/verification
- Remaining integration work is tracked in [#28787](https://github.com/guardian/frontend/issues/28787)

## Notes

- Parent issue: [guardian/email-rendering#930](https://github.com/guardian/email-rendering/issues/930)