### PR TITLE
Routing for Football Match Day 'atom' component

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -487,6 +487,13 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     post(ws, json, Configuration.rendering.articleBaseURL + "/FootballMatchListPage", CacheTime.Football)
   }
 
+  def getFootballEmbed(
+      ws: WSClient,
+      json: JsValue,
+  )(implicit request: RequestHeader): Future[Result] = {
+    post(ws, json, Configuration.rendering.articleBaseURL + "/FootballMatchDayEmbed", CacheTime.Football)
+  }
+
   def getFootballMatchSummaryPage(
       ws: WSClient,
       json: JsValue,

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -137,6 +137,7 @@ GET            /football/match-day/:year/:month/:day.json                       
 GET            /football/match-day/:year/:month/:day                                                                             football.controllers.MatchDayController.matchesFor(year, month, day)
 GET            /football/match-day/:competition/:year/:month/:day.json                                                           football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
 GET            /football/match-day/:competition/:year/:month/:day                                                                football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
+GET            /football/:competition/match-day/embed                                                                            football.controllers.MatchDayController.competitionMatchesEmbed(competition)
 
 GET            /football/tables                                                                                                  football.controllers.LeagueTableController.renderLeagueTables()
 GET            /football/tables.json                                                                                             football.controllers.LeagueTableController.renderLeagueTablesJson()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -137,6 +137,7 @@ GET            /football/match-day/:year/:month/:day.json                       
 GET            /football/match-day/:year/:month/:day                                                                             football.controllers.MatchDayController.matchesFor(year, month, day)
 GET            /football/match-day/:competition/:year/:month/:day.json                                                           football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
 GET            /football/match-day/:competition/:year/:month/:day                                                                football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
+GET            /football/:competition/match-day/embed.json                                                                       football.controllers.MatchDayController.competitionMatchesEmbedJson(competition)
 GET            /football/:competition/match-day/embed                                                                            football.controllers.MatchDayController.competitionMatchesEmbed(competition)
 
 GET            /football/tables                                                                                                  football.controllers.LeagueTableController.renderLeagueTables()

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -80,7 +80,8 @@ GET        /football/:competition/live.json                                     
 GET        /football/match-day/:year/:month/:day.json                                          football.controllers.MatchDayController.matchesForJson(year, month, day)
 GET        /football/match-day/:year/:month/:day                                               football.controllers.MatchDayController.matchesFor(year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day.json                             football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
-GET        /football/match-day/:competition/:year/:month/:day                football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
+GET        /football/match-day/:competition/:year/:month/:day                                  football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
+GET        /football/:competition/match-day/embed                                              football.controllers.MatchDayController.competitionMatchesEmbed(competition)
 
 GET        /football/tables                                                  football.controllers.LeagueTableController.renderLeagueTables()
 GET        /football/tables.json                                             football.controllers.LeagueTableController.renderLeagueTablesJson()

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -81,6 +81,7 @@ GET        /football/match-day/:year/:month/:day.json                           
 GET        /football/match-day/:year/:month/:day                                               football.controllers.MatchDayController.matchesFor(year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day.json                             football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day                                  football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
+GET        /football/:competition/match-day/embed.json                                         football.controllers.MatchDayController.competitionMatchesEmbedJson(competition)
 GET        /football/:competition/match-day/embed                                              football.controllers.MatchDayController.competitionMatchesEmbed(competition)
 
 GET        /football/tables                                                  football.controllers.LeagueTableController.renderLeagueTables()

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -42,6 +42,7 @@ class MatchDayController(
   def competitionMatchesJson(competitionTag: String): Action[AnyContent] = competitionMatches(competitionTag)
   def competitionMatches(competitionTag: String): Action[AnyContent] =
     renderCompetitionMatches(competitionTag, LocalDate.now(Edition.defaultEdition.timezoneId))
+  def competitionMatchesEmbedJson(competitionTag: String): Action[AnyContent] = competitionMatchesEmbed(competitionTag)
   def competitionMatchesEmbed(competitionTag: String): Action[AnyContent] =
     renderCompetitionMatchesEmbed(competitionTag, LocalDate.now(Edition.defaultEdition.timezoneId))
 

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -78,12 +78,8 @@ class MatchDayController(
     Action.async { implicit request =>
       lookupCompetition(competitionTag)
         .map { competition =>
-          val webTitle =
-            if (date == LocalDate.now(Edition.defaultEdition.timezoneId)) s"Today's ${competition.fullName} matches"
-            else s" ${competition.fullName} matches"
-          val page = new FootballPage(s"football/$competitionTag/live", "football", webTitle)
           val matches = CompetitionMatchDayList(competitionsService.competitions, competition.id, date)
-          renderMatchDayEmbed(page, matches, filters)
+          renderMatchDayEmbed(matches)
         }
         .getOrElse {
           Future.successful(NotFound)

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -79,7 +79,7 @@ class MatchDayController(
       lookupCompetition(competitionTag)
         .map { competition =>
           val matches = CompetitionMatchDayList(competitionsService.competitions, competition.id, date)
-          renderMatchDayEmbed(matches)
+          renderMatchDayEmbed(competitionTag, matches)
         }
         .getOrElse {
           Future.successful(NotFound)

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -42,6 +42,8 @@ class MatchDayController(
   def competitionMatchesJson(competitionTag: String): Action[AnyContent] = competitionMatches(competitionTag)
   def competitionMatches(competitionTag: String): Action[AnyContent] =
     renderCompetitionMatches(competitionTag, LocalDate.now(Edition.defaultEdition.timezoneId))
+  def competitionMatchesEmbed(competitionTag: String): Action[AnyContent] =
+    renderCompetitionMatchesEmbed(competitionTag, LocalDate.now(Edition.defaultEdition.timezoneId))
 
   def competitionMatchesFor(competitionTag: String, year: String, month: String, day: String): Action[AnyContent] =
     renderCompetitionMatches(competitionTag, createDate(year, month, day))
@@ -65,6 +67,22 @@ class MatchDayController(
           )
 
           futureAtom.flatMap(maybeAtom => renderMatchList(page, matches, filters, maybeAtom))
+        }
+        .getOrElse {
+          Future.successful(NotFound)
+        }
+    }
+
+  private def renderCompetitionMatchesEmbed(competitionTag: String, date: LocalDate): Action[AnyContent] =
+    Action.async { implicit request =>
+      lookupCompetition(competitionTag)
+        .map { competition =>
+          val webTitle =
+            if (date == LocalDate.now(Edition.defaultEdition.timezoneId)) s"Today's ${competition.fullName} matches"
+            else s" ${competition.fullName} matches"
+          val page = new FootballPage(s"football/$competitionTag/live", "football", webTitle)
+          val matches = CompetitionMatchDayList(competitionsService.competitions, competition.id, date)
+          renderMatchDayEmbed(page, matches, filters)
         }
         .getOrElse {
           Future.successful(NotFound)

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -4,6 +4,7 @@ import common.{Edition, JsonComponent}
 import common._
 import feed.Competitions
 import football.model.{DotcomRenderingFootballMatchListDataModel, MatchesList}
+import football.model.{DotcomRenderingFootballMatchDayDataModel, MatchesList}
 import implicits.{HtmlFormat, JsonFormat, Requests}
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, CacheTime, Cached, Competition, TeamMap}
@@ -77,29 +78,20 @@ trait MatchListController extends BaseController with Requests with ImplicitCont
   }
 
   protected def renderMatchDayEmbed(
-      page: FootballPage,
       matchesList: MatchesList,
-      filters: Map[String, Seq[CompetitionFilter]],
-      atom: Option[InteractiveAtom] = None,
   )(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
 
     request.getRequestFormat match {
       case JsonFormat =>
-        val model = DotcomRenderingFootballMatchListDataModel(
-          page = page,
+        val model = DotcomRenderingFootballMatchDayDataModel(
           matchesList = matchesList,
-          filters = filters,
-          atom,
         )
         successful(Cached(CacheTime.Football)(JsonComponent.fromWritable(model)))
       case HtmlFormat =>
-        val model = DotcomRenderingFootballMatchListDataModel(
-          page = page,
+        val model = DotcomRenderingFootballMatchDayDataModel(
           matchesList = matchesList,
-          filters = filters,
-          atom,
         )
-        remoteRenderer.getFootballEmbed(wsClient, DotcomRenderingFootballMatchListDataModel.toJson(model))
+        remoteRenderer.getFootballEmbed(wsClient, DotcomRenderingFootballMatchDayDataModel.toJson(model))
       case _ => successful(NotFound)
     }
   }

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -83,10 +83,8 @@ trait MatchListController extends BaseController with Requests with ImplicitCont
       atom: Option[InteractiveAtom] = None,
   )(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
 
-    val tier = FootballPagePicker.getTier(page)
-
     request.getRequestFormat match {
-      case JsonFormat if request.forceDCR =>
+      case JsonFormat =>
         val model = DotcomRenderingFootballMatchListDataModel(
           page = page,
           matchesList = matchesList,
@@ -94,16 +92,7 @@ trait MatchListController extends BaseController with Requests with ImplicitCont
           atom,
         )
         successful(Cached(CacheTime.Football)(JsonComponent.fromWritable(model)))
-      case JsonFormat =>
-        successful(Cached(CacheTime.Football) {
-          JsonComponent(
-            "html" -> football.views.html.matchList.matchesComponent(matchesList),
-            "next" -> Html(matchesList.nextPage.getOrElse("")),
-            "previous" -> Html(matchesList.previousPage.getOrElse("")),
-            "atom" -> atom.isDefined,
-          )
-        })
-      case HtmlFormat if tier == RemoteRender =>
+      case HtmlFormat =>
         val model = DotcomRenderingFootballMatchListDataModel(
           page = page,
           matchesList = matchesList,
@@ -111,10 +100,7 @@ trait MatchListController extends BaseController with Requests with ImplicitCont
           atom,
         )
         remoteRenderer.getFootballEmbed(wsClient, DotcomRenderingFootballMatchListDataModel.toJson(model))
-      case _ =>
-        successful(Cached(CacheTime.Football) {
-          RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters, atom))
-        })
+      case _ => successful(NotFound)
     }
   }
 

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -76,6 +76,48 @@ trait MatchListController extends BaseController with Requests with ImplicitCont
     }
   }
 
+  protected def renderMatchDayEmbed(
+      page: FootballPage,
+      matchesList: MatchesList,
+      filters: Map[String, Seq[CompetitionFilter]],
+      atom: Option[InteractiveAtom] = None,
+  )(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
+
+    val tier = FootballPagePicker.getTier(page)
+
+    request.getRequestFormat match {
+      case JsonFormat if request.forceDCR =>
+        val model = DotcomRenderingFootballMatchListDataModel(
+          page = page,
+          matchesList = matchesList,
+          filters = filters,
+          atom,
+        )
+        successful(Cached(CacheTime.Football)(JsonComponent.fromWritable(model)))
+      case JsonFormat =>
+        successful(Cached(CacheTime.Football) {
+          JsonComponent(
+            "html" -> football.views.html.matchList.matchesComponent(matchesList),
+            "next" -> Html(matchesList.nextPage.getOrElse("")),
+            "previous" -> Html(matchesList.previousPage.getOrElse("")),
+            "atom" -> atom.isDefined,
+          )
+        })
+      case HtmlFormat if tier == RemoteRender =>
+        val model = DotcomRenderingFootballMatchListDataModel(
+          page = page,
+          matchesList = matchesList,
+          filters = filters,
+          atom,
+        )
+        remoteRenderer.getFootballEmbed(wsClient, DotcomRenderingFootballMatchListDataModel.toJson(model))
+      case _ =>
+        successful(Cached(CacheTime.Football) {
+          RevalidatableResult.Ok(football.views.html.matchList.matchesPage(page, matchesList, filters, atom))
+        })
+    }
+  }
+
   protected def renderMoreMatches(
       page: FootballPage,
       matchesList: MatchesList,

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -78,17 +78,20 @@ trait MatchListController extends BaseController with Requests with ImplicitCont
   }
 
   protected def renderMatchDayEmbed(
+      competitionTag: String,
       matchesList: MatchesList,
   )(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
 
     request.getRequestFormat match {
       case JsonFormat =>
         val model = DotcomRenderingFootballMatchDayDataModel(
+          competitionTag = competitionTag,
           matchesList = matchesList,
         )
         successful(Cached(CacheTime.Football)(JsonComponent.fromWritable(model)))
       case HtmlFormat =>
         val model = DotcomRenderingFootballMatchDayDataModel(
+          competitionTag = competitionTag,
           matchesList = matchesList,
         )
         remoteRenderer.getFootballEmbed(wsClient, DotcomRenderingFootballMatchDayDataModel.toJson(model))

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -196,6 +196,58 @@ object DotcomRenderingFootballMatchListDataModel {
   }
 }
 
+case class DotcomRenderingFootballMatchDayDataModel(
+    matchesList: Seq[MatchesByDateAndCompetition],
+    editionId: String,
+    guardianBaseURL: String,
+)
+
+object DotcomRenderingFootballMatchDayDataModel {
+  def apply(
+      matchesList: MatchesList,
+  )(implicit
+      request: RequestHeader,
+      context: ApplicationContext,
+  ): DotcomRenderingFootballMatchDayDataModel = {
+    val edition = Edition(request)
+
+    val matches =
+      getMatchesList(matchesList.matchesGroupedByDateAndCompetition)
+
+    DotcomRenderingFootballMatchDayDataModel(
+      matchesList = matches,
+      editionId = edition.id,
+      guardianBaseURL = Configuration.site.host,
+    )
+  }
+
+  import football.model.DotcomRenderingFootballDataModelImplicits._
+
+  implicit def dotcomRenderingFootballMatchDayDataModel: Writes[DotcomRenderingFootballMatchDayDataModel] =
+    Json.writes[DotcomRenderingFootballMatchDayDataModel]
+
+  def toJson(model: DotcomRenderingFootballMatchDayDataModel): JsValue = {
+    val jsValue = Json.toJson(model)
+    withoutNull(jsValue)
+  }
+
+  private def getMatchesList(
+      matches: Seq[(LocalDate, List[(Competition, List[FootballMatch])])],
+  ): Seq[MatchesByDateAndCompetition] = {
+    matches.map { case (date, competitionMatches) =>
+      MatchesByDateAndCompetition(
+        date = date,
+        competitionMatches = competitionMatches.map { case (competition, matches) =>
+          CompetitionMatches(
+            competitionSummary = competition,
+            matches = matches,
+          )
+        },
+      )
+    }
+  }
+}
+
 case class DotcomRenderingFootballHeaderDataModel(
     footballMatch: FootballMatch,
     competitionName: String,

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -197,6 +197,7 @@ object DotcomRenderingFootballMatchListDataModel {
 }
 
 case class DotcomRenderingFootballMatchDayDataModel(
+    competitionTag: String,
     matchesList: Seq[MatchesByDateAndCompetition],
     editionId: String,
     guardianBaseURL: String,
@@ -204,10 +205,10 @@ case class DotcomRenderingFootballMatchDayDataModel(
 
 object DotcomRenderingFootballMatchDayDataModel {
   def apply(
+      competitionTag: String,
       matchesList: MatchesList,
   )(implicit
       request: RequestHeader,
-      context: ApplicationContext,
   ): DotcomRenderingFootballMatchDayDataModel = {
     val edition = Edition(request)
 
@@ -215,6 +216,7 @@ object DotcomRenderingFootballMatchDayDataModel {
       getMatchesList(matchesList.matchesGroupedByDateAndCompetition)
 
     DotcomRenderingFootballMatchDayDataModel(
+      competitionTag = competitionTag,
       matchesList = matches,
       editionId = edition.id,
       guardianBaseURL = Configuration.site.host,

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -46,6 +46,7 @@ GET        /football/match-day/:year/:month/:day.json                           
 GET        /football/match-day/:year/:month/:day                                               football.controllers.MatchDayController.matchesFor(year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day.json                             football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day                                  football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
+GET        /football/:competition/match-day/embed                                              football.controllers.MatchDayController.competitionMatchesEmbed(competition)
 
 GET        /football/tables                                                                    football.controllers.LeagueTableController.renderLeagueTables()
 GET        /football/tables.json                                                               football.controllers.LeagueTableController.renderLeagueTablesJson()

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -46,6 +46,7 @@ GET        /football/match-day/:year/:month/:day.json                           
 GET        /football/match-day/:year/:month/:day                                               football.controllers.MatchDayController.matchesFor(year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day.json                             football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day                                  football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
+GET        /football/:competition/match-day/embed.json                                         football.controllers.MatchDayController.competitionMatchesEmbedJson(competition)
 GET        /football/:competition/match-day/embed                                              football.controllers.MatchDayController.competitionMatchesEmbed(competition)
 
 GET        /football/tables                                                                    football.controllers.LeagueTableController.renderLeagueTables()


### PR DESCRIPTION
## What does this change?

Adds routing and data model for Football Match Day 'atom' component.

See companion DCAR PR which adds the new component and DCAR endpoint: https://github.com/guardian/dotcom-rendering/pull/15880

## Screenshots

<img width="897" height="162" alt="Screenshot 2026-05-14 at 20 02 54" src="https://github.com/user-attachments/assets/0d1dad0f-3b37-4d81-b296-c8de1ce0b114" />
