### PR TITLE
Add cricket match stats summary API route

### DIFF
--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -4,7 +4,7 @@ import common._
 import conf.Configuration
 import conf.cricketPa.{CricketTeam, CricketTeams, PaFeed}
 import contentapi.ContentApiClient
-import cricketModel.{Match, MatchHeader}
+import cricketModel.{Match, MatchHeader, MatchStatsSummary}
 import football.datetime.DateHelpers
 import football.model.{CricketScoreBoardDataModel, DotcomRenderingCricketDataModel}
 import implicits.{HtmlFormat, JsonFormat}
@@ -87,6 +87,19 @@ class CricketMatchController(
               val model = MatchHeader(page, relatedContents, requestedDate)
               Cached(CacheTime.Cricket)(JsonComponent.fromWritable(model))
             }
+          }
+        }
+        .getOrElse(successful(NoCache(NotFound)))
+    }
+
+  def matchStatsSummaryJson(date: String, teamId: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      CricketTeams
+        .byWordsForUrl(teamId)
+        .flatMap { team =>
+          cricketStatsJob.findMatch(team, date).map { matchData =>
+            val summary = MatchStatsSummary(matchData)
+            successful(Cached(CacheTime.Cricket)(JsonComponent.fromWritable(summary)))
           }
         }
         .getOrElse(successful(NoCache(NotFound)))

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -202,7 +202,7 @@ object MatchStatsSummary {
 
   def apply(theMatch: Match): MatchStatsSummary = {
     theMatch.result match {
-      case "in-play" =>
+      case "in-play" | "tea" | "lunch" | "between-innings" =>
         MatchStatsSummary(
           status = theMatch.result,
           currentBattingTeam = theMatch.lastInnings.map(_.battingTeam),

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -190,3 +190,32 @@ object MatchHeader extends DCARUrlHelper {
     )
   }
 }
+
+case class MatchStatsSummary(
+    status: String,
+    currentBattingTeam: Option[String] = None,
+    notOutBatters: Option[List[InningsBatter]] = None,
+)
+
+object MatchStatsSummary {
+  implicit val writes: OWrites[MatchStatsSummary] = Json.writes[MatchStatsSummary]
+
+  def apply(theMatch: Match): MatchStatsSummary = {
+    val innings = theMatch.lastInnings.filter(_ => theMatch.innings.nonEmpty && theMatch.fullResult.isEmpty)
+
+    theMatch.result match {
+      case "in-play" =>
+        MatchStatsSummary(
+          status = theMatch.result,
+          currentBattingTeam = innings.map(_.battingTeam),
+          notOutBatters = innings.map(_.batters.filter(_.notOut)),
+        )
+      case _ =>
+        MatchStatsSummary(
+          status = theMatch.result,
+          currentBattingTeam = None,
+          notOutBatters = None,
+        )
+    }
+  }
+}

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -201,14 +201,12 @@ object MatchStatsSummary {
   implicit val writes: OWrites[MatchStatsSummary] = Json.writes[MatchStatsSummary]
 
   def apply(theMatch: Match): MatchStatsSummary = {
-    val innings = theMatch.lastInnings.filter(_ => theMatch.innings.nonEmpty && theMatch.fullResult.isEmpty)
-
     theMatch.result match {
       case "in-play" =>
         MatchStatsSummary(
           status = theMatch.result,
-          currentBattingTeam = innings.map(_.battingTeam),
-          notOutBatters = innings.map(_.batters.filter(_.notOut)),
+          currentBattingTeam = theMatch.lastInnings.map(_.battingTeam),
+          notOutBatters = theMatch.lastInnings.map(_.batters.filter(_.notOut)),
         )
       case _ =>
         MatchStatsSummary(

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -13,7 +13,8 @@ GET        /football/wallchart/:competitionTag                                  
 GET        /sport/cricket/match/:matchDate/:teamId.json                                        cricket.controllers.CricketMatchController.renderMatchIdJson(matchDate, teamId)
 GET        /sport/cricket/match/:matchDate/:teamId                                             cricket.controllers.CricketMatchController.renderMatchId(matchDate, teamId)
 GET        /sport/cricket/match-scoreboard/:matchDate/:teamId.json                             cricket.controllers.CricketMatchController.renderMatchScoreboardJson(matchDate, teamId)
-GET        /sport/cricket/match-header/:matchDate/:teamId.json                              cricket.controllers.CricketMatchController.matchHeaderJson(matchDate, teamId)
+GET        /sport/cricket/match-header/:matchDate/:teamId.json                                 cricket.controllers.CricketMatchController.matchHeaderJson(matchDate, teamId)
+GET        /sport/cricket/match-stats-summary/:matchDate/:teamId.json                          cricket.controllers.CricketMatchController.matchStatsSummaryJson(matchDate, teamId)
 
 GET        /football/fixtures/more/:year/:month/:day.json                                      football.controllers.FixturesController.moreFixturesForJson(year, month, day)
 GET        /football/fixtures/:year/:month/:day.json                                           football.controllers.FixturesController.allFixturesForJson(year, month, day)


### PR DESCRIPTION
## What does this change?
We need this API to power the mini match stats that will appear on liveblogs, we have [an idea of what it will show](https://github.com/guardian/dotcom-rendering/issues/15898#issuecomment-4769213461) but not the design yet.

It returns the match status, and if the game is in play also the current batting team and the current not out batters.