### PR TITLE
Add stage to scoreboard data model

### DIFF
--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -97,6 +97,7 @@ object CricketScoreBoardDataModel {
     Json.obj(
       "matchId" -> theMatch.matchId,
       "competitionName" -> theMatch.competitionName,
+      "stage" -> theMatch.stage,
       "venueName" -> theMatch.venueName,
       "teams" -> theMatch.teams.map(getTeam),
       "innings" -> theMatch.innings.map(getInnings),


### PR DESCRIPTION
## What does this change?
As part of the work to add the actual competition name to cricket match data type I made the following changes"
- Add PA cricket competition name to the match data in frontend https://github.com/guardian/frontend/pull/28842
- Update frontend cricket match data type to make it in sync with frontend in DCAR https://github.com/guardian/dotcom-rendering/pull/16150

I was about to complete the work with the 3rd PR (Update cricket competitionName value https://github.com/guardian/frontend/pull/28867) but I realised that there was another endpoint `/sport/cricket/match-scoreboard/:matchDate/:teamId.json` which has it's own custom response type so  I needed to add the `stage` field to this response type too.

This PR adds the stage field. **Next steps are:**
- DCAR needs to update to use the new stage field
- Frontend PR to update the value of the competitionName to the actual competition name rather than the stage name. 


Fixes part of https://github.com/guardian/dotcom-rendering/issues/15980
