### PR TITLE
Update "Golden Boot" casing on the World Cup subnav

### DIFF
--- a/common/app/views/fragments/nav/worldCupSubNav.scala.html
+++ b/common/app/views/fragments/nav/worldCupSubNav.scala.html
@@ -17,7 +17,7 @@
                     "/football/world-cup-2026/overview" -> "Match centre",
                     "/football/ng-interactive/2026/jun/04/world-cup-2026-complete-player-guide" -> "Player guide",
                     "/football/ng-interactive/2026/jun/04/bracketology-predict-a-path-to-world-cup-victory" -> "Bracketology",
-                    "/football/ng-interactive/2026/jun/04/golden-boot-world-cup-2026-top-goalscorers-winner" -> "Golden boot",
+                    "/football/ng-interactive/2026/jun/04/golden-boot-world-cup-2026-top-goalscorers-winner" -> "Golden Boot",
                     "/football" -> "More football",
                 )) {
                 <li>


### PR DESCRIPTION
## What does this change?

Update "Golden Boot" casing on the World Cup subnav

Closes: https://github.com/guardian/dotcom-rendering/issues/16173

