### PR TITLE
Include yesterday live matches in our cached data

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -56,6 +56,11 @@ trait Competitions extends implicits.Football {
       })
       .headOption
 
+  def liveMatchesFromYesterday(clock: Clock): Seq[FootballMatch] = {
+    val yesterday = LocalDate.now(clock).minusDays(1)
+    competitions.flatMap(_.matches.filter(m => m.isOn(yesterday) && m.isLive))
+  }
+
   lazy val matchDates = competitions.flatMap(_.matchDates).distinct.sorted
 
   def nextMatchDates(startDate: LocalDate, numDays: Int): Seq[LocalDate] =
@@ -418,8 +423,31 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
   def refreshMatchDay(
       clock: Clock,
   )(implicit executionContext: ExecutionContext): Future[immutable.Iterable[Competition]] = {
-    log.debug("Refreshing match day data")
-    val result = getLiveMatches(clock).map(_.map { case (compId, newMatches) =>
+    println("Refreshing match day data 2")
+
+    val today = LocalDate.now(clock)
+    val todayMatchesFuture = getDayMatches(today)
+
+    val allMatches: Future[Map[String, Seq[MatchDay]]] =
+      if (liveMatchesFromYesterday(clock).nonEmpty) {
+        log.debug("Live matches from yesterday detected - also refreshing yesterday's match day data")
+        for {
+          todayMatches <- todayMatchesFuture
+          yesterdayMatches <- getDayMatches(today.minusDays(1))
+        } yield {
+          val liveYesterdayMatches = yesterdayMatches.collect {
+            case (compId, matches) if matches.exists(_.isLive) =>
+              compId -> matches.filter(_.isLive)
+          }
+          liveYesterdayMatches.foldLeft(todayMatches) { case (acc, (compId, liveMatches)) =>
+            acc.updated(compId, acc.getOrElse(compId, Seq.empty) ++ liveMatches)
+          }
+        }
+      } else {
+        todayMatchesFuture
+      }
+
+    val result = allMatches.map(_.map { case (compId, newMatches) =>
       competitionAgents.find(_.competition.id == compId).map { agent =>
         agent.addMatches(newMatches)
       }

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -423,7 +423,7 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
   def refreshMatchDay(
       clock: Clock,
   )(implicit executionContext: ExecutionContext): Future[immutable.Iterable[Competition]] = {
-    println("Refreshing match day data 2")
+    log.debug("Refreshing match day data")
 
     val today = LocalDate.now(clock)
     val todayMatchesFuture = getDayMatches(today)

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -28,9 +28,11 @@ trait LiveMatches extends GuLogging {
   def footballClient: FootballClient
   def teamNameBuilder: TeamNameBuilder
 
-  def getLiveMatches(clock: Clock)(implicit executionContext: ExecutionContext): Future[Map[String, Seq[MatchDay]]] =
+  def getDayMatches(localDate: LocalDate)(implicit
+      executionContext: ExecutionContext,
+  ): Future[Map[String, Seq[MatchDay]]] =
     footballClient
-      .matchDay(LocalDate.now(clock))
+      .matchDay(localDate)
       .map { todaysMatches: List[MatchDay] =>
         val matchesWithCompetitions = todaysMatches.filter(_.competition.isDefined)
 

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -152,7 +152,7 @@ class CompetitionAgent(
         comp.matches.find(_.id == newMatch.id).foreach { oldMatch =>
           val newSummary = newMatch.statusSummary
           val oldSummary = oldMatch.statusSummary
-          if (newSummary != oldSummary) log.debug(s"Match Status Changed $oldSummary -> $newSummary")
+          if (newSummary != oldSummary) log.info(s"Match Status Changed $oldSummary -> $newSummary")
         }
       }
 

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -1,5 +1,7 @@
 package test
-import scala.concurrent.Await
+
+import conf.{FootballClient}
+import scala.concurrent.{Await, Future}
 import feed.CompetitionsService
 import model.Competition
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
@@ -7,10 +9,12 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Span}
-import test.FootballTestData.fixture
+import test.FootballTestData.{fixture, liveMatch, result}
+import pa.{MatchDay, Result}
 
 import java.time.{Clock, LocalDate, ZonedDateTime}
 import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import scala.concurrent.duration._
 
 @DoNotDiscover class CompetitionAgentTest
@@ -43,6 +47,16 @@ import scala.concurrent.duration._
 
   def testCompetitionsService(competition: Competition): CompetitionsService =
     new CompetitionsService(testFootballClient, Seq(competition))
+
+  def testCompetitionsServiceWithCustomClient(
+      competition: Competition,
+      getResponse: String => Future[pa.Response],
+  ): CompetitionsService = {
+    val stubClient = new FootballClient(wsClient) {
+      override def GET(url: String): Future[pa.Response] = getResponse(url)
+    }
+    new CompetitionsService(stubClient, Seq(competition))
+  }
 
   "CompetitionAgentTest" should "load fixtures" in {
 
@@ -92,6 +106,78 @@ import scala.concurrent.duration._
       comps.matches.filter(_.isLive).map(_.id) should be(List()) // well, it's off season now...
     }
 
+  }
+
+  def testCompetitionsServiceWithMatchDayResponses(
+      competition: Competition,
+      todayMatches: Seq[MatchDay],
+      yesterdayMatches: Seq[MatchDay],
+  ): CompetitionsService = {
+    testCompetitionsServiceWithCustomClient(
+      competition,
+      url => {
+        val fmt = DateTimeFormatter.ofPattern("yyyyMMdd")
+        val today = LocalDate.now(fixedClock)
+        val yesterday = today.minusDays(1)
+        if (url.contains(today.format(fmt))) {
+          Future.successful(pa.Response(200, matchDayXml(competition.id, competition.fullName, todayMatches), "ok"))
+        } else if (url.contains(yesterday.format(fmt))) {
+          Future.successful(pa.Response(200, matchDayXml(competition.id, competition.fullName, yesterdayMatches), "ok"))
+        } else {
+          testFootballClient.GET(url)
+        }
+      },
+    )
+  }
+
+  // ...existing code...
+
+  it should "load live matches from yesterday that haven't yet finished" in {
+
+    val yesterdayFirstMatchDate = ZonedDateTime.of(2016, 6, 21, 15, 30, 0, 0, ZoneId.of("Europe/London"))
+    val yesterdaySecondMatchDate = ZonedDateTime.of(2016, 6, 21, 22, 0, 0, 0, ZoneId.of("Europe/London"))
+    val todayMatchDate = ZonedDateTime.of(2016, 6, 22, 20, 0, 0, 0, ZoneId.of("Europe/London"))
+
+    val runningMatch =
+      liveMatch("Southampton", "Millwall", Some(1), Some(1), yesterdaySecondMatchDate, isLive = true, isResult = false)
+    val resultMatch = result("Hull", "Middlesbrough", 1, 0, yesterdayFirstMatchDate)
+
+    val competition = Competition(
+      "101",
+      "/football/championship",
+      "Championship",
+      "Championship",
+      "English",
+      showInTeamsList = true,
+      matches = Seq(resultMatch, runningMatch),
+    )
+    val fixtureMatchDay = liveMatch("Millwall", "Hull", None, None, todayMatchDate, isLive = false, isResult = false)
+
+    val compService = testCompetitionsServiceWithMatchDayResponses(
+      competition,
+      todayMatches = Seq(fixtureMatchDay),
+      yesterdayMatches = Seq(
+        liveMatch("Hull", "Middlesbrough", Some(1), Some(1), yesterdayFirstMatchDate, isLive = false, isResult = true),
+        runningMatch.copy(homeTeam = runningMatch.homeTeam.copy(score = Some(2))),
+      ),
+    )
+
+    whenReady(compService.refreshMatchDay(fixedClock)) { _ =>
+      compService.matches.length should be(3)
+
+      val resultMatch = compService.matches(0)
+      resultMatch shouldBe a[Result]
+      resultMatch.id should be(resultMatch.id)
+
+      val liveMatch = compService.matches(1)
+      liveMatch shouldBe a[MatchDay]
+      liveMatch.id should be(runningMatch.id)
+      liveMatch.homeTeam.score should be(Some(2))
+
+      val fixtureMatch = compService.matches(2)
+      fixtureMatch shouldBe a[MatchDay]
+      fixtureMatch.id should be(fixtureMatchDay.id)
+    }
   }
 
   it should "load league tables" in {
@@ -175,5 +261,22 @@ import scala.concurrent.duration._
     assert(competitionAgent.competition.matches.contains(firstPlaceHolderMatch))
     assert(competitionAgent.competition.matches.contains(matchWithKnownOpponents))
 
+  }
+
+//  case class PAMatchDayData(matchId: String, homeTeam: String, awayTeam: String, isLive: Boolean, date: ZonedDateTime)
+  def matchDayXml(competitionId: String, competitionName: String, matches: Seq[MatchDay]): String = {
+    val dateFmt = java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy")
+    val timeFmt = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+
+    val matchElements = matches.map { theMatch =>
+      val live = if (theMatch.liveMatch) "Yes" else "No"
+      val result = if (theMatch.result) "Yes" else "No"
+      val date = theMatch.date.format(dateFmt)
+      val koTime = theMatch.date.format(timeFmt)
+      val homeScore = theMatch.homeTeam.score.getOrElse(0)
+      val awayScore = theMatch.awayTeam.score.getOrElse(0)
+      s"""<match matchID="${theMatch.id}" date="$date" koTime="$koTime"><competition competitionID="$competitionId" seasonID="6100">$competitionName</competition><stage stageNumber="1" stageType="League"></stage><round roundNumber="1">Regular Season</round><leg>1</leg><liveMatch>$live</liveMatch><result>$result</result><previewAvailable>Yes</previewAvailable><reportAvailable>Yes</reportAvailable><lineupsAvailable>Yes</lineupsAvailable><homeTeam teamID="${theMatch.homeTeam.id}"><teamName>${theMatch.homeTeam.name}</teamName><score>$homeScore</score><htScore>0</htScore><aggregateScore></aggregateScore><scorers><![CDATA[]]></scorers></homeTeam><awayTeam teamID="${theMatch.awayTeam.id}"><teamName>${theMatch.awayTeam.name}</teamName><score>$awayScore</score><htScore>0</htScore><aggregateScore></aggregateScore><scorers><![CDATA[]]></scorers></awayTeam><comments></comments></match>"""
+    }.mkString
+    s"""<?xml version="1.0" encoding="utf-8"?><matches>$matchElements</matches>"""
   }
 }

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -130,8 +130,6 @@ import scala.concurrent.duration._
     )
   }
 
-  // ...existing code...
-
   it should "load live matches from yesterday that haven't yet finished" in {
 
     val yesterdayFirstMatchDate = ZonedDateTime.of(2016, 6, 21, 15, 30, 0, 0, ZoneId.of("Europe/London"))
@@ -263,7 +261,6 @@ import scala.concurrent.duration._
 
   }
 
-//  case class PAMatchDayData(matchId: String, homeTeam: String, awayTeam: String, isLive: Boolean, date: ZonedDateTime)
   def matchDayXml(competitionId: String, competitionName: String, matches: Seq[MatchDay]): String = {
     val dateFmt = java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy")
     val timeFmt = java.time.format.DateTimeFormatter.ofPattern("HH:mm")

--- a/sport/test/FootballTestData.scala
+++ b/sport/test/FootballTestData.scala
@@ -100,8 +100,8 @@ object FootballTestData {
         result("Fulham", "Norwich", 0, 0, today.minusDays(3)),
         result("Wigan", "Everton", 1, 1, today.minusDays(1)),
         result("Sunderland", "West Ham", 1, 1, today.`with`(LocalTime.of(13, 0))),
-        liveMatch("Arsenal", "Spurs", 1, 0, today.`with`(LocalTime.of(15, 0)), true),
-        liveMatch("Chelsea", "Man U", 0, 0, today.`with`(LocalTime.of(15, 0)), true),
+        liveMatch("Arsenal", "Spurs", Some(1), Some(0), today.`with`(LocalTime.of(15, 0)), true),
+        liveMatch("Chelsea", "Man U", Some(0), Some(0), today.`with`(LocalTime.of(15, 0)), true),
         fixture("Liverpool", "Man C", today.plusDays(2)),
         fixture("Wigan", "Fulham", today.plusDays(2)),
         fixture("Stoke", "Everton", today.plusDays(3)),
@@ -127,7 +127,7 @@ object FootballTestData {
       startDate = Some((today.minusMonths(2)).toLocalDate),
       matches = Seq(
         result("Bolton", "Derby", 1, 1, today.minusDays(1), Some("Bolton win 4-2 on penalties.")),
-        liveMatch("Cardiff", "Brighton", 2, 0, today.`with`(LocalTime.of(15, 0)), true),
+        liveMatch("Cardiff", "Brighton", Some(2), Some(0), today.`with`(LocalTime.of(15, 0)), true),
         fixture("Wolves", "Burnley", today.plusDays(2)),
       ),
       leagueTable = Seq(
@@ -166,17 +166,19 @@ object FootballTestData {
   def liveMatch(
       homeName: String,
       awayName: String,
-      homeScore: Int,
-      awayScore: Int,
+      homeScore: Option[Int],
+      awayScore: Option[Int],
       date: ZonedDateTime,
       isLive: Boolean,
+      isResult: Boolean = false,
   ) =
     matchDay.copy(
       id = s"liveMatch $homeName $awayName ${date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ"))}",
       date = date,
-      homeTeam = team.copy(id = homeName, name = homeName, score = Some(homeScore)),
-      awayTeam = team.copy(id = awayName, name = awayName, score = Some(awayScore)),
+      homeTeam = team.copy(id = homeName, name = homeName, score = homeScore),
+      awayTeam = team.copy(id = awayName, name = awayName, score = awayScore),
       liveMatch = isLive,
+      result = isResult,
     )
 
   def fixture(homeName: String, awayName: String, date: ZonedDateTime) =

--- a/sport/test/football/feed/CompetitionsTest.scala
+++ b/sport/test/football/feed/CompetitionsTest.scala
@@ -25,7 +25,7 @@ class CompetitionsTest extends AnyFreeSpec with Matchers with OptionValues {
         val matches: Seq[FootballMatch] =
           Seq(
             result("Bolton", "Derby", 1, 1, today.minusDays(1), Some("Bolton win 4-2 on penalties.")),
-            liveMatch("Cardiff", "Brighton", 2, 0, today.minus(testcase.startTimeDelta), testcase.isLive),
+            liveMatch("Cardiff", "Brighton", Some(2), Some(0), today.minus(testcase.startTimeDelta), testcase.isLive),
             fixture("Wolves", "Burnley", today.plusDays(2)),
           )
 
@@ -51,7 +51,7 @@ class CompetitionsTest extends AnyFreeSpec with Matchers with OptionValues {
         val matches: Seq[FootballMatch] =
           Seq(
             result("Bolton", "Derby", 1, 1, today.minusDays(1), Some("Bolton win 4-2 on penalties.")),
-            liveMatch("Cardiff", "Brighton", 2, 0, today.plus(testcase.startTimeDelta), testcase.isLive),
+            liveMatch("Cardiff", "Brighton", Some(2), Some(0), today.plus(testcase.startTimeDelta), testcase.isLive),
             fixture("Wolves", "Burnley", today.plusDays(2)),
           )
         val testCompetition = competitions(1).copy(matches = matches)

--- a/sport/test/football/implicits/FootballTest.scala
+++ b/sport/test/football/implicits/FootballTest.scala
@@ -38,7 +38,7 @@ class FootballTest extends AnyFeatureSpec with GivenWhenThen with Matchers with 
 
       Given("a match which happens today")
       val todayMatch =
-        liveMatch("Aston Villa", "Cardiff", 1, 0, today, isLive = true)
+        liveMatch("Aston Villa", "Cardiff", Some(1), Some(0), today, isLive = true)
 
       Then("calling isOn with today's date should return true")
       val isMatchOnToday = todayMatch.isOn(today.toLocalDate)
@@ -50,7 +50,7 @@ class FootballTest extends AnyFeatureSpec with GivenWhenThen with Matchers with 
       Given("a match which happens in 5 minutes")
       val fiveMinutesFromNow = ZonedDateTime.now().plusMinutes(5)
       val theMatch =
-        liveMatch("Aston Villa", "Cardiff", 1, 0, fiveMinutesFromNow, isLive = true)
+        liveMatch("Aston Villa", "Cardiff", Some(1), Some(0), fiveMinutesFromNow, isLive = true)
 
       Then("calling isAboutToStart should return true")
       theMatch.isAboutToStart shouldBe (true)
@@ -61,7 +61,7 @@ class FootballTest extends AnyFeatureSpec with GivenWhenThen with Matchers with 
       Given("a match starting in more than 5 minutes")
       val fiveMinutesFromNow = ZonedDateTime.now().plusMinutes(5).plusSeconds(1)
       val theMatch =
-        liveMatch("Aston Villa", "Cardiff", 1, 0, fiveMinutesFromNow, isLive = true)
+        liveMatch("Aston Villa", "Cardiff", Some(1), Some(0), fiveMinutesFromNow, isLive = true)
 
       Then("calling isAboutToStart should return fals")
       theMatch.isAboutToStart shouldBe (false)


### PR DESCRIPTION
## What does this change?
This PR updates the refreshMatchDay implementation to prevent losing live match updates when the date boundary changes (midnight). The job now checks if any match in the cache started yesterday but still has isLive = true. If so, it makes an additional PA call to fetch yesterday's matches alongside today's, ensuring we capture score updates for matches that span the date boundary.

## How
The implementation:
1. Calls `liveMatchesFromYesterday()` to detect live matches from the previous day
2. If found, fetches both today's and yesterday's match data from PA in parallel
3. Merges both responses, filtering yesterday's matches to only live ones (avoiding re-adding finished results)
4. Pushes all merged matches to the competition agents

### Known timezone quirk:

PA always returns match data in Europe/London timezone, while the Sport server uses UTC as its [default clock](https://github.com/guardian/frontend/blob/main/sport/app/football/conf/context.scala#L24). Although ZonedDateTime handles this correctly in most cases, refreshMatchDay uses LocalDate.now(clock) which can cause a one-hour discrepancy during BST (British Summer Time). Specifically, between midnight and 1 AM during summer months, we may fetch yesterday's matches even though technically it's already "today" in London time.
Although this is better to get fixed, I prefer not to do it as part of this PR to minimise the changes and reduce the risk as we are in the middle of the world cup.
Ticket is created for this https://github.com/guardian/frontend/issues/28887

## Testing
To properly unit test this scenario, I created a testCompetitionsServiceWithMatchDayResponses helper that allows stubbing PA responses for specific dates. This lets us:
- Control what data PA returns for today vs. yesterday
- Verify that live matches from yesterday are fetched and merged correctly
- Confirm that finished results from yesterday are not re-added to the cache

The test validates that:
- A live match from yesterday with an updated score is refreshed
- A finished result from yesterday MatchDay is not re-added
- The final state contains all unique matches (cached + updated yesterday (still live) + new today)

Fixes https://github.com/guardian/dotcom-rendering/issues/16241