### PR TITLE
Add cricket matchStatsUrl to data model

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -80,7 +80,7 @@ object DotcomRenderingUtils extends DCARUrlHelper {
           DotcomRenderingMatchData(
             matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
             matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
-            matchStatsUrl = None,
+            matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats-summary/$date/$team.json"),
             matchType = CricketMatchType,
           ),
         )


### PR DESCRIPTION
## Why
Followup to #28886 we need to tell DCR the URL of the match stats summary, I definitely didn't forget to add this to that PR.