### PR TITLE
Ensure cricket match controller and data model have same criteria for what is a match report/liveblog

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -84,14 +84,18 @@ object DotcomRenderingUtils extends DCARUrlHelper {
     if (isCricketMatchRelated(item)) {
       val date = item.content.cricketMatchDate
       val team = item.content.cricketTeam
-      Some(
-        DotcomRenderingMatchData(
-          matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
-          matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
-          matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats-summary/$date/$team.json"),
-          matchType = CricketMatchType,
-        ),
-      )
+      (date, team) match {
+        case (Some(date), Some(team)) =>
+          Some(
+            DotcomRenderingMatchData(
+              matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/$team.json",
+              matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
+              matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats-summary/$date/$team.json"),
+              matchType = CricketMatchType,
+            ),
+          )
+        case _ => None
+      }
     } else None
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -30,6 +30,7 @@ import play.api.mvc.RequestHeader
 import views.support.AffiliateLinksCleaner
 
 import java.net.URLEncoder
+import model.Tags
 
 sealed trait DotcomRenderingMatchType
 
@@ -70,33 +71,25 @@ object DotcomRenderingUtils extends DCARUrlHelper {
     makeFootballMatch(articlePage, pageType).orElse(makeCricketMatch(articlePage.item))
   }
 
-  def isCricketMatchRelated(item: ContentType): Boolean = {
-    val hasCricketDate = item.content.cricketMatchDate.isDefined
-    val hasCricketTeam = item.content.cricketTeam.isDefined
-    val hasExactlyTwoTeams = item.content.tags.tags.count(tag => {
-      tag.id.endsWith("-cricket-team") || tag.id.endsWith("cricketteam")
-    }) == 2
-
-    hasCricketDate && hasCricketTeam && hasExactlyTwoTeams
-  }
+  def hasExactlyTwoTeams(tags: Tags): Boolean = tags.tags.count(tag => {
+    tag.id.endsWith("-cricket-team") || tag.id.endsWith("cricketteam")
+  }) == 2
 
   def makeCricketMatch(item: ContentType): Option[DotcomRenderingMatchData] = {
-    if (isCricketMatchRelated(item)) {
-      val date = item.content.cricketMatchDate
-      val team = item.content.cricketTeam
-      (date, team) match {
-        case (Some(date), Some(team)) =>
-          Some(
-            DotcomRenderingMatchData(
-              matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/$team.json",
-              matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
-              matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats-summary/$date/$team.json"),
-              matchType = CricketMatchType,
-            ),
-          )
-        case _ => None
-      }
-    } else None
+    val date = item.content.cricketMatchDate
+    val team = item.content.cricketTeam
+    (date, team, hasExactlyTwoTeams(item.content.tags)) match {
+      case (Some(date), Some(team), true) =>
+        Some(
+          DotcomRenderingMatchData(
+            matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/$team.json",
+            matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
+            matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats-summary/$date/$team.json"),
+            matchType = CricketMatchType,
+          ),
+        )
+      case _ => None
+    }
   }
 
   def getMatchNavUrl(host: String, date: LocalDate, team1: String, team2: String, pageId: String): String = {

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -67,25 +67,32 @@ trait DCARUrlHelper {
 
 object DotcomRenderingUtils extends DCARUrlHelper {
   def makeMatchData(articlePage: ContentPage, pageType: PageType): Option[DotcomRenderingMatchData] = {
-    makeFootballMatch(articlePage, pageType).orElse(makeCricketMatch(articlePage))
+    makeFootballMatch(articlePage, pageType).orElse(makeCricketMatch(articlePage.item))
   }
 
-  def makeCricketMatch(articlePage: ContentPage): Option[DotcomRenderingMatchData] = {
-    val cricketDate = articlePage.item.content.cricketMatchDate
-    val cricketTeam = articlePage.item.content.cricketTeam
+  def isCricketMatchRelated(item: ContentType): Boolean = {
+    val hasCricketDate = item.content.cricketMatchDate.isDefined
+    val hasCricketTeam = item.content.cricketTeam.isDefined
+    val hasExactlyTwoTeams = item.content.tags.tags.count(tag => {
+      tag.id.endsWith("-cricket-team") || tag.id.endsWith("cricketteam")
+    }) == 2
 
-    (cricketDate, cricketTeam) match {
-      case (Some(date), Some(team)) =>
-        Some(
-          DotcomRenderingMatchData(
-            matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
-            matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
-            matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats-summary/$date/$team.json"),
-            matchType = CricketMatchType,
-          ),
-        )
-      case _ => None
-    }
+    hasCricketDate && hasCricketTeam && hasExactlyTwoTeams
+  }
+
+  def makeCricketMatch(item: ContentType): Option[DotcomRenderingMatchData] = {
+    if (isCricketMatchRelated(item)) {
+      val date = item.content.cricketMatchDate
+      val team = item.content.cricketTeam
+      Some(
+        DotcomRenderingMatchData(
+          matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/${team}.json",
+          matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
+          matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats-summary/$date/$team.json"),
+          matchType = CricketMatchType,
+        ),
+      )
+    } else None
   }
 
   def getMatchNavUrl(host: String, date: LocalDate, team1: String, team2: String, pageId: String): String = {

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -19,7 +19,7 @@ import services.dotcomrendering.{CricketPagePicker, RemoteRender}
 import java.time.{LocalDate, ZoneId, ZonedDateTime}
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
-import model.dotcomrendering.DotcomRenderingUtils.isCricketMatchRelated
+import model.dotcomrendering.DotcomRenderingUtils.hasExactlyTwoTeams
 
 case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam) extends StandalonePage {
   override val metadata = MetaData.make(

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -152,7 +152,7 @@ class CricketMatchController(
         response.results
           .map(Content(_))
           .toList
-          .filter(c => isCricketMatchRelated(c))
+          .filter(c => hasExactlyTwoTeams(c.tags))
       }
   }
 }

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -19,6 +19,7 @@ import services.dotcomrendering.{CricketPagePicker, RemoteRender}
 import java.time.{LocalDate, ZoneId, ZonedDateTime}
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
+import model.dotcomrendering.DotcomRenderingUtils.isCricketMatchRelated
 
 case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam) extends StandalonePage {
   override val metadata = MetaData.make(
@@ -151,11 +152,7 @@ class CricketMatchController(
         response.results
           .map(Content(_))
           .toList
-          .filter(c => hasExactlyTwoTeams(c))
+          .filter(c => isCricketMatchRelated(c))
       }
   }
-
-  private def hasExactlyTwoTeams(content: ContentType): Boolean = content.tags.tags.count(tag => {
-    tag.id.endsWith("-cricket-team") || tag.id.endsWith("cricketteam")
-  }) == 2
 }


### PR DESCRIPTION
## What does this change?
Use the same function to check if an article should have the header, and for finding the article links for the cricket header API response.

The slight difference at the moment means that a header can appear on an article but without working tab links, like this live blog at time of writing https://www.theguardian.com/sport/live/2026/jun/30/australia-v-west-indies-womens-t20-world-cup-semi-final-live