### PR TITLE
Increase the frequency of the live football match job

### DIFF
--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -66,7 +66,7 @@ class FootballLifecycle(
     }
 
     // if preview "Every hour at 40 minutes" otherwise "Every minute"
-    jobs.schedule("MaybeMatchDayAgentRefreshJob", if (context.isPreview) "0 41 * * * ?" else "0 0/1 * * * ?") {
+    jobs.schedule("MaybeMatchDayAgentRefreshJob", if (context.isPreview) "0 41 * * * ?" else "0/30 * * * * ?") {
       competitionsService.maybeRefreshLiveMatches(defaultClock)
     }
 

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -65,7 +65,7 @@ class FootballLifecycle(
       competitionsService.refreshMatchDay(defaultClock)
     }
 
-    // if preview "Every hour at 40 minutes" otherwise "Every minute"
+    // if preview "Every hour at 40 minutes" otherwise "Every 30 seconds"
     jobs.schedule("MaybeMatchDayAgentRefreshJob", if (context.isPreview) "0 41 * * * ?" else "0/30 * * * * ?") {
       competitionsService.maybeRefreshLiveMatches(defaultClock)
     }


### PR DESCRIPTION
Co-authored-by: Ravi <7014230+arelra@users.noreply.github.com>

## What does this change?
This PR is increasing the football live match background job from once every minute to once every 30 seconds. 

We think this should be safe but will also monitor and will revert back the frequency if it largely increases the number of calls to PA. 

Fixes part of https://github.com/guardian/dotcom-rendering/issues/16148