### PR TITLE
Align team names with DCAR

### DIFF
--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -185,18 +185,20 @@ object CompetitionDisplayHelpers {
       .replace("Ladies", "")
       .replace("Holland", "The Netherlands")
       .replace("Union Saint Gilloise", "Union Saint-Gilloise")
+      .replace("Ivory Coast", "Côte d’Ivoire")
+      .replace("Bialystock", "Białystok")
+      .replace("Bosnia-Herzegovina", "Bosnia and Herzegovina")
+      .replace("Congo DR", "DR Congo")
+      .replace("Curacao", "Curaçao")
+      .replace("Czech Republic", "Czechia");
   }
 
   def cleanTeamNameNextGenApi(teamName: String): String = {
-    teamName
-      .replace("Ladies", "")
-      .replace("Holland", "Netherlands")
+    cleanTeamName(teamName)
   }
 
   def cleanTeamNameSpider(teamName: String): String = {
-    teamName
-      .replace("Czech Republic", "Czech Rep.")
-      .replace("Holland", "Netherlands")
+    cleanTeamName(teamName)
       .replace("Winner of Match", "Winner match")
   }
 


### PR DESCRIPTION
## What does this change?

Aligns team names on the [World Cup overview page](https://www.theguardian.com/football/world-cup-2026/overview) and football atoms with those used in DCAR.

There's no attempt to maintain a list of shortened team names for the knockout spider chart in the `cleanTeamNameSpider` method as this would potentially become a very long list and the chart now truncates names if too long.

## Screenshots

<img width="948" height="224" alt="Screenshot 2026-06-09 at 09 59 28" src="https://github.com/user-attachments/assets/c70a3a03-b8df-4b14-b90b-217abc39e45a" />

<img width="950" height="226" alt="Screenshot 2026-06-09 at 10 01 08" src="https://github.com/user-attachments/assets/4c1f4140-1753-4c64-9b0e-8649b96db04f" />
