### PR TITLE
More permissive XML parsing in live harness

### DIFF
--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -67,25 +67,10 @@ object LiveHarness {
       }),
   )
 
-  private val voidElements = Set(
-    "area",
-    "base",
-    "br",
-    "col",
-    "embed",
-    "hr",
-    "img",
-    "input",
-    "link",
-    "meta",
-    "param",
-    "source",
-    "track",
-    "wbr",
-  )
+  private val voidTextElements = Set("br", "hr", "wbr")
 
   private[utils] def splitIntoTags(html: String): List[String] = {
-    val sanitised = voidElements.foldLeft(html) { (acc, tag) =>
+    val sanitised = voidTextElements.foldLeft(html) { (acc, tag) =>
       acc.replaceAll(s"<$tag(\\s[^>]*)?>", "")
     }
     val xml = XML.loadString(s"<root>$sanitised</root>")

--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -5,6 +5,7 @@ import model.content.InteractiveAtom
 import model.meta.BlocksOn
 import model.{ArticlePage, Content, ContentPage, InteractivePage}
 import play.api.libs.json.{Json, Reads}
+import scala.util.{Try, Success, Failure}
 import scala.xml.XML
 
 case class LiveHarnessInteractiveAtom(
@@ -68,8 +69,10 @@ object LiveHarness {
   )
 
   private[utils] def splitIntoTags(html: String): List[String] = {
-    val xml = XML.loadString(s"<root>$html</root>")
-    xml.child.toList.map(_.toString).filter(_.trim.nonEmpty)
+    Try(XML.loadString(s"<root>$html</root>")) match {
+      case Success(xml) => xml.child.toList.map(_.toString).filter(_.trim.nonEmpty)
+      case Failure(_)   => List(html)
+    }
   }
 
   private[utils] def insertAtomsAtNthPoints(

--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -5,7 +5,6 @@ import model.content.InteractiveAtom
 import model.meta.BlocksOn
 import model.{ArticlePage, Content, ContentPage, InteractivePage}
 import play.api.libs.json.{Json, Reads}
-import scala.util.{Try, Success, Failure}
 import scala.xml.XML
 
 case class LiveHarnessInteractiveAtom(
@@ -68,11 +67,29 @@ object LiveHarness {
       }),
   )
 
+  private val voidElements = Set(
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+  )
+
   private[utils] def splitIntoTags(html: String): List[String] = {
-    Try(XML.loadString(s"<root>$html</root>")) match {
-      case Success(xml) => xml.child.toList.map(_.toString).filter(_.trim.nonEmpty)
-      case Failure(_)   => List(html)
+    val sanitised = voidElements.foldLeft(html) { (acc, tag) =>
+      acc.replaceAll(s"<$tag(\\s[^>]*)?>", "")
     }
+    val xml = XML.loadString(s"<root>$sanitised</root>")
+    xml.child.toList.map(_.toString).filter(_.trim.nonEmpty)
   }
 
   private[utils] def insertAtomsAtNthPoints(

--- a/preview/test/utils/LiveHarnessTest.scala
+++ b/preview/test/utils/LiveHarnessTest.scala
@@ -53,4 +53,13 @@ class LiveHarnessTest extends AnyFlatSpec with Matchers {
   it should "handle an empty string" in {
     LiveHarness.splitIntoTags("") shouldEqual List.empty
   }
+
+  it should "strip void elements and split remaining tags" in {
+    val html = "<p>First</p><p>Second</p><br><h2>A heading</h2>"
+    LiveHarness.splitIntoTags(html) shouldEqual List(
+      "<p>First</p>",
+      "<p>Second</p>",
+      "<h2>A heading</h2>",
+    )
+  }
 }


### PR DESCRIPTION
Addresses a bug where self-closing elements present in Composer content were causing live harnesses to fall over! This rejigs the parsing logic to handle void elements that are likely to appear in text blocks.