### PR TITLE
commit pressed files now done with putPublic

### DIFF
--- a/common/app/services/dotcomrendering/InteractiveLibrarian.scala
+++ b/common/app/services/dotcomrendering/InteractiveLibrarian.scala
@@ -63,7 +63,7 @@ object InteractiveLibrarian extends GuLogging {
   private def commitCleanedDocumentToS3(s3path: String, document: String): (Boolean, String) = {
     try {
       // On local bucket is: aws-frontend-archive-code
-      services.S3Archive.putPrivate(s3path, document, "text/html")
+      services.S3Archive.putPublic(s3path, document, "text/html")
       (true, "")
     } catch {
       case e: Exception => (false, e.getMessage)


### PR DESCRIPTION
## What is the value of this and can you measure success?

In a [previous PR](https://github.com/guardian/frontend/pull/28855) I change the way pressed files are commited to the S3 bucket. I made both commiting methods private but actually the page that website users will request the page from needed to be publically readable. This can be done with the putPublic method.

## What does this change?

putPrivate is changed to putPublic.