### PR TITLE
Add all groups needed for world cup

### DIFF
--- a/admin/app/views/football/fragments/chooseGroup.scala.html
+++ b/admin/app/views/football/fragments/chooseGroup.scala.html
@@ -10,4 +10,8 @@
     <option value="group-f">Group F</option>
     <option value="group-g">Group G</option>
     <option value="group-h">Group H</option>
+    <option value="group-i">Group I</option>
+    <option value="group-j">Group J</option>
+    <option value="group-k">Group K</option>
+    <option value="group-l">Group L</option>
 </select>


### PR DESCRIPTION
## What does this change?
Add all possible groups in the admin tool for League Tables 


<img width="846" height="651" alt="image" src="https://github.com/user-attachments/assets/44b8c412-45c2-4685-be67-b4f1c1121bfa" />

<img width="846" height="651" alt="image" src="https://github.com/user-attachments/assets/a709a4ad-51bd-441f-959b-bf595c3ec735" />
