### PR TITLE
Update capi and facia versions to preview version

### DIFF
--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -186,6 +186,7 @@ object BlockElement {
       case Timeline         => Some(UnsupportedBlockElement(None))
       case Link             => Some(UnsupportedBlockElement(None))
       case Product          => Some(UnsupportedBlockElement(None))
+      case ResponsiveImage  => Some(UnsupportedBlockElement(None))
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.44.12"
-  val capiVersion = "45.0.1-PREVIEW.content-models-4200-thrift-0230.2026-07-01T1425.01118c47"
-  val faciaVersion = "33.0.1-PREVIEW.update-content-api-client.2026-07-02T1520.692fbca7"
+  val capiVersion = "45.0.1"
+  val faciaVersion = "33.0.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.22.0"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "42.0.0"
+  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "44.0.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.44.12"
-  val capiVersion = "45.0.0-PREVIEW.content-models-4200-thrift-0230.2026-06-16T1332.43ea7949"
+  val capiVersion = "45.0.1-PREVIEW.content-models-4200-thrift-0230.2026-07-01T1425.01118c47"
   val faciaVersion = "33.0.0-PREVIEW.update-content-api-client.2026-06-16T1351.9338e59a"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,9 @@ import sbt._
 
 object Dependencies {
   val identityLibVersion = "4.31"
-  val awsVersion = "2.46.18"
-  val capiVersion = "44.0.0"
-  val faciaVersion = "32.0.0"
+  val awsVersion = "2.44.12"
+  val capiVersion = "45.0.0-PREVIEW.content-models-4200-thrift-0230.2026-06-16T1332.43ea7949"
+  val faciaVersion = "33.0.0-PREVIEW.update-content-api-client.2026-06-16T1351.9338e59a"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -29,7 +29,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.22.0"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "41.0.0"
+  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "42.0.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.44.12"
   val capiVersion = "45.0.1-PREVIEW.content-models-4200-thrift-0230.2026-07-01T1425.01118c47"
-  val faciaVersion = "33.0.0-PREVIEW.update-content-api-client.2026-06-16T1351.9338e59a"
+  val faciaVersion = "33.0.1-PREVIEW.update-content-api-client.2026-07-02T1520.692fbca7"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
