### PR TITLE
Add world cup to nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -423,6 +423,7 @@ object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
+      footballWorldCup2026,
       football,
       cricket,
       rugbyUnion,
@@ -467,6 +468,7 @@ object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
+      footballWorldCup2026,
       football,
       cricket,
       rugbyUnion,
@@ -479,6 +481,7 @@ object NavLinks {
   )
   val eurSportPillar = ukSportPillar.copy(
     children = List(
+      footballWorldCup2026,
       football,
       cricket,
       rugbyUnion,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -276,6 +276,7 @@ object NavLinks {
     iconName = Some("home"),
     List(
       ukNews,
+      footballWorldCup2026,
       usPolitics,
       world,
       climateCrisis,
@@ -298,6 +299,7 @@ object NavLinks {
       world,
       auPolitics,
       auEnvironment,
+      footballWorldCup2026,
       climateCrisis,
       indigenousAustralia,
       auImmigration,
@@ -314,12 +316,12 @@ object NavLinks {
     List(
       usNews,
       usPolitics,
+      footballWorldCup2026,
       world,
       climateCrisis,
       middleEast,
       ukraine,
       usImmigration,
-      usSoccer,
       usBusiness,
       usEnvironment,
       usTech,
@@ -332,6 +334,7 @@ object NavLinks {
   val intNewsPillar = ukNewsPillar.copy(
     children = List(
       world,
+      footballWorldCup2026,
       usPolitics,
       ukNews,
       climateCrisis,
@@ -349,6 +352,7 @@ object NavLinks {
   val eurNewsPillar = ukNewsPillar.copy(
     children = List(
       world,
+      footballWorldCup2026,
       ukNews,
       climateCrisis,
       ukraine,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -432,6 +432,12 @@
 			"iconName": "home",
 			"children": [
 				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -2814,6 +2820,12 @@
 			"iconName": "home",
 			"children": [
 				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Football",
 					"url": "/football",
 					"children": [
@@ -3818,6 +3830,12 @@
 			"longTitle": "Sport home",
 			"iconName": "home",
 			"children": [
+				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
+					"classList": []
+				},
 				{
 					"title": "Football",
 					"url": "/football",

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -88,6 +88,12 @@
 					"classList": []
 				},
 				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "US politics",
 					"url": "/us-news/us-politics",
 					"children": [],
@@ -981,6 +987,12 @@
 					"classList": []
 				},
 				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "World",
 					"url": "/world",
 					"longTitle": "World news",
@@ -1066,61 +1078,6 @@
 					"title": "US immigration",
 					"url": "/us-news/usimmigration",
 					"children": [],
-					"classList": []
-				},
-				{
-					"title": "Soccer",
-					"url": "/us/soccer",
-					"children": [
-						{
-							"title": "Live scores",
-							"url": "/football/live",
-							"longTitle": "football/live",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Tables",
-							"url": "/football/tables",
-							"longTitle": "football/tables",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Schedules",
-							"url": "/football/fixtures",
-							"longTitle": "football/fixtures",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Results",
-							"url": "/football/results",
-							"longTitle": "football/results",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "World Cup 2026",
-							"url": "/football/world-cup-2026",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Competitions",
-							"url": "/football/competitions",
-							"longTitle": "football/competitions",
-							"children": [],
-							"classList": []
-						},
-						{
-							"title": "Clubs",
-							"url": "/football/teams",
-							"longTitle": "football/teams",
-							"children": [],
-							"classList": []
-						}
-					],
 					"classList": []
 				},
 				{
@@ -1866,6 +1823,12 @@
 					"classList": []
 				},
 				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "Climate crisis",
 					"url": "/environment/climate-crisis",
 					"children": [],
@@ -2511,6 +2474,12 @@
 							"classList": []
 						}
 					],
+					"classList": []
+				},
+				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
 					"classList": []
 				},
 				{
@@ -3498,6 +3467,12 @@
 							"classList": []
 						}
 					],
+					"classList": []
+				},
+				{
+					"title": "World Cup 2026",
+					"url": "/football/world-cup-2026",
+					"children": [],
 					"classList": []
 				},
 				{


### PR DESCRIPTION
## What is the value of this and can you measure success?

Digital editors have discussed and summarised a request for [World Cup 2026](https://www.theguardian.com/football/world-cup-2026) to be placed in the nav bar in a few places:

UK - 2nd, and can drop Science if there's too little space.**
Same on Int
Europe it can go 2nd without needing to lose anything.
US would like it 3rd, just after US politics, and then to lose 'Soccer'
Aus say 5th just after environment

And then UK/Eu/Int sport - they want it to be first on desktop nav bar

## Screenshots


Aus 
<img width="1321" height="199" alt="image" src="https://github.com/user-attachments/assets/c18bf50f-4c11-4101-908d-9e782356b7db" />

Uk
<img width="1349" height="225" alt="image" src="https://github.com/user-attachments/assets/ad67f6ef-2874-4cd5-83a1-81d8855bd8c8" />

Us (page rendered by frontend on code)
<img width="1360" height="149" alt="image" src="https://github.com/user-attachments/assets/bb83f210-f807-4ed5-bab4-4713504b468b" />

Int
<img width="1592" height="279" alt="image" src="https://github.com/user-attachments/assets/b9b5e764-dd80-4434-9117-28e601085916" />

Eur
<img width="1322" height="194" alt="image" src="https://github.com/user-attachments/assets/8d3f21cf-6d61-4a53-97f8-0cb95734d7d6" />


Uk Sport: 
<img width="1069" height="117" alt="image" src="https://github.com/user-attachments/assets/304cc24f-40c6-42d0-b05d-b7ddb6c986fa" />

