### PR TITLE
Try to move world cup to first position on football/soccer fronts

### DIFF
--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -277,7 +277,22 @@ object NavMenu {
             currentParent.map(_.children).getOrElse(Nil)
           }
 
+        // Editorial: on the Football and Soccer fronts (and their child pages), the World Cup 2026
+        // link should appear before the Football/Soccer self-link in the subnav. The default
+        // ParentSubnav layout always renders the parent first, so we instead emit a FlatSubnav
+        // with the World Cup promoted to first position, the parent self-link second, and the
+        // remaining children following.
+        //
+        // Guarded on the first child being the World Cup link, so this special case
+        // automatically disappears when the link is removed from NavLinks after the tournament.
+        val isFootballOrSoccerSubnav =
+          parent.exists(p => p.url == "/football" || p.url == "/us/soccer")
+        val firstChildIsWorldCup =
+          links.headOption.exists(_.url == "/football/world-cup-2026")
+
         parent match {
+          case Some(p) if isFootballOrSoccerSubnav && firstChildIsWorldCup =>
+            Some(FlatSubnav(links.head +: p +: links.tail))
           case Some(p)                => Some(ParentSubnav(p, links))
           case None if links.nonEmpty => Some(FlatSubnav(links))
           case None                   => None

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -134,6 +134,55 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     subnav shouldBe Some(FlatSubnav(auCulturePillar.children))
   }
 
+  "On `/football`, the subnav" should "promote World Cup 2026 above the Football self-link" in {
+    val edition = Uk
+    val root = NavMenu.navRoot(edition)
+    val maybeNavLink = NavMenu.findDescendantByUrl("/football", edition, root.children, root.otherLinks)
+    val parent = maybeNavLink.flatMap(link => NavMenu.findParent(link, edition, root.children, root.otherLinks))
+    val pillar = NavMenu.getPillar(parent, edition, root.children, root.otherLinks)
+    val subnav = NavMenu.getSubnav(fakePage().metadata.customSignPosting, maybeNavLink, parent, pillar)
+
+    subnav match {
+      case Some(FlatSubnav(links)) =>
+        links.map(_.title).take(2) shouldBe List("World Cup 2026", "Football")
+        links.map(_.url) should contain("/football")
+        links.map(_.url) should contain("/football/world-cup-2026")
+      case other => fail(s"Expected FlatSubnav with promoted World Cup, got $other")
+    }
+  }
+
+  "On `/football/tables`, the subnav" should "also promote World Cup 2026 above the Football self-link" in {
+    val edition = Uk
+    val root = NavMenu.navRoot(edition)
+    val maybeNavLink = NavMenu.findDescendantByUrl("/football/tables", edition, root.children, root.otherLinks)
+    val parent = maybeNavLink.flatMap(link => NavMenu.findParent(link, edition, root.children, root.otherLinks))
+    val pillar = NavMenu.getPillar(parent, edition, root.children, root.otherLinks)
+    val subnav = NavMenu.getSubnav(fakePage().metadata.customSignPosting, maybeNavLink, parent, pillar)
+
+    subnav match {
+      case Some(FlatSubnav(links)) =>
+        links.map(_.title).take(2) shouldBe List("World Cup 2026", "Football")
+      case other => fail(s"Expected FlatSubnav with promoted World Cup, got $other")
+    }
+  }
+
+  "On `/us/soccer`, the subnav" should "promote World Cup 2026 above the Soccer self-link" in {
+    val edition = Us
+    val root = NavMenu.navRoot(edition)
+    val maybeNavLink = NavMenu.findDescendantByUrl("/us/soccer", edition, root.children, root.otherLinks)
+    val parent = maybeNavLink.flatMap(link => NavMenu.findParent(link, edition, root.children, root.otherLinks))
+    val pillar = NavMenu.getPillar(parent, edition, root.children, root.otherLinks)
+    val subnav = NavMenu.getSubnav(fakePage().metadata.customSignPosting, maybeNavLink, parent, pillar)
+
+    subnav match {
+      case Some(FlatSubnav(links)) =>
+        links.map(_.title).take(2) shouldBe List("World Cup 2026", "Soccer")
+        links.map(_.url) should contain("/us/soccer")
+        links.map(_.url) should contain("/football/world-cup-2026")
+      case other => fail(s"Expected FlatSubnav with promoted World Cup, got $other")
+    }
+  }
+
   "The section `Indigenous Australians`" should "still be in the pillar News in the Uk edition" in {
     val edition = Uk
     val root = NavMenu.navRoot(edition)


### PR DESCRIPTION
## What does this change?

From editorial: "I can see that 'World Cup 2026' is now in the second position on both those fronts. Would it be possible to move it up so it is now first matching the [Sport front](https://www.theguardian.com/uk/sport)? 

This means that Football and Soccer will be moved second."

As per the comment in the code, by default, the nav logic renders the parent link first (/football, /soccer), so we tweak the logic to promote the world cup to the first position, the parent self-link second, and the remaining children (live scores/tables/etc) following.

This code should be removed when we're ready to update the nav after the world cup, but the logic is predicated on the first child being the World Cup link, so this special case would be obsolete anyway when the world cup link is removed from NavLinks after the tournament.


## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
