### PR TITLE
Update cricket competitionName value

### DIFF
--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -108,9 +108,8 @@ object MatchResult {
 case class Match(
     teams: List[Team],
     innings: List[Innings],
-    competitionName: String, // TODO: this needs to be removed after DCAR is updated to use stage
+    competitionName: String,
     stage: String,
-    competitionNameV2: String, // TODO: this needs renaming to competitionName after DCAR is updated
     venueName: String,
     result: String,
     currentDay: Int,

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -20,9 +20,8 @@ object Parser {
     Match(
       teams = parseTeams(lineupData \ "match" \ "team"),
       innings = parseInnings(scorecardData \ "match" \ "innings"),
-      competitionName = matchDetail.competitionName,
-      stage = matchDetail.competitionName,
-      competitionNameV2 = competitionMatch.competitionName,
+      competitionName = competitionMatch.competitionName,
+      stage = matchDetail.stage,
       venueName = matchDetail.venueName,
       result = matchDetail.status,
       currentDay = matchDetail.currentDay,
@@ -35,7 +34,7 @@ object Parser {
   }
 
   private case class MatchDetail(
-      competitionName: String,
+      stage: String,
       venueName: String,
       status: String,
       currentDay: Int,
@@ -62,7 +61,7 @@ object Parser {
 
   private def parseMatchDetail(matchDetail: NodeSeq): MatchDetail =
     MatchDetail(
-      competitionName = matchDetail \ "stage" text,
+      stage = matchDetail \ "stage" text,
       venueName = matchDetail \ "venue" \ "name" text,
       status = matchDetail \ "status" text,
       currentDay = (matchDetail \ "currentDay").text.toInt,


### PR DESCRIPTION
## What does this change?
This PR updates the vale for the cricket match `competitionName`. Previously the `matchDetail.competitionName` which indicated the Stage rather than the competition name but now `competitionMatch.competitionName` is used which indicates the actual competition name. 

In previous PRs in DCAR https://github.com/guardian/dotcom-rendering/pull/16150 & https://github.com/guardian/dotcom-rendering/pull/16230 we started using the stage field so now we can use the correct value for the competitionName.

These are all previous PRs in order to prepare DCAR for this change:

- frontend: https://github.com/guardian/frontend/pull/28842
- DCAR: https://github.com/guardian/dotcom-rendering/pull/16150
- frontend: https://github.com/guardian/frontend/pull/28869
- DCAR: https://github.com/guardian/dotcom-rendering/pull/16230
- Final frontend: Current PR

More details can be found in this frontend PR https://github.com/guardian/frontend/pull/28842

This completes https://github.com/guardian/dotcom-rendering/issues/15980