### PR TITLE
added short links to world cup nav

### DIFF
--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -40,7 +40,7 @@ object DotcomFrontsRenderingDataModel {
       deeplyRead: Option[Seq[Trail]],
   ): DotcomFrontsRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition)(request)
+    val nav = Nav(page, edition)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
@@ -43,7 +43,7 @@ object DotcomNewslettersPageRenderingDataModel {
       request: RequestHeader,
   ): DotcomNewslettersPageRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition)(request)
+    val nav = Nav(page, edition)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -658,7 +658,7 @@ object DotcomRenderingDataModel {
       matchHeaderUrl = matchData.flatMap(_.matchHeaderUrl),
       matchStatsUrl = matchData.flatMap(_.matchStatsUrl),
       matchType = matchData.map(_.matchType),
-      nav = Nav(page, edition)(request),
+      nav = Nav(page, edition),
       openGraphData = page.getOpenGraphProperties,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),
       pageId = content.metadata.id,

--- a/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
@@ -73,7 +73,7 @@ object DotcomTagPagesRenderingDataModel {
       pageType: PageType,
   ): DotcomTagPagesRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition)(request)
+    val nav = Nav(page, edition)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -94,7 +94,7 @@ object Nav {
 
   implicit val writes: OWrites[Nav] = Json.writes[Nav]
 
-  def apply(page: Page, edition: Edition)(implicit request: RequestHeader): Nav = {
+  def apply(page: Page, edition: Edition): Nav = {
     val navMenu = NavMenu(page, edition)
     Nav(
       currentUrl = navMenu.currentUrl,

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -5,10 +5,8 @@ import common.{Edition, editions}
 import navigation.NavMenu.navRoot
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json.{Json, Writes, _}
-import ab.ABTests
 
 import scala.annotation.tailrec
-import play.api.mvc.RequestHeader
 
 sealed trait Subnav
 case class FlatSubnav(links: Seq[NavLink]) extends Subnav
@@ -79,7 +77,7 @@ object NavMenu {
       brandExtensions: Seq[NavLink],
   )
 
-  def apply(page: Page, edition: Edition)(implicit request: RequestHeader): NavMenu = {
+  def apply(page: Page, edition: Edition): NavMenu = {
     val root = navRoot(edition)
     val currentUrl = getSectionOrPageUrl(page, edition)
     val currentNavLink = findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks)
@@ -89,7 +87,7 @@ object NavMenu {
 
     // On the world cup overview page, we want to show the special football header atom
     val subNavSections =
-      if (isWorldCupOverview && ABTests.isUserInTest("webx-world-cup-2026-subnav")) {
+      if (isWorldCupOverview) {
         None
       } else {
         getSubnav(page.metadata.customSignPosting, currentNavLink, currentParent, currentPillar)

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -143,7 +143,7 @@
             @fragments.nav.subNav(navMenu, page.metadata.designType)
         }
 
-        @if(page.metadata.id == "football/world-cup-2026/overview" && ABTests.isUserInTest("webx-world-cup-2026-subnav")) {
+        @if(page.metadata.id == "football/world-cup-2026/overview") {
             @fragments.nav.worldCupSubNav(page.metadata.id)
         }
     </header>

--- a/common/app/views/fragments/nav/worldCupSubNav.scala.html
+++ b/common/app/views/fragments/nav/worldCupSubNav.scala.html
@@ -15,9 +15,9 @@
                 }
                 @for((href, label) <- Seq(
                     "/football/world-cup-2026/overview" -> "Match centre",
-                    "p/x4n6cb" -> "Player guide", // TODO: update when url is finalised
-                    "p/x4z6hj" -> "Bracketology", // TODO: update when url is finalised
-                    "p/x5vn6x" -> "Golden boot", // TODO: update when url is finalised
+                    "/football/ng-interactive/2026/jun/04/world-cup-2026-complete-player-guide" -> "Player guide",
+                    "/football/ng-interactive/2026/jun/04/bracketology-predict-a-path-to-world-cup-victory" -> "Bracketology",
+                    "/football/ng-interactive/2026/jun/04/golden-boot-world-cup-2026-top-goalscorers-winner" -> "Golden boot",
                     "/football" -> "More football",
                 )) {
                 <li>

--- a/common/app/views/fragments/nav/worldCupSubNav.scala.html
+++ b/common/app/views/fragments/nav/worldCupSubNav.scala.html
@@ -15,9 +15,9 @@
                 }
                 @for((href, label) <- Seq(
                     "/football/world-cup-2026/overview" -> "Match centre",
-                    "/football/world-cup-2026/player-guide" -> "Player guide", // TODO: update when url is finalised
-                    "/football/world-cup-2026/bracketology" -> "Bracketology", // TODO: update when url is finalised
-                    "/football/world-cup-2026/golden-boot" -> "Golden boot", // TODO: update when url is finalised
+                    "p/x4n6cb" -> "Player guide", // TODO: update when url is finalised
+                    "p/x4z6hj" -> "Bracketology", // TODO: update when url is finalised
+                    "p/x5vn6x" -> "Golden boot", // TODO: update when url is finalised
                     "/football" -> "More football",
                 )) {
                 <li>

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -9,7 +9,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, WithTestWsClient}
-import play.api.test.FakeRequest
 
 @DoNotDiscover class NavigationTest
     extends AnyFlatSpec
@@ -203,7 +202,7 @@ import play.api.test.FakeRequest
     whenReady(response) { item: ItemResponse =>
       item.content.map { apiContent =>
         val page = TestPage(Content(apiContent))
-        val menu = NavMenu(page, edition)(FakeRequest())
+        val menu = NavMenu(page, edition)
         val currentNavLink = menu.currentNavLink
         val pillar = menu.currentPillar
 
@@ -223,7 +222,7 @@ import play.api.test.FakeRequest
     whenReady(response) { item: ItemResponse =>
       item.content.map { apiContent =>
         val page = TestPage(Content(apiContent))
-        val menu = NavMenu(page, edition)(FakeRequest())
+        val menu = NavMenu(page, edition)
         val currentNavLink = menu.currentNavLink
         val pillar = menu.currentPillar
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

As part of this: https://github.com/guardian/dotcom-rendering/issues/16018 we want to add links to the world cup nav. 

## What does this change?

Have added short links to Player Guide, Bracketology and Golden Boot. I believe we will want to replace them with proper links when they become available.