### PR TITLE
Restucture knockout round embed output

### DIFF
--- a/sport/app/football/views/matchList/spiderMatchesList.scala.html
+++ b/sport/app/football/views/matchList/spiderMatchesList.scala.html
@@ -39,9 +39,6 @@
             }
         </td>
         <td class="football-match__crest football-match__crest--home">
-            <!--
-            <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/60/@{theMatch.homeTeam.id}.png" />
-            -->
         </td>
         <td class="football-match__teams table-column--main">
             <a @(theMatch.smartUrl.map(url => s"href=${LinkTo(url)}").getOrElse("")) class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
@@ -67,9 +64,6 @@
             </a>
         </td>
         <td class="football-match__crest football-match__crest--home">
-            <!--
-            <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{theMatch.awayTeam.id}.png" />
-            -->
         </td>
     </tr>
 }

--- a/sport/app/football/views/matchList/spiderMatchesList.scala.html
+++ b/sport/app/football/views/matchList/spiderMatchesList.scala.html
@@ -1,0 +1,75 @@
+@import java.time.format.DateTimeFormatter
+@import java.time.ZonedDateTime
+@import football.model.GuTeamCodes
+@import common.Edition
+@import java.time.LocalTime
+
+@(matchesList: List[pa.FootballMatch],
+    competition: model.Competition,
+    date: java.time.LocalDate,
+    matchType: String = "",
+    linkToCompetition: Boolean = false,
+)(implicit request: RequestHeader)
+@import implicits.Football._
+@import common.LinkTo
+@import views.support.RenderClasses
+@import views.MatchStatus
+@import conf.Configuration
+@import model.CompetitionDisplayHelpers.cleanTeamName
+
+@matchesList.map{ theMatch =>
+    <tr @(theMatch.smartUrl.map(url=>s"data-link-to=${LinkTo(url)}").getOrElse(""))
+        data-match-id="@theMatch.id"
+        data-score-home="@theMatch.homeTeam.score"
+        data-score-away="@theMatch.awayTeam.score"
+        data-match-status="@MatchStatus(theMatch.matchStatus)"
+        id="football-match-@theMatch.id"
+        class="@RenderClasses(Map(
+            "football-match" -> true,
+            "football-match--live" -> theMatch.isLive,
+            "football-match--fixture" -> theMatch.isFixture,
+            "football-match--result" -> theMatch.isResult
+        ))">
+        <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub">
+            @if(theMatch.isFixture){
+                <time datetime="@theMatch.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZone(Edition(request).timezoneId))" data-timestamp="@theMatch.date.toInstant.toEpochMilli">
+                    @theMatch.date.format(DateTimeFormatter.ofPattern("E d MMM HH:mm z").withZone(Edition(request).timezoneId))</time>
+            }else{
+                @MatchStatus(theMatch.matchStatus)
+            }
+        </td>
+        <td class="football-match__crest football-match__crest--home">
+            <!--
+            <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/60/@{theMatch.homeTeam.id}.png" />
+            -->
+        </td>
+        <td class="football-match__teams table-column--main">
+            <a @(theMatch.smartUrl.map(url => s"href=${LinkTo(url)}").getOrElse("")) class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
+                <div class="football-match__team football-match__team--home football-team">
+                    <div class="football-team__name team-name" data-abbr="@GuTeamCodes.codeFor(theMatch.homeTeam)">
+                        <span class="team-name__long">@cleanTeamName(theMatch.homeTeam.name)</span>
+                    </div>
+                    <div class="football-team__score">@theMatch.homeTeam.score</div>
+                </div>
+
+                <div class="football-match__team football-match__team--away football-team">
+                    <div class="football-team__name team-name" data-abbr="@GuTeamCodes.codeFor(theMatch.awayTeam)">
+                        <span class="team-name__long">@cleanTeamName(theMatch.awayTeam.name)</span>
+                    </div>
+                    <div class="football-team__score">@theMatch.awayTeam.score</div>
+                </div>
+
+                <div class="football-teams__battleline"></div>
+
+                @theMatch.comments.map { comments =>
+                    <div class="football-match__comments">@comments.reverse.dropWhile(_ == '.').reverse</div>
+                }
+            </a>
+        </td>
+        <td class="football-match__crest football-match__crest--home">
+            <!--
+            <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{theMatch.awayTeam.id}.png" />
+            -->
+        </td>
+    </tr>
+}

--- a/sport/app/football/views/wallchart/spiderRoundEmbed.scala.html
+++ b/sport/app/football/views/wallchart/spiderRoundEmbed.scala.html
@@ -4,26 +4,34 @@
 
 @knockoutList(competition: model.Competition, knockoutStage: football.model.KnockoutSpider, rounds: Round, hasSpider: Boolean) = {
     <div class="football-knockouts @if(hasSpider) {football-knockouts--has-spider}">
-    @round.name.map { name =>
-        <ul class="u-unstyled u-cf">
-            <li>
-                @{
-                    knockoutStage.matchesList(competition, round).matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
-                        competitionMatches.map { case (competition, matches) =>
-                            football.views.html.matchList.matchesList(matches, competition, date,
-                                heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
-                            )
+        @round.name.map { name =>
+            <ul class="u-unstyled u-cf">
+                <li>
+                    <table class="table table--football football-matches">
+                    <thead hidden>
+                        <tr>
+                            <th class="match__status">Match status / kick off time</th>
+                            <th class="match__details">Match details</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @{
+                            knockoutStage.matchesList(competition, round).matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
+                                competitionMatches.map { case (competition, matches) =>
+                                    football.views.html.matchList.spiderMatchesList(matches, competition, date)
+                                }
+                            }
                         }
-                    }
-                }
-            </li>
-        </ul>
-    }
+                    </tbody>
+                    <caption class="table__caption table__caption--top">
+                        <span class="football-matches__heading">Fixtures and results</span>
+                    </caption>
+                </li>
+            </ul>
+        }
     </div>
 }
 
 <div class="knockout-container" data-link-name="@competition.fullName knockout chart">
-@knockoutList(competition, competitionStage, round, true)
+    @knockoutList(competition, competitionStage, round, true)
 </div>
-
-


### PR DESCRIPTION
## What does this change?

The knockout tables in the [football atoms collection](https://github.com/guardian/interactives/tree/main/atoms/webex/football-atoms-collection) are rendered via Frontend templates that expose the rendered HTML via an 'embed' endpoint. The atom build step fetches the HTML from this endpoint and packages it up with the CSS and JS in the football atoms collection project ready to be published. eg.:

https://www.theguardian.com/football/world-cup-2026/spider/3/embed

To make it easier to localise the dates and times shown in these atoms we've restructured the layout of the tables to remove grouping of matches by day. This enables us to localise the date and time of each match in isolation without having to move matches between groups due to matches taking place on different days depending upon the current timezone.

The `spiderMatchesList.scala.html` template has been copied from the existing `matchesList.scala.html` template and modified to flatten the table structure.

## Screenshots

<img width="1006" height="324" alt="Screenshot 2026-05-28 at 17 45 31" src="https://github.com/user-attachments/assets/c8e95063-0614-47d4-90a6-c20b10eb07a2" />
