### PR TITLE
made template render only specific tables

### DIFF
--- a/sport/app/football/views/wallchart/groupTableEmbed.scala.html
+++ b/sport/app/football/views/wallchart/groupTableEmbed.scala.html
@@ -26,7 +26,9 @@
 
 <ul class="football-groups u-unstyled u-cf">
 @groupStage.groupTables.zipWithIndex.map { case (groupTable, index) =>
-    @footballGroup(groupTable._1, groupTable._2, !groupId.contains(index + 1))
+  @if(groupId.contains(index + 1)) {
+      @footballGroup(groupTable._1, groupTable._2, !groupId.contains(index + 1))
+  }
 }
 </ul>
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

This is an attempt to fix our ability to embed a single world cup group stage table. Up until now embedding a single table has resulted in every table being used. This fix should result in only the requested tables being embedded.

## What does this change?

The atoms pull their HTML from a frontend twirl template which didn't seem to be doing any filtering of tables. I've added an if statement to check which tables were asked for. Interestingly it seems like the tables which weren't asked for are given a "hide-on-mobile" class.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| test | test |
| ![before][] | ![after][] |

-->

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[after]: https://github.com/user-attachments/assets/6e4cae76-37f5-48ba-bc60-47b15a4ac61d
[before]: https://github.com/user-attachments/assets/f98f9830-a656-448c-a904-b0ae15950b24


## Checklist

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
