### PR TITLE
added football and football/world-cup-2026 to high frequency fronts

### DIFF
--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -23,7 +23,7 @@ object HighFrequency extends FrontType {
       "us/sport",
       "au/sport",
       "football",
-      "football/world-cup-2026"
+      "football/world-cup-2026",
     )
 }
 

--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -22,6 +22,8 @@ object HighFrequency extends FrontType {
       "uk/sport",
       "us/sport",
       "au/sport",
+      "football",
+      "football/world-cup-2026"
     )
 }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

In reference to https://github.com/guardian/dotcom-rendering/issues/15971 we want to update fronts that have the Match Day atom frequently so as to keep the scores and information up to date. 

## What does this change?

Added /football and /football/world-cup-2026 fronts to the high frequency jobs list.
