### PR TITLE
Ensure cricket team is set on data model for match report articles

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -323,7 +323,9 @@ final case class Content(
     )
 
   def cricketTeam: Option[String] = {
-    if (tags.isCricketLiveBlog && conf.switches.Switches.CricketScoresSwitch.isSwitchedOn) {
+    if (
+      (tags.isCricketLiveBlog || tags.isCricketMatchReport) && conf.switches.Switches.CricketScoresSwitch.isSwitchedOn
+    ) {
       CricketTeams.teamFor(this).map(_.wordsForUrl)
     } else None
   }


### PR DESCRIPTION
## What does this change?
We also need the cricket team to ensure that the header data url is added to the data model [here](https://github.com/guardian/frontend/blob/jlk/match-report-header/common/app/model/dotcomrendering/DotcomRenderingUtils.scala#L73)
