### PR TITLE
Update HostedContentPicker.scala

### DIFF
--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -27,14 +27,15 @@ object HostedContentPicker extends GuLogging {
   def decideTier(isGallery: Boolean = false)(implicit
       request: RequestHeader,
   ): RenderType = {
-    if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
     // Gallery pages are not supported in DCR yet
-    else if (isGallery) LocalRender
+    if (isGallery) LocalRender
     else if (request.forceDCROff) LocalRender
-    else if (request.forceDCR) RemoteRender
-    // Apps traffic bypasses Fastly MVT so can never be bucketed into the AB test;
-    // route unconditionally to DCR for apps.
+    // Apps traffic bypasses Fastly MVT so can never be bucketed into the AB test,
+    // and has no meaningful fallback to the Scala template — route unconditionally
+    // to DCR for apps regardless of the DCRHostedContent feature switch.
     else if (request.getRequestFormat == AppsFormat) RemoteRender
+    else if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
+    else if (request.forceDCR) RemoteRender
     else if (isUserInTestGroup("commercial-hosted-content", "preview")) RemoteRender
     else LocalRender
   }

--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -32,6 +32,9 @@ object HostedContentPicker extends GuLogging {
     else if (isGallery) LocalRender
     else if (request.forceDCROff) LocalRender
     else if (request.forceDCR) RemoteRender
+    // Apps traffic bypasses Fastly MVT so can never be bucketed into the AB test;
+    // route unconditionally to DCR for apps.
+    else if (request.getRequestFormat == AppsFormat) RemoteRender
     else if (isUserInTestGroup("commercial-hosted-content", "preview")) RemoteRender
     else LocalRender
   }


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
