### PR TITLE
removing unused routes

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -90,8 +90,6 @@ GET            /preference/edition/:edition                                     
 GET            /cards/opengraph/*path.json                                                                                       controllers.CardController.opengraph(path)
 GET            /tagged.json                                                                                                      controllers.TaggedContentController.renderJson(tag: String)
 
-GET            /:mediaType/section/:sectionId/*seriesId.json                                                                     controllers.MediaInSectionController.renderSectionMediaWithSeries(mediaType, sectionId, seriesId)
-GET            /:mediaType/section/:sectionId.json                                                                               controllers.MediaInSectionController.renderSectionMedia(mediaType, sectionId)
 GET            /video/most-viewed.json                                                                                           controllers.MostViewedVideoController.renderMostViewed()
 GET            /video/in-series/*series.json                                                                                     controllers.MostViewedVideoController.renderInSeries(series: String)
 GET            /audio/most-viewed.json                                                                                           controllers.MostViewedAudioController.renderMostViewed()
@@ -267,9 +265,6 @@ POST        /commercial/adops/app-ads-txt                                       
 # AMP
 GET            /related-mf2/*path.json                                                                                           controllers.RelatedController.renderMf2(path)
 GET            /series-mf2/*path.json                                                                                            controllers.SeriesController.renderMf2SeriesStories(path)
-
-GET            /container/count/:count/offset/:offset/mf2.json                                                                   controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "")
-GET            /container/count/:count/offset/:offset/section/:section/mf2.json                                                  controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section)
 
 GET            /football-mf2/api/match-summary/:year/:month/:day/:home/:away.json                                                football.controllers.MoreOnMatchController.matchSummaryMf2(year, month, day, home, away)
 


### PR DESCRIPTION
## What does this change?

In this PR https://github.com/guardian/frontend/pull/28841 some controllers were removed but a few routes in dev-build still pointed to them so I have removed those routes.