### PR TITLE
Update Hosted Content picker logic

### DIFF
--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -27,8 +27,8 @@ object HostedContentPicker extends GuLogging {
   def decideTier(isGallery: Boolean = false)(implicit
       request: RequestHeader,
   ): RenderType = {
-    if (Switches.DCRHostedContent.isSwitchedOff && !isUserInTestGroup("commercial-hosted-content", "preview"))
-      LocalRender
+    if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
+    else if (!isUserInTestGroup("commercial-hosted-content", "preview")) LocalRender
     // Gallery pages are not supported in DCR yet
     else if (isGallery) LocalRender
     else if (request.forceDCROff) LocalRender

--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -28,11 +28,11 @@ object HostedContentPicker extends GuLogging {
       request: RequestHeader,
   ): RenderType = {
     if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
-    else if (!isUserInTestGroup("commercial-hosted-content", "preview")) LocalRender
     // Gallery pages are not supported in DCR yet
     else if (isGallery) LocalRender
     else if (request.forceDCROff) LocalRender
     else if (request.forceDCR) RemoteRender
+    else if (isUserInTestGroup("commercial-hosted-content", "preview")) RemoteRender
     else LocalRender
   }
 }

--- a/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
+++ b/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
@@ -1,5 +1,6 @@
 package services.dotcomrendering
 
+import conf.switches.Switches
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.DoNotDiscover
@@ -7,8 +8,9 @@ import services.dotcomrendering.{LocalRender, RemoteRender}
 import test.TestRequest
 
 @DoNotDiscover class HostedContentPickerTest extends AnyFlatSpec with Matchers {
-  "Hosted Content Picker decideTier" should "return LocalRender if forceDCROff" in {
-    val testRequest = TestRequest("hosted-content-path?dcr=false")
+  "Hosted Content Picker decideTier" should "return LocalRender if the feature switch is off" in {
+    Switches.DCRHostedContent.switchOff()
+    val testRequest = TestRequest("hosted-content-path")
     val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
@@ -19,18 +21,30 @@ import test.TestRequest
     tier should be(LocalRender)
   }
 
-  it should "return RemoteRender if force DCR and in the test group" in {
-    val testRequest = TestRequest("hosted-content-path?dcr=true").withHeaders(
-      "X-GU-Server-AB-Tests" -> "commercial-hosted-content:preview",
-    )
+  it should "return LocalRender if forcing DCR to be off via the query parameter" in {
+    val testRequest = TestRequest("hosted-content-path?dcr=false")
     val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
   }
 
-  it should "return LocalRender if force DCR and not in the test group" in {
+  it should "return RemoteRender if forcing DCR to be on via the query parameter" in {
     val testRequest = TestRequest("hosted-content-path?dcr=true")
     val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(LocalRender)
+  }
+
+  it should "return LocalRender if not in the test group without forcing DCR" in {
+    val testRequest = TestRequest("hosted-content-path")
+    val tier = HostedContentPicker.decideTier()(testRequest)
+    tier should be(LocalRender)
+  }
+
+  it should "return RemoteRender if in the test group without forcing DCR" in {
+    val testRequest = TestRequest("hosted-content-path").withHeaders(
+      "X-GU-Server-AB-Tests" -> "commercial-hosted-content:preview",
+    )
+    val tier = HostedContentPicker.decideTier()(testRequest)
+    tier should be(RemoteRender)
   }
 
   it should "return LocalRender otherwise" in {


### PR DESCRIPTION
## What is the value of this and can you measure success?

Allows the hosted content picker to prevent any rendering in DCR when the switch is off and conditionally allows it if opted into the AB test OR if using the force DCR query parameter.

We're now ready to demo these pages to stakeholders so need a way to reliably opt in and scale up the traffic. Using the query parameter is an easy way for internal folk to preview the pages and using the opt in for other scenarios is what we want to scale up to the full audience.

## What does this change?

Updates the `HostedContentPicker` logic to allow the switch to control the feature at an overall level and the force DCR param & AB test to control individual participation.

This is getting us ready to go live.
