### PR TITLE
Instrument Twirl template with a java agent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,20 +15,22 @@ https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-proj
 ThisBuild / asciiGraphWidth := 999999999
 ThisBuild / scalaVersion := SCALA_VERSION
 
+val templateTrackerJar = "template-tracker-agent.jar"
+
 /*
  * Standalone JVM agent that records which Twirl templates are rendered at runtime.
  *
- * It is NOT a Play module: it's a plain, pure-Java project assembled into a shaded, self-contained
- * jar (with a `Premain-Class` manifest entry) that gets attached to a host app via `-javaagent`.
- * ByteBuddy is relocated under com.gu.shaded.bytebuddy so it can never clash with anything on an
- * application's classpath (e.g. the byte-buddy that mockito pulls in for tests).
+ * This is a pure java project that uses ByteBuddy to instrument the Twirl template classes at runtime
+ * It is self-contained and any dependency is shadded to avoid any dependency conflict.
+ *
+ * The output of this module is a JAR file that gets attached to any service that requires this instrumentation
  */
 val templateTrackerAgent = Project("template-tracker-agent", file("template-tracker-agent"))
   .settings(
     crossPaths := false, // pure Java: don't append a _2.13 suffix to the artifact
     autoScalaLibrary := false, // pure Java: no scala-library dependency
     libraryDependencies += byteBuddy,
-    assembly / assemblyJarName := "template-tracker-agent.jar",
+    assembly / assemblyJarName := templateTrackerJar,
     assembly / assemblyShadeRules := Seq(
       ShadeRule.rename("net.bytebuddy.**" -> "com.gu.shaded.bytebuddy.@1").inAll,
     ),
@@ -38,6 +40,14 @@ val templateTrackerAgent = Project("template-tracker-agent", file("template-trac
       "Can-Retransform-Classes" -> "true",
     ),
   )
+
+val withTwirlInstrumentation: Seq[SettingsDefinition] = Seq(
+  Universal / mappings += {
+    val agentJar = (templateTrackerAgent / assembly).value
+    agentJar -> s"agent/${templateTrackerJar}"
+  },
+  bashScriptExtraDefines += s"""addJava "-javaagent:$${app_home}/../agent/${templateTrackerJar}"""",
+)
 
 val common = library("common")
   .settings(
@@ -127,17 +137,7 @@ val sport = application("sport")
 val discussion = application("discussion")
   .dependsOn(commonWithTests)
   .aggregate(common)
-  .settings(
-    // --- Twirl template usage tracker (PoC) ---
-    // Bundle the shaded agent jar into the packaged app under agent/, then have the generated
-    // native-packager start script attach it via -javaagent. ${app_home} is resolved by the start
-    // script at launch time, so this needs no change to the CDK/systemd launch config.
-    Universal / mappings += {
-      val agentJar = (templateTrackerAgent / assembly).value
-      agentJar -> "agent/template-tracker-agent.jar"
-    },
-    bashScriptExtraDefines += """addJava "-javaagent:${app_home}/../agent/template-tracker-agent.jar"""",
-  )
+  .settings(withTwirlInstrumentation: _*)
 
 val admin = application("admin")
   .dependsOn(commonWithTests)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import play.sbt.routes.RoutesKeys
 import com.typesafe.sbt.web.SbtWeb.autoImport._
+import com.typesafe.sbt.packager.archetypes.JavaAppPackaging.autoImport._
 import com.gu.Dependencies._
 import com.gu.ProjectSettings._
 
@@ -13,6 +14,30 @@ https://support.snyk.io/hc/en-us/articles/9590215676189-Deeply-nested-Scala-proj
  */
 ThisBuild / asciiGraphWidth := 999999999
 ThisBuild / scalaVersion := SCALA_VERSION
+
+/*
+ * Standalone JVM agent that records which Twirl templates are rendered at runtime.
+ *
+ * It is NOT a Play module: it's a plain, pure-Java project assembled into a shaded, self-contained
+ * jar (with a `Premain-Class` manifest entry) that gets attached to a host app via `-javaagent`.
+ * ByteBuddy is relocated under com.gu.shaded.bytebuddy so it can never clash with anything on an
+ * application's classpath (e.g. the byte-buddy that mockito pulls in for tests).
+ */
+val templateTrackerAgent = Project("template-tracker-agent", file("template-tracker-agent"))
+  .settings(
+    crossPaths := false, // pure Java: don't append a _2.13 suffix to the artifact
+    autoScalaLibrary := false, // pure Java: no scala-library dependency
+    libraryDependencies += byteBuddy,
+    assembly / assemblyJarName := "template-tracker-agent.jar",
+    assembly / assemblyShadeRules := Seq(
+      ShadeRule.rename("net.bytebuddy.**" -> "com.gu.shaded.bytebuddy.@1").inAll,
+    ),
+    assembly / packageOptions += Package.ManifestAttributes(
+      "Premain-Class" -> "com.gu.templatetracker.TemplateTrackerAgent",
+      "Can-Redefine-Classes" -> "true",
+      "Can-Retransform-Classes" -> "true",
+    ),
+  )
 
 val common = library("common")
   .settings(
@@ -99,7 +124,20 @@ val sport = application("sport")
     ),
   )
 
-val discussion = application("discussion").dependsOn(commonWithTests).aggregate(common)
+val discussion = application("discussion")
+  .dependsOn(commonWithTests)
+  .aggregate(common)
+  .settings(
+    // --- Twirl template usage tracker (PoC) ---
+    // Bundle the shaded agent jar into the packaged app under agent/, then have the generated
+    // native-packager start script attach it via -javaagent. ${app_home} is resolved by the start
+    // script at launch time, so this needs no change to the CDK/systemd launch config.
+    Universal / mappings += {
+      val agentJar = (templateTrackerAgent / assembly).value
+      agentJar -> "agent/template-tracker-agent.jar"
+    },
+    bashScriptExtraDefines += """addJava "-javaagent:${app_home}/../agent/template-tracker-agent.jar"""",
+  )
 
 val admin = application("admin")
   .dependsOn(commonWithTests)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,6 +12,10 @@ object Dependencies {
   val jerseyVersion = "1.19.4"
   val playJsonVersion = "3.0.6"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.16.0"
+  // ByteBuddy powers the standalone template-tracker JVM agent (shaded at assembly time).
+  // Pinned to 1.15.x: later releases bundle Java 24 multi-release classes that the assembly
+  // shader can't read/relocate (harmless on our Java 21 runtime, but noisy and not cleanly shaded).
+  val byteBuddy = "net.bytebuddy" % "byte-buddy" % "1.15.11"
   val awsCloudwatch = "software.amazon.awssdk" % "cloudwatch" % awsVersion
   val awsDynamodb = "software.amazon.awssdk" % "dynamodb" % awsVersion
   val awsKinesis = "software.amazon.awssdk" % "kinesis" % awsVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,9 @@ addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.11")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")
 
+// Used to build the shaded, self-contained template-tracker JVM agent jar
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/RecordTemplateAdvice.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/RecordTemplateAdvice.java
@@ -1,0 +1,23 @@
+package com.gu.templatetracker;
+
+import net.bytebuddy.asm.Advice;
+
+/**
+ * The advice whose body ByteBuddy inlines at the entry of each instrumented template method.
+ *
+ * <p>Keep this minimal: only the {@link Advice.OnMethodEnter} method's bytecode is copied into the
+ * target. It must reference only types resolvable from the instrumented class's classloader - here
+ * just {@link TemplateTracker}, which is loaded by the system classloader (the {@code -javaagent}
+ * jar is appended to the system class path) and therefore visible to Play's child application
+ * classloader.
+ */
+public final class RecordTemplateAdvice {
+
+    private RecordTemplateAdvice() {}
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Origin("#t") String templateClassName) {
+        TemplateTracker.recordFirstSeen(templateClassName);
+    }
+}
+

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/RecordTemplateAdvice.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/RecordTemplateAdvice.java
@@ -13,11 +13,12 @@ import net.bytebuddy.asm.Advice;
  */
 public final class RecordTemplateAdvice {
 
-    private RecordTemplateAdvice() {}
+    private RecordTemplateAdvice() {
+    }
 
     @Advice.OnMethodEnter
     public static void onEnter(@Advice.Origin("#t") String templateClassName) {
-        TemplateTracker.recordFirstSeen(templateClassName);
+        TemplateTracker.recordRendering(templateClassName);
     }
 }
 

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/SimpleLogger.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/SimpleLogger.java
@@ -1,0 +1,28 @@
+package com.gu.templatetracker;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Inefficient but hopefully simple logger
+ * We don't expect a crazy volume of log so this might just about do it.
+ */
+public class SimpleLogger {
+    Path path;
+
+    public SimpleLogger(Path path) {
+        this.path = path;
+
+        this.path.getParent().toFile().mkdirs();
+    }
+
+    public synchronized void log(String json) throws IOException {
+        // SYNC guarantees the file content and metadata are successfully written to disk.
+        Files.writeString(this.path, json + System.lineSeparator(),
+            StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND,
+            StandardOpenOption.SYNC);
+    }
+}

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -1,39 +1,43 @@
 package com.gu.templatetracker;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Holds the set of Twirl templates seen so far in this JVM and logs each one the first time it is
- * rendered.
- *
- * <p>This class is loaded by the system classloader (it lives in the {@code -javaagent} jar) so it
- * is shared across the whole application and visible to the woven {@code views.html.*} classes.
- *
- * <p>The PoC logs to stdout as a single structured JSON line so the ELK pipeline can pick it up.
- * We intentionally do not use the application's {@code GuLogging}: that lives in the {@code common}
- * module on Play's application classloader and is not (cleanly) reachable from an agent on the
- * system classloader without coupling the two together. If we later productionise this, the
- * delegate target can be swapped for a registry in {@code common} that emits via {@code GuLogging}
- * + CloudWatch + S3/Athena.
  */
 public final class TemplateTracker {
 
     private static final Set<String> SEEN = ConcurrentHashMap.newKeySet();
+    private static SimpleLogger logger = new SimpleLogger(Path.of("../logs/twirl-usage.log"));
 
-    private TemplateTracker() {}
+    private static DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
 
-    public static void recordFirstSeen(String rawClassName) {
+    public static void recordRendering(String rawClassName) {
         String template = normalise(rawClassName);
         // After the first sighting of a template, `add` returns false and we do nothing further -
         // so the hot path for high-traffic templates is a single concurrent-set membership check.
         if (SEEN.add(template)) {
-            System.out.println(
-                "{\"marker\":\"TEMPLATE_FIRST_SEEN\",\"template\":\"" + template + "\"}");
+            try {
+                logger.log("{" +
+                    "\"marker\":\"TEMPLATE_FIRST_SEEN\"," +
+                    "\"template\":\"" + template + "\", " +
+                    "\"timestamp\":\"" + formatter.format(ZonedDateTime.now()) + "\"" +
+                    "}");
+            } catch (IOException e) {
+                // not much we can do, so let's print the error in stderr at least
+                e.printStackTrace();
+            }
         }
     }
 
-    /** Scala {@code object}s compile to a {@code Foo$} class; strip the trailing {@code $}. */
+    /**
+     * Scala {@code object}s compile to a {@code Foo$} class; strip the trailing {@code $}.
+     */
     private static String normalise(String className) {
         if (className != null && className.endsWith("$")) {
             return className.substring(0, className.length() - 1);

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -1,0 +1,44 @@
+package com.gu.templatetracker;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Holds the set of Twirl templates seen so far in this JVM and logs each one the first time it is
+ * rendered.
+ *
+ * <p>This class is loaded by the system classloader (it lives in the {@code -javaagent} jar) so it
+ * is shared across the whole application and visible to the woven {@code views.html.*} classes.
+ *
+ * <p>The PoC logs to stdout as a single structured JSON line so the ELK pipeline can pick it up.
+ * We intentionally do not use the application's {@code GuLogging}: that lives in the {@code common}
+ * module on Play's application classloader and is not (cleanly) reachable from an agent on the
+ * system classloader without coupling the two together. If we later productionise this, the
+ * delegate target can be swapped for a registry in {@code common} that emits via {@code GuLogging}
+ * + CloudWatch + S3/Athena.
+ */
+public final class TemplateTracker {
+
+    private static final Set<String> SEEN = ConcurrentHashMap.newKeySet();
+
+    private TemplateTracker() {}
+
+    public static void recordFirstSeen(String rawClassName) {
+        String template = normalise(rawClassName);
+        // After the first sighting of a template, `add` returns false and we do nothing further -
+        // so the hot path for high-traffic templates is a single concurrent-set membership check.
+        if (SEEN.add(template)) {
+            System.out.println(
+                "{\"marker\":\"TEMPLATE_FIRST_SEEN\",\"template\":\"" + template + "\"}");
+        }
+    }
+
+    /** Scala {@code object}s compile to a {@code Foo$} class; strip the trailing {@code $}. */
+    private static String normalise(String className) {
+        if (className != null && className.endsWith("$")) {
+            return className.substring(0, className.length() - 1);
+        }
+        return className;
+    }
+}
+

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
@@ -1,0 +1,46 @@
+package com.gu.templatetracker;
+
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatchers;
+
+import java.lang.instrument.Instrumentation;
+
+/**
+ * A JVM agent that records, once per JVM, the first time each Twirl template is rendered.
+ *
+ * <p>It is wired into the host application via {@code -javaagent:.../template-tracker-agent.jar}
+ * (see the {@code discussion} module in {@code build.sbt}). The JVM calls {@link #premain} before
+ * the application's {@code main}, i.e. before Play boots and before any {@code views.html.*}
+ * template class is loaded - so every template is woven naturally as it is first class-loaded.
+ *
+ * <p>The instrumentation is deliberately tiny: it inlines a single call at the entry of each
+ * template's {@code apply}/{@code render} method, which delegates to {@link TemplateTracker} where a
+ * first-seen {@link java.util.Set} membership check makes every render after the first essentially free.
+ */
+public final class TemplateTrackerAgent {
+
+    private TemplateTrackerAgent() {
+    }
+
+    public static void premain(String args, Instrumentation instrumentation) {
+        System.out.println(
+            "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"installing Twirl template usage tracker\"}");
+
+        new AgentBuilder.Default()
+            // Only consider compiled Twirl templates: classes under views.html.* that are
+            // subtypes of play.twirl.api.Template* (Template0..Template22). This excludes the
+            // many anonymous-function classes Scala generates inside a template
+            // (e.g. views.html.fragments.articleBody$$anonfun$...), which also live under
+            // views.html.* and also have an `apply` method, but are not templates.
+            .type(
+                ElementMatchers.<net.bytebuddy.description.type.TypeDescription>nameStartsWith("views.html.")
+                    .and(ElementMatchers.hasSuperType(ElementMatchers.nameStartsWith("play.twirl.api.Template"))))
+            .transform((builder, typeDescription, classLoader, module, protectionDomain) ->
+                builder.visit(
+                    Advice.to(RecordTemplateAdvice.class)
+                        .on(ElementMatchers.named("apply").or(ElementMatchers.named("render")))))
+            .installOn(instrumentation);
+    }
+}
+

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
@@ -2,19 +2,22 @@ package com.gu.templatetracker;
 
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import java.lang.instrument.Instrumentation;
 
 /**
  * A JVM agent that records, once per JVM, the first time each Twirl template is rendered.
- *
- * <p>It is wired into the host application via {@code -javaagent:.../template-tracker-agent.jar}
- * (see the {@code discussion} module in {@code build.sbt}). The JVM calls {@link #premain} before
- * the application's {@code main}, i.e. before Play boots and before any {@code views.html.*}
- * template class is loaded - so every template is woven naturally as it is first class-loaded.
- *
- * <p>The instrumentation is deliberately tiny: it inlines a single call at the entry of each
+ * This is useful during the frontend -> DCAR migration in order to understand:
+ * - which templates are still being used and therefore needs migrating to DCAR
+ * - which templates aren't used and could be removed from the codebase
+ * <p>
+ * It is wired into the service via {@code -javaagent:.../template-tracker-agent.jar}
+ * The JVM calls {@link #premain} before the application's {@code main}, i.e.
+ * before Play boots and before any {@code views.html.*} template class is loaded.
+ * <p>
+ * The instrumentation is deliberately small: it inlines a single call at the entry of each
  * template's {@code apply}/{@code render} method, which delegates to {@link TemplateTracker} where a
  * first-seen {@link java.util.Set} membership check makes every render after the first essentially free.
  */
@@ -23,23 +26,23 @@ public final class TemplateTrackerAgent {
     private TemplateTrackerAgent() {
     }
 
+    // We define a "Twirl template" as: classes under views.html.* that are subtypes of play.twirl.api.Template* (Template0..Template22).
+    private static ElementMatcher TWIRL_TEMPLATE_MATCHER = ElementMatchers.<net.bytebuddy.description.type.TypeDescription>nameStartsWith("views.html.")
+        .and(ElementMatchers.hasSuperType(ElementMatchers.nameStartsWith("play.twirl.api.Template")));
+
+    // This transformer inlines `TemplateTracker.recordRendering` (via RecordTemplateAdvice) at the entry of each template's `apply` and `render` methods.
+    private static AgentBuilder.Transformer RECORD_TEMPLATE_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) ->
+        builder.visit(
+            Advice.to(RecordTemplateAdvice.class)
+                .on(ElementMatchers.named("apply").or(ElementMatchers.named("render"))));
+
     public static void premain(String args, Instrumentation instrumentation) {
         System.out.println(
-            "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"installing Twirl template usage tracker\"}");
+            "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Installing Twirl template usage tracker\"}");
 
         new AgentBuilder.Default()
-            // Only consider compiled Twirl templates: classes under views.html.* that are
-            // subtypes of play.twirl.api.Template* (Template0..Template22). This excludes the
-            // many anonymous-function classes Scala generates inside a template
-            // (e.g. views.html.fragments.articleBody$$anonfun$...), which also live under
-            // views.html.* and also have an `apply` method, but are not templates.
-            .type(
-                ElementMatchers.<net.bytebuddy.description.type.TypeDescription>nameStartsWith("views.html.")
-                    .and(ElementMatchers.hasSuperType(ElementMatchers.nameStartsWith("play.twirl.api.Template"))))
-            .transform((builder, typeDescription, classLoader, module, protectionDomain) ->
-                builder.visit(
-                    Advice.to(RecordTemplateAdvice.class)
-                        .on(ElementMatchers.named("apply").or(ElementMatchers.named("render")))))
+            .type(TWIRL_TEMPLATE_MATCHER)
+            .transform(RECORD_TEMPLATE_TRANSFORMER)
             .installOn(instrumentation);
     }
 }


### PR DESCRIPTION
See https://github.com/guardian/frontend/issues/28909 and  https://github.com/guardian/frontend/issues/28894

This was coded with the help of Opus 4.8. I don't think I could have cooked it this quick otherwise.

## What is the value of this and can you measure success?

Can we measure which twirl template is being used in production? if so: success.

## What does this change?

Instrument production artefacts at runtime in order to detect which twirl templates truly are used in a live environment. The instrumentation writes a json log line in a separate file each time a new template is encountered.

The logging implementation is voluntarily naive, it's inefficient but it's a trade-off for simplicity that I'm willing to accept because:
- the number of log lines is going to be very small (< 200)
- it will only be slowing down the first few requests
- keeping this code as simple as technically feasible is key for maintainability

As of now this is only applied to the `discussion` service, and it will be generalised in [this ticket](https://github.com/guardian/frontend/issues/28911)

## Screenshots

```
root@ip-10-0-1-41:/home/discussion/logs# tail -n10000 -f twirl-usage.log
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.discussionComments.discussionPage", "timestamp":"2026-07-03T08:57:23.164191162Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.comment", "timestamp":"2026-07-03T08:57:23.280691371Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.inlineSvg", "timestamp":"2026-07-03T08:57:23.317208482Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.commentBadges", "timestamp":"2026-07-03T08:57:23.451675149Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.commentPagination", "timestamp":"2026-07-03T08:57:23.808396215Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.pagination", "timestamp":"2026-07-03T08:57:23.83499089Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.reportComment", "timestamp":"2026-07-03T08:57:23.856467665Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.recommendationTooltip", "timestamp":"2026-07-03T08:57:23.872501405Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.mainLegacy", "timestamp":"2026-07-03T08:57:23.876149815Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.main", "timestamp":"2026-07-03T08:57:23.900311874Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.head", "timestamp":"2026-07-03T08:57:23.926315961Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.metaData", "timestamp":"2026-07-03T08:57:23.972617671Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.stylesheets", "timestamp":"2026-07-03T08:57:24.207628616Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.fontFaces", "timestamp":"2026-07-03T08:57:24.22786444Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.stylesheetLink", "timestamp":"2026-07-03T08:57:24.249071521Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.head.fixIEReferenceErrors", "timestamp":"2026-07-03T08:57:24.283257482Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.head.checkModuleSupport", "timestamp":"2026-07-03T08:57:24.299675049Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.inlineJSBlocking", "timestamp":"2026-07-03T08:57:24.32102723Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.commercial.topBanner", "timestamp":"2026-07-03T08:57:25.785808864Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.commercial.standardAd", "timestamp":"2026-07-03T08:57:25.81496349Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.commercial.adSlot", "timestamp":"2026-07-03T08:57:25.853580442Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.header", "timestamp":"2026-07-03T08:57:25.872392544Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.nav.userAccountDropdown", "timestamp":"2026-07-03T08:57:25.925532721Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.nav.editionPickerDropdown", "timestamp":"2026-07-03T08:57:25.953651679Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.nav.headerMenu", "timestamp":"2026-07-03T08:57:25.970834776Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.nav.editionPicker", "timestamp":"2026-07-03T08:57:26.052853344Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.nav.subNav", "timestamp":"2026-07-03T08:57:26.084050579Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.footer", "timestamp":"2026-07-03T08:57:26.11388966Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.email.signup.emailFooterLink", "timestamp":"2026-07-03T08:57:26.14095677Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.message", "timestamp":"2026-07-03T08:57:26.196277385Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.inlineJSNonBlocking", "timestamp":"2026-07-03T08:57:26.215546915Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.analytics.base", "timestamp":"2026-07-03T08:57:26.361353019Z[Etc/UTC]"}
```

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
