### PR TITLE
Hide subnav on worldcup 2026 page

### DIFF
--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -40,7 +40,7 @@ object DotcomFrontsRenderingDataModel {
       deeplyRead: Option[Seq[Trail]],
   ): DotcomFrontsRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition)
+    val nav = Nav(page, edition)(request)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
@@ -43,7 +43,7 @@ object DotcomNewslettersPageRenderingDataModel {
       request: RequestHeader,
   ): DotcomNewslettersPageRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition)
+    val nav = Nav(page, edition)(request)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -664,7 +664,7 @@ object DotcomRenderingDataModel {
       matchHeaderUrl = matchData.flatMap(_.matchHeaderUrl),
       matchStatsUrl = matchData.flatMap(_.matchStatsUrl),
       matchType = matchData.map(_.matchType),
-      nav = Nav(page, edition),
+      nav = Nav(page, edition)(request),
       openGraphData = page.getOpenGraphProperties,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),
       pageId = content.metadata.id,

--- a/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
@@ -73,7 +73,7 @@ object DotcomTagPagesRenderingDataModel {
       pageType: PageType,
   ): DotcomTagPagesRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition)
+    val nav = Nav(page, edition)(request)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -5,6 +5,7 @@ import model.Page
 import navigation.ReaderRevenueSite.{PrintCTA, Support, SupportContribute, SupportSubscribe, SupporterCTA}
 import navigation.UrlHelpers._
 import play.api.libs.json.{Json, OWrites, Writes}
+import play.api.mvc.RequestHeader
 
 case class ReaderRevenueLink(
     contribute: String,
@@ -93,7 +94,7 @@ object Nav {
 
   implicit val writes: OWrites[Nav] = Json.writes[Nav]
 
-  def apply(page: Page, edition: Edition): Nav = {
+  def apply(page: Page, edition: Edition)(implicit request: RequestHeader): Nav = {
     val navMenu = NavMenu(page, edition)
     Nav(
       currentUrl = navMenu.currentUrl,

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -5,8 +5,10 @@ import common.{Edition, editions}
 import navigation.NavMenu.navRoot
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json.{Json, Writes, _}
+import ab.ABTests
 
 import scala.annotation.tailrec
+import play.api.mvc.RequestHeader
 
 sealed trait Subnav
 case class FlatSubnav(links: Seq[NavLink]) extends Subnav
@@ -77,12 +79,22 @@ object NavMenu {
       brandExtensions: Seq[NavLink],
   )
 
-  def apply(page: Page, edition: Edition): NavMenu = {
+  def apply(page: Page, edition: Edition)(implicit request: RequestHeader): NavMenu = {
     val root = navRoot(edition)
     val currentUrl = getSectionOrPageUrl(page, edition)
     val currentNavLink = findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks)
     val currentParent = currentNavLink.flatMap(link => findParent(link, edition, root.children, root.otherLinks))
     val currentPillar = getPillar(currentParent, edition, root.children, root.otherLinks)
+    val isWorldCupOverview = page.metadata.id == "/football/world-cup-2026"
+
+    // On the world cup overview page, we want to show the special football header atom
+    val subNavSections =
+      if (isWorldCupOverview && ABTests.isUserInTest("webx-world-cup-2026-subnav")) {
+        None
+      } else {
+        getSubnav(page.metadata.customSignPosting, currentNavLink, currentParent, currentPillar)
+      }
+
     NavMenu(
       currentUrl = currentUrl,
       pillars = root.children,
@@ -91,7 +103,7 @@ object NavMenu {
       currentNavLink = currentNavLink,
       currentParent = currentParent,
       currentPillar = currentPillar,
-      subNavSections = getSubnav(page.metadata.customSignPosting, currentNavLink, currentParent, currentPillar),
+      subNavSections = subNavSections,
     )
   }
 
@@ -239,7 +251,6 @@ object NavMenu {
       currentParent: Option[NavLink],
       currentPillar: Option[NavLink],
   ): Option[Subnav] = {
-
     customSignPosting match {
 
       case Some(navItem) =>

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -9,7 +9,6 @@
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, PrintCTA, PrintCTAWeekly}
 @import conf.Configuration
 @import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch}
-@import ab.ABTests
 
 @editionListItem(edition: Edition, isCurrentEdition: Boolean = false) = {
 <li class="dropdown-menu__item">
@@ -194,9 +193,7 @@
         </label>
     </nav>
 
-    @if(page.metadata.id == "/football/world-cup-2026" && ABTests.isUserInTest("webx-world-cup-2026-subnav")) {
-    } else {
-        @fragments.nav.subNav(navMenu, page.metadata.designType)
-    }
+
+    @fragments.nav.subNav(navMenu, page.metadata.designType)
 </header>
 }

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -9,6 +9,7 @@
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, PrintCTA, PrintCTAWeekly}
 @import conf.Configuration
 @import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch}
+@import ab.ABTests
 
 @editionListItem(edition: Edition, isCurrentEdition: Boolean = false) = {
 <li class="dropdown-menu__item">
@@ -193,7 +194,9 @@
         </label>
     </nav>
 
-
-    @fragments.nav.subNav(navMenu, page.metadata.designType)
+    @if(page.metadata.id == "/football/world-cup-2026" && ABTests.isUserInTest("webx-world-cup-2026-subnav")) {
+    } else {
+        @fragments.nav.subNav(navMenu, page.metadata.designType)
+    }
 </header>
 }

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, WithTestWsClient}
+import play.api.test.FakeRequest
 
 @DoNotDiscover class NavigationTest
     extends AnyFlatSpec
@@ -202,7 +203,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     whenReady(response) { item: ItemResponse =>
       item.content.map { apiContent =>
         val page = TestPage(Content(apiContent))
-        val menu = NavMenu(page, edition)
+        val menu = NavMenu(page, edition)(FakeRequest())
         val currentNavLink = menu.currentNavLink
         val pillar = menu.currentPillar
 
@@ -222,7 +223,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     whenReady(response) { item: ItemResponse =>
       item.content.map { apiContent =>
         val page = TestPage(Content(apiContent))
-        val menu = NavMenu(page, edition)
+        val menu = NavMenu(page, edition)(FakeRequest())
         val currentNavLink = menu.currentNavLink
         val pillar = menu.currentPillar
 


### PR DESCRIPTION
## What does this change?
Hide the subnav if you're on the world cup overview page and in the ab test `webx-world-cup-2026-subnav`

The nav atom hasn't been implemented yet, so this is behind an AB test.

## Screenshots

<img width="1374" height="641" alt="Screenshot 2026-05-28 at 18 18 22" src="https://github.com/user-attachments/assets/ca9c0f29-7572-4b0e-89fb-165d9a2ea5ad" />
