### PR TITLE
Static analysis, part II

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -223,3 +223,9 @@ badgeHash := {
 
   println(result)
 }
+
+val staticAnalysis = Project("static-analysis", file("static-analysis"))
+  .settings(
+    libraryDependencies += "org.scalameta" %% "semanticdb-shared" % "4.17.0",
+    libraryDependencies += "org.scalameta" %% "scalameta" % "4.17.0"
+  )

--- a/static-analysis/README.md
+++ b/static-analysis/README.md
@@ -67,3 +67,4 @@ Initial results confirm the intuition that automation was necessary as we find a
 
 Beyound building the inventory that will help use decide what to keep, what to delete and what to migrate, we can imagine using these capabilities to automatically flag all the code trees that are candidates for deletion by only giving a list of controllers we would like to remove.
 This would require more work and is beyound the scope of this initial step.
+

--- a/static-analysis/README.md
+++ b/static-analysis/README.md
@@ -1,0 +1,69 @@
+# Static Analysis
+
+## Context
+See [corresponding PR](https://github.com/guardian/frontend/pull/28816)
+
+This module uses scala's [semanticDB](https://scalameta.org/docs/semanticdb/guide.html) and scala-meta in order to analyse the codebase and figure out which twirl template is used by which controller.
+This was implemented within a broader piece of work about code deletion in this application. Given the sheer size of frontend it made sense to invest the engineering time to automate this discovery.
+
+## Usage
+
+- modify ./project/ProjectSettings.scala, and add these options for all modules:
+```scala
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalacOptions ++= Seq(
+      "-Wunused",
+      "-Wconf:cat=unused:info",
+    )
+```
+- in sbt: `reload`, `clean`, `compile` and `Test / compile`
+- still in sbt `project static-analysis` then `run`
+
+## How does this work?
+
+The scala compiler has a feature called semanticDB that generates metadata about each scala file during the compilation phase.
+This data contains which symbols (classes, traits, objects, methods, variable etc) are declared in the file as well as which symbol are referenced within the file.
+
+At the file level this isn't very useful to us, but at a codebase level this allows us to understand the relationship between symbols.
+However the semanticDB isn't enough for us to which method is calling which symbol.
+
+For this we need the scala AST (abstract syntax tree), which luckily can be easily obtained using scala-meta's toolkit.
+
+Combining this two datasets, and with enough perserverance it's possible to build "Call Hierarchies" (or [call graphs](https://en.wikipedia.org/wiki/Call_graph)) like this:
+```
+views/html/fragments/email/emailArticleBody. in article/target/scala-2.13/twirl/main/views/html/fragments/email/emailArticleBody.template.scala:18:7
+  views/html/fragments/email/emailArticleBody. in article/app/pages/ArticleEmailHtmlPage.scala:7:35
+    No call to views/html/fragments/email/emailArticleBody. found (entry point)
+  views/html/fragments/email/emailArticleBody. in article/app/pages/ArticleEmailHtmlPage.scala:20:8
+    pages/ArticleEmailHtmlPage.html(). in article/app/controllers/LiveBlogController.scala:50:70
+      controllers/LiveBlogController#renderEmail(). in article/target/scala-2.13/routes/main/router/Routes.scala:152:25
+        router/Routes# in article/target/scala-2.13/routes/main/router/Routes.scala:41:37
+        ...
+      controllers/LiveBlogController#renderEmail(). in article/target/scala-2.13/routes/main/router/Routes.scala:188:25
+        router/Routes# in article/target/scala-2.13/routes/main/router/Routes.scala:41:37
+          No call to router/Routes# found (entry point)
+        ...
+    pages/ArticleEmailHtmlPage.html(). in article/app/controllers/ArticleController.scala:103:66
+      controllers/ArticleController#render(). in article/app/controllers/ArticleController.scala:43:42
+        controllers/ArticleController#mapAndRender(). in article/app/controllers/ArticleController.scala:38:4
+          controllers/ArticleController#renderItem(). in article/app/controllers/PublicationController.scala:49:26
+            controllers/PublicationController#publishedOn(). in article/target/scala-2.13/routes/main/router/Routes.scala:332:28
+              router/Routes# in article/target/scala-2.13/routes/main/router/Routes.scala:41:37
+                No call to router/Routes# found (entry point)
+              ...
+            controllers/PublicationController#publishedOn(). in article/target/scala-2.13/routes/main/router/Routes.scala:461:93
+              No call to controllers/PublicationController#publishedOn(). found (entry point)
+            controllers/PublicationController#publishedOn(). in article/test/PublicationControllerTest.scala:48:39
+              test/PublicationControllerTest# in article/test/package.scala:12:10
+                No call to test/PublicationControllerTest# found (entry point)
+              ... more tests
+```
+
+Finally, with these call hierarchies we're able to build the mapping between controllers `controllers/PublicationController#publishedOn()` and twirl template `views/html/fragments/email/emailArticleBody`.
+Initial results confirm the intuition that automation was necessary as we find almost 1300 such relations between controllers and twirl templates.
+
+## Potential uses
+
+Beyound building the inventory that will help use decide what to keep, what to delete and what to migrate, we can imagine using these capabilities to automatically flag all the code trees that are candidates for deletion by only giving a list of controllers we would like to remove.
+This would require more work and is beyound the scope of this initial step.

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -109,7 +109,10 @@ object Analysis {
   }
 
   def printCallHierarchy(node: CallHierarchyNode, indent: String = ""): Unit = {
-    println(s"$indent${node.node.owner}")
+    if (indent.isEmpty) {
+      println(s"${node.node.subject}")
+    }
+    println(s"  $indent${node.node.owner}")
     node.callers.foreach(caller => printCallHierarchy(caller, indent + "  "))
   }
 
@@ -123,8 +126,9 @@ object Analysis {
 
     val viewsCallSites = findViewsCallSites(source)
     val nextCallers = viewsCallSites.map { node =>
-      val fullyQualifiedName = identifyFullyQualifiedName(node).map(formatFullyQualifiedName).getOrElse("unknown")
-      val call = Call(node.name.value, fullyQualifiedName, node)
+      val fullyQualifiedCallerName = identifyFullyQualifiedName(node).map(formatFullyQualifiedName).getOrElse("unknown")
+      val fullyQualifiedSubjectName = s"${node.qual.text}.${node.name.value}"
+      val call = Call(fullyQualifiedSubjectName, fullyQualifiedCallerName, node)
       buildCallHierarchy(call, source, document)
     }.distinct
     nextCallers.foreach(node => printCallHierarchy(node))

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -3,42 +3,17 @@ import scala.meta.internal.semanticdb.{SymbolInformation, SymbolOccurrence}
 
 object Analysis {
 
-  def findViewsDefinitions(semanticDB: SemanticDB): Seq[(SourceRef, SymbolInformation)] = {
-    semanticDB.allDocuments.flatMap { case (file, document) =>
-      document.symbols
-        .filter { symbol =>
-          symbol.symbol.startsWith("views/html/") && (symbol.kind.isMethod || symbol.kind.isObject)
-        }
-        .map(definitions => file -> definitions)
-        .map { case (file, definition) =>
-
-          file -> definition
-        }
-    }
-  }
-
-  def findViewsCallSites(semanticDB: SemanticDB): Seq[(SourceRef, SymbolOccurrence)] = {
-    val allDefs = findViewsDefinitions(semanticDB)
-    allDefs.flatMap { case (_, definition) =>
-      semanticDB
-        .getOccurrences(SemanticDBSymbol(definition.symbol))
-        .filter { case (_, occurrence) => occurrence.role.isReference }
-        .map { case (callFile, occurrence) => callFile -> occurrence }
-    }
-  }
+  def isViewsDefinition(symbolInfo: SymbolInformation, file: SourceRef): Boolean =
+    symbolInfo.symbol.startsWith("views/html/") && (symbolInfo.kind.isMethod || symbolInfo.kind.isObject)
 
   def main(args: Array[String]): Unit = {
     val sources = SourceLoader.loadSources(Path.of("./article"))
     val semanticDB = SourceLoader.loadSemanticDB(Path.of("./article"))
 
     val callHierarchyBuilder = new CallHierarchyBuilder(sources, semanticDB)
-
-    findViewsCallSites(semanticDB)
-      .map { case (file, occurrence) =>
-        val methodRef = MethodRef(SemanticDBSymbol(occurrence.symbol), occurrence, file)
-        callHierarchyBuilder.buildCallHierarchy(methodRef)
-      }
-      .foreach(node => CallHierarchy.printCallHierarchy(node))
+    callHierarchyBuilder
+      .buildCallHierarchy(isViewsDefinition)
+      .foreach(node => CallHierarchy.printCallHierarchy(node, indent = ""))
   }
 
 }

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -85,52 +85,48 @@ object Analysis {
 
   }
 
-  def findNextCallers(call: Call, scalaSources: ScalaSources, semanticDB: SemanticDB): Seq[Call] = {
-    val callSites = semanticDB.allDocuments.flatMap { case (file, document) =>
+  def findNextCallers(method: MethodRef, scalaSources: ScalaSources, semanticDB: SemanticDB): Seq[MethodRef] = {
+    val fullyQualifiedCallers =
+      symbolOccurrenceToSourceTree(Seq(method.file -> method.occurrence), scalaSources)
+        .filterNot(isPackageOrImport)
+        .map { callerNode =>
+          identifyFullyQualifiedNameOfOwner(callerNode)
+            .map(formatFullyQualifiedName)
+            .getOrElse("unknown")
+        }
+        .toSet
+
+    semanticDB.allDocuments.flatMap { case (file, document) =>
       document.occurrences
         .filter { symbol =>
-          symbol.symbol == call.owner && symbol.role.isReference
+          fullyQualifiedCallers.contains(symbol.symbol) && symbol.role.isReference
         }
-        .map(occurrence => file -> occurrence)
-    }
-
-    symbolOccurrenceToSourceTree(callSites, scalaSources).map { callerNode =>
-      val callerOwner = identifyFullyQualifiedNameOfOwner(callerNode)
-        .map(formatFullyQualifiedName)
-        .getOrElse("unknown")
-      Call(call.owner, callerOwner, callerNode)
+        .map(occurrence => MethodRef(occurrence.symbol, occurrence, file))
     }
   }
 
   def buildCallHierarchy(
-      call: Call,
+      callee: MethodRef,
       scalaSources: ScalaSources,
       semanticDB: SemanticDB,
   ): CallHierarchyNode = {
-    val callers = findNextCallers(call, scalaSources, semanticDB).map { caller =>
-      buildCallHierarchy(caller, scalaSources, semanticDB)
+    val callers = findNextCallers(callee, scalaSources, semanticDB).map { case caller =>
+      buildCallHierarchy(callee = caller, scalaSources, semanticDB)
     }
-    CallHierarchyNode(call, callers)
+    CallHierarchyNode(callee, callers)
   }
 
   def main(args: Array[String]): Unit = {
     val sources = SourceLoader.loadSources(Path.of("./article"))
     val semanticDB = SourceLoader.loadSemanticDB(Path.of("./article"))
 
-    val viewsCallSites = findViewsCallSites(semanticDB)
-
-    viewsCallSites.foreach { case (file, occurrence) =>
-      val sourceTrees = symbolOccurrenceToSourceTree(Seq(file -> occurrence), sources).filterNot(isPackageOrImport)
-
-      val nextCallers = sourceTrees.map { case node: Term.Name =>
-        val fullyQualifiedCallerName =
-          identifyFullyQualifiedNameOfOwner(node).map(formatFullyQualifiedName).getOrElse("unknown")
-
-        val call = Call(occurrence.symbol, fullyQualifiedCallerName, node)
-        buildCallHierarchy(call, sources, semanticDB)
-      }.distinct
-      nextCallers.foreach(node => CallHierarchy.printCallHierarchy(node))
-    }
+    findViewsCallSites(semanticDB)
+      .map { case (file, occurrence) =>
+        val methodRed = MethodRef(occurrence.symbol, occurrence, file)
+        buildCallHierarchy(methodRed, sources, semanticDB)
+      }
+      .distinct
+      .foreach(node => CallHierarchy.printCallHierarchy(node))
   }
 
 }

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -1,3 +1,4 @@
+import java.nio.file.Files.writeString
 import java.nio.file.Path
 import scala.meta.internal.semanticdb.{SymbolInformation, SymbolOccurrence}
 
@@ -5,6 +6,29 @@ object Analysis {
 
   def isViewsDefinition(symbolInfo: SymbolInformation, file: SourceRef): Boolean =
     symbolInfo.symbol.startsWith("views/html/") && (symbolInfo.kind.isMethod || symbolInfo.kind.isObject)
+
+  def isTwirlTemplate(methodRef: MethodRef): Boolean = methodRef.file.file.endsWith(".template.scala")
+  def isRouter(methodRef: MethodRef): Boolean = methodRef.symbolName.symbolName.startsWith("router/Routes")
+  def isController(callers: Seq[CallHierarchy]): Boolean = callers.exists(caller => isRouter(caller.callee))
+
+  // for each hierarchy, create a mapping from the twirl template to the controller
+  // a twirl template is defined as any symbol in a file that ends in .template.scala
+  // a controller is defined as any method called from within a router/Routes file
+  def recursivelyMap(
+      node: CallHierarchy,
+      templates: List[MethodRef],
+      controllers: List[MethodRef],
+  ): (List[MethodRef], List[MethodRef]) = node match {
+    case CallHierarchyCycle(_)                            => (templates, controllers)
+    case CallHierarchyEntryPoint(_)                       => (templates, controllers)
+    case CallHierarchyNode(callee, _) if isRouter(callee) => (templates, controllers)
+    case CallHierarchyNode(callee, callers)               =>
+      val newTemplates = if (isTwirlTemplate(callee)) callee :: templates else templates
+      val newControllers = if (isController(callers)) callee :: controllers else controllers
+      callers.foldLeft((newTemplates, newControllers)) { case ((accTemplates, accControllers), caller) =>
+        recursivelyMap(caller, accTemplates, accControllers)
+      }
+  }
 
   def main(args: Array[String]): Unit = {
     val sources = SourceLoader.loadSources(Path.of("."))
@@ -14,45 +38,33 @@ object Analysis {
     val callHierarchies = callHierarchyBuilder
       .buildCallHierarchy(isViewsDefinition)
 
-    callHierarchies.foreach(node => CallHierarchy.printCallHierarchy(node, indent = ""))
-
-    // for each hierarchy, create a twirl template file to controller method mapping
-    // a twirl template is defined as a file that ends in .template.scala
-    // a controller is defined as any file called from a router/Routes file
-    def isTwirlTemplate(methodRef: MethodRef): Boolean = methodRef.file.file.endsWith(".template.scala")
-    def isRouter(methodRef: MethodRef): Boolean = methodRef.symbolName.symbolName.startsWith("router/Routes")
-    def isController(callers: Seq[CallHierarchy]): Boolean = callers.exists(caller => isRouter(caller.callee))
-    def recursivelyMap(
-        node: CallHierarchy,
-        templates: List[MethodRef],
-        controllers: List[MethodRef],
-    ): (List[MethodRef], List[MethodRef]) = node match {
-      case CallHierarchyCycle(_)                            => (templates, controllers)
-      case CallHierarchyEntryPoint(_)                       => (templates, controllers)
-      case CallHierarchyNode(callee, _) if isRouter(callee) => (templates, controllers)
-      case CallHierarchyNode(callee, callers)               =>
-        val newTemplates = if (isTwirlTemplate(callee)) callee :: templates else templates
-        val newControllers = if (isController(callers)) callee :: controllers else controllers
-        callers.foldLeft((newTemplates, newControllers)) { case ((accTemplates, accControllers), caller) =>
-          recursivelyMap(caller, accTemplates, accControllers)
-        }
-    }
+    // callHierarchies.foreach(node => CallHierarchy.printCallHierarchy(node, indent = ""))
 
     val mappings = callHierarchies
       .flatMap { node =>
         val (templates, controllers) = recursivelyMap(node, Nil, Nil)
         // cartesian product of templates and controllers
+        // This is because in a single call hierarchy you could have multiple templates and multiple controllers
         for {
           template <- templates
           controller <- controllers
         } yield (controller, template)
       }
+      // with all the distinct possibilities, we deduplicate and sort for easier handling
       .distinctBy(i => i._1.symbolName.symbolName + "->" + i._2.symbolName.symbolName)
       .sortBy(entry => entry._1.symbolName.symbolName + "->" + entry._2.symbolName.symbolName)
 
-    mappings.foreach { case (controller, template) =>
-      println(s"${controller.symbolName} -> ${template.symbolName}")
+    val csvContent = mappings.map { case (controller, template) =>
+      val controllerLocation =
+        s"${controller.file}:${controller.occurrence.range.map(r => s"${r.startLine}:${r.startCharacter}").getOrElse("unknown")}"
+      val templateLocation =
+        s"${template.file}:${template.occurrence.range.map(r => s"${r.startLine}:${r.startCharacter}").getOrElse("unknown")}"
+      s"${controller.symbolName};${controllerLocation};${template.symbolName};${templateLocation};"
     }
+    val csvHeader = "Controller Symbol;Controller Location;Template Symbol;Template Location;"
+    val csvOutput = (csvHeader +: csvContent).mkString("\n")
+    val outputPath = Path.of("controller_template_mappings.csv")
+    writeString(outputPath, csvOutput)
   }
 
 }

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -7,8 +7,8 @@ object Analysis {
     symbolInfo.symbol.startsWith("views/html/") && (symbolInfo.kind.isMethod || symbolInfo.kind.isObject)
 
   def main(args: Array[String]): Unit = {
-    val sources = SourceLoader.loadSources(Path.of("./article"))
-    val semanticDB = SourceLoader.loadSemanticDB(Path.of("./article"))
+    val sources = SourceLoader.loadSources(Path.of("."))
+    val semanticDB = SourceLoader.loadSemanticDB(Path.of("."))
 
     val callHierarchyBuilder = new CallHierarchyBuilder(sources, semanticDB)
     val callHierarchies = callHierarchyBuilder

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -1,6 +1,8 @@
+import SourceLoader.SourceRef
+
 import java.nio.file.Path
 import scala.meta.{Defn, Import, Importer, Input, Pkg, Position, Source, Term, Tree}
-import scala.meta.internal.semanticdb.{Range, Locator, SymbolOccurrence, TextDocument}
+import scala.meta.internal.semanticdb.{Locator, Range, SymbolInformation, SymbolOccurrence, TextDocument}
 
 object Analysis {
 
@@ -15,29 +17,27 @@ object Analysis {
     case None                 => false
   }
 
-  def findViewsCallSites(scalaSources: ScalaSources): Seq[Term.Select] = {
-    val allCallSites = scalaSources.collect {
-      case (file, s: Term.Select) if s.qual.text.startsWith("views.html") && !isPackageOrImport(s) => file -> s
+  def findViewsDefinitions(semanticDB: SemanticDB): Seq[(SourceRef, SymbolInformation)] = {
+    semanticDB.allDocuments.flatMap { case (file, document) =>
+      document.symbols
+        .filter { symbol =>
+          symbol.symbol.startsWith("views/html/") && (symbol.kind.isMethod || symbol.kind.isObject)
+        }
+        .map(definitions => file -> definitions)
+        .map { case (file, definition) =>
+
+          file -> definition
+        }
     }
-    // dedupe to avoid selecting views.html.fragment as well as views.html.fragments.articleBody
-    val grouped = allCallSites
-      // we identify unique call sites by their start position in the source code
-      .groupBy { case (file, callSite) =>
-        val position = callSite.origin.position
-        (file, position.startLine, position.startColumn)
-      }
-    // for all the call sites at a given start position
-    // sorting by name length keeps the longest (most specific) at the end
-    grouped.flatMap { case (_, calls) =>
-      val sortedCalls = calls.sortBy(_._2.name.value.length).lastOption.map(_._2)
-      sortedCalls
-    }.toSeq
   }
-  def findViewsCallSites2(semanticDB: Map[String, TextDocument]): Seq[SymbolOccurrence] = {
-    semanticDB.toSeq.flatMap { case (_, document) =>
-      document.occurrences.filter { symbol =>
-        symbol.symbol.startsWith("views/html/") && symbol.role.isReference
-      }
+
+  def findViewsCallSites(semanticDB: SemanticDB): Seq[(SourceRef, SymbolOccurrence)] = {
+    val allDefs = findViewsDefinitions(semanticDB)
+    allDefs.flatMap { case (_, definition) =>
+      semanticDB
+        .getOccurrences(definition.symbol)
+        .filter { case (_, occurrence) => occurrence.role.isReference }
+        .map { case (callFile, occurrence) => callFile -> occurrence }
     }
   }
 
@@ -51,60 +51,63 @@ object Analysis {
     case None                    => None
   }
 
-  def identifyFullyQualifiedName(node: Tree, parents: List[Tree] = List.empty): Option[List[Tree]] = findOwner(
+  def identifyFullyQualifiedNameOfOwner(node: Tree, parents: List[Tree] = List.empty): Option[List[Tree]] = findOwner(
     node,
   ) match {
-    case Some(owner) => identifyFullyQualifiedName(owner, owner :: parents)
+    case Some(owner) => identifyFullyQualifiedNameOfOwner(owner, owner :: parents)
     case None        => Some(parents)
   }
 
   def formatFullyQualifiedName(nodes: List[Tree]): String = nodes.map {
-    case defn: Defn.Def    => s"#${defn.name.value}()."
-    case defn: Defn.Class  => defn.name.value
-    case defn: Defn.Trait  => defn.name.value
-    case defn: Defn.Object => defn.name.value
+    case defn: Defn.Def    => s"${defn.name.value}()."
+    case defn: Defn.Class  => s"${defn.name.value}#"
+    case defn: Defn.Trait  => s"${defn.name.value}#"
+    case defn: Defn.Object => s"${defn.name.value}."
     case pkg: Pkg          => s"${pkg.name.value.replace(".", "/")}/"
     case other             => other.toString()
   }.mkString
 
-  def findNextCallers(node: Tree, scalaSources: ScalaSources, semanticDB: Map[String, TextDocument]): Seq[Call] = {
-    identifyFullyQualifiedName(node).map(formatFullyQualifiedName) match {
-      case Some(fullyQualifiedName) =>
-        val callSites = semanticDB.toSeq.flatMap { case (file, document) =>
-          document.occurrences
-            .filter { symbol =>
-              symbol.symbol == fullyQualifiedName && symbol.role.isReference
-            }
-            .map(occurrence => file -> occurrence)
+  def symbolOccurrenceToSourceTree(
+      callSites: Seq[(SourceRef, SymbolOccurrence)],
+      scalaSources: ScalaSources,
+  ): Seq[Tree] = {
+    val positions = callSites.collect { case (file, SymbolOccurrence(Some(range), _, _)) =>
+      (file, range)
+    }.toSet
+
+    def toRange(position: Position): Range =
+      Range(position.startLine, position.startColumn, position.endLine, position.endColumn)
+
+    scalaSources
+      .collect {
+        case (file, node) if positions.contains(file -> toRange(node.origin.position)) => node
+      }
+
+  }
+
+  def findNextCallers(call: Call, scalaSources: ScalaSources, semanticDB: SemanticDB): Seq[Call] = {
+    val callSites = semanticDB.allDocuments.flatMap { case (file, document) =>
+      document.occurrences
+        .filter { symbol =>
+          symbol.symbol == call.owner && symbol.role.isReference
         }
+        .map(occurrence => file -> occurrence)
+    }
 
-        val positions = callSites.collect { case (file, SymbolOccurrence(Some(range), _, _)) =>
-          (file, range)
-        }.toSet
-
-        def toRange(position: Position): Range =
-          Range(position.startLine, position.startColumn, position.endLine, position.endColumn)
-
-        scalaSources
-          .collect {
-            case (file, node) if positions.contains(file -> toRange(node.origin.position)) => node
-          }
-          .map { callerNode =>
-            val callerOwner = identifyFullyQualifiedName(callerNode)
-              .map(formatFullyQualifiedName)
-              .getOrElse("unknown")
-            Call(fullyQualifiedName, callerOwner, callerNode)
-          }
-      case None => List.empty
+    symbolOccurrenceToSourceTree(callSites, scalaSources).map { callerNode =>
+      val callerOwner = identifyFullyQualifiedNameOfOwner(callerNode)
+        .map(formatFullyQualifiedName)
+        .getOrElse("unknown")
+      Call(call.owner, callerOwner, callerNode)
     }
   }
 
   def buildCallHierarchy(
       call: Call,
       scalaSources: ScalaSources,
-      semanticDB: Map[String, TextDocument],
+      semanticDB: SemanticDB,
   ): CallHierarchyNode = {
-    val callers = findNextCallers(call.node, scalaSources, semanticDB).map { caller =>
+    val callers = findNextCallers(call, scalaSources, semanticDB).map { caller =>
       buildCallHierarchy(caller, scalaSources, semanticDB)
     }
     CallHierarchyNode(call, callers)
@@ -114,20 +117,20 @@ object Analysis {
     val sources = SourceLoader.loadSources(Path.of("./article"))
     val semanticDB = SourceLoader.loadSemanticDB(Path.of("./article"))
 
-    val viewsCallSites = findViewsCallSites(sources)
-    // val viewsCallSites = findViewsCallSites2(semanticDB)
+    val viewsCallSites = findViewsCallSites(semanticDB)
 
-    // TODO use matching the position to the source to match to the source and find parent
+    viewsCallSites.foreach { case (file, occurrence) =>
+      val sourceTrees = symbolOccurrenceToSourceTree(Seq(file -> occurrence), sources).filterNot(isPackageOrImport)
 
-    val nextCallers = viewsCallSites.map { node =>
-      val fullyQualifiedSubjectName = s"${node.qual.text}.${node.name.value}"
-      println("Processing call site: " + fullyQualifiedSubjectName)
-      val fullyQualifiedCallerName = identifyFullyQualifiedName(node).map(formatFullyQualifiedName).getOrElse("unknown")
+      val nextCallers = sourceTrees.map { case node: Term.Name =>
+        val fullyQualifiedCallerName =
+          identifyFullyQualifiedNameOfOwner(node).map(formatFullyQualifiedName).getOrElse("unknown")
 
-      val call = Call(fullyQualifiedSubjectName, fullyQualifiedCallerName, node)
-      buildCallHierarchy(call, sources, semanticDB)
-    }.distinct
-    nextCallers.foreach(node => CallHierarchy.printCallHierarchy(node))
+        val call = Call(occurrence.symbol, fullyQualifiedCallerName, node)
+        buildCallHierarchy(call, sources, semanticDB)
+      }.distinct
+      nextCallers.foreach(node => CallHierarchy.printCallHierarchy(node))
+    }
   }
 
 }

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -1,28 +1,37 @@
 import java.nio.file.Path
-import scala.meta.{Defn, Input, Pkg, Source, Term, Tree}
+import scala.meta.{Defn, Import, Importer, Input, Pkg, Source, Term, Tree}
 import scala.meta.internal.semanticdb.{Locator, TextDocument}
-
-case class Call(subject: String, owner: String, node: Tree)
-case class CallHierarchyNode(node: Call, callers: Seq[CallHierarchyNode])
 
 object Analysis {
 
-  def findViewsCallSites(node: Tree): Seq[Term.Select] = {
-    val allCallSites = node.collect {
-      case s: Term.Select if s.qual.text.startsWith("views.html") => s
+  def isPackageOrImport(node: Tree): Boolean = node.parent match {
+    case Some(_: Pkg)         => true
+    case Some(_: Importer)    => true
+    case Some(_: Defn.Def)    => false
+    case Some(_: Defn.Class)  => false
+    case Some(_: Defn.Trait)  => false
+    case Some(_: Defn.Object) => false
+    case Some(parent)         => isPackageOrImport(parent)
+    case None                 => false
+  }
+
+  def findViewsCallSites(scalaSources: ScalaSources): Seq[Term.Select] = {
+    val allCallSites = scalaSources.collect {
+      case (file, s: Term.Select) if s.qual.text.startsWith("views.html") && !isPackageOrImport(s) => file -> s
     }
     // dedupe to avoid selecting views.html.fragment as well as views.html.fragments.articleBody
-    allCallSites
+    val grouped = allCallSites
       // we identify unique call sites by their start position in the source code
-      .groupBy { callSite =>
+      .groupBy { case (file, callSite) =>
         val position = callSite.origin.position
-        (position.startLine, position.startColumn)
+        (file, position.startLine, position.startColumn)
       }
-      // for all the call sites at a given start position
-      // sorting by name length keeps the longest (most specific) at the end
-      .flatMap(_._2.sortBy(_.name.value.length).lastOption)
-      .toSeq
-
+    // for all the call sites at a given start position
+    // sorting by name length keeps the longest (most specific) at the end
+    grouped.flatMap { case (_, calls) =>
+      val sortedCalls = calls.sortBy(_._2.name.value.length).lastOption.map(_._2)
+      sortedCalls
+    }.toSeq
   }
 
   def findOwner(node: Tree): Option[Tree] = node.parent match {
@@ -70,7 +79,7 @@ object Analysis {
     document
   }
 
-  def findNextCallers(node: Tree, root: Tree, document: TextDocument): Seq[Call] = {
+  def findNextCallers(node: Tree, scalaSources: ScalaSources, document: TextDocument): Seq[Call] = {
     identifyFullyQualifiedName(node).map(formatFullyQualifiedName) match {
       case Some(fullyQualifiedName) =>
         val callSites = document.occurrences.filter { symbol =>
@@ -87,9 +96,9 @@ object Analysis {
             node.pos.endColumn == pos.endCharacter
           }
         }
-        root
+        scalaSources
           .collect {
-            case node if startLines.contains(node.origin.position.startLine) && matchesPosition(node) => node
+            case (_, node) if startLines.contains(node.origin.position.startLine) && matchesPosition(node) => node
           }
           .map { callerNode =>
             val callerOwner = identifyFullyQualifiedName(callerNode)
@@ -101,37 +110,29 @@ object Analysis {
     }
   }
 
-  def buildCallHierarchy(call: Call, root: Tree, document: TextDocument): CallHierarchyNode = {
-    val callers = findNextCallers(call.node, root, document).map { caller =>
-      buildCallHierarchy(caller, root, document)
+  def buildCallHierarchy(call: Call, scalaSources: ScalaSources, document: TextDocument): CallHierarchyNode = {
+    val callers = findNextCallers(call.node, scalaSources, document).map { caller =>
+      buildCallHierarchy(caller, scalaSources, document)
     }
     CallHierarchyNode(call, callers)
   }
 
-  def printCallHierarchy(node: CallHierarchyNode, indent: String = ""): Unit = {
-    if (indent.isEmpty) {
-      println(s"${node.node.subject}")
-    }
-    println(s"  $indent${node.node.owner}")
-    node.callers.foreach(caller => printCallHierarchy(caller, indent + "  "))
-  }
-
   def main(args: Array[String]): Unit = {
-
-    val scalaFilePath = java.nio.file.Paths.get("./article/app/controllers/ArticleController.scala")
-    val source = parseScalaFile(scalaFilePath).get
+    val sources = SourceLoader.load(Path.of("./article"))
 
     val semanticDBPath = Path.of("./article/target/scala-2.13/meta/META-INF/semanticdb/article/app/controllers")
     val document = loadSemanticDB(semanticDBPath, "ArticleController.scala.semanticdb").get
 
-    val viewsCallSites = findViewsCallSites(source)
+    val viewsCallSites = findViewsCallSites(sources)
     val nextCallers = viewsCallSites.map { node =>
-      val fullyQualifiedCallerName = identifyFullyQualifiedName(node).map(formatFullyQualifiedName).getOrElse("unknown")
       val fullyQualifiedSubjectName = s"${node.qual.text}.${node.name.value}"
+      println("Processing call site: " + fullyQualifiedSubjectName)
+      val fullyQualifiedCallerName = identifyFullyQualifiedName(node).map(formatFullyQualifiedName).getOrElse("unknown")
+
       val call = Call(fullyQualifiedSubjectName, fullyQualifiedCallerName, node)
-      buildCallHierarchy(call, source, document)
+      buildCallHierarchy(call, sources, document)
     }.distinct
-    nextCallers.foreach(node => printCallHierarchy(node))
+    nextCallers.foreach(node => CallHierarchy.printCallHierarchy(node))
   }
 
 }

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -11,9 +11,48 @@ object Analysis {
     val semanticDB = SourceLoader.loadSemanticDB(Path.of("./article"))
 
     val callHierarchyBuilder = new CallHierarchyBuilder(sources, semanticDB)
-    callHierarchyBuilder
+    val callHierarchies = callHierarchyBuilder
       .buildCallHierarchy(isViewsDefinition)
-      .foreach(node => CallHierarchy.printCallHierarchy(node, indent = ""))
+
+    callHierarchies.foreach(node => CallHierarchy.printCallHierarchy(node, indent = ""))
+
+    // for each hierarchy, create a twirl template file to controller method mapping
+    // a twirl template is defined as a file that ends in .template.scala
+    // a controller is defined as any file called from a router/Routes file
+    def isTwirlTemplate(methodRef: MethodRef): Boolean = methodRef.file.file.endsWith(".template.scala")
+    def isRouter(methodRef: MethodRef): Boolean = methodRef.symbolName.symbolName.startsWith("router/Routes")
+    def isController(callers: Seq[CallHierarchy]): Boolean = callers.exists(caller => isRouter(caller.callee))
+    def recursivelyMap(
+        node: CallHierarchy,
+        templates: List[MethodRef],
+        controllers: List[MethodRef],
+    ): (List[MethodRef], List[MethodRef]) = node match {
+      case CallHierarchyCycle(_)                            => (templates, controllers)
+      case CallHierarchyEntryPoint(_)                       => (templates, controllers)
+      case CallHierarchyNode(callee, _) if isRouter(callee) => (templates, controllers)
+      case CallHierarchyNode(callee, callers)               =>
+        val newTemplates = if (isTwirlTemplate(callee)) callee :: templates else templates
+        val newControllers = if (isController(callers)) callee :: controllers else controllers
+        callers.foldLeft((newTemplates, newControllers)) { case ((accTemplates, accControllers), caller) =>
+          recursivelyMap(caller, accTemplates, accControllers)
+        }
+    }
+
+    val mappings = callHierarchies
+      .flatMap { node =>
+        val (templates, controllers) = recursivelyMap(node, Nil, Nil)
+        // cartesian product of templates and controllers
+        for {
+          template <- templates
+          controller <- controllers
+        } yield (controller, template)
+      }
+      .distinctBy(i => i._1.symbolName.symbolName + "->" + i._2.symbolName.symbolName)
+      .sortBy(entry => entry._1.symbolName.symbolName + "->" + entry._2.symbolName.symbolName)
+
+    mappings.foreach { case (controller, template) =>
+      println(s"${controller.symbolName} -> ${template.symbolName}")
+    }
   }
 
 }

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -1,0 +1,133 @@
+import java.nio.file.Path
+import scala.meta.{Defn, Input, Pkg, Source, Term, Tree}
+import scala.meta.internal.semanticdb.{Locator, TextDocument}
+
+case class Call(subject: String, owner: String, node: Tree)
+case class CallHierarchyNode(node: Call, callers: Seq[CallHierarchyNode])
+
+object Analysis {
+
+  def findViewsCallSites(node: Tree): Seq[Term.Select] = {
+    val allCallSites = node.collect {
+      case s: Term.Select if s.qual.text.startsWith("views.html") => s
+    }
+    // dedupe to avoid selecting views.html.fragment as well as views.html.fragments.articleBody
+    allCallSites
+      // we identify unique call sites by their start position in the source code
+      .groupBy { callSite =>
+        val position = callSite.origin.position
+        (position.startLine, position.startColumn)
+      }
+      // for all the call sites at a given start position
+      // sorting by name length keeps the longest (most specific) at the end
+      .flatMap(_._2.sortBy(_.name.value.length).lastOption)
+      .toSeq
+
+  }
+
+  def findOwner(node: Tree): Option[Tree] = node.parent match {
+    case Some(defn: Defn.Def)    => Some(defn)
+    case Some(defn: Defn.Class)  => Some(defn)
+    case Some(defn: Defn.Trait)  => Some(defn)
+    case Some(defn: Defn.Object) => Some(defn)
+    case Some(pkg: Pkg)          => Some(pkg)
+    case Some(parentNode)        => findOwner(parentNode)
+    case None                    => None
+  }
+
+  def identifyFullyQualifiedName(node: Tree, parents: List[Tree] = List.empty): Option[List[Tree]] = findOwner(
+    node,
+  ) match {
+    case Some(owner) => identifyFullyQualifiedName(owner, owner :: parents)
+    case None        => Some(parents)
+  }
+
+  def formatFullyQualifiedName(nodes: List[Tree]): String = nodes.map {
+    case defn: Defn.Def    => s"#${defn.name.value}()."
+    case defn: Defn.Class  => defn.name.value
+    case defn: Defn.Trait  => defn.name.value
+    case defn: Defn.Object => defn.name.value
+    case pkg: Pkg          => s"${pkg.name.value.replace(".", "/")}/"
+    case other             => other.toString()
+  }.mkString
+
+  def parseScalaFile(path: Path): Option[Source] = {
+    val bytes = java.nio.file.Files.readAllBytes(path)
+    val text = new String(bytes, "UTF-8")
+    val input = Input.VirtualFile(path.toString, text)
+    input.parse[Source].toOption
+  }
+
+  def loadSemanticDB(path: Path, filename: String): Option[TextDocument] = {
+    var document: Option[TextDocument] = None
+    Locator(path) { case (path, documents) =>
+      if (path.getFileName.toString == filename) {
+        documents.documents.headOption.foreach { doc =>
+          document = Some(doc)
+        }
+      }
+    }
+    document
+  }
+
+  def findNextCallers(node: Tree, root: Tree, document: TextDocument): Seq[Call] = {
+    identifyFullyQualifiedName(node).map(formatFullyQualifiedName) match {
+      case Some(fullyQualifiedName) =>
+        val callSites = document.occurrences.filter { symbol =>
+          symbol.symbol == fullyQualifiedName && symbol.role.isReference
+        }
+
+        val positions = callSites.flatMap(_.range)
+        val startLines = positions.map(_.startLine).toSet
+        def matchesPosition(node: Tree): Boolean = {
+          positions.exists { pos =>
+            node.pos.startLine == pos.startLine &&
+            node.pos.startColumn == pos.startCharacter &&
+            node.pos.endLine == pos.endLine &&
+            node.pos.endColumn == pos.endCharacter
+          }
+        }
+        root
+          .collect {
+            case node if startLines.contains(node.origin.position.startLine) && matchesPosition(node) => node
+          }
+          .map { callerNode =>
+            val callerOwner = identifyFullyQualifiedName(callerNode)
+              .map(formatFullyQualifiedName)
+              .getOrElse("unknown")
+            Call(fullyQualifiedName, callerOwner, callerNode)
+          }
+      case None => List.empty
+    }
+  }
+
+  def buildCallHierarchy(call: Call, root: Tree, document: TextDocument): CallHierarchyNode = {
+    val callers = findNextCallers(call.node, root, document).map { caller =>
+      buildCallHierarchy(caller, root, document)
+    }
+    CallHierarchyNode(call, callers)
+  }
+
+  def printCallHierarchy(node: CallHierarchyNode, indent: String = ""): Unit = {
+    println(s"$indent${node.node.owner}")
+    node.callers.foreach(caller => printCallHierarchy(caller, indent + "  "))
+  }
+
+  def main(args: Array[String]): Unit = {
+
+    val scalaFilePath = java.nio.file.Paths.get("./article/app/controllers/ArticleController.scala")
+    val source = parseScalaFile(scalaFilePath).get
+
+    val semanticDBPath = Path.of("./article/target/scala-2.13/meta/META-INF/semanticdb/article/app/controllers")
+    val document = loadSemanticDB(semanticDBPath, "ArticleController.scala.semanticdb").get
+
+    val viewsCallSites = findViewsCallSites(source)
+    val nextCallers = viewsCallSites.map { node =>
+      val fullyQualifiedName = identifyFullyQualifiedName(node).map(formatFullyQualifiedName).getOrElse("unknown")
+      val call = Call(node.name.value, fullyQualifiedName, node)
+      buildCallHierarchy(call, source, document)
+    }.distinct
+    nextCallers.foreach(node => printCallHierarchy(node))
+  }
+
+}

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -1,5 +1,3 @@
-import SourceLoader.SourceRef
-
 import java.nio.file.Path
 import scala.meta.internal.semanticdb.{SymbolInformation, SymbolOccurrence}
 
@@ -23,7 +21,7 @@ object Analysis {
     val allDefs = findViewsDefinitions(semanticDB)
     allDefs.flatMap { case (_, definition) =>
       semanticDB
-        .getOccurrences(definition.symbol)
+        .getOccurrences(SemanticDBSymbol(definition.symbol))
         .filter { case (_, occurrence) => occurrence.role.isReference }
         .map { case (callFile, occurrence) => callFile -> occurrence }
     }
@@ -37,7 +35,7 @@ object Analysis {
 
     findViewsCallSites(semanticDB)
       .map { case (file, occurrence) =>
-        val methodRef = MethodRef(occurrence.symbol, occurrence, file)
+        val methodRef = MethodRef(SemanticDBSymbol(occurrence.symbol), occurrence, file)
         callHierarchyBuilder.buildCallHierarchy(methodRef)
       }
       .foreach(node => CallHierarchy.printCallHierarchy(node))

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -1,6 +1,6 @@
 import java.nio.file.Path
-import scala.meta.{Defn, Import, Importer, Input, Pkg, Source, Term, Tree}
-import scala.meta.internal.semanticdb.{Locator, TextDocument}
+import scala.meta.{Defn, Import, Importer, Input, Pkg, Position, Source, Term, Tree}
+import scala.meta.internal.semanticdb.{Range, Locator, SymbolOccurrence, TextDocument}
 
 object Analysis {
 
@@ -33,6 +33,13 @@ object Analysis {
       sortedCalls
     }.toSeq
   }
+  def findViewsCallSites2(semanticDB: Map[String, TextDocument]): Seq[SymbolOccurrence] = {
+    semanticDB.toSeq.flatMap { case (_, document) =>
+      document.occurrences.filter { symbol =>
+        symbol.symbol.startsWith("views/html/") && symbol.role.isReference
+      }
+    }
+  }
 
   def findOwner(node: Tree): Option[Tree] = node.parent match {
     case Some(defn: Defn.Def)    => Some(defn)
@@ -63,25 +70,24 @@ object Analysis {
   def findNextCallers(node: Tree, scalaSources: ScalaSources, semanticDB: Map[String, TextDocument]): Seq[Call] = {
     identifyFullyQualifiedName(node).map(formatFullyQualifiedName) match {
       case Some(fullyQualifiedName) =>
-        val callSites = semanticDB.toSeq.flatMap { case (_, document) =>
-          document.occurrences.filter { symbol =>
-            symbol.symbol == fullyQualifiedName && symbol.role.isReference
-          }
+        val callSites = semanticDB.toSeq.flatMap { case (file, document) =>
+          document.occurrences
+            .filter { symbol =>
+              symbol.symbol == fullyQualifiedName && symbol.role.isReference
+            }
+            .map(occurrence => file -> occurrence)
         }
 
-        val positions = callSites.flatMap(_.range)
-        val startLines = positions.map(_.startLine).toSet
-        def matchesPosition(node: Tree): Boolean = {
-          positions.exists { pos =>
-            node.pos.startLine == pos.startLine &&
-            node.pos.startColumn == pos.startCharacter &&
-            node.pos.endLine == pos.endLine &&
-            node.pos.endColumn == pos.endCharacter
-          }
-        }
+        val positions = callSites.collect { case (file, SymbolOccurrence(Some(range), _, _)) =>
+          (file, range)
+        }.toSet
+
+        def toRange(position: Position): Range =
+          Range(position.startLine, position.startColumn, position.endLine, position.endColumn)
+
         scalaSources
           .collect {
-            case (_, node) if startLines.contains(node.origin.position.startLine) && matchesPosition(node) => node
+            case (file, node) if positions.contains(file -> toRange(node.origin.position)) => node
           }
           .map { callerNode =>
             val callerOwner = identifyFullyQualifiedName(callerNode)
@@ -106,10 +112,13 @@ object Analysis {
 
   def main(args: Array[String]): Unit = {
     val sources = SourceLoader.loadSources(Path.of("./article"))
-
     val semanticDB = SourceLoader.loadSemanticDB(Path.of("./article"))
 
     val viewsCallSites = findViewsCallSites(sources)
+    // val viewsCallSites = findViewsCallSites2(semanticDB)
+
+    // TODO use matching the position to the source to match to the source and find parent
+
     val nextCallers = viewsCallSites.map { node =>
       val fullyQualifiedSubjectName = s"${node.qual.text}.${node.name.value}"
       println("Processing call site: " + fullyQualifiedSubjectName)

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -60,30 +60,13 @@ object Analysis {
     case other             => other.toString()
   }.mkString
 
-  def parseScalaFile(path: Path): Option[Source] = {
-    val bytes = java.nio.file.Files.readAllBytes(path)
-    val text = new String(bytes, "UTF-8")
-    val input = Input.VirtualFile(path.toString, text)
-    input.parse[Source].toOption
-  }
-
-  def loadSemanticDB(path: Path, filename: String): Option[TextDocument] = {
-    var document: Option[TextDocument] = None
-    Locator(path) { case (path, documents) =>
-      if (path.getFileName.toString == filename) {
-        documents.documents.headOption.foreach { doc =>
-          document = Some(doc)
-        }
-      }
-    }
-    document
-  }
-
-  def findNextCallers(node: Tree, scalaSources: ScalaSources, document: TextDocument): Seq[Call] = {
+  def findNextCallers(node: Tree, scalaSources: ScalaSources, semanticDB: Map[String, TextDocument]): Seq[Call] = {
     identifyFullyQualifiedName(node).map(formatFullyQualifiedName) match {
       case Some(fullyQualifiedName) =>
-        val callSites = document.occurrences.filter { symbol =>
-          symbol.symbol == fullyQualifiedName && symbol.role.isReference
+        val callSites = semanticDB.toSeq.flatMap { case (_, document) =>
+          document.occurrences.filter { symbol =>
+            symbol.symbol == fullyQualifiedName && symbol.role.isReference
+          }
         }
 
         val positions = callSites.flatMap(_.range)
@@ -110,18 +93,21 @@ object Analysis {
     }
   }
 
-  def buildCallHierarchy(call: Call, scalaSources: ScalaSources, document: TextDocument): CallHierarchyNode = {
-    val callers = findNextCallers(call.node, scalaSources, document).map { caller =>
-      buildCallHierarchy(caller, scalaSources, document)
+  def buildCallHierarchy(
+      call: Call,
+      scalaSources: ScalaSources,
+      semanticDB: Map[String, TextDocument],
+  ): CallHierarchyNode = {
+    val callers = findNextCallers(call.node, scalaSources, semanticDB).map { caller =>
+      buildCallHierarchy(caller, scalaSources, semanticDB)
     }
     CallHierarchyNode(call, callers)
   }
 
   def main(args: Array[String]): Unit = {
-    val sources = SourceLoader.load(Path.of("./article"))
+    val sources = SourceLoader.loadSources(Path.of("./article"))
 
-    val semanticDBPath = Path.of("./article/target/scala-2.13/meta/META-INF/semanticdb/article/app/controllers")
-    val document = loadSemanticDB(semanticDBPath, "ArticleController.scala.semanticdb").get
+    val semanticDB = SourceLoader.loadSemanticDB(Path.of("./article"))
 
     val viewsCallSites = findViewsCallSites(sources)
     val nextCallers = viewsCallSites.map { node =>
@@ -130,7 +116,7 @@ object Analysis {
       val fullyQualifiedCallerName = identifyFullyQualifiedName(node).map(formatFullyQualifiedName).getOrElse("unknown")
 
       val call = Call(fullyQualifiedSubjectName, fullyQualifiedCallerName, node)
-      buildCallHierarchy(call, sources, document)
+      buildCallHierarchy(call, sources, semanticDB)
     }.distinct
     nextCallers.foreach(node => CallHierarchy.printCallHierarchy(node))
   }

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -1,21 +1,9 @@
 import SourceLoader.SourceRef
 
 import java.nio.file.Path
-import scala.meta.{Defn, Import, Importer, Input, Pkg, Position, Source, Term, Tree}
-import scala.meta.internal.semanticdb.{Locator, Range, SymbolInformation, SymbolOccurrence, TextDocument}
+import scala.meta.internal.semanticdb.{SymbolInformation, SymbolOccurrence}
 
 object Analysis {
-
-  def isPackageOrImport(node: Tree): Boolean = node.parent match {
-    case Some(_: Pkg)         => true
-    case Some(_: Importer)    => true
-    case Some(_: Defn.Def)    => false
-    case Some(_: Defn.Class)  => false
-    case Some(_: Defn.Trait)  => false
-    case Some(_: Defn.Object) => false
-    case Some(parent)         => isPackageOrImport(parent)
-    case None                 => false
-  }
 
   def findViewsDefinitions(semanticDB: SemanticDB): Seq[(SourceRef, SymbolInformation)] = {
     semanticDB.allDocuments.flatMap { case (file, document) =>
@@ -41,91 +29,17 @@ object Analysis {
     }
   }
 
-  def findOwner(node: Tree): Option[Tree] = node.parent match {
-    case Some(defn: Defn.Def)    => Some(defn)
-    case Some(defn: Defn.Class)  => Some(defn)
-    case Some(defn: Defn.Trait)  => Some(defn)
-    case Some(defn: Defn.Object) => Some(defn)
-    case Some(pkg: Pkg)          => Some(pkg)
-    case Some(parentNode)        => findOwner(parentNode)
-    case None                    => None
-  }
-
-  def identifyFullyQualifiedNameOfOwner(node: Tree, parents: List[Tree] = List.empty): Option[List[Tree]] = findOwner(
-    node,
-  ) match {
-    case Some(owner) => identifyFullyQualifiedNameOfOwner(owner, owner :: parents)
-    case None        => Some(parents)
-  }
-
-  def formatFullyQualifiedName(nodes: List[Tree]): String = nodes.map {
-    case defn: Defn.Def    => s"${defn.name.value}()."
-    case defn: Defn.Class  => s"${defn.name.value}#"
-    case defn: Defn.Trait  => s"${defn.name.value}#"
-    case defn: Defn.Object => s"${defn.name.value}."
-    case pkg: Pkg          => s"${pkg.name.value.replace(".", "/")}/"
-    case other             => other.toString()
-  }.mkString
-
-  def symbolOccurrenceToSourceTree(
-      callSites: Seq[(SourceRef, SymbolOccurrence)],
-      scalaSources: ScalaSources,
-  ): Seq[Tree] = {
-    val positions = callSites.collect { case (file, SymbolOccurrence(Some(range), _, _)) =>
-      (file, range)
-    }.toSet
-
-    def toRange(position: Position): Range =
-      Range(position.startLine, position.startColumn, position.endLine, position.endColumn)
-
-    scalaSources
-      .collect {
-        case (file, node) if positions.contains(file -> toRange(node.origin.position)) => node
-      }
-
-  }
-
-  def findNextCallers(method: MethodRef, scalaSources: ScalaSources, semanticDB: SemanticDB): Seq[MethodRef] = {
-    val fullyQualifiedCallers =
-      symbolOccurrenceToSourceTree(Seq(method.file -> method.occurrence), scalaSources)
-        .filterNot(isPackageOrImport)
-        .map { callerNode =>
-          identifyFullyQualifiedNameOfOwner(callerNode)
-            .map(formatFullyQualifiedName)
-            .getOrElse("unknown")
-        }
-        .toSet
-
-    semanticDB.allDocuments.flatMap { case (file, document) =>
-      document.occurrences
-        .filter { symbol =>
-          fullyQualifiedCallers.contains(symbol.symbol) && symbol.role.isReference
-        }
-        .map(occurrence => MethodRef(occurrence.symbol, occurrence, file))
-    }
-  }
-
-  def buildCallHierarchy(
-      callee: MethodRef,
-      scalaSources: ScalaSources,
-      semanticDB: SemanticDB,
-  ): CallHierarchyNode = {
-    val callers = findNextCallers(callee, scalaSources, semanticDB).map { case caller =>
-      buildCallHierarchy(callee = caller, scalaSources, semanticDB)
-    }
-    CallHierarchyNode(callee, callers)
-  }
-
   def main(args: Array[String]): Unit = {
     val sources = SourceLoader.loadSources(Path.of("./article"))
     val semanticDB = SourceLoader.loadSemanticDB(Path.of("./article"))
 
+    val callHierarchyBuilder = new CallHierarchyBuilder(sources, semanticDB)
+
     findViewsCallSites(semanticDB)
       .map { case (file, occurrence) =>
-        val methodRed = MethodRef(occurrence.symbol, occurrence, file)
-        buildCallHierarchy(methodRed, sources, semanticDB)
+        val methodRef = MethodRef(occurrence.symbol, occurrence, file)
+        callHierarchyBuilder.buildCallHierarchy(methodRef)
       }
-      .distinct
       .foreach(node => CallHierarchy.printCallHierarchy(node))
   }
 

--- a/static-analysis/src/main/scala/Analysis.scala
+++ b/static-analysis/src/main/scala/Analysis.scala
@@ -38,8 +38,6 @@ object Analysis {
     val callHierarchies = callHierarchyBuilder
       .buildCallHierarchy(isViewsDefinition)
 
-    // callHierarchies.foreach(node => CallHierarchy.printCallHierarchy(node, indent = ""))
-
     val mappings = callHierarchies
       .flatMap { node =>
         val (templates, controllers) = recursivelyMap(node, Nil, Nil)

--- a/static-analysis/src/main/scala/CallHierarchy.scala
+++ b/static-analysis/src/main/scala/CallHierarchy.scala
@@ -8,6 +8,14 @@ case class SourceRef(file: String) extends AnyVal {
   override def toString() = file
 }
 
+case class SymbolCoordinates(
+    file: SourceRef,
+    startLine: Int,
+    startCharacter: Int,
+    endLine: Int,
+    endCharacter: Int,
+)
+
 case class MethodRef(symbolName: SemanticDBSymbol, occurrence: SymbolOccurrence, file: SourceRef)
 
 sealed trait CallHierarchy {

--- a/static-analysis/src/main/scala/CallHierarchy.scala
+++ b/static-analysis/src/main/scala/CallHierarchy.scala
@@ -1,0 +1,14 @@
+import scala.meta.Tree
+
+case class Call(subject: String, owner: String, node: Tree)
+case class CallHierarchyNode(node: Call, callers: Seq[CallHierarchyNode])
+
+object CallHierarchy {
+  def printCallHierarchy(node: CallHierarchyNode, indent: String = ""): Unit = {
+    if (indent.isEmpty) {
+      println(s"${node.node.subject}")
+    }
+    println(s"  $indent${node.node.owner}")
+    node.callers.foreach(caller => printCallHierarchy(caller, indent + "  "))
+  }
+}

--- a/static-analysis/src/main/scala/CallHierarchy.scala
+++ b/static-analysis/src/main/scala/CallHierarchy.scala
@@ -10,20 +10,27 @@ case class SourceRef(file: String) extends AnyVal {
 
 case class MethodRef(symbolName: SemanticDBSymbol, occurrence: SymbolOccurrence, file: SourceRef)
 
-sealed trait CallHierarchy
+sealed trait CallHierarchy {
+  def callee: MethodRef
+}
+
 case class CallHierarchyNode(callee: MethodRef, callers: Seq[CallHierarchy]) extends CallHierarchy
 case class CallHierarchyCycle(callee: MethodRef) extends CallHierarchy
 case class CallHierarchyEntryPoint(callee: MethodRef) extends CallHierarchy
 
 object CallHierarchy {
   def printCallHierarchy(node: CallHierarchy, indent: String = ""): Unit = {
+    def formatMethodRef(methodRef: MethodRef): String = {
+      s"${methodRef.symbolName} in ${methodRef.file}:${methodRef.occurrence.range.map(r => s"${r.startLine}:${r.startCharacter}").getOrElse("unknown")}"
+    }
     node match {
       case CallHierarchyCycle(callee) =>
-        println(s"${indent}${callee.symbolName} (cycle detected)")
+        println(s"${indent}${formatMethodRef(callee)} (cycle detected)")
       case CallHierarchyEntryPoint(callee) =>
-        println(s"${indent}${callee.symbolName}")
+        println(s"${indent}${formatMethodRef(callee)}")
+        println(s"${indent}  No call to ${callee.symbolName} found (entry point)")
       case CallHierarchyNode(callee, callers) =>
-        println(s"${indent}${callee.symbolName}")
+        println(s"${indent}${formatMethodRef(callee)}")
         callers.foreach(caller => printCallHierarchy(caller, indent + "  "))
     }
   }

--- a/static-analysis/src/main/scala/CallHierarchy.scala
+++ b/static-analysis/src/main/scala/CallHierarchy.scala
@@ -1,14 +1,13 @@
-import scala.meta.Tree
+import SourceLoader.SourceRef
 
-case class Call(subject: String, owner: String, node: Tree)
-case class CallHierarchyNode(node: Call, callers: Seq[CallHierarchyNode])
+import scala.meta.internal.semanticdb.SymbolOccurrence
+
+case class MethodRef(qualifiedName: String, occurrence: SymbolOccurrence, file: SourceRef)
+case class CallHierarchyNode(callee: MethodRef, callers: Seq[CallHierarchyNode])
 
 object CallHierarchy {
   def printCallHierarchy(node: CallHierarchyNode, indent: String = ""): Unit = {
-    if (indent.isEmpty) {
-      println(s"${node.node.subject}")
-    }
-    println(s"  $indent${node.node.owner}")
+    println(s"${indent}${node.callee.qualifiedName}")
     node.callers.foreach(caller => printCallHierarchy(caller, indent + "  "))
   }
 }

--- a/static-analysis/src/main/scala/CallHierarchy.scala
+++ b/static-analysis/src/main/scala/CallHierarchy.scala
@@ -2,12 +2,23 @@ import SourceLoader.SourceRef
 
 import scala.meta.internal.semanticdb.SymbolOccurrence
 
-case class MethodRef(qualifiedName: String, occurrence: SymbolOccurrence, file: SourceRef)
-case class CallHierarchyNode(callee: MethodRef, callers: Seq[CallHierarchyNode])
+case class MethodRef(symbolName: String, occurrence: SymbolOccurrence, file: SourceRef)
+
+sealed trait CallHierarchy
+case class CallHierarchyNode(callee: MethodRef, callers: Seq[CallHierarchy]) extends CallHierarchy
+case class CallHierarchyCycle(callee: MethodRef) extends CallHierarchy
+case class CallHierarchyEntryPoint(callee: MethodRef) extends CallHierarchy
 
 object CallHierarchy {
-  def printCallHierarchy(node: CallHierarchyNode, indent: String = ""): Unit = {
-    println(s"${indent}${node.callee.qualifiedName}")
-    node.callers.foreach(caller => printCallHierarchy(caller, indent + "  "))
+  def printCallHierarchy(node: CallHierarchy, indent: String = ""): Unit = {
+    node match {
+      case CallHierarchyCycle(callee) =>
+        println(s"${indent}${callee.symbolName} (cycle detected)")
+      case CallHierarchyEntryPoint(callee) =>
+        println(s"${indent}${callee.symbolName}")
+      case CallHierarchyNode(callee, callers) =>
+        println(s"${indent}${callee.symbolName}")
+        callers.foreach(caller => printCallHierarchy(caller, indent + "  "))
+    }
   }
 }

--- a/static-analysis/src/main/scala/CallHierarchy.scala
+++ b/static-analysis/src/main/scala/CallHierarchy.scala
@@ -1,8 +1,14 @@
-import SourceLoader.SourceRef
-
 import scala.meta.internal.semanticdb.SymbolOccurrence
 
-case class MethodRef(symbolName: String, occurrence: SymbolOccurrence, file: SourceRef)
+case class SemanticDBSymbol(symbolName: String) extends AnyVal {
+  override def toString() = symbolName
+}
+
+case class SourceRef(file: String) extends AnyVal {
+  override def toString() = file
+}
+
+case class MethodRef(symbolName: SemanticDBSymbol, occurrence: SymbolOccurrence, file: SourceRef)
 
 sealed trait CallHierarchy
 case class CallHierarchyNode(callee: MethodRef, callers: Seq[CallHierarchy]) extends CallHierarchy

--- a/static-analysis/src/main/scala/CallHierarchyBuilder.scala
+++ b/static-analysis/src/main/scala/CallHierarchyBuilder.scala
@@ -1,5 +1,5 @@
 import scala.meta.{Defn, Importer, Pkg, Position, Tree}
-import scala.meta.internal.semanticdb.{Range, SymbolOccurrence}
+import scala.meta.internal.semanticdb.{Range, SymbolInformation, SymbolOccurrence}
 
 class CallHierarchyBuilder(
     scalaSources: ScalaSources,
@@ -58,19 +58,20 @@ class CallHierarchyBuilder(
       case defn: Defn.Class  => s"${defn.name.value}#"
       case defn: Defn.Trait  => s"${defn.name.value}#"
       case defn: Defn.Object => s"${defn.name.value}."
-      case pkg: Pkg          => s"${pkg.name.value.replace(".", "/")}/"
+      case pkg: Pkg          => s"${pkg.ref.text.replace(".", "/")}/"
       case other => throw new RuntimeException(s"Unexpected tree node type: ${other.getClass.getSimpleName}")
     }.mkString
     SemanticDBSymbol(symbol)
   }
 
   private def nextLevelCallers(method: MethodRef): Seq[MethodRef] = {
-    val fullyQualifiedCallers =
-      symbolOccurrenceToSourceTree(method.file, method.occurrence)
-        // we don't care if a reference is just an import or a package declaration
-        // we want usage within the logic
-        .filterNot(isPackageOrImport)
-        .map(resolveEnclosingSymbolName)
+    val symbols = symbolOccurrenceToSourceTree(method.file, method.occurrence)
+    val fullyQualifiedCallers = symbols
+
+      // we don't care if a reference is just an import or a package declaration
+      // we want usage within the logic
+      .filterNot(isPackageOrImport)
+      .map(resolveEnclosingSymbolName)
 
     fullyQualifiedCallers
       .flatMap(semanticDB.getOccurrences)
@@ -80,13 +81,13 @@ class CallHierarchyBuilder(
 
   private def recursivelyBuildCallHierarchy(
       callee: MethodRef,
-      visited: Set[SemanticDBSymbol] = Set.empty,
+      visited: Set[SymbolOccurrence] = Set.empty,
   ): CallHierarchy = {
-    if (visited.contains(callee.symbolName)) {
+    if (visited.contains(callee.occurrence)) {
       CallHierarchyCycle(callee)
     } else {
       val callers = nextLevelCallers(callee).map { case caller =>
-        recursivelyBuildCallHierarchy(callee = caller, visited = visited + callee.symbolName)
+        recursivelyBuildCallHierarchy(callee = caller, visited = visited + callee.occurrence)
       }
       if (callers.isEmpty) {
         CallHierarchyEntryPoint(callee)
@@ -104,7 +105,24 @@ class CallHierarchyBuilder(
     *   a call hierarchy tree
     */
   def buildCallHierarchy(
-      callee: MethodRef,
-  ): CallHierarchy = recursivelyBuildCallHierarchy(callee)
+      isStartPoint: (SymbolInformation, SourceRef) => Boolean,
+  ): Seq[CallHierarchy] = {
+    val startingPoints = semanticDB.allDocuments
+      .flatMap { case (file, document) =>
+        document.symbols
+          .filter(symbol => isStartPoint(symbol, file))
+          .map(symbol => file -> symbol)
+      }
+      .flatMap { case (file, symbolInfo) =>
+        // find corresponding symbol occurrence for the definition
+        semanticDB
+          .getOccurrences(SemanticDBSymbol(symbolInfo.symbol))
+          .collect {
+            case (definitionFile, occurrence) if occurrence.role.isDefinition && definitionFile == file =>
+              MethodRef(SemanticDBSymbol(occurrence.symbol), occurrence, file)
+          }
+      }
+    startingPoints.map(callee => recursivelyBuildCallHierarchy(callee))
+  }
 
 }

--- a/static-analysis/src/main/scala/CallHierarchyBuilder.scala
+++ b/static-analysis/src/main/scala/CallHierarchyBuilder.scala
@@ -21,16 +21,13 @@ class CallHierarchyBuilder(
       file: SourceRef,
       symbolOccurrence: SymbolOccurrence,
   ): Seq[Tree] = {
-    def toRange(position: Position): Range =
-      Range(position.startLine, position.startColumn, position.endLine, position.endColumn)
+    def toCoordinages(range: Range): SymbolCoordinates =
+      SymbolCoordinates(file, range.startLine, range.startCharacter, range.endLine, range.endCharacter)
 
-    def sameCoordinates(sourceFile: SourceRef, position: Position): Boolean =
-      sourceFile == file && symbolOccurrence.range.contains(toRange(position))
-
-    scalaSources
-      .collect {
-        case (sourceFile, node) if sameCoordinates(sourceFile, node.origin.position) => node
-      }
+    symbolOccurrence.range match {
+      case None        => return Seq.empty
+      case Some(range) => scalaSources.getByCoordinates(toCoordinages(range))
+    }
   }
 
   private def findEnclosingConstruct(node: Tree): Option[Tree] = node.parent match {

--- a/static-analysis/src/main/scala/CallHierarchyBuilder.scala
+++ b/static-analysis/src/main/scala/CallHierarchyBuilder.scala
@@ -1,0 +1,94 @@
+import SourceLoader.SourceRef
+
+import scala.meta.{Defn, Importer, Pkg, Position, Tree}
+import scala.meta.internal.semanticdb.{Range, SymbolOccurrence}
+
+class CallHierarchyBuilder(
+    scalaSources: ScalaSources,
+    semanticDB: SemanticDB,
+) {
+
+  private def isPackageOrImport(node: Tree): Boolean = node.parent match {
+    case Some(_: Pkg)         => true
+    case Some(_: Importer)    => true
+    case Some(_: Defn.Def)    => false
+    case Some(_: Defn.Class)  => false
+    case Some(_: Defn.Trait)  => false
+    case Some(_: Defn.Object) => false
+    case Some(parent)         => isPackageOrImport(parent)
+    case None                 => false
+  }
+
+  private def symbolOccurrenceToSourceTree(
+      callSites: Seq[(SourceRef, SymbolOccurrence)],
+  ): Seq[Tree] = {
+    val positions = callSites.collect { case (file, SymbolOccurrence(Some(range), _, _)) =>
+      (file, range)
+    }.toSet
+
+    def toRange(position: Position): Range =
+      Range(position.startLine, position.startColumn, position.endLine, position.endColumn)
+
+    scalaSources
+      .collect {
+        case (file, node) if positions.contains(file -> toRange(node.origin.position)) => node
+      }
+  }
+
+  private def findOwner(node: Tree): Option[Tree] = node.parent match {
+    case Some(defn: Defn.Def)    => Some(defn)
+    case Some(defn: Defn.Class)  => Some(defn)
+    case Some(defn: Defn.Trait)  => Some(defn)
+    case Some(defn: Defn.Object) => Some(defn)
+    case Some(pkg: Pkg)          => Some(pkg)
+    case Some(parentNode)        => findOwner(parentNode)
+    case None                    => None
+  }
+
+  private def identifyFullyQualifiedNameOfOwner(node: Tree, parents: List[Tree] = List.empty): Option[List[Tree]] =
+    findOwner(
+      node,
+    ) match {
+      case Some(owner) => identifyFullyQualifiedNameOfOwner(owner, owner :: parents)
+      case None        => Some(parents)
+    }
+
+  def formatFullyQualifiedName(nodes: List[Tree]): String = nodes.map {
+    case defn: Defn.Def    => s"${defn.name.value}()."
+    case defn: Defn.Class  => s"${defn.name.value}#"
+    case defn: Defn.Trait  => s"${defn.name.value}#"
+    case defn: Defn.Object => s"${defn.name.value}."
+    case pkg: Pkg          => s"${pkg.name.value.replace(".", "/")}/"
+    case other             => other.toString()
+  }.mkString
+
+  private def findNextCallers(method: MethodRef): Seq[MethodRef] = {
+    val fullyQualifiedCallers =
+      symbolOccurrenceToSourceTree(Seq(method.file -> method.occurrence))
+        .filterNot(isPackageOrImport)
+        .map { callerNode =>
+          identifyFullyQualifiedNameOfOwner(callerNode)
+            .map(formatFullyQualifiedName)
+            .getOrElse("unknown")
+        }
+        .toSet
+
+    semanticDB.allDocuments.flatMap { case (file, document) =>
+      document.occurrences
+        .filter { symbol =>
+          fullyQualifiedCallers.contains(symbol.symbol) && symbol.role.isReference
+        }
+        .map(occurrence => MethodRef(occurrence.symbol, occurrence, file))
+    }
+  }
+
+  def buildCallHierarchy(
+      callee: MethodRef,
+  ): CallHierarchyNode = {
+    val callers = findNextCallers(callee).map { case caller =>
+      buildCallHierarchy(callee = caller)
+    }
+    CallHierarchyNode(callee, callers)
+  }
+
+}

--- a/static-analysis/src/main/scala/CallHierarchyBuilder.scala
+++ b/static-analysis/src/main/scala/CallHierarchyBuilder.scala
@@ -1,5 +1,3 @@
-import SourceLoader.SourceRef
-
 import scala.meta.{Defn, Importer, Pkg, Position, Tree}
 import scala.meta.internal.semanticdb.{Range, SymbolOccurrence}
 
@@ -35,56 +33,60 @@ class CallHierarchyBuilder(
       }
   }
 
-  private def findOwner(node: Tree): Option[Tree] = node.parent match {
+  private def findEnclosingConstruct(node: Tree): Option[Tree] = node.parent match {
     case Some(defn: Defn.Def)    => Some(defn)
     case Some(defn: Defn.Class)  => Some(defn)
     case Some(defn: Defn.Trait)  => Some(defn)
     case Some(defn: Defn.Object) => Some(defn)
     case Some(pkg: Pkg)          => Some(pkg)
-    case Some(parentNode)        => findOwner(parentNode)
+    case Some(parentNode)        => findEnclosingConstruct(parentNode)
     case None                    => None
   }
 
-  private def identifyFullyQualifiedNameOfOwner(node: Tree, parents: List[Tree] = List.empty): List[Tree] =
-    findOwner(
+  private def buildFullyQualifiedSymbolName(node: Tree, parents: List[Tree] = List.empty): List[Tree] =
+    findEnclosingConstruct(
       node,
     ) match {
-      case Some(owner) => identifyFullyQualifiedNameOfOwner(owner, owner :: parents)
+      case Some(owner) => buildFullyQualifiedSymbolName(owner, owner :: parents)
       case None        => parents
     }
 
-  def formatFullyQualifiedName(nodes: List[Tree]): String = nodes.map {
-    case defn: Defn.Def    => s"${defn.name.value}()."
-    case defn: Defn.Class  => s"${defn.name.value}#"
-    case defn: Defn.Trait  => s"${defn.name.value}#"
-    case defn: Defn.Object => s"${defn.name.value}."
-    case pkg: Pkg          => s"${pkg.name.value.replace(".", "/")}/"
-    case other             => throw new RuntimeException(s"Unexpected tree node type: ${other.getClass.getSimpleName}")
-  }.mkString
+  // Given a node in the AST, will resolve the fully qualified symbol name of the enclosing method
+  private def resolveEnclosingSymbolName(node: Tree): SemanticDBSymbol = {
+    val symbol = buildFullyQualifiedSymbolName(node).map {
+      case defn: Defn.Def    => s"${defn.name.value}()."
+      case defn: Defn.Class  => s"${defn.name.value}#"
+      case defn: Defn.Trait  => s"${defn.name.value}#"
+      case defn: Defn.Object => s"${defn.name.value}."
+      case pkg: Pkg          => s"${pkg.name.value.replace(".", "/")}/"
+      case other => throw new RuntimeException(s"Unexpected tree node type: ${other.getClass.getSimpleName}")
+    }.mkString
+    SemanticDBSymbol(symbol)
+  }
 
   private def nextLevelCallers(method: MethodRef): Seq[MethodRef] = {
     val fullyQualifiedCallers =
       symbolOccurrenceToSourceTree(method.file, method.occurrence)
+        // we don't care if a reference is just an import or a package declaration
+        // we want usage within the logic
         .filterNot(isPackageOrImport)
-        .map { callerNode =>
-          formatFullyQualifiedName(identifyFullyQualifiedNameOfOwner(callerNode))
-        }
+        .map(resolveEnclosingSymbolName)
 
     fullyQualifiedCallers
       .flatMap(semanticDB.getOccurrences)
       .filter { case (_, occurrence) => occurrence.role.isReference }
-      .map { case (file, occurrence) => MethodRef(occurrence.symbol, occurrence, file) }
+      .map { case (file, occurrence) => MethodRef(SemanticDBSymbol(occurrence.symbol), occurrence, file) }
   }
 
-  def buildCallHierarchy(
+  private def recursivelyBuildCallHierarchy(
       callee: MethodRef,
-      visited: Set[String] = Set.empty,
+      visited: Set[SemanticDBSymbol] = Set.empty,
   ): CallHierarchy = {
     if (visited.contains(callee.symbolName)) {
       CallHierarchyCycle(callee)
     } else {
       val callers = nextLevelCallers(callee).map { case caller =>
-        buildCallHierarchy(callee = caller, visited = visited + callee.symbolName)
+        recursivelyBuildCallHierarchy(callee = caller, visited = visited + callee.symbolName)
       }
       if (callers.isEmpty) {
         CallHierarchyEntryPoint(callee)
@@ -93,5 +95,16 @@ class CallHierarchyBuilder(
       }
     }
   }
+
+  /** Given a method reference, build the call hierarchy tree for that method, recursively finding all callers up the
+    * chain until reaching entry points (methods with no callers) or recursion (cycles).
+    * @param callee
+    *   the method reference to build the call hierarchy from
+    * @return
+    *   a call hierarchy tree
+    */
+  def buildCallHierarchy(
+      callee: MethodRef,
+  ): CallHierarchy = recursivelyBuildCallHierarchy(callee)
 
 }

--- a/static-analysis/src/main/scala/CallHierarchyBuilder.scala
+++ b/static-analysis/src/main/scala/CallHierarchyBuilder.scala
@@ -21,12 +21,12 @@ class CallHierarchyBuilder(
       file: SourceRef,
       symbolOccurrence: SymbolOccurrence,
   ): Seq[Tree] = {
-    def toCoordinages(range: Range): SymbolCoordinates =
+    def toCoordinates(range: Range): SymbolCoordinates =
       SymbolCoordinates(file, range.startLine, range.startCharacter, range.endLine, range.endCharacter)
 
     symbolOccurrence.range match {
       case None        => return Seq.empty
-      case Some(range) => scalaSources.getByCoordinates(toCoordinages(range))
+      case Some(range) => scalaSources.getByCoordinates(toCoordinates(range))
     }
   }
 

--- a/static-analysis/src/main/scala/CallHierarchyBuilder.scala
+++ b/static-analysis/src/main/scala/CallHierarchyBuilder.scala
@@ -20,18 +20,18 @@ class CallHierarchyBuilder(
   }
 
   private def symbolOccurrenceToSourceTree(
-      callSites: Seq[(SourceRef, SymbolOccurrence)],
+      file: SourceRef,
+      symbolOccurrence: SymbolOccurrence,
   ): Seq[Tree] = {
-    val positions = callSites.collect { case (file, SymbolOccurrence(Some(range), _, _)) =>
-      (file, range)
-    }.toSet
-
     def toRange(position: Position): Range =
       Range(position.startLine, position.startColumn, position.endLine, position.endColumn)
 
+    def sameCoordinates(sourceFile: SourceRef, position: Position): Boolean =
+      sourceFile == file && symbolOccurrence.range.contains(toRange(position))
+
     scalaSources
       .collect {
-        case (file, node) if positions.contains(file -> toRange(node.origin.position)) => node
+        case (sourceFile, node) if sameCoordinates(sourceFile, node.origin.position) => node
       }
   }
 
@@ -45,12 +45,12 @@ class CallHierarchyBuilder(
     case None                    => None
   }
 
-  private def identifyFullyQualifiedNameOfOwner(node: Tree, parents: List[Tree] = List.empty): Option[List[Tree]] =
+  private def identifyFullyQualifiedNameOfOwner(node: Tree, parents: List[Tree] = List.empty): List[Tree] =
     findOwner(
       node,
     ) match {
       case Some(owner) => identifyFullyQualifiedNameOfOwner(owner, owner :: parents)
-      case None        => Some(parents)
+      case None        => parents
     }
 
   def formatFullyQualifiedName(nodes: List[Tree]): String = nodes.map {
@@ -59,36 +59,39 @@ class CallHierarchyBuilder(
     case defn: Defn.Trait  => s"${defn.name.value}#"
     case defn: Defn.Object => s"${defn.name.value}."
     case pkg: Pkg          => s"${pkg.name.value.replace(".", "/")}/"
-    case other             => other.toString()
+    case other             => throw new RuntimeException(s"Unexpected tree node type: ${other.getClass.getSimpleName}")
   }.mkString
 
-  private def findNextCallers(method: MethodRef): Seq[MethodRef] = {
+  private def nextLevelCallers(method: MethodRef): Seq[MethodRef] = {
     val fullyQualifiedCallers =
-      symbolOccurrenceToSourceTree(Seq(method.file -> method.occurrence))
+      symbolOccurrenceToSourceTree(method.file, method.occurrence)
         .filterNot(isPackageOrImport)
         .map { callerNode =>
-          identifyFullyQualifiedNameOfOwner(callerNode)
-            .map(formatFullyQualifiedName)
-            .getOrElse("unknown")
+          formatFullyQualifiedName(identifyFullyQualifiedNameOfOwner(callerNode))
         }
-        .toSet
 
-    semanticDB.allDocuments.flatMap { case (file, document) =>
-      document.occurrences
-        .filter { symbol =>
-          fullyQualifiedCallers.contains(symbol.symbol) && symbol.role.isReference
-        }
-        .map(occurrence => MethodRef(occurrence.symbol, occurrence, file))
-    }
+    fullyQualifiedCallers
+      .flatMap(semanticDB.getOccurrences)
+      .filter { case (_, occurrence) => occurrence.role.isReference }
+      .map { case (file, occurrence) => MethodRef(occurrence.symbol, occurrence, file) }
   }
 
   def buildCallHierarchy(
       callee: MethodRef,
-  ): CallHierarchyNode = {
-    val callers = findNextCallers(callee).map { case caller =>
-      buildCallHierarchy(callee = caller)
+      visited: Set[String] = Set.empty,
+  ): CallHierarchy = {
+    if (visited.contains(callee.symbolName)) {
+      CallHierarchyCycle(callee)
+    } else {
+      val callers = nextLevelCallers(callee).map { case caller =>
+        buildCallHierarchy(callee = caller, visited = visited + callee.symbolName)
+      }
+      if (callers.isEmpty) {
+        CallHierarchyEntryPoint(callee)
+      } else {
+        CallHierarchyNode(callee, callers)
+      }
     }
-    CallHierarchyNode(callee, callers)
   }
 
 }

--- a/static-analysis/src/main/scala/SourceLoader.scala
+++ b/static-analysis/src/main/scala/SourceLoader.scala
@@ -2,9 +2,27 @@ import scala.jdk.CollectionConverters._
 import java.nio.file.{Files, Path}
 import scala.collection.{MapView, mutable}
 import scala.meta.internal.semanticdb.{Locator, SymbolOccurrence, TextDocument}
-import scala.meta.{Input, Source, Tree}
+import scala.meta.{Input, Position, Source, Tree}
 
 case class ScalaSources(private val sources: Map[SourceRef, Source]) {
+  private val byCoordinates: MapView[SymbolCoordinates, Seq[Tree]] = sources.toSeq
+    .flatMap { case (filePath, source) =>
+      source.collect { case node =>
+        val coordinates = SymbolCoordinates(
+          filePath,
+          node.pos.startLine,
+          node.pos.startColumn,
+          node.pos.endLine,
+          node.pos.endColumn,
+        )
+        coordinates -> node
+      }
+    }
+    .groupBy(_._1)
+    .view
+    .mapValues(_.map(_._2))
+  def getByCoordinates(coordinates: SymbolCoordinates): Seq[Tree] =
+    byCoordinates.getOrElse(coordinates, Seq.empty)
   def getSource(filePath: SourceRef): Option[Source] = sources.get(filePath)
   def collect[T](f: PartialFunction[(SourceRef, Tree), T]): Seq[T] = {
     sources.toSeq.flatMap { case (filePath, source) =>

--- a/static-analysis/src/main/scala/SourceLoader.scala
+++ b/static-analysis/src/main/scala/SourceLoader.scala
@@ -1,5 +1,3 @@
-import SourceLoader.SourceRef
-
 import scala.jdk.CollectionConverters._
 import java.nio.file.{Files, Path}
 import scala.collection.{MapView, mutable}
@@ -8,7 +6,7 @@ import scala.meta.{Input, Source, Tree}
 
 case class ScalaSources(private val sources: Map[SourceRef, Source]) {
   def getSource(filePath: SourceRef): Option[Source] = sources.get(filePath)
-  def collect[T](f: PartialFunction[(String, Tree), T]): Seq[T] = {
+  def collect[T](f: PartialFunction[(SourceRef, Tree), T]): Seq[T] = {
     sources.toSeq.flatMap { case (filePath, source) =>
       val pf: PartialFunction[Tree, T] = {
         case node if f.isDefinedAt((filePath, node)) => f((filePath, node))
@@ -20,28 +18,30 @@ case class ScalaSources(private val sources: Map[SourceRef, Source]) {
 
 case class SemanticDB(private val documents: Map[SourceRef, TextDocument]) {
   // Giant map to look up all occurrences of a symbol across all documents, keyed by the symbol name
-  private val occurrences: MapView[String, Seq[(SourceRef, SymbolOccurrence)]] = documents.toSeq
+  private val occurrences: MapView[SemanticDBSymbol, Seq[(SourceRef, SymbolOccurrence)]] = documents.toSeq
     .flatMap { case (filePath, document) =>
-      document.occurrences.map(occurrence => occurrence.symbol -> (filePath, occurrence))
+      document.occurrences.map(occurrence => SemanticDBSymbol(occurrence.symbol) -> (filePath, occurrence))
     }
     .groupBy(_._1)
     .view
     .mapValues(_.map(_._2))
-  def getOccurrences(symbol: String): Seq[(SourceRef, SymbolOccurrence)] = occurrences.getOrElse(symbol, Seq.empty)
+  def getOccurrences(symbol: SemanticDBSymbol): Seq[(SourceRef, SymbolOccurrence)] =
+    occurrences.getOrElse(symbol, Seq.empty)
   def allDocuments = documents.toSeq
-  def getDocument(filePath: String): Option[TextDocument] = documents.get(filePath)
 }
 
 object SourceLoader {
 
-  type SourceRef = String
   def loadSemanticDB(path: Path): SemanticDB = {
-    val result = mutable.Map.empty[String, TextDocument]
+    val result = mutable.Map.empty[SourceRef, TextDocument]
     Locator(path) { case (path, documents) =>
       documents.documents.headOption.foreach { doc =>
-        val filePath =
-          path.toString.split("META-INF/semanticdb/").lastOption.getOrElse(path.toString).replaceAll(".semanticdb$", "")
-        result.put(filePath, doc)
+        val filePath = path.toString
+          .split("META-INF/semanticdb/")
+          .lastOption
+          .getOrElse(path.toString)
+          .replaceAll(".semanticdb$", "")
+        result.put(SourceRef(filePath), doc)
       }
     }
     SemanticDB(result.toMap)
@@ -58,7 +58,7 @@ object SourceLoader {
         val input = Input.VirtualFile(p.toString, content)
         val source = input.parse[Source].get
         val filePath = p.toString().replaceFirst("\\./", "")
-        filePath -> source
+        SourceRef(filePath) -> source
       }
       .toMap
 

--- a/static-analysis/src/main/scala/SourceLoader.scala
+++ b/static-analysis/src/main/scala/SourceLoader.scala
@@ -63,8 +63,6 @@ object SourceLoader {
         result.put(SourceRef(filePath), doc)
       }
     }
-    val debug = result.flatMap(_._2.occurrences.filter(_.symbol.contains("emailArticleBody")))
-    println(debug)
     SemanticDB(result.toMap)
   }
 

--- a/static-analysis/src/main/scala/SourceLoader.scala
+++ b/static-analysis/src/main/scala/SourceLoader.scala
@@ -1,0 +1,37 @@
+import scala.jdk.CollectionConverters._
+import java.nio.file.{Files, Path}
+import scala.meta.{Input, Source, Tree}
+
+case class ScalaSources(private val sources: Map[String, Source]) {
+  def getSource(filePath: String): Option[Source] = sources.get(filePath)
+  def collect[T](f: PartialFunction[(String, Tree), T]): Seq[T] = {
+    sources.toSeq.flatMap { case (filePath, source) =>
+      val pf: PartialFunction[Tree, T] = {
+        case node if f.isDefinedAt((filePath, node)) => f((filePath, node))
+      }
+      source.collect(pf)
+    }
+  }
+}
+
+object SourceLoader {
+
+  def load(path: Path): ScalaSources = {
+    val source = Files
+      .walk(path)
+      .iterator()
+      .asScala
+      .filter(p => p.toString.endsWith(".scala"))
+      .map { p =>
+        val content = new String(Files.readAllBytes(p), "UTF-8")
+        val input = Input.VirtualFile(p.toString, content)
+        val source = input.parse[Source].get
+        val filePath = p.toString.split("src/main/scala/").lastOption.getOrElse(p.toString)
+        filePath -> source
+      }
+      .toMap
+
+    ScalaSources(source)
+  }
+
+}

--- a/static-analysis/src/main/scala/SourceLoader.scala
+++ b/static-analysis/src/main/scala/SourceLoader.scala
@@ -28,6 +28,7 @@ case class SemanticDB(private val documents: Map[SourceRef, TextDocument]) {
   def getOccurrences(symbol: SemanticDBSymbol): Seq[(SourceRef, SymbolOccurrence)] =
     occurrences.getOrElse(symbol, Seq.empty)
   def allDocuments = documents.toSeq
+  def getDocument(filePath: SourceRef): Option[TextDocument] = documents.get(filePath)
 }
 
 object SourceLoader {
@@ -44,6 +45,8 @@ object SourceLoader {
         result.put(SourceRef(filePath), doc)
       }
     }
+    val debug = result.flatMap(_._2.occurrences.filter(_.symbol.contains("emailArticleBody")))
+    println(debug)
     SemanticDB(result.toMap)
   }
 

--- a/static-analysis/src/main/scala/SourceLoader.scala
+++ b/static-analysis/src/main/scala/SourceLoader.scala
@@ -22,7 +22,8 @@ object SourceLoader {
     val result = mutable.Map.empty[String, TextDocument]
     Locator(path) { case (path, documents) =>
       documents.documents.headOption.foreach { doc =>
-        val filePath = path.toString.split("target/semanticdb/").lastOption.getOrElse(path.toString)
+        val filePath =
+          path.toString.split("META-INF/semanticdb/").lastOption.getOrElse(path.toString).replaceAll(".semanticdb$", "")
         result.put(filePath, doc)
       }
     }
@@ -39,7 +40,8 @@ object SourceLoader {
         val content = new String(Files.readAllBytes(p), "UTF-8")
         val input = Input.VirtualFile(p.toString, content)
         val source = input.parse[Source].get
-        val filePath = p.toString.split("src/main/scala/").lastOption.getOrElse(p.toString)
+        val filePath = p.toString().replaceFirst("\\./", "")
+        println(filePath)
         filePath -> source
       }
       .toMap

--- a/static-analysis/src/main/scala/SourceLoader.scala
+++ b/static-analysis/src/main/scala/SourceLoader.scala
@@ -1,11 +1,13 @@
+import SourceLoader.SourceRef
+
 import scala.jdk.CollectionConverters._
 import java.nio.file.{Files, Path}
-import scala.collection.mutable
-import scala.meta.internal.semanticdb.{Locator, TextDocument}
+import scala.collection.{MapView, mutable}
+import scala.meta.internal.semanticdb.{Locator, SymbolOccurrence, TextDocument}
 import scala.meta.{Input, Source, Tree}
 
-case class ScalaSources(private val sources: Map[String, Source]) {
-  def getSource(filePath: String): Option[Source] = sources.get(filePath)
+case class ScalaSources(private val sources: Map[SourceRef, Source]) {
+  def getSource(filePath: SourceRef): Option[Source] = sources.get(filePath)
   def collect[T](f: PartialFunction[(String, Tree), T]): Seq[T] = {
     sources.toSeq.flatMap { case (filePath, source) =>
       val pf: PartialFunction[Tree, T] = {
@@ -16,9 +18,24 @@ case class ScalaSources(private val sources: Map[String, Source]) {
   }
 }
 
+case class SemanticDB(private val documents: Map[SourceRef, TextDocument]) {
+  // Giant map to look up all occurrences of a symbol across all documents, keyed by the symbol name
+  private val occurrences: MapView[String, Seq[(SourceRef, SymbolOccurrence)]] = documents.toSeq
+    .flatMap { case (filePath, document) =>
+      document.occurrences.map(occurrence => occurrence.symbol -> (filePath, occurrence))
+    }
+    .groupBy(_._1)
+    .view
+    .mapValues(_.map(_._2))
+  def getOccurrences(symbol: String): Seq[(SourceRef, SymbolOccurrence)] = occurrences.getOrElse(symbol, Seq.empty)
+  def allDocuments = documents.toSeq
+  def getDocument(filePath: String): Option[TextDocument] = documents.get(filePath)
+}
+
 object SourceLoader {
 
-  def loadSemanticDB(path: Path): Map[String, TextDocument] = {
+  type SourceRef = String
+  def loadSemanticDB(path: Path): SemanticDB = {
     val result = mutable.Map.empty[String, TextDocument]
     Locator(path) { case (path, documents) =>
       documents.documents.headOption.foreach { doc =>
@@ -27,7 +44,7 @@ object SourceLoader {
         result.put(filePath, doc)
       }
     }
-    result.toMap
+    SemanticDB(result.toMap)
   }
 
   def loadSources(path: Path): ScalaSources = {
@@ -41,7 +58,6 @@ object SourceLoader {
         val input = Input.VirtualFile(p.toString, content)
         val source = input.parse[Source].get
         val filePath = p.toString().replaceFirst("\\./", "")
-        println(filePath)
         filePath -> source
       }
       .toMap

--- a/static-analysis/src/main/scala/SourceLoader.scala
+++ b/static-analysis/src/main/scala/SourceLoader.scala
@@ -1,5 +1,7 @@
 import scala.jdk.CollectionConverters._
 import java.nio.file.{Files, Path}
+import scala.collection.mutable
+import scala.meta.internal.semanticdb.{Locator, TextDocument}
 import scala.meta.{Input, Source, Tree}
 
 case class ScalaSources(private val sources: Map[String, Source]) {
@@ -16,7 +18,18 @@ case class ScalaSources(private val sources: Map[String, Source]) {
 
 object SourceLoader {
 
-  def load(path: Path): ScalaSources = {
+  def loadSemanticDB(path: Path): Map[String, TextDocument] = {
+    val result = mutable.Map.empty[String, TextDocument]
+    Locator(path) { case (path, documents) =>
+      documents.documents.headOption.foreach { doc =>
+        val filePath = path.toString.split("target/semanticdb/").lastOption.getOrElse(path.toString)
+        result.put(filePath, doc)
+      }
+    }
+    result.toMap
+  }
+
+  def loadSources(path: Path): ScalaSources = {
     val source = Files
       .walk(path)
       .iterator()


### PR DESCRIPTION
The frontend repository for the Guardian's website was created in February 2012: 14 years ago.
It has had an increasing number of features and services added, leading this repo becoming pretty big.

Parallel to that, the [DCAR project](https://github.com/guardian/dotcom-rendering) was started with the objective of centralising all the rendering happening at the Guardian.

We're getting closer to all the rendering happening in that new project, but at this stage we find ourselves unable to easily answer a question: what rendering is still happening from within the frontend repo?

More generally, this is the beginning of a larger piece of work: removing unused or undesirable code from this repo, at scale.

## Measuring, Measuring, Measuring

[The first step](https://github.com/guardian/play-access-logs-to-metrics) to understanding which endpoints are being used, is to look at live traffic data.

This work has been done already and is using the ALB access logs as well as the routes definitions of this application to undesrstand which endpoints are actively in use.

## Digging deeper

If we know which endpoints are being used, and to what extent, we can now start looking at which endpoints are rendering HTML content by looking at the code.

On a smaller application, this is something that could have been done manually by reading the code, helped with an IDE.

But this project is at the scale where it makes sense to spend a few days writing the tool to help us do that for us, which explain the existence of this module.

This module leverages the scala-meta library to map all the twirl templates to their corresponding controller(s).

This is done by constructing "call hierarchies" (also known as [call graphs](https://en.wikipedia.org/wiki/Call_graph)), where the root of the tree is a twirl template, and we find all the places where this template is called, recusrively.

The end result is a tree data-structure that describes all the possible code paths to the twirl template across the application. Here's an edited down version to illustrate it:

```
views/html/fragments/email/emailArticleBody. in article/target/scala-2.13/twirl/main/views/html/fragments/email/emailArticleBody.template.scala:18:7
  views/html/fragments/email/emailArticleBody. in article/app/pages/ArticleEmailHtmlPage.scala:7:35
    No call to views/html/fragments/email/emailArticleBody. found (entry point)
  views/html/fragments/email/emailArticleBody. in article/app/pages/ArticleEmailHtmlPage.scala:20:8
    pages/ArticleEmailHtmlPage.html(). in article/app/controllers/LiveBlogController.scala:50:70
      controllers/LiveBlogController#renderEmail(). in article/target/scala-2.13/routes/main/router/Routes.scala:152:25
        router/Routes# in article/target/scala-2.13/routes/main/router/Routes.scala:41:37
        ...
      controllers/LiveBlogController#renderEmail(). in article/target/scala-2.13/routes/main/router/Routes.scala:188:25
        router/Routes# in article/target/scala-2.13/routes/main/router/Routes.scala:41:37
          No call to router/Routes# found (entry point)
        ...
    pages/ArticleEmailHtmlPage.html(). in article/app/controllers/ArticleController.scala:103:66
      controllers/ArticleController#render(). in article/app/controllers/ArticleController.scala:43:42
        controllers/ArticleController#mapAndRender(). in article/app/controllers/ArticleController.scala:38:4
          controllers/ArticleController#renderItem(). in article/app/controllers/PublicationController.scala:49:26
            controllers/PublicationController#publishedOn(). in article/target/scala-2.13/routes/main/router/Routes.scala:332:28
              router/Routes# in article/target/scala-2.13/routes/main/router/Routes.scala:41:37
                No call to router/Routes# found (entry point)
              ...
            controllers/PublicationController#publishedOn(). in article/target/scala-2.13/routes/main/router/Routes.scala:461:93
              No call to controllers/PublicationController#publishedOn(). found (entry point)
            controllers/PublicationController#publishedOn(). in article/test/PublicationControllerTest.scala:48:39
              test/PublicationControllerTest# in article/test/package.scala:12:10
                No call to test/PublicationControllerTest# found (entry point)
              ... more tests
```

## But why pushing this to the frontend repo?

The work that went into writing this static analysis tool for this one specific question is likely to be re-used when we continue cleaning the codebase from unused features.

For instance, now that we're able to create call hierarchies we could also look at identifying which method could be safely removed once we've decided which controller entrypoints can be dropped.

Once the cleanup is finished, then this module can be entirely dropped, or spun into its own repo.

## End result and next steps

This PR proposes a module that is capable of generating a csv that contains the mapping between endpoints (controller methods), and twirl templates.

The next step is to ingest this CSV as well as the aggregated live traffic data into a small local database (sqlite) and to understand:
- which endpoints aren't used, and therefore which twirl templates aren't rendering anything
- which endpoints are used, and therefore which templates are rendering HTML in production. Then we can decide what to do with this code (port to DCAR, keep, remove feature etc)

## About the review of this code

This code does not come with the usual unit tests and general rigour that is expected in production, simply because it is NOT production code. It is only meant to run locally by engineers.