### PR TITLE
Fix Callout rendering in list-type articles

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -69,6 +69,7 @@ final case class Content(
     showByline: Boolean,
     rawOpenGraphImage: Option[ImageAsset],
     schemaOrg: Option[SchemaOrg],
+    listElementCampaignIds: Seq[String] = Seq.empty,
 ) {
 
   lazy val isBlog: Boolean = tags.blogs.nonEmpty
@@ -92,13 +93,13 @@ final case class Content(
   lazy val isUSProductionOffice: Boolean = productionOffice.exists(_.toLowerCase == "us")
 
   // Some campaigns (Community callouts) are added to an article using a tag. Others (Reporter callouts) just use the
-  // campaign ID from the targeting tool. We need to fetch boh here
+  // campaign ID from the targeting tool. We need to fetch both here, including callouts nested within list-type elements
   lazy val campaignIds = fields.blocks
     .map(_.body.flatMap(_.elements.flatMap {
       case CalloutBlockElement(campaignId, _) => Seq(campaignId)
       case _                                  => Seq()
     }))
-    .getOrElse(Seq())
+    .getOrElse(Seq()) ++ listElementCampaignIds
   lazy val idCampaigns: List[Campaign] =
     _root_.commercial.targeting.CampaignAgent.getCampaignsForIds(campaignIds)
   lazy val tagCampaigns: List[Campaign] =
@@ -461,6 +462,18 @@ object Content {
     val cardStyle: fapiutils.CardStyle = CardStylePicker(apiContent)
     val schemaOrg = apiContent.schemaOrg
 
+    // Extract callout campaign IDs from within list-type elements (e.g. QAndAExplainer).
+    val listElementCampaignIds: Seq[String] = apiContent.blocks.toSeq
+      .flatMap(_.body.toSeq.flatten)
+      .flatMap(_.elements)
+      .filter(_.`type` == contentapi.ElementType.List)
+      .flatMap(_.listTypeData.toSeq)
+      .flatMap(_.items)
+      .flatMap(_.elements)
+      .filter(_.`type` == contentapi.ElementType.Callout)
+      .flatMap(_.calloutTypeData)
+      .flatMap(_.campaignId)
+
     Content(
       trail = trail,
       metadata = metadata,
@@ -506,6 +519,7 @@ object Content {
         .orElse(elements.mainPicture.flatMap(_.images.largestImage))
         .orElse(trail.trailPicture.flatMap(_.largestImage)),
       schemaOrg = schemaOrg,
+      listElementCampaignIds = listElementCampaignIds,
     )
   }
 }


### PR DESCRIPTION
## What does this change?

Fixes Callout rendering in list-type articles (e.g. Q&A Explainer).

Callout elements nested within list items were not rendering because their campaign IDs weren't being extracted correctly. This is because the `BlockElement` model [discards list item contents](https://github.com/guardian/frontend/blob/main/common/app/model/liveblog/BlockElement.scala#L185), so the existing `campaignIds` extraction missed them.

This change adds a `listElementCampaignIds` field to `Content` which extracts callout campaign IDs from within list-type elements. These are appended to `campaignIds` so the campaign data is fetched and available for rendering.

## Testing

Deployed this branch to CODE and verified the Callout renders correctly.

## Screenshots

| Before      | After      |
|-------------|------------|
|<img width="138" height="24" alt="Screenshot 2026-06-18 at 10 16 20" src="https://github.com/user-attachments/assets/16a60304-e087-4de8-8e2b-ee09c7425af3" /> | <img width="683" height="749" alt="Screenshot 2026-06-18 at 10 16 08" src="https://github.com/user-attachments/assets/d8b65e60-aa2d-420f-a8a1-3efabfe9f3c5" /> |
| <img width="638" height="477" alt="Screenshot 2026-06-18 at 10 12 09" src="https://github.com/user-attachments/assets/ef9d4f2b-0740-4a4a-abe1-b09c46c032a6" /> | <img width="639" height="686" alt="Screenshot 2026-06-18 at 09 48 30" src="https://github.com/user-attachments/assets/b7b14479-d226-4bd8-b0c7-09b86e0e40f6" /> |



## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
