### PR TITLE
Release Hosted Article and Video pages to everyone, hold Gallery pages behind the AB test

### DIFF
--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -29,10 +29,10 @@ object HostedContentPicker extends GuLogging {
   ): RenderType = {
     if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
     // Gallery pages are not supported in DCR yet
-    else if (isGallery) LocalRender
+    else if (isGallery && !isUserInTestGroup("commercial-hosted-content", "preview")) LocalRender
+    else if (isGallery && request.forceDCR) RemoteRender
     else if (request.forceDCROff) LocalRender
     else if (request.forceDCR) RemoteRender
-    else if (isUserInTestGroup("commercial-hosted-content", "preview")) RemoteRender
-    else LocalRender
+    else RemoteRender
   }
 }

--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -29,7 +29,7 @@ object HostedContentPicker extends GuLogging {
   ): RenderType = {
     if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
     // Gallery pages are not supported in DCR yet
-    else if (isGallery && !isUserInTestGroup("commercial-hosted-content", "preview")) LocalRender
+    else if (isGallery && !isUserInTestGroup("commercial-hosted-gallery", "preview")) LocalRender
     else if (isGallery && request.forceDCR) RemoteRender
     else if (request.forceDCROff) LocalRender
     else if (request.forceDCR) RemoteRender

--- a/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
+++ b/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
@@ -29,7 +29,7 @@ import test.TestRequest
 
   it should "return RemoteRender if in the test group and forcing DCR for isGallery = true" in {
     val testRequest = TestRequest("hosted-content-path?dcr=true").withHeaders(
-      "X-GU-Server-AB-Tests" -> "commercial-hosted-content:preview",
+      "X-GU-Server-AB-Tests" -> "commercial-hosted-gallery:preview",
     )
     val tier = HostedContentPicker.decideTier(isGallery = true)(testRequest)
     tier should be(RemoteRender)

--- a/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
+++ b/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
@@ -16,9 +16,23 @@ import test.TestRequest
   }
 
   it should "return LocalRender if isGallery is true" in {
+    val testRequest = TestRequest("hosted-content-path")
+    val tier = HostedContentPicker.decideTier(isGallery = true)(testRequest)
+    tier should be(LocalRender)
+  }
+
+  it should "return LocalRender if not in the test group whilst forcing DCR for isGallery = true" in {
     val testRequest = TestRequest("hosted-content-path?dcr=true")
     val tier = HostedContentPicker.decideTier(isGallery = true)(testRequest)
     tier should be(LocalRender)
+  }
+
+  it should "return RemoteRender if in the test group and forcing DCR for isGallery = true" in {
+    val testRequest = TestRequest("hosted-content-path?dcr=true").withHeaders(
+      "X-GU-Server-AB-Tests" -> "commercial-hosted-content:preview",
+    )
+    val tier = HostedContentPicker.decideTier(isGallery = true)(testRequest)
+    tier should be(RemoteRender)
   }
 
   it should "return LocalRender if forcing DCR to be off via the query parameter" in {
@@ -30,7 +44,7 @@ import test.TestRequest
   it should "return RemoteRender if forcing DCR to be on via the query parameter" in {
     val testRequest = TestRequest("hosted-content-path?dcr=true")
     val tier = HostedContentPicker.decideTier()(testRequest)
-    tier should be(LocalRender)
+    tier should be(RemoteRender)
   }
 
   it should "return LocalRender if not in the test group without forcing DCR" in {
@@ -39,17 +53,9 @@ import test.TestRequest
     tier should be(LocalRender)
   }
 
-  it should "return RemoteRender if in the test group without forcing DCR" in {
-    val testRequest = TestRequest("hosted-content-path").withHeaders(
-      "X-GU-Server-AB-Tests" -> "commercial-hosted-content:preview",
-    )
-    val tier = HostedContentPicker.decideTier()(testRequest)
-    tier should be(RemoteRender)
-  }
-
-  it should "return LocalRender otherwise" in {
+  it should "return RemoteRender otherwise" in {
     val testRequest = TestRequest("hosted-content-path")
     val tier = HostedContentPicker.decideTier()(testRequest)
-    tier should be(LocalRender)
+    tier should be(RemoteRender)
   }
 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

- Fully releases DCR Hosted Article and Video pages
- Keeps Hosted Gallery pages behind a 0% test and force DCR params

## What did you change?

Reversed the logic so that we now `RemoteRender` Hosted content article and video pages by default and catch the gallery ones early, so that we can only render them if we force DCR and are opted into the AB test