### PR TITLE
Extend expiry of hosted content feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -634,7 +634,7 @@ trait FeatureSwitches {
     description = "Render hosted content pages with DCR",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2026, 6, 17)),
+    sellByDate = Some(LocalDate.of(2026, 8, 19)),
     exposeClientSide = false,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

We haven't finished the Hosted Content pages migration so need to extend the expiry of the feature switch

## What does this change?

Extends the expiry date to 19th August 2026
