### PR TITLE
Live harness service handles articles with no atoms

### DIFF
--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -1,7 +1,7 @@
 package utils
 
 import com.gu.contentapi.client.model.v1.{BlockElement, ContentAtomElementFields, ElementType, TextElementFields}
-import model.content.InteractiveAtom
+import model.content.{Atoms, InteractiveAtom}
 import model.meta.BlocksOn
 import model.{ArticlePage, Content, ContentPage, InteractivePage}
 import play.api.libs.json.{Json, Reads}
@@ -57,7 +57,11 @@ object LiveHarness {
   ): BlocksOn[P] => BlocksOn[P] = _.mapBoth(
     page => {
       val content = page.item.content
-      updater.update(page, content.copy(atoms = content.atoms.map(_.copy(interactives = harnessAtoms.map(_.atom)))))
+      val interactives = harnessAtoms.map(_.atom)
+      val updatedAtoms = content.atoms
+        .getOrElse(emptyAtoms)
+        .copy(interactives = interactives)
+      updater.update(page, content.copy(atoms = Some(updatedAtoms)))
     },
     blocks =>
       blocks.copy(body = blocks.body.map { bodyBlocks =>
@@ -65,6 +69,22 @@ object LiveHarness {
           block.copy(elements = insertAtomsAtNthPoints(block.elements.toSeq, harnessAtoms))
         }
       }),
+  )
+
+  private val emptyAtoms = Atoms(
+    audios = Seq.empty,
+    charts = Seq.empty,
+    commonsdivisions = Seq.empty,
+    explainers = Seq.empty,
+    guides = Seq.empty,
+    interactives = Seq.empty,
+    media = Seq.empty,
+    profiles = Seq.empty,
+    qandas = Seq.empty,
+    quizzes = Seq.empty,
+    reviews = Seq.empty,
+    timelines = Seq.empty,
+    callToAction = Seq.empty,
   )
 
   private val voidTextElements = Set("br", "hr", "wbr")


### PR DESCRIPTION
This adjusts the live harness service after I noticed an issue where atoms weren't appearing in freshly made Composer articles. Some articles have no atoms at all in their CAPI response. The original code couldn't handle `content.atoms` being `None`. Without being registered in the atoms registry, the renderer doesn't know what to render when it encounters the atom's block element in the body, so nothing appears. 

The fix constructs a fresh `model.content.Atoms` with empty sequences for all atom types except interactives when the article has no existing atoms, ensuring the harness atom always gets registered regardless of the article's original content.

Have tested locally and seems to do the trick:

<img width="1006" height="235" alt="image" src="https://github.com/user-attachments/assets/5ae27c57-a7c5-4393-91de-f9865d7bec80" />
