### PR TITLE
added matchStats field to FootballMatchSummary Model

### DIFF
--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -380,6 +380,7 @@ object DotcomRenderingFootballTablesDataModel {
 case class DotcomRenderingFootballMatchSummaryDataModel(
     // this field will need to get renamed to matchStats in upcoming PR
     footballMatch: MatchStats,
+    matchStats: MatchStats,
     matchInfo: FootballMatch,
     group: Option[Group],
     competitionName: String,
@@ -416,6 +417,7 @@ object DotcomRenderingFootballMatchSummaryDataModel extends DCARUrlHelper {
     )
     DotcomRenderingFootballMatchSummaryDataModel(
       footballMatch = matchStats,
+      matchStats = matchStats,
       matchInfo = matchInfo,
       group = group,
       competitionName = competitionName,


### PR DESCRIPTION
## What is the value of this and can you measure success?
In the model sent from frontend to DCR there are currently two parameters: footballMatch and matchInfo. Renaming footballMatch to matchStats makes the distinction between the two values clearer and highlights the fact that they will be used for separate parts of the page. 

## What does this change?
Added a duplicate field of footballMatch which is called matchStats. In a follow up PR footballMatch will be removed. 