### PR TITLE
Fix cricket match-header url in dotcome rendering data

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -79,7 +79,7 @@ object DotcomRenderingUtils extends DCARUrlHelper {
         Some(
           DotcomRenderingMatchData(
             matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
-            matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/api/match-header/$date/$team.json"),
+            matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
             matchStatsUrl = None,
             matchType = CricketMatchType,
           ),


### PR DESCRIPTION
## What does this change?
The cricket match header endpoint `/sport/cricket/match-header/:matchDate/:teamId.json` was added as part of this PR https://github.com/guardian/frontend/pull/28733 but the url used in the dotcom rendering data model had a type (an extra api in the url). This PR fixes that