### PR TITLE
Release Hosted Gallery pages

### DIFF
--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.ItemQuery
-import com.gu.contentapi.client.model.v1.ContentType.{Gallery, Video}
+import com.gu.contentapi.client.model.v1.ContentType.Video
 import com.gu.contentapi.client.model.v1.{Blocks, ItemResponse}
 import commercial.model.hosted.HostedTrails
 import common.`package`.convertApiExceptionsWithoutEither

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -116,8 +116,7 @@ class HostedContentController(
   def renderHostedPage(campaignName: String, pageName: String): Action[AnyContent] =
     Action.async { implicit request =>
       lookup(campaignName, pageName) flatMap { response =>
-        val isGallery = response.content.exists(_.`type` == Gallery)
-        val tier = HostedContentPicker.getTier(isGallery)
+        val tier = HostedContentPicker.getTier()
         tier match {
           // DCR pages
           case RemoteRender =>

--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -8,10 +8,10 @@ import implicits.AppsFormat
 import conf.switches.Switches
 
 object HostedContentPicker extends GuLogging {
-  def getTier(isGallery: Boolean = false)(implicit
+  def getTier()(implicit
       request: RequestHeader,
   ): RenderType = {
-    val tier: RenderType = decideTier(isGallery)
+    val tier: RenderType = decideTier()
     tier match {
       case RemoteRender =>
         if (request.getRequestFormat == AppsFormat)
@@ -24,13 +24,10 @@ object HostedContentPicker extends GuLogging {
     tier
   }
 
-  def decideTier(isGallery: Boolean = false)(implicit
+  def decideTier()(implicit
       request: RequestHeader,
   ): RenderType = {
     if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
-    // Gallery pages are not supported in DCR yet
-    else if (isGallery && !isUserInTestGroup("commercial-hosted-gallery", "preview")) LocalRender
-    else if (isGallery && request.forceDCR) RemoteRender
     else if (request.forceDCROff) LocalRender
     else if (request.forceDCR) RemoteRender
     else RemoteRender

--- a/commercial/app/services/dotcomrendering/HostedContentPicker.scala
+++ b/commercial/app/services/dotcomrendering/HostedContentPicker.scala
@@ -1,6 +1,5 @@
 package services.dotcomrendering
 
-import ab.ABTests.isUserInTestGroup
 import common.GuLogging
 import implicits.Requests._
 import play.api.mvc.RequestHeader
@@ -27,9 +26,9 @@ object HostedContentPicker extends GuLogging {
   def decideTier()(implicit
       request: RequestHeader,
   ): RenderType = {
-    if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
+    if (request.forceDCR) RemoteRender
     else if (request.forceDCROff) LocalRender
-    else if (request.forceDCR) RemoteRender
+    else if (Switches.DCRHostedContent.isSwitchedOff) LocalRender
     else RemoteRender
   }
 }

--- a/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
+++ b/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
@@ -8,11 +8,10 @@ import services.dotcomrendering.LocalRender
 import test.TestRequest
 
 @DoNotDiscover class HostedContentPickerTest extends AnyFlatSpec with Matchers {
-  "Hosted Content Picker decideTier" should "return LocalRender if the feature switch is off" in {
-    Switches.DCRHostedContent.switchOff()
-    val testRequest = TestRequest("hosted-content-path")
+  "Hosted Content Picker decideTier" should "return RemoteRender if forcing DCR to be on via the query parameter" in {
+    val testRequest = TestRequest("hosted-content-path?dcr=true")
     val tier = HostedContentPicker.decideTier()(testRequest)
-    tier should be(LocalRender)
+    tier should be(RemoteRender)
   }
 
   it should "return LocalRender if forcing DCR to be off via the query parameter" in {
@@ -21,10 +20,11 @@ import test.TestRequest
     tier should be(LocalRender)
   }
 
-  it should "return RemoteRender if forcing DCR to be on via the query parameter" in {
-    val testRequest = TestRequest("hosted-content-path?dcr=true")
+  it should "return LocalRender if the feature switch is off" in {
+    Switches.DCRHostedContent.switchOff()
+    val testRequest = TestRequest("hosted-content-path")
     val tier = HostedContentPicker.decideTier()(testRequest)
-    tier should be(RemoteRender)
+    tier should be(LocalRender)
   }
 
   it should "return RemoteRender otherwise" in {

--- a/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
+++ b/commercial/test/services/dotcomrendering/HostedContentPickerTest.scala
@@ -15,26 +15,6 @@ import test.TestRequest
     tier should be(LocalRender)
   }
 
-  it should "return LocalRender if isGallery is true" in {
-    val testRequest = TestRequest("hosted-content-path")
-    val tier = HostedContentPicker.decideTier(isGallery = true)(testRequest)
-    tier should be(LocalRender)
-  }
-
-  it should "return LocalRender if not in the test group whilst forcing DCR for isGallery = true" in {
-    val testRequest = TestRequest("hosted-content-path?dcr=true")
-    val tier = HostedContentPicker.decideTier(isGallery = true)(testRequest)
-    tier should be(LocalRender)
-  }
-
-  it should "return RemoteRender if in the test group and forcing DCR for isGallery = true" in {
-    val testRequest = TestRequest("hosted-content-path?dcr=true").withHeaders(
-      "X-GU-Server-AB-Tests" -> "commercial-hosted-gallery:preview",
-    )
-    val tier = HostedContentPicker.decideTier(isGallery = true)(testRequest)
-    tier should be(RemoteRender)
-  }
-
   it should "return LocalRender if forcing DCR to be off via the query parameter" in {
     val testRequest = TestRequest("hosted-content-path?dcr=false")
     val tier = HostedContentPicker.decideTier()(testRequest)
@@ -45,12 +25,6 @@ import test.TestRequest
     val testRequest = TestRequest("hosted-content-path?dcr=true")
     val tier = HostedContentPicker.decideTier()(testRequest)
     tier should be(RemoteRender)
-  }
-
-  it should "return LocalRender if not in the test group without forcing DCR" in {
-    val testRequest = TestRequest("hosted-content-path")
-    val tier = HostedContentPicker.decideTier()(testRequest)
-    tier should be(LocalRender)
   }
 
   it should "return RemoteRender otherwise" in {


### PR DESCRIPTION
## What is the value of this and can you measure success?

We're ready to launch Hosted Gallery pages to prod so this PR removes the conditions holding these pages behind AB test participation and query parameters

## What does this change?

Removes the Hosted Gallery condition in the Hosted Content picker to allow all Hosted Content page types to render via DCR by default if the feature switch is turned on