### PR TITLE
accepting cache buster query param in responsive viewer

### DIFF
--- a/preview/app/views/responsive_viewer.scala.html
+++ b/preview/app/views/responsive_viewer.scala.html
@@ -93,7 +93,6 @@
 
             function init ( ) {
                 var sbWidth = 15, // scrollbar width
-                    html = '',
                     leftAcc = 0,
                     src = '@path';
 
@@ -108,17 +107,29 @@
 
                 iframeSrc += inheritedHash;
 
+                var framesContainer = document.querySelector ( '.frames' );
+                framesContainer.textContent = '';
+
                 breakpoints.forEach ( function ( bp ) {
-                    html += '<div style="left:' + leftAcc + 'px">' +
-                            '<h2>' + bp.name + '</h2>' +
-                            '<iframe frameBorder="0" sandbox="allow-same-origin allow-forms allow-scripts" seamless ' +
-                            'src="' + iframeSrc + '" ' +
-                            'width="' + ( bp.width + sbWidth ) + '"></iframe>' +
-                            '</div>' ;
+                    var wrapper = document.createElement('div');
+                    wrapper.style.left = leftAcc + 'px';
+
+                    var heading = document.createElement('h2');
+                    heading.textContent = bp.name;
+
+                    var iframe = document.createElement('iframe');
+                    iframe.setAttribute('frameBorder', '0');
+                    iframe.setAttribute('sandbox', 'allow-same-origin allow-forms allow-scripts');
+                    iframe.setAttribute('seamless', '');
+                    iframe.src = iframeSrc;
+                    iframe.width = ( bp.width + sbWidth ).toString();
+
+                    wrapper.appendChild(heading);
+                    wrapper.appendChild(iframe);
+                    framesContainer.appendChild(wrapper);
+
                     leftAcc += bp.width + sbWidth + 15 ;
                 });
-
-                document.querySelector ( '.frames' ).innerHTML = html ;
 
                 document.getElementById('toggle-ads' ).innerHTML = 'Turn ads ' +
                     (window.location.hash === '#noads' ? 'on' : 'off');

--- a/preview/app/views/responsive_viewer.scala.html
+++ b/preview/app/views/responsive_viewer.scala.html
@@ -97,11 +97,22 @@
                     leftAcc = 0,
                     src = '@path';
 
+                var cacheBust = new URLSearchParams(window.location.search).get('cacheBust');
+                var inheritedQuery = cacheBust ? 'cacheBust=' + encodeURIComponent(cacheBust) : '';
+                var inheritedHash = window.location.hash ? window.location.hash : '';
+                var iframeSrc = src;
+
+                if ( inheritedQuery ) {
+                    iframeSrc += ( src.indexOf('?') === -1 ? '?' : '&' ) + inheritedQuery;
+                }
+
+                iframeSrc += inheritedHash;
+
                 breakpoints.forEach ( function ( bp ) {
                     html += '<div style="left:' + leftAcc + 'px">' +
                             '<h2>' + bp.name + '</h2>' +
                             '<iframe frameBorder="0" sandbox="allow-same-origin allow-forms allow-scripts" seamless ' +
-                            'src="' + src + (window.location.hash ? window.location.hash : '') + '" ' +
+                            'src="' + iframeSrc + '" ' +
                             'width="' + ( bp.width + sbWidth ) + '"></iframe>' +
                             '</div>' ;
                     leftAcc += bp.width + sbWidth + 15 ;


### PR DESCRIPTION
## What is the value of this and can you measure success?

It enables editors to see real time changes in responsive viewer preview when used for fronts based newsletters rendered by email rendering.

## What does this change?

This change adds handling for `cacheBuster` query param in the responsive viewer

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
