### PR TITLE
Add world cup sub nav to overview page

### DIFF
--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -85,7 +85,7 @@ object NavMenu {
     val currentNavLink = findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks)
     val currentParent = currentNavLink.flatMap(link => findParent(link, edition, root.children, root.otherLinks))
     val currentPillar = getPillar(currentParent, edition, root.children, root.otherLinks)
-    val isWorldCupOverview = page.metadata.id == "/football/world-cup-2026"
+    val isWorldCupOverview = page.metadata.id == "football/world-cup-2026/overview"
 
     // On the world cup overview page, we want to show the special football header atom
     val subNavSections =

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -1,3 +1,4 @@
+@import ab.ABTests
 @()(implicit page: model.Page, request: RequestHeader)
 
 @import common.{LinkTo, Edition}
@@ -140,6 +141,10 @@
 
         @if(!page.metadata.hasSlimHeader) {
             @fragments.nav.subNav(navMenu, page.metadata.designType)
+        }
+
+        @if(page.metadata.id == "football/world-cup-2026/overview" && ABTests.isUserInTest("webx-world-cup-2026-subnav")) {
+            @fragments.nav.worldCupSubNav(page.metadata.id)
         }
     </header>
 }

--- a/common/app/views/fragments/nav/worldCupSubNav.scala.html
+++ b/common/app/views/fragments/nav/worldCupSubNav.scala.html
@@ -15,9 +15,9 @@
                 }
                 @for((href, label) <- Seq(
                     "/football/world-cup-2026/overview" -> "Match centre",
-                    "/football/world-cup-2026/player-guide" -> "Player guide",
-                    "/football/world-cup-2026/bracketology" -> "Bracketology",
-                    "/football/world-cup-2026/golden-boot" -> "Golden boot",
+                    "/football/world-cup-2026/player-guide" -> "Player guide", // TODO: update when url is finalised
+                    "/football/world-cup-2026/bracketology" -> "Bracketology", // TODO: update when url is finalised
+                    "/football/world-cup-2026/golden-boot" -> "Golden boot", // TODO: update when url is finalised
                     "/football" -> "More football",
                 )) {
                 <li>

--- a/common/app/views/fragments/nav/worldCupSubNav.scala.html
+++ b/common/app/views/fragments/nav/worldCupSubNav.scala.html
@@ -1,0 +1,28 @@
+@(pageId: String)(implicit request: RequestHeader)
+        <nav class="world-cup-sub-nav">
+            <ul class="world-cup-sub-nav-list">
+                @defining("/football/world-cup-2026") { href =>
+                <li>
+                    <a href="@href" class="world-cup-sub-nav-primary-link dcr-qnrtfb @if(pageId == href.stripPrefix("/")){ current-section}"><svg
+                    xmlns="http://www.w3.org/2000/svg" width="16" height="17"
+                    viewBox="0 0 16 17" fill="none">
+                        <rect width="4.39184" height="11.5286" fill="#90DCFF"></rect>
+                        <rect x="5.80347" y="5" width="4.39184" height="11.5286" fill="#90DCFF"></rect>
+                        <rect x="11.6084" width="4.39184" height="11.5286" fill="#90DCFF"></rect>
+                        <circle cx="7.99939" cy="2.19592" r="2.19592" fill="#90DCFF"></circle>
+                    </svg>World Cup 2026</a>
+                </li>
+                }
+                @for((href, label) <- Seq(
+                    "/football/world-cup-2026/overview" -> "Match centre",
+                    "/football/world-cup-2026/player-guide" -> "Player guide",
+                    "/football/world-cup-2026/bracketology" -> "Bracketology",
+                    "/football/world-cup-2026/golden-boot" -> "Golden boot",
+                    "/football" -> "More football",
+                )) {
+                <li>
+                    <a href="@href" class="@if(pageId == href.stripPrefix("/")){ current-section}">@label</a>
+                </li>
+                }
+            </ul>
+        </nav>

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -44,8 +44,9 @@ class WallchartController(
       competitionsService
         .competitionsWithTag(competitionTag)
         .map { competition =>
+          val tag = competition.url.stripSuffix("/").stripPrefix("/")
           val page = new FootballPage(
-            competition.url.stripSuffix("/"),
+            s"$tag/overview",
             "football",
             s"${competition.fullName} wallchart",
           )

--- a/static/src/stylesheets/layout/nav/_subnav.scss
+++ b/static/src/stylesheets/layout/nav/_subnav.scss
@@ -78,7 +78,7 @@
         content: '';
         display: block;
         height: 13px;
-        
+
         @include mq(tablet) {
             border: 1px solid $brightness-86;
             border-top: 0;
@@ -114,5 +114,171 @@
 
     .subnav-link  {
         color: $brightness-100;
+    }
+}
+
+.world-cup-sub-nav {
+    background-color: $brand-main;
+    display: grid;
+    grid-template-columns: [grid-start] 0px [centre-column-start] repeat(6, 1fr) [centre-column-end] 0px [grid-end];
+    column-gap: 10px;
+    align-content: space-between;
+    position: relative;
+
+    @include mq(mobileLandscape) {
+        column-gap: 20px;
+    }
+
+    @include mq(tablet) {
+        grid-template-columns: [grid-start] 1fr [centre-column-start] repeat(12, 40px) [centre-column-end] 1fr [grid-end];
+        width: 740px;
+        margin: 0 auto;
+
+        &::before,
+        &::after {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 1px;
+            background-color: $brand-pastel;
+            content: '';
+        }
+
+        &::before {
+            grid-column: centre-column-start;
+            transform: translateX(-20px);
+        }
+
+        &::after {
+            grid-column: right-column-end;
+            transform: translateX(-1px);
+        }
+    }
+
+    @include mq(tablet, $until: desktop) {
+        &::after {
+            grid-column: centre-column-end;
+        }
+    }
+
+    @include mq(desktop) {
+        grid-template-columns: [grid-start] 1fr [centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [grid-end];
+        width: 980px;
+    }
+
+    @include mq(leftCol) {
+        grid-template-columns: [grid-start] 1fr [left-column-start] repeat(2, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [grid-end];
+        width: 1140px;
+
+        &::before {
+            grid-column: left-column-start;
+        }
+    }
+
+    @include mq(wide) {
+        grid-template-columns: [grid-start] 1fr [left-column-start] repeat(3, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end] 60px [right-column-start] repeat(4, 60px) [right-column-end] 1fr [grid-end];
+        width: 1300px;
+    }
+}
+
+.world-cup-sub-nav-list {
+    grid-column: grid-start / grid-end;
+    margin-block: 0;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    position: relative;
+    overflow-x: scroll;
+    scrollbar-width: none;
+    border-bottom: 1px solid;
+    border-top: 1px solid;
+    border-color: $brand-pastel;
+    padding: 0 12px;
+    height: 40px;
+    margin-left: 0;
+
+    &::after {
+        content: '';
+        position: sticky;
+        right: -12px;
+        top: 0;
+        height: 100%;
+        min-width: 40px;
+        background: linear-gradient(to left, #052962, transparent);
+    }
+
+    @include mq(mobileLandscape) {
+        padding: 0 20px;
+        height: 40px;
+
+        &::after {
+            right: -20px;
+        }
+    }
+}
+
+.world-cup-sub-nav-list li {
+    position: relative;
+}
+
+.world-cup-sub-nav-list li a.current-section {
+    font-weight: 700;
+}
+
+.world-cup-sub-nav-list li a {
+    font-family: GuardianTextSans, 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    font-size: 0.875rem;
+    line-height: 1;
+    font-weight: 400;
+    font-style: normal;
+    padding-right: 12px;
+    display: block;
+    text-decoration: none;
+    white-space: nowrap;
+    color: $brightness-100;
+
+    &:hover {
+        text-decoration: underline;
+        color: $highlight-main;
+    }
+
+    &.world-cup-sub-nav-primary-link {
+        display: flex;
+        align-items: center;
+        padding-right: 24px;
+
+        svg {
+            margin-right: 8px;
+        }
+
+        &::after {
+            content: '';
+            display: block;
+            position: absolute;
+            right: 12px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 1px;
+            height: 12px;
+            background-color: $brand-pastel;
+        }
+
+        &:not(:hover) {
+            color: $sport-pastel;
+
+            svg rect,
+            svg circle {
+                fill: $sport-pastel;
+            }
+        }
+
+        &:hover {
+            text-decoration: none;
+
+            svg rect,
+            svg circle {
+                fill: $highlight-main;
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does this change?
Add world cup sub nav to the overview page

For the world cup 2026 we are using a different sub nav. The old sub nav is now hidden as part of https://github.com/guardian/frontend/pull/28819 and the new sub nav is added via a new twirl template. For all the other pages, the sub nav component that was implemented in DCAR is used, but since the overview page is the only one rendered by frontend, we decided to just update the twirl template. The plan is to migrate the overview page into DCAR  in the future. 

Currently this new sub nav is behind a 0% test `webx-world-cup-2026-subnav` which can be opted in via http://theguardian.com/ab-tests/opt-in/webx-world-cup-2026-subnav:enable

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/579607e7-57ed-4be3-b95e-8130004ad206
[after]: https://github.com/user-attachments/assets/0869ea11-cbe3-44c0-a18e-75e63eee5ee0



Tested in CODE. 

Fixes https://github.com/guardian/dotcom-rendering/issues/15867