### PR TITLE
Update group stage tables and spider chart to support localisation in atoms

### DIFF
--- a/sport/app/football/views/wallchart/groupTablesEmbed.scala.html
+++ b/sport/app/football/views/wallchart/groupTablesEmbed.scala.html
@@ -2,7 +2,6 @@
 
 @competitionStages.map { groupStage =>
     <div data-link-name="@competition.fullName groups">
-    @football.views.html.wallchart.groups(competition, groupStage)
+    @football.views.html.wallchart.groups(competition, groupStage, true)
     </div>
 }
-

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -3,7 +3,10 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.RowInfo
 
-@(competition: model.Competition, groupStage: _root_.football.model.Groups)(implicit request: RequestHeader)
+@(competition: model.Competition,
+    groupStage: _root_.football.model.Groups,
+    embed: Boolean = false
+)(implicit request: RequestHeader)
 
 @footballGroup(round: Round, leagueTableEntries: Seq[LeagueTableEntry], row: RowInfo) = {
     @defining(groupStage.matchesList(competition, round)) { matches =>
@@ -19,14 +22,35 @@
                         )
                     </div>
                     <div class="football-group__matches">
-                    @{matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
-                        competitionMatches.map { case (competition, matches) =>
-                            football.views.html.matchList.matchesList(matches, competition, date,
-                                linkToCompetition = false,
-                                heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
-                            )
+                        @if(embed) {
+                            <table class="table table--football football-matches">
+                                <thead hidden>
+                                    <tr>
+                                        <th class="match__status">Match status / kick off time</th>
+                                        <th class="match__details">Match details</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @{matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
+                                        competitionMatches.map { case (competition, matches) =>
+                                            football.views.html.matchList.spiderMatchesList(matches, competition, date)
+                                        }
+                                    }}
+                                </tbody>
+                                <caption class="table__caption table__caption--top">
+                                    <span class="football-matches__heading">Fixtures and results</span>
+                                </caption>
+                            </table>
+                        } else {
+                            @{matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
+                                competitionMatches.map { case (competition, matches) =>
+                                    football.views.html.matchList.matchesList(matches, competition, date,
+                                        linkToCompetition = false,
+                                        heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
+                                    )
+                                }
+                            }}
                         }
-                    }}
                     </div>
                 }
             </div>

--- a/sport/app/football/views/wallchart/knockoutListEmbed.scala.html
+++ b/sport/app/football/views/wallchart/knockoutListEmbed.scala.html
@@ -1,0 +1,41 @@
+@import _root_.football.model.Knockout
+@import model.Competition
+@import views.support.`package`.Seq2zipWithRowInfo
+@import football.model.MatchesList
+
+@(competition: Competition, knockoutStage: Knockout, hasSpider: Boolean = false)(implicit request: RequestHeader)
+
+@matchTemplate(matches: MatchesList) = {
+    <li>
+        <table class="table table--football football-matches">
+            <thead hidden>
+                <tr>
+                    <th class="match__status">Match status / kick off time</th>
+                    <th class="match__details">Match details</th>
+                </tr>
+            </thead>
+            <tbody>
+                @{matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
+                    competitionMatches.map { case (competition, matches) =>
+                        football.views.html.matchList.spiderMatchesList(matches, competition, date)
+                    }
+                }}
+            </tbody>
+            <caption class="table__caption table__caption--top">
+                <span class="football-matches__heading">Fixtures and results</span>
+            </caption>
+        </table>
+    </li>
+}
+
+<div class="football-knockouts @if(hasSpider){football-knockouts--has-spider}">
+    @knockoutStage.rounds.zipWithRowInfo.map{ case (round, row) =>
+        @round.name.map { name =>
+            @fragments.dropdown(name, isActive = knockoutStage.isActiveRound(round)){
+                <ul class="u-unstyled u-cf">
+                @matchTemplate(knockoutStage.matchesList(competition, round))
+                </ul>
+            }
+        }
+    }
+</div>

--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -24,10 +24,10 @@
                 <div class="football-match__name"><b>Final</b></div>
             }
             @if(fm.isFixture){
-                <div class="football-match__date">
+                <time class="football-match__date" datetime="@fm.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZone(Edition(request).timezoneId))">
                     <span class="football-match__kickoff">@fm.date.format(DateTimeFormatter.ofPattern("HH:mm  z").withZone(Edition(request).timezoneId))</span>
                     @fm.date.withZoneSameInstant(Edition(request).timezoneId).toLocalDate.format(DateTimeFormatter.ofPattern("E dd MMMM "))
-                </div>
+                </time>
             }
 
             @fm.comments.map { comments =>

--- a/sport/app/football/views/wallchart/knockoutSpider.scala.html
+++ b/sport/app/football/views/wallchart/knockoutSpider.scala.html
@@ -2,9 +2,16 @@
 @import java.time.ZonedDateTime
 @import common.Edition
 @import java.time.LocalTime
-@(competition: model.Competition, knockoutStage: _root_.football.model.KnockoutSpider)(implicit request: RequestHeader)
+@(competition: model.Competition,
+    knockoutStage: _root_.football.model.KnockoutSpider,
+    embed: Boolean = false
+)(implicit request: RequestHeader)
 
-@football.views.html.wallchart.knockoutList(competition, knockoutStage, true)
+@if(embed) {
+    @football.views.html.wallchart.knockoutListEmbed(competition, knockoutStage, true)
+} else {
+    @football.views.html.wallchart.knockoutList(competition, knockoutStage, true)
+}
 
 <div class="football-knockout-chart football-knockout-chart--@knockoutStage.rounds.length-rounds u-cf">
     <div class="football-rounds football-rounds--first-half">

--- a/sport/app/football/views/wallchart/spiderEmbed.scala.html
+++ b/sport/app/football/views/wallchart/spiderEmbed.scala.html
@@ -2,6 +2,6 @@
 
 @competitionStages.map { knockoutStage =>
     <div class="knockout-container" data-link-name="@competition.fullName knockout chart">
-    @football.views.html.wallchart.knockoutSpider(competition, knockoutStage)
+    @football.views.html.wallchart.knockoutSpider(competition, knockoutStage, true)
     </div>
 }

--- a/sport/app/football/views/wallchart/spiderRoundEmbed.scala.html
+++ b/sport/app/football/views/wallchart/spiderRoundEmbed.scala.html
@@ -8,24 +8,25 @@
             <ul class="u-unstyled u-cf">
                 <li>
                     <table class="table table--football football-matches">
-                    <thead hidden>
-                        <tr>
-                            <th class="match__status">Match status / kick off time</th>
-                            <th class="match__details">Match details</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @{
-                            knockoutStage.matchesList(competition, round).matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
-                                competitionMatches.map { case (competition, matches) =>
-                                    football.views.html.matchList.spiderMatchesList(matches, competition, date)
+                        <thead hidden>
+                            <tr>
+                                <th class="match__status">Match status / kick off time</th>
+                                <th class="match__details">Match details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @{
+                                knockoutStage.matchesList(competition, round).matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
+                                    competitionMatches.map { case (competition, matches) =>
+                                        football.views.html.matchList.spiderMatchesList(matches, competition, date)
+                                    }
                                 }
                             }
-                        }
-                    </tbody>
-                    <caption class="table__caption table__caption--top">
-                        <span class="football-matches__heading">Fixtures and results</span>
-                    </caption>
+                        </tbody>
+                        <caption class="table__caption table__caption--top">
+                            <span class="football-matches__heading">Fixtures and results</span>
+                        </caption>
+                    </table>
                 </li>
             </ul>
         }


### PR DESCRIPTION
## What does this change?

This follows on from the #28820 and makes additional changes to the templates used to render football atoms to support localisation of match dates and times:

- Flattens table structure in full group table to removing grouping by date
- Flattens table structure of knockout stages (displayed in place of full spider chart on smaller screens)
- Adds `time` element to spider chart match dates so they can be found and localised

## Screenshots

<img width="1209" height="889" alt="Screenshot 2026-06-05 at 10 11 49" src="https://github.com/user-attachments/assets/35576bd9-a51a-48ca-8f33-c190cb01dfa4" />
