### PR TITLE
Add PA cricket competition name to the match data

### DIFF
--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -108,7 +108,9 @@ object MatchResult {
 case class Match(
     teams: List[Team],
     innings: List[Innings],
-    competitionName: String,
+    competitionName: String, // TODO: this needs to be removed after DCAR is updated to use stage
+    stage: String,
+    competitionNameV2: String, // TODO: this needs renaming to competitionName after DCAR is updated
     venueName: String,
     result: String,
     currentDay: Int,
@@ -138,7 +140,6 @@ object Match {
 
 case class MatchHeader(
     cricketMatch: Match,
-//    competitionName: String, TODO: we currently don't have this but need to retrieve it e.g., "Ashes 2025-26"
     liveURL: Option[String],
     reportURL: Option[String],
     infoURL: String,

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -11,7 +11,7 @@ import java.util.TimeZone
 
 object Parser {
 
-  def parseMatch(scorecard: String, detail: String, lineups: String, matchId: String): Match = {
+  def parseMatch(scorecard: String, detail: String, lineups: String, competitionMatch: CompetitionMatch): Match = {
     val matchData = XML.loadString(detail) \ "match"
     val matchDetail = parseMatchDetail(matchData)
     val lineupData = XML.loadString(lineups)
@@ -21,13 +21,15 @@ object Parser {
       teams = parseTeams(lineupData \ "match" \ "team"),
       innings = parseInnings(scorecardData \ "match" \ "innings"),
       competitionName = matchDetail.competitionName,
+      stage = matchDetail.competitionName,
+      competitionNameV2 = competitionMatch.competitionName,
       venueName = matchDetail.venueName,
       result = matchDetail.status,
       currentDay = matchDetail.currentDay,
       totalDays = matchDetail.totalDays,
       gameDate = matchDetail.gameDate,
       officials = matchDetail.officials,
-      matchId = matchId,
+      matchId = competitionMatch.matchId,
       fullResult = matchDetail.result,
     )
   }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -18,6 +18,8 @@ object PaFeed {
   val dateFormat = Chronos.dateFormatter("yyyy-MM-dd", ZoneId.of("UTC"))
 }
 
+case class CompetitionMatch(matchId: String, competitionId: String, competitionName: String)
+
 class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materializer: Materializer) extends GuLogging {
 
   private val paEndpoint = "https://cricket-api.guardianapis.com/v1"
@@ -48,19 +50,21 @@ class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materialize
       .getOrElse(Future.failed(CricketFeedException("No cricket api key found")))
   }
 
-  def getMatch(matchId: String)(implicit executionContext: ExecutionContext): Future[cricketModel.Match] = {
+  def getMatch(
+      competitionMatch: CompetitionMatch,
+  )(implicit executionContext: ExecutionContext): Future[cricketModel.Match] = {
     for {
-      lineups: String <- getMatchPaResponse(s"match/$matchId/line-ups")
-      details: String <- getMatchPaResponse(s"match/$matchId")
-      scorecard: String <- getMatchPaResponse(s"match/$matchId/scorecard")
+      lineups: String <- getMatchPaResponse(s"match/${competitionMatch.matchId}/line-ups")
+      details: String <- getMatchPaResponse(s"match/${competitionMatch.matchId}")
+      scorecard: String <- getMatchPaResponse(s"match/${competitionMatch.matchId}/scorecard")
     } yield {
-      Parser.parseMatch(scorecard, details, lineups, matchId)
+      Parser.parseMatch(scorecard, details, lineups, competitionMatch)
     }
   }
 
-  def getMatchIds(team: CricketTeam, fromDate: LocalDate)(implicit
+  def getCompetitionMatches(team: CricketTeam, fromDate: LocalDate)(implicit
       executionContext: ExecutionContext,
-  ): Future[Seq[String]] = {
+  ): Future[Seq[CompetitionMatch]] = {
     Future
       .sequence(
         Seq(
@@ -73,7 +77,7 @@ class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materialize
 
   private def getTeamMatches(team: CricketTeam, matchType: String, startDate: LocalDate, endDate: LocalDate)(implicit
       executionContext: ExecutionContext,
-  ): Future[Seq[String]] = {
+  ): Future[Seq[CompetitionMatch]] = {
 
     credentials
       .map(header =>
@@ -89,7 +93,23 @@ class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materialize
             .get()
             .map { response =>
               response.status match {
-                case 200 => XML.loadString(response.body) \\ "match" map (content => (content \ "@id").text)
+                case 200 =>
+                  val xml = XML.loadString(response.body)
+
+                  // Iterate over each competition
+                  (xml \ "competition").flatMap { comp =>
+                    val compId = (comp \ "@id").text
+                    val compName = (comp \ "name").text
+
+                    // Iterate over the matches within this competition
+                    (comp \ "match").map { m =>
+                      CompetitionMatch(
+                        matchId = (m \ "@id").text,
+                        competitionId = compId,
+                        competitionName = compName,
+                      )
+                    }
+                  }
 
                 case 204 => Nil // No content for this date range.
 

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -1,7 +1,7 @@
 package jobs
 
 import common.{Box, GuLogging}
-import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
+import conf.cricketPa.{CompetitionMatch, CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
 
 import java.time.{Duration, LocalDate, LocalDateTime}
@@ -38,18 +38,21 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
           // Omit any recent match within the last 5 days, to account for test matches.
           Duration.between(cricketMatch.gameDate, LocalDateTime.now).toDays() > 5,
         )
-        .map(_.matchId)
+        .map(m => m.matchId)
         .toSeq
 
       paFeed
-        .getMatchIds(team, fromDate)
-        .map { matchIds =>
-          // never fetch more than 10 matches
-          val matches = matchIds.diff(loadedMatches).take(Math.min(matchesToFetch, 10))
+        .getCompetitionMatches(team, fromDate)
+        .map { competitionMatches: Seq[CompetitionMatch] =>
+          // Filter the incoming matches against the agent loaded IDs
+          // And never fetch more than 10 matches
+          val filteredCompetitionMatches = competitionMatches
+            .filterNot(theMatch => loadedMatches.contains(theMatch.matchId))
+            .take(Math.min(matchesToFetch, 10))
 
-          matches.map { matchId =>
+          filteredCompetitionMatches.map { competitionMatch =>
             paFeed
-              .getMatch(matchId)
+              .getMatch(competitionMatch)
               .map { matchData =>
                 val date = PaFeed.dateFormat.format(matchData.gameDate)
                 log.debug(s"Updating cricket match: ${matchData.homeTeam.name} v ${matchData.awayTeam.name}, $date")


### PR DESCRIPTION
## What does this change?
This PR adds the actual cricket competition name to our match data payload while preserving backward compatibility for existing usage in DCAR.



### Why?
Currently, our competitionName field actually stores the match stage (e.g., Phase One instead of ICC World Twenty20). 

For many of the competitions the competition name is very similar to the stage name, e.g. competition `One Day International Series` has these stages: `First One Day International`, `Second One Day International` & `Third One Day International`

But for some other competitions the competition and stage names are quite different, e.g. competition `ICC World Twenty20` which has stages `Phase One` & `Phase Three`

Therefore we need access to the true competition name.

### Migration Strategy
To avoid breaking changes, we are rolling this out in phases:

1. This PR (Phase 1):

   - Introduces a stage field (mirrors the current competitionName value).

   - Introduces competitionNameV2 (holds the actual competition name).

2. Next Steps:

   - Update DCAR to use the new stage field.

   - Deprecate competitionNameV2 and revert competitionName to hold the true competition name.

Fixes part of https://github.com/guardian/dotcom-rendering/issues/15980