### PR TITLE
Add cricket match stats endpoint

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -80,7 +80,7 @@ object DotcomRenderingUtils extends DCARUrlHelper {
           DotcomRenderingMatchData(
             matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
             matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
-            matchStatsUrl = None,
+            matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats/$date/$team.json"),
             matchType = CricketMatchType,
           ),
         )

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -4,7 +4,7 @@ import common._
 import conf.Configuration
 import conf.cricketPa.{CricketTeam, CricketTeams, PaFeed}
 import contentapi.ContentApiClient
-import cricketModel.{Match, MatchHeader}
+import cricketModel.{Match, MatchHeader, MatchStats}
 import football.datetime.DateHelpers
 import football.model.{CricketScoreBoardDataModel, DotcomRenderingCricketDataModel}
 import implicits.{HtmlFormat, JsonFormat}
@@ -87,6 +87,19 @@ class CricketMatchController(
               val model = MatchHeader(page, relatedContents, requestedDate)
               Cached(CacheTime.Cricket)(JsonComponent.fromWritable(model))
             }
+          }
+        }
+        .getOrElse(successful(NoCache(NotFound)))
+    }
+
+  def matchStatsJson(date: String, teamId: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      CricketTeams
+        .byWordsForUrl(teamId)
+        .flatMap { team =>
+          cricketStatsJob.findMatch(team, date).map { matchData =>
+            val model = MatchStats(matchData)
+            successful(Cached(CacheTime.Cricket)(JsonComponent.fromWritable(model)))
           }
         }
         .getOrElse(successful(NoCache(NotFound)))

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -122,22 +122,97 @@ case class Match(
   def awayTeam: Team = teams.filter(!_.home).head
   def homeTeamInnings: List[Innings] = innings.filter(x => x.battingTeam == homeTeam.name).sortBy(_.order)
   def awayTeamInnings: List[Innings] = innings.filter(x => x.battingTeam == awayTeam.name).sortBy(_.order)
-
-  def lastInnings: Option[Innings] = innings.lastOption
-
-  def firstInBatter: Option[InningsBatter] = lastInnings.flatMap(_.firstIn)
-
-  def secondInBatter: Option[InningsBatter] = lastInnings.flatMap(_.secondIn)
-
-  def lastOut: Option[InningsBatter] = lastInnings.flatMap(_.lastOut)
 }
 
 object Match {
   implicit val writes: OWrites[Match] = Json.writes[Match]
 }
 
+// *********** Cricket match stats data ***********
+case class MatchStats(
+    innings: List[Innings],
+    teams: List[Team],
+    officials: List[String],
+)
+
+object MatchStats {
+  implicit val writes: OWrites[MatchStats] = Json.writes[MatchStats]
+
+  def apply(matchData: Match): MatchStats = {
+    MatchStats(
+      innings = matchData.innings,
+      teams = matchData.teams,
+      officials = matchData.officials,
+    )
+  }
+}
+
+// *********** Cricket match header data ***********
+case class InningsOverview(
+    battingTeam: String,
+    order: Int,
+    runs: Int,
+    wickets: Int,
+    overs: String,
+    declared: Boolean,
+    allOut: Boolean,
+)
+
+object InningsOverview {
+  implicit val writes: OWrites[InningsOverview] = Json.writes[InningsOverview]
+
+  // convert heavy Innings type to the lightweight Overview type
+  def fromInnings(innings: Innings): InningsOverview = {
+    InningsOverview(
+      battingTeam = innings.battingTeam,
+      order = innings.order,
+      runs = innings.runsScored,
+      wickets = innings.wickets,
+      overs = innings.overs,
+      declared = innings.declared,
+      allOut = innings.allOut,
+    )
+  }
+}
+
+case class TeamOverview(name: String, id: String, home: Boolean, teamTagId: Option[String])
+
+object TeamOverview {
+  implicit val writes: OWrites[TeamOverview] = Json.writes[TeamOverview]
+}
+
+case class MatchOverview(
+    teamsOverview: List[TeamOverview],
+    inningsOverview: List[InningsOverview],
+    competitionName: String,
+    venueName: String,
+    result: String,
+    currentDay: Int,
+    totalDays: Int,
+    gameDate: LocalDateTime,
+    matchId: String,
+)
+
+object MatchOverview {
+  implicit val writes: OWrites[MatchOverview] = Json.writes[MatchOverview]
+
+  def fromMatch(matchData: Match): MatchOverview = {
+    MatchOverview(
+      teamsOverview = matchData.teams.map(team => TeamOverview(team.name, team.id, team.home, team.teamTagId)),
+      inningsOverview = matchData.innings.map(InningsOverview.fromInnings),
+      competitionName = matchData.competitionName,
+      venueName = matchData.venueName,
+      result = matchData.result,
+      currentDay = matchData.currentDay,
+      totalDays = matchData.totalDays,
+      gameDate = matchData.gameDate,
+      matchId = matchData.matchId,
+    )
+  }
+}
+
 case class MatchHeader(
-    cricketMatch: Match,
+    cricketMatch: MatchOverview,
 //    competitionName: String, TODO: we currently don't have this but need to retrieve it e.g., "Ashes 2025-26"
     liveURL: Option[String],
     reportURL: Option[String],
@@ -182,8 +257,9 @@ object MatchHeader extends DCARUrlHelper {
       }
       .map(content => getPageUrl(content.metadata.url))
 
+    println("Marji")
     MatchHeader(
-      cricketMatch = page.theMatch,
+      cricketMatch = MatchOverview.fromMatch(page.theMatch),
       liveURL = liveBlogUrl,
       reportURL = matchReportUrl,
       infoURL = getPageUrl(page.metadata.id),

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -13,7 +13,8 @@ GET        /football/wallchart/:competitionTag                                  
 GET        /sport/cricket/match/:matchDate/:teamId.json                                        cricket.controllers.CricketMatchController.renderMatchIdJson(matchDate, teamId)
 GET        /sport/cricket/match/:matchDate/:teamId                                             cricket.controllers.CricketMatchController.renderMatchId(matchDate, teamId)
 GET        /sport/cricket/match-scoreboard/:matchDate/:teamId.json                             cricket.controllers.CricketMatchController.renderMatchScoreboardJson(matchDate, teamId)
-GET        /sport/cricket/match-header/:matchDate/:teamId.json                              cricket.controllers.CricketMatchController.matchHeaderJson(matchDate, teamId)
+GET        /sport/cricket/match-header/:matchDate/:teamId.json                                 cricket.controllers.CricketMatchController.matchHeaderJson(matchDate, teamId)
+GET        /sport/cricket/match-stats/:matchDate/:teamId.json                                  cricket.controllers.CricketMatchController.matchStatsJson(matchDate, teamId)
 
 GET        /football/fixtures/more/:year/:month/:day.json                                      football.controllers.FixturesController.moreFixturesForJson(year, month, day)
 GET        /football/fixtures/:year/:month/:day.json                                           football.controllers.FixturesController.allFixturesForJson(year, month, day)


### PR DESCRIPTION
## What does this change?
Add cricket match stats endpoint

- Add `MatchStats` model containing innings, teams and officials data
- Add new route: GET /sport/cricket/match-stats/:matchDate/:teamId.json
- Refactor `MatchHeader` to use a lightweight `MatchOverview` type instead of the full `Match` model

**Note:**
The scorecard tab isn’t served via its own URL and is instead loaded as part of the main page via AJAX, so its data could technically be included in the match header response. However, the header needs to render immediately on page load, whereas the scorecard data is only required when the user opens the scorecard tab. Keeping these as separate JSON endpoints ensures the header payload stays lightweight and can be parsed faster. 

Happy to discuss if anyone thinks this separation is unnecessary.

Relevant PR to add the nginx route https://github.com/guardian/platform/pull/2253

Fixes part of https://github.com/guardian/dotcom-rendering/issues/15979