### PR TITLE
Refactor cricket data fetching to reduce API requests

### DIFF
--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -3,9 +3,10 @@ package cricket.conf
 import app.LifecycleComponent
 import common.{JobScheduler, PekkoAsync}
 import jobs.CricketStatsJob
+import jobs.CricketStatsJob.MatchType
 import model.ApplicationContext
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.duration._
@@ -25,20 +26,29 @@ class CricketLifecycle(
     }
   }
 
+  // We only keep 2 months of historical matches in the cache.
+  private val discoveryLookBack = 2 // months
+
   private def scheduleJobs(): Unit = {
-    // if preview "Every hour" otherwise "Every 5 minutes"
-    jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", if (context.isPreview) 1.hour else 5.minutes) {
-      Future(cricketStatsJob.run(fromDate = LocalDate.now, matchesToFetch = 1))
+    // Discover matches and load any newly seen match
+    jobs.scheduleEvery("CricketDiscoverMatches", 1.day) {
+      Future(cricketStatsJob.discoverMatches(fromDate = LocalDateTime.now.minusMonths(discoveryLookBack)))
     }
-    // if preview "Every hour" otherwise "Every 10 minutes"
-    jobs.scheduleEvery("CricketAgentRefreshHistoricalMatches", if (context.isPreview) 1.hour else 10.minutes) {
-      Future(cricketStatsJob.run(fromDate = LocalDate.now.minusMonths(2), matchesToFetch = 10))
+
+    // Refresh match data for upcoming (not-yet-started) fixtures. Hourly.
+    jobs.scheduleEvery("CricketRefreshUpcomingMatches", 1.hour) {
+      Future(cricketStatsJob.refreshUpcomingMatchData())
+    }
+    // Frequent refresh for near/live/recently-started matches.
+    jobs.scheduleEvery("CricketRefreshLiveMatches", if (context.isPreview) 1.hour else 5.minutes) {
+      Future(cricketStatsJob.refreshActiveMatchData())
     }
   }
 
   private def descheduleJobs(): Unit = {
-    jobs.deschedule("CricketAgentRefreshCurrentMatches")
-    jobs.deschedule("CricketAgentRefreshHistoricalMatches")
+    jobs.deschedule("CricketDiscoverMatches")
+    jobs.deschedule("CricketRefreshUpcomingMatches")
+    jobs.deschedule("CricketRefreshLiveMatches")
   }
 
   override def start(): Unit = {
@@ -47,7 +57,9 @@ class CricketLifecycle(
 
     // ensure that we populate the cricket stats cache immediately
     pekkoAsync.after1s {
-      cricketStatsJob.run(fromDate = LocalDate.now.minusMonths(2), matchesToFetch = 10)
+      cricketStatsJob.discoverMatches(fromDate = LocalDateTime.now.minusMonths(discoveryLookBack))
+      cricketStatsJob.refreshUpcomingMatchData()
+      cricketStatsJob.refreshActiveMatchData()
     }
   }
 }

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -36,20 +36,26 @@ class CricketLifecycle(
     }
 
     // Fetch active matches every 5 minutes to ensure the scorecard is up to date.
-    jobs.scheduleEvery("CricketFrequentMatchUpdates", if (context.isPreview) 1.hour else 5.minutes) {
-      cricketStatsJob.frequentMatchDataRefresh()
+    jobs.scheduleEvery("CricketActiveMatchUpdates", if (context.isPreview) 1.hour else 5.minutes) {
+      cricketStatsJob.activeMatchDataRefresh()
     }
 
-    // Fetch other matches every hour.
-    jobs.scheduleEvery("CricketInfrequentMatchUpdates", 1.hour) {
+    // Fetch upcoming matches every hour.
+    jobs.scheduleEvery("CricketUpcomingMatchUpdates", 1.hour) {
+      cricketStatsJob.upcomingMatchDataRefresh()
+    }
+
+    // Fetch historical and future matches every day.
+    jobs.scheduleEvery("CricketOtherMatchUpdates", 1.day) {
       cricketStatsJob.infrequentMatchDataRefresh()
     }
   }
 
   private def descheduleJobs(): Unit = {
     jobs.deschedule("CricketDiscoverMatches")
-    jobs.deschedule("CricketFrequentMatchUpdates")
-    jobs.deschedule("CricketInfrequentMatchUpdates")
+    jobs.deschedule("CricketActiveMatchUpdates")
+    jobs.deschedule("CricketUpcomingMatchUpdates")
+    jobs.deschedule("CricketOtherMatchUpdates")
   }
 
   override def start(): Unit = {

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -58,8 +58,6 @@ class CricketLifecycle(
     // ensure that we populate the cricket stats cache immediately
     pekkoAsync.after1s {
       cricketStatsJob.discoverMatches(fromDate = LocalDateTime.now.minusMonths(discoveryLookBack))
-      cricketStatsJob.refreshUpcomingMatchData()
-      cricketStatsJob.refreshActiveMatchData()
     }
   }
 }

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -3,7 +3,6 @@ package cricket.conf
 import app.LifecycleComponent
 import common.{JobScheduler, PekkoAsync}
 import jobs.CricketStatsJob
-import jobs.CricketStatsJob.MatchType
 import model.ApplicationContext
 
 import java.time.LocalDateTime
@@ -11,6 +10,7 @@ import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import conf.cricketPa.PaFeed
 
 class CricketLifecycle(
     appLifeCycle: ApplicationLifecycle,
@@ -26,29 +26,38 @@ class CricketLifecycle(
     }
   }
 
-  // We only keep 2 months of historical matches in the cache.
-  private val discoveryLookBack = 2 // months
-
   private def scheduleJobs(): Unit = {
-    // Discover matches and load any newly seen match
+    // Refresh the fixtures/results registry once a day.
     jobs.scheduleEvery("CricketDiscoverMatches", 1.day) {
-      Future(cricketStatsJob.discoverMatches(fromDate = LocalDateTime.now.minusMonths(discoveryLookBack)))
+      Future(
+        cricketStatsJob.discoverMatches(
+          fromDate = LocalDateTime.now.minusMonths(PaFeed.dateWindowMonths),
+          toDate = LocalDateTime.now.plusMonths(PaFeed.dateWindowMonths),
+        ),
+      )
     }
 
-    // Refresh match data for upcoming (not-yet-started) fixtures. Hourly.
-    jobs.scheduleEvery("CricketRefreshUpcomingMatches", 1.hour) {
-      Future(cricketStatsJob.refreshUpcomingMatchData())
+    // Ensure cache is updated when cold or when new matches are discovered.
+    jobs.scheduleEvery("CricketBackfillMatches", if (context.isPreview) 1.hour else 5.minutes) {
+      Future(cricketStatsJob.backfillMatches())
     }
-    // Frequent refresh for near/live/recently-started matches.
-    jobs.scheduleEvery("CricketRefreshLiveMatches", if (context.isPreview) 1.hour else 5.minutes) {
+
+    // Fetch active matches every 5 minutes to ensure the scorecard is up to date.
+    jobs.scheduleEvery("CricketActiveMatches", if (context.isPreview) 1.hour else 5.minutes) {
       Future(cricketStatsJob.refreshActiveMatchData())
+    }
+
+    // Fetch upcoming matches every hour.
+    jobs.scheduleEvery("CricketUpcomingMatches", 1.hour) {
+      Future(cricketStatsJob.refreshUpcomingMatchData())
     }
   }
 
   private def descheduleJobs(): Unit = {
     jobs.deschedule("CricketDiscoverMatches")
-    jobs.deschedule("CricketRefreshUpcomingMatches")
-    jobs.deschedule("CricketRefreshLiveMatches")
+    jobs.deschedule("CricketBackfillMatches")
+    jobs.deschedule("CricketActiveMatches")
+    jobs.deschedule("CricketUpcomingMatches")
   }
 
   override def start(): Unit = {
@@ -57,7 +66,12 @@ class CricketLifecycle(
 
     // ensure that we populate the cricket stats cache immediately
     pekkoAsync.after1s {
-      cricketStatsJob.discoverMatches(fromDate = LocalDateTime.now.minusMonths(discoveryLookBack))
+      cricketStatsJob.discoverMatches(
+        fromDate = LocalDateTime.now.minusMonths(PaFeed.dateWindowMonths),
+        toDate = LocalDateTime.now.plusMonths(PaFeed.dateWindowMonths),
+      )
+      cricketStatsJob.backfillMatches()
     }
+
   }
 }

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -37,11 +37,6 @@ class CricketLifecycle(
       )
     }
 
-    // Ensure cache is updated when cold or when new matches are discovered.
-    jobs.scheduleEvery("CricketBackfillMatches", if (context.isPreview) 1.hour else 5.minutes) {
-      Future(cricketStatsJob.backfillMatches())
-    }
-
     // Fetch active matches every 5 minutes to ensure the scorecard is up to date.
     jobs.scheduleEvery("CricketActiveMatches", if (context.isPreview) 1.hour else 5.minutes) {
       Future(cricketStatsJob.refreshActiveMatchData())
@@ -70,7 +65,6 @@ class CricketLifecycle(
         fromDate = LocalDateTime.now.minusMonths(PaFeed.dateWindowMonths),
         toDate = LocalDateTime.now.plusMonths(PaFeed.dateWindowMonths),
       )
-      cricketStatsJob.backfillMatches()
     }
 
   }

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -38,20 +38,20 @@ class CricketLifecycle(
     }
 
     // Fetch active matches every 5 minutes to ensure the scorecard is up to date.
-    jobs.scheduleEvery("CricketActiveMatches", if (context.isPreview) 1.hour else 5.minutes) {
-      Future(cricketStatsJob.refreshActiveMatchData())
+    jobs.scheduleEvery("CricketFrequentMatchUpdates", if (context.isPreview) 1.hour else 5.minutes) {
+      Future(cricketStatsJob.frequentMatchDataRefresh())
     }
 
-    // Fetch upcoming matches every hour.
-    jobs.scheduleEvery("CricketUpcomingMatches", 1.hour) {
-      Future(cricketStatsJob.refreshUpcomingMatchData())
+    // Fetch other matches every hour.
+    jobs.scheduleEvery("CricketInfrequentMatchUpdates", 1.hour) {
+      Future(cricketStatsJob.infrequentMatchDataRefresh())
     }
   }
 
   private def descheduleJobs(): Unit = {
     jobs.deschedule("CricketDiscoverMatches")
-    jobs.deschedule("CricketActiveMatches")
-    jobs.deschedule("CricketUpcomingMatches")
+    jobs.deschedule("CricketFrequentMatchUpdates")
+    jobs.deschedule("CricketInfrequentMatchUpdates")
   }
 
   override def start(): Unit = {

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -29,22 +29,20 @@ class CricketLifecycle(
   private def scheduleJobs(): Unit = {
     // Refresh the fixtures/results registry once a day.
     jobs.scheduleEvery("CricketDiscoverMatches", 1.day) {
-      Future(
-        cricketStatsJob.discoverMatches(
-          fromDate = LocalDate.now.minusMonths(PaFeed.dateWindowMonths),
-          toDate = LocalDate.now.plusMonths(PaFeed.dateWindowMonths),
-        ),
+      cricketStatsJob.discoverMatches(
+        fromDate = LocalDate.now.minusMonths(PaFeed.dateWindowMonths),
+        toDate = LocalDate.now.plusMonths(PaFeed.dateWindowMonths),
       )
     }
 
     // Fetch active matches every 5 minutes to ensure the scorecard is up to date.
     jobs.scheduleEvery("CricketFrequentMatchUpdates", if (context.isPreview) 1.hour else 5.minutes) {
-      Future(cricketStatsJob.frequentMatchDataRefresh())
+      cricketStatsJob.frequentMatchDataRefresh()
     }
 
     // Fetch other matches every hour.
     jobs.scheduleEvery("CricketInfrequentMatchUpdates", 1.hour) {
-      Future(cricketStatsJob.infrequentMatchDataRefresh())
+      cricketStatsJob.infrequentMatchDataRefresh()
     }
   }
 

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -50,7 +50,6 @@ class CricketLifecycle(
 
   private def descheduleJobs(): Unit = {
     jobs.deschedule("CricketDiscoverMatches")
-    jobs.deschedule("CricketBackfillMatches")
     jobs.deschedule("CricketActiveMatches")
     jobs.deschedule("CricketUpcomingMatches")
   }
@@ -66,6 +65,5 @@ class CricketLifecycle(
         toDate = LocalDateTime.now.plusMonths(PaFeed.dateWindowMonths),
       )
     }
-
   }
 }

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -5,7 +5,7 @@ import common.{JobScheduler, PekkoAsync}
 import jobs.CricketStatsJob
 import model.ApplicationContext
 
-import java.time.LocalDateTime
+import java.time.LocalDate
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.duration._
@@ -31,8 +31,8 @@ class CricketLifecycle(
     jobs.scheduleEvery("CricketDiscoverMatches", 1.day) {
       Future(
         cricketStatsJob.discoverMatches(
-          fromDate = LocalDateTime.now.minusMonths(PaFeed.dateWindowMonths),
-          toDate = LocalDateTime.now.plusMonths(PaFeed.dateWindowMonths),
+          fromDate = LocalDate.now.minusMonths(PaFeed.dateWindowMonths),
+          toDate = LocalDate.now.plusMonths(PaFeed.dateWindowMonths),
         ),
       )
     }
@@ -61,8 +61,8 @@ class CricketLifecycle(
     // ensure that we populate the cricket stats cache immediately
     pekkoAsync.after1s {
       cricketStatsJob.discoverMatches(
-        fromDate = LocalDateTime.now.minusMonths(PaFeed.dateWindowMonths),
-        toDate = LocalDateTime.now.plusMonths(PaFeed.dateWindowMonths),
+        fromDate = LocalDate.now.minusMonths(PaFeed.dateWindowMonths),
+        toDate = LocalDate.now.plusMonths(PaFeed.dateWindowMonths),
       )
     }
   }

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -9,6 +9,7 @@ import cricketModel._
 import java.time.LocalDateTime
 import java.util.TimeZone
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 object Parser {
 
@@ -53,7 +54,8 @@ object Parser {
 
   object ZonedDate {
     private val dateTimePattern = "yyyy-MM-dd'T'HH:mm:ss"
-    private val dateTimeParser = Chronos.dateFormatter(dateTimePattern, TimeZone.getTimeZone("UTC").toZoneId)
+    private val dateTimeParser =
+      DateTimeFormatter.ofPattern(dateTimePattern).withZone(TimeZone.getTimeZone("UTC").toZoneId)
     def apply(dateTime: String): ZonedDateTime = ZonedDateTime.parse(dateTime, dateTimeParser)
   }
 

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -33,6 +33,10 @@ object Parser {
     )
   }
 
+  def parseDate(dateTime: String): LocalDateTime = {
+    Date(dateTime)
+  }
+
   private case class MatchDetail(
       stage: String,
       venueName: String,

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -8,6 +8,7 @@ import cricketModel._
 
 import java.time.LocalDateTime
 import java.util.TimeZone
+import java.time.ZonedDateTime
 
 object Parser {
 
@@ -33,10 +34,6 @@ object Parser {
     )
   }
 
-  def parseDate(dateTime: String): LocalDateTime = {
-    Date(dateTime)
-  }
-
   private case class MatchDetail(
       stage: String,
       venueName: String,
@@ -52,6 +49,12 @@ object Parser {
     private val dateTimePattern = "yyyy-MM-dd'T'HH:mm:ss"
     private val dateTimeParser = Chronos.dateFormatter(dateTimePattern, TimeZone.getTimeZone("Europe/London").toZoneId)
     def apply(dateTime: String): LocalDateTime = LocalDateTime.parse(dateTime, dateTimeParser)
+  }
+
+  object ZonedDate {
+    private val dateTimePattern = "yyyy-MM-dd'T'HH:mm:ss"
+    private val dateTimeParser = Chronos.dateFormatter(dateTimePattern, TimeZone.getTimeZone("UTC").toZoneId)
+    def apply(dateTime: String): ZonedDateTime = ZonedDateTime.parse(dateTime, dateTimeParser)
   }
 
   private def inningsDescription(inningsOrder: Int, battingTeam: String): String = {

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -6,7 +6,7 @@ import common.GuLogging
 import cricket.feed.CricketThrottler
 import org.apache.pekko.stream.Materializer
 
-import java.time.{LocalDate, ZoneId}
+import java.time.{LocalDate, LocalDateTime, ZoneId}
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,7 +18,12 @@ object PaFeed {
   val dateFormat = Chronos.dateFormatter("yyyy-MM-dd", ZoneId.of("UTC"))
 }
 
-case class CompetitionMatch(matchId: String, competitionId: String, competitionName: String)
+case class CompetitionMatch(
+    matchId: String,
+    competitionId: String,
+    competitionName: String,
+    startDate: LocalDateTime,
+)
 
 class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materializer: Materializer) extends GuLogging {
 
@@ -103,10 +108,13 @@ class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materialize
 
                     // Iterate over the matches within this competition
                     (comp \ "match").map { m =>
+                      val matchId = (m \ "@id").text
+                      val startDate = (m \ "dateTime").text
                       CompetitionMatch(
-                        matchId = (m \ "@id").text,
+                        matchId = matchId,
                         competitionId = compId,
                         competitionName = compName,
+                        startDate = Parser.parseDate(startDate),
                       )
                     }
                   }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -12,6 +12,7 @@ import play.api.libs.ws.WSClient
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.XML
 import scala.util.Try
+import java.time.ZonedDateTime
 
 case class CricketFeedException(message: String) extends RuntimeException(message)
 
@@ -25,8 +26,7 @@ case class CompetitionMatch(
     matchId: String,
     competitionId: String,
     competitionName: String,
-    startDate: LocalDate,
-    endDate: LocalDate,
+    startDateTime: ZonedDateTime,
 )
 
 class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materializer: Materializer) extends GuLogging {
@@ -113,16 +113,13 @@ class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materialize
                     // Iterate over the matches within this competition
                     (comp \ "match").map { m =>
                       val matchId = (m \ "@id").text
-                      val startDate = Parser.parseDate((m \ "dateTime").text)
-                      val totalDays =
-                        Try((m \ "totalDays").text.toInt).getOrElse(5) - 1 // default to 5 days if not provided
-                      val endDate = startDate.plusDays(totalDays)
+                      // The PA API returns the match start time in UTC, so we parse it as a ZonedDateTime in UTC.
+                      val startDateTime = Parser.ZonedDate((m \ "dateTime").text)
                       CompetitionMatch(
                         matchId = matchId,
                         competitionId = compId,
                         competitionName = compName,
-                        startDate = startDate.toLocalDate,
-                        endDate = endDate.toLocalDate,
+                        startDateTime = startDateTime,
                       )
                     }
                   }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -16,6 +16,8 @@ case class CricketFeedException(message: String) extends RuntimeException(messag
 
 object PaFeed {
   val dateFormat = Chronos.dateFormatter("yyyy-MM-dd", ZoneId.of("UTC"))
+
+  val dateWindowMonths = 2
 }
 
 case class CompetitionMatch(

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -6,11 +6,12 @@ import common.GuLogging
 import cricket.feed.CricketThrottler
 import org.apache.pekko.stream.Materializer
 
-import java.time.{LocalDate, LocalDateTime, ZoneId}
+import java.time.{LocalDate, ZoneId}
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.XML
+import scala.util.Try
 
 case class CricketFeedException(message: String) extends RuntimeException(message)
 
@@ -24,8 +25,8 @@ case class CompetitionMatch(
     matchId: String,
     competitionId: String,
     competitionName: String,
-    startDate: LocalDateTime,
-    endDate: LocalDateTime
+    startDate: LocalDate,
+    endDate: LocalDate,
 )
 
 class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materializer: Materializer) extends GuLogging {
@@ -113,14 +114,15 @@ class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materialize
                     (comp \ "match").map { m =>
                       val matchId = (m \ "@id").text
                       val startDate = Parser.parseDate((m \ "dateTime").text)
-                      val totalDays = (m \ "totalDays").text
-                      val endDate = startDate.plusDays(totalDays.toInt)
+                      val totalDays =
+                        Try((m \ "totalDays").text.toInt).getOrElse(5) - 1 // default to 5 days if not provided
+                      val endDate = startDate.plusDays(totalDays)
                       CompetitionMatch(
                         matchId = matchId,
                         competitionId = compId,
                         competitionName = compName,
-                        startDate = startDate,
-                        endDate = endDate,
+                        startDate = startDate.toLocalDate,
+                        endDate = endDate.toLocalDate,
                       )
                     }
                   }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -25,6 +25,7 @@ case class CompetitionMatch(
     competitionId: String,
     competitionName: String,
     startDate: LocalDateTime,
+    endDate: LocalDateTime
 )
 
 class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materializer: Materializer) extends GuLogging {
@@ -111,12 +112,15 @@ class PaFeed(wsClient: WSClient, pekkoActorSystem: PekkoActorSystem, materialize
                     // Iterate over the matches within this competition
                     (comp \ "match").map { m =>
                       val matchId = (m \ "@id").text
-                      val startDate = (m \ "dateTime").text
+                      val startDate = Parser.parseDate((m \ "dateTime").text)
+                      val totalDays = (m \ "totalDays").text
+                      val endDate = startDate.plusDays(totalDays.toInt)
                       CompetitionMatch(
                         matchId = matchId,
                         competitionId = compId,
                         competitionName = compName,
-                        startDate = Parser.parseDate(startDate),
+                        startDate = startDate,
+                        endDate = endDate,
                       )
                     }
                   }

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -48,11 +48,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
         paFeed
           .getCompetitionMatches(team, fromDate)
           .map { competitionMatches: Seq[CompetitionMatch] =>
-            val discovered = competitionMatches.filterNot(_.startDate.isAfter(toDate))
-            log.info(s"Discovered ${discovered.size} matches for ${team.paId} between $fromDate and $toDate")
-            discoveredCricketTeamMatches(team).send(discovered.map(cm => cm.matchId -> cm).toMap)
-
-            fetchNewMatchData() // fetch the full match data for any newly discovered matches
+            discoveredCricketTeamMatches(team).send(competitionMatches.map(cm => cm.matchId -> cm).toMap)
           }
           .recover {
             case paFeedError: CricketFeedException =>
@@ -60,10 +56,12 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
             case error: Exception => log.warn(error.getMessage)
           }
       }
-      .map(_ => ())
+      .map { _ =>
+        fetchNewMatchData()
+      }
   }
 
-  def fetchNewMatchData()(implicit executionContext: ExecutionContext): Unit = {
+  def fetchNewMatchData()(implicit executionContext: ExecutionContext): Future[Unit] = {
     val newMatches = CricketTeams.teams.flatMap { team =>
       discoveredCricketTeamMatches(team)
         .apply()

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -5,7 +5,7 @@ import conf.cricketPa.{CompetitionMatch, CricketFeedException, CricketTeam, Cric
 import cricketModel.Match
 import jobs.CricketStatsJob._
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.{LocalDate}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -37,15 +37,16 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     matchObjects.flatten.headOption
   }
 
-  /** Refresh the fixtures/results registry for every team. This only updates the lightweight list of known matches.
+  /** Refresh the fixtures/results registry for every team and fetch the full match data for any newly discovered
+    * matches.
     */
-  def discoverMatches(fromDate: LocalDateTime, toDate: LocalDateTime)(implicit
+  def discoverMatches(fromDate: LocalDate, toDate: LocalDate)(implicit
       executionContext: ExecutionContext,
   ): Future[Unit] = {
     Future
       .traverse(CricketTeams.teams) { team =>
         paFeed
-          .getCompetitionMatches(team, fromDate.toLocalDate)
+          .getCompetitionMatches(team, fromDate)
           .map { competitionMatches: Seq[CompetitionMatch] =>
             val discovered = competitionMatches.filterNot(_.startDate.isAfter(toDate))
             log.info(s"Discovered ${discovered.size} matches for ${team.paId} between $fromDate and $toDate")
@@ -127,6 +128,8 @@ object CricketStatsJob {
   sealed trait MatchType
   object MatchType {
 
+    case object Future extends MatchType
+
     case object Upcoming extends MatchType
 
     case object Active extends MatchType
@@ -137,14 +140,18 @@ object CricketStatsJob {
   // A match is considered "upcoming" when it starts within this many days.
   private val upcomingDays = 5L
 
-  /** Classify a match by the proximity of its start date to `today`. */
-  def classify(startDate: LocalDateTime, endDate: LocalDateTime): MatchType = {
+  def classify(startDate: LocalDate, endDate: LocalDate): MatchType = {
     val today = LocalDate.now
-    (startDate.toLocalDate(), endDate.toLocalDate()) match {
-      case (start, _) if start.isAfter(today) && start.isBefore(today.plusDays(upcomingDays)) =>
-        MatchType.Upcoming
-      case (start, end) if (start.isEqual(today) || start.isBefore(today)) && end.isAfter(today) => MatchType.Active
-      case _                                                                                     => MatchType.Historical
+
+    if (!startDate.isAfter(today) && !endDate.isBefore(today)) {
+      // startDate <= today <= endDate  (covers single-day and both boundaries)
+      MatchType.Active
+    } else if (startDate.isAfter(today) && startDate.isBefore(today.plusDays(upcomingDays))) {
+      MatchType.Upcoming
+    } else if (endDate.isBefore(today)) {
+      MatchType.Historical
+    } else {
+      MatchType.Future
     }
   }
 }

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -87,7 +87,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
       discoveredCricketTeamMatches(team)
         .apply()
         .values
-        .filter(cm => classify(cm.startDate) == band)
+        .filter(cm => classify(cm.startDate, cm.endDate) == band)
         .map(cm => (team, cm))
     }
 
@@ -137,18 +137,14 @@ object CricketStatsJob {
   // A match is considered "upcoming" when it starts within this many days.
   private val upcomingDays = 5L
 
-  // A match stays "active" until this many days after its start, to cover
-  // multi-day test matches (seen to run at least 6 days) while they settle.
-  private val historicalAfterDays = 6L
-
   /** Classify a match by the proximity of its start date to `today`. */
-  def classify(startDate: LocalDateTime): MatchType = {
-    val today = LocalDateTime.now
-    startDate match {
-      case d if d.isAfter(today.plusDays(upcomingDays))              => MatchType.Upcoming
-      case d if d.isBefore(today.minusDays(historicalAfterDays + 1)) =>
-        MatchType.Historical // + 1 to include the start date itself in the active band
-      case _ => MatchType.Active
+  def classify(startDate: LocalDateTime, endDate: LocalDateTime): MatchType = {
+    val today = LocalDate.now
+    (startDate.toLocalDate(), endDate.toLocalDate()) match {
+      case (start, _) if start.isAfter(today) && start.isBefore(today.plusDays(upcomingDays)) =>
+        MatchType.Upcoming
+      case (start, end) if (start.isEqual(today) || start.isBefore(today)) && end.isAfter(today) => MatchType.Active
+      case _                                                                                     => MatchType.Historical
     }
   }
 }

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -3,18 +3,25 @@ package jobs
 import common.{Box, GuLogging}
 import conf.cricketPa.{CompetitionMatch, CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
+import jobs.CricketStatsJob._
 
-import java.time.{Duration, LocalDate, LocalDateTime}
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext
+import java.time.LocalDateTime
+import scala.tools.nsc.tasty.SafeEq
 
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
-  private val cricketStatsAgents = CricketTeams.teams.map(Team => (Team, Box[Map[String, Match]](Map.empty)))
+  // The full match data cache with scorecard, line-ups, and match details.
+  private val cricketMatchData: Map[CricketTeam, Box[Map[String, Match]]] =
+    CricketTeams.teams.map(team => team -> Box[Map[String, Match]](Map.empty)).toMap
+
+  // Overview of the matches for each team, with only the match ID and start date.
+  private val cricketTeamMatches: Map[CricketTeam, Box[Map[String, CompetitionMatch]]] =
+    CricketTeams.teams.map(team => team -> Box[Map[String, CompetitionMatch]](Map.empty)).toMap
 
   def getMatch(team: CricketTeam, date: String): Option[Match] =
-    cricketStatsAgents
-      .find(_._1 == team)
-      .flatMap { case (_, agent) => agent().get(date) }
+    cricketMatchData.get(team).flatMap(_.apply().get(date))
 
   def findMatch(team: CricketTeam, date: String): Option[Match] = {
     val dateFormat = PaFeed.dateFormat
@@ -29,47 +36,92 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     matchObjects.flatten.headOption
   }
 
-  def run(fromDate: LocalDate, matchesToFetch: Int)(implicit executionContext: ExecutionContext): Unit = {
-
-    cricketStatsAgents.foreach { case (team, agent) =>
-      // Find new ids which are not in the stats agent. Caveat: always include live matches to update.
-      val loadedMatches = agent().values
-        .filter(cricketMatch =>
-          // Omit any recent match within the last 5 days, to account for test matches.
-          Duration.between(cricketMatch.gameDate, LocalDateTime.now).toDays() > 5,
-        )
-        .map(m => m.matchId)
-        .toSeq
-
+  /** Discovery: refresh the registry from the fixtures/results lists, then load
+    * (once) any newly discovered match that is not yet in the cache. This is the
+    * only place historical matches are fetched.
+    */
+  def discoverMatches(fromDate: LocalDateTime)(implicit executionContext: ExecutionContext): Unit = {
+    CricketTeams.teams.foreach { team =>
       paFeed
-        .getCompetitionMatches(team, fromDate)
+        .getCompetitionMatches(team, fromDate.toLocalDate)
         .map { competitionMatches: Seq[CompetitionMatch] =>
-          // Filter the incoming matches against the agent loaded IDs
-          // And never fetch more than 10 matches
-          val filteredCompetitionMatches = competitionMatches
-            .filterNot(theMatch => loadedMatches.contains(theMatch.matchId))
-            .take(Math.min(matchesToFetch, 10))
+          cricketTeamMatches(team).send(competitionMatches.map(cm => cm.matchId -> cm).toMap)
 
-          filteredCompetitionMatches.map { competitionMatch =>
-            paFeed
-              .getMatch(competitionMatch)
-              .map { matchData =>
-                val date = PaFeed.dateFormat.format(matchData.gameDate)
-                log.debug(s"Updating cricket match: ${matchData.homeTeam.name} v ${matchData.awayTeam.name}, $date")
-                agent.send(_ + (date -> matchData))
-              }
-              .recover {
-                case paFeedError: CricketFeedException =>
-                  log.warn(s"CricketStatsJob encountered errors: ${paFeedError.message}")
-                case error: Exception => log.warn(error.getMessage)
-              }
-          }
+          val cachedIds = cricketMatchData(team).apply().values.map(_.matchId).toSet
+          competitionMatches
+            .filterNot(cm => cachedIds.contains(cm.matchId))
+            .foreach(cm => updateMatchData(team, cm))
         }
         .recover {
           case paFeedError: CricketFeedException =>
-            log.warn(s"CricketStatsJob couldn't find matches: ${paFeedError.message}")
+            log.warn(s"CricketStatsJob discovery couldn't find matches: ${paFeedError.message}")
           case error: Exception => log.warn(error.getMessage)
         }
+    }
+  }
+
+  def refreshActiveMatchData()(implicit executionContext: ExecutionContext): Unit = {
+    refreshMatchData(MatchType.Active)
+  }
+
+  def refreshUpcomingMatchData()(implicit executionContext: ExecutionContext): Unit = {
+    refreshMatchData(MatchType.Upcoming)
+  }
+
+  private def refreshMatchData(band: MatchType)(implicit executionContext: ExecutionContext): Unit = {
+    CricketTeams.teams.foreach { team =>
+      cricketTeamMatches(team)
+        .apply()
+        .values
+        .filter(cm => classify(cm.startDate) == band)
+        .foreach(cm => updateMatchData(team, cm))
+    }
+  }
+
+  private def updateMatchData(team: CricketTeam, competitionMatch: CompetitionMatch)(implicit
+      executionContext: ExecutionContext,
+  ): Unit = {
+    paFeed
+      .getMatch(competitionMatch)
+      .map { matchData =>
+        val date = PaFeed.dateFormat.format(matchData.gameDate)
+        log.debug(s"Updating cricket match: ${matchData.homeTeam.name} v ${matchData.awayTeam.name}, $date")
+        cricketMatchData(team).send(_ + (date -> matchData))
+      }
+      .recover {
+        case paFeedError: CricketFeedException =>
+          log.warn(s"CricketStatsJob encountered errors: ${paFeedError.message}")
+        case error: Exception => log.warn(error.getMessage)
+      }
+  }
+}
+
+object CricketStatsJob {
+
+  sealed trait MatchType
+  object MatchType {
+
+    case object Upcoming extends MatchType
+
+    case object Active extends MatchType
+
+    case object Historical extends MatchType
+  }
+
+  // A match is considered "upcoming" when it starts within this many days.
+  private val upcomingDays = 5L
+
+  // A match stays "active" until this many days after its start, to cover
+  // multi-day test matches (seen to run at least 6 days) while they settle.
+  private val historicalAfterDays = 6L
+
+  /** Classify a match by the proximity of its start date to `today`. */
+  def classify(startDate: LocalDateTime): MatchType = {
+    val today = LocalDateTime.now
+    startDate match {
+      case d if d.isAfter(today.plusDays(upcomingDays)) => MatchType.Upcoming
+      case d if d.isBefore(today.minusDays(historicalAfterDays + 1)) => MatchType.Historical // + 1 to include the start date itself in the active band
+      case _ => MatchType.Active
     }
   }
 }

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -11,6 +11,8 @@ import scala.concurrent.Future
 
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
+  private val batchRequestSize = 10
+
   // The full match data cache with scorecard, line-ups, and match details.
   private val cricketMatchData: Map[CricketTeam, Box[Map[String, Match]]] =
     CricketTeams.teams.map(team => team -> Box[Map[String, Match]](Map.empty)).toMap
@@ -95,7 +97,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
   private def batchUpdateMatchData(matches: Seq[(CricketTeam, CompetitionMatch)])(implicit
       executionContext: ExecutionContext,
   ): Future[Unit] = {
-    matches.grouped(matchesPerCycle).foldLeft(Future.successful(())) { (previousBatch, batch) =>
+    matches.grouped(batchRequestSize).foldLeft(Future.successful(())) { (previousBatch, batch) =>
       previousBatch.flatMap { _ =>
         Future.traverse(batch) { case (team, cm) => updateMatchData(team, cm) }.map(_ => ())
       }
@@ -131,9 +133,6 @@ object CricketStatsJob {
 
     case object Historical extends MatchType
   }
-
-  // The most matches to start loading in a single backfill cycle.
-  val matchesPerCycle = 10
 
   // A match is considered "upcoming" when it starts within this many days.
   private val upcomingDays = 5L

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -49,10 +49,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
             log.info(s"Discovered ${discovered.size} matches for ${team.paId} between $fromDate and $toDate")
             discoveredCricketTeamMatches(team).send(discovered.map(cm => cm.matchId -> cm).toMap)
 
-            val cachedIds = cricketMatchData(team).apply().values.map(_.matchId).toSet
-            competitionMatches
-              .filterNot(cm => cachedIds.contains(cm.matchId))
-              .foreach(cm => updateMatchData(team, cm))
+            fetchNewMatchData() // fetch the full match data for any newly discovered matches
           }
           .recover {
             case paFeedError: CricketFeedException =>
@@ -63,25 +60,16 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
       .map(_ => ())
   }
 
-  /** Discovered matches (across all teams) whose full data has never been fetched. */
-  private def unfetchedMatches: Seq[(CricketTeam, CompetitionMatch)] =
-    CricketTeams.teams.flatMap { team =>
-      val cachedIds = cricketMatchData(team).apply().values.map(_.matchId).toSet
+  def fetchNewMatchData()(implicit executionContext: ExecutionContext): Unit = {
+    val newMatches = CricketTeams.teams.flatMap { team =>
       discoveredCricketTeamMatches(team)
         .apply()
         .values
-        .filterNot(cm => cachedIds.contains(cm.matchId))
+        .filterNot(cm => cricketMatchData(team).apply().values.exists(_.matchId == cm.matchId))
         .map(cm => (team, cm))
     }
 
-  /** Backfill the full match data for discovered matches that have never been fetched. This is done in batches to avoid
-    * overloading the cricket API.
-    */
-  def backfillMatches()(implicit executionContext: ExecutionContext): Unit = {
-    val unfetched = unfetchedMatches
-    log.info(s"Backfilling ${unfetched.size} unfetched matches")
-    batchUpdateMatchData(unfetched)
-
+    batchUpdateMatchData(newMatches)
   }
 
   def refreshActiveMatchData()(implicit executionContext: ExecutionContext): Unit = {

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -5,10 +5,8 @@ import conf.cricketPa.{CompetitionMatch, CricketFeedException, CricketTeam, Cric
 import cricketModel.Match
 import jobs.CricketStatsJob._
 
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime}
 import scala.concurrent.ExecutionContext
-import java.time.LocalDateTime
-import scala.tools.nsc.tasty.SafeEq
 
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
@@ -17,7 +15,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     CricketTeams.teams.map(team => team -> Box[Map[String, Match]](Map.empty)).toMap
 
   // Overview of the matches for each team, with only the match ID and start date.
-  private val cricketTeamMatches: Map[CricketTeam, Box[Map[String, CompetitionMatch]]] =
+  private val discoveredCricketTeamMatches: Map[CricketTeam, Box[Map[String, CompetitionMatch]]] =
     CricketTeams.teams.map(team => team -> Box[Map[String, CompetitionMatch]](Map.empty)).toMap
 
   def getMatch(team: CricketTeam, date: String): Option[Match] =
@@ -36,20 +34,17 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     matchObjects.flatten.headOption
   }
 
-  /** Discovery: refresh the registry from the fixtures/results lists, then load (once) any newly discovered match that
-    * is not yet in the cache. This is the only place historical matches are fetched.
+  /** Refresh the fixtures/results registry for every team. This only updates the lightweight list of known matches.
     */
-  def discoverMatches(fromDate: LocalDateTime)(implicit executionContext: ExecutionContext): Unit = {
+  def discoverMatches(fromDate: LocalDateTime, toDate: LocalDateTime)(implicit
+      executionContext: ExecutionContext,
+  ): Unit = {
     CricketTeams.teams.foreach { team =>
       paFeed
         .getCompetitionMatches(team, fromDate.toLocalDate)
         .map { competitionMatches: Seq[CompetitionMatch] =>
-          cricketTeamMatches(team).send(competitionMatches.map(cm => cm.matchId -> cm).toMap)
-
-          val cachedIds = cricketMatchData(team).apply().values.map(_.matchId).toSet
-          competitionMatches
-            .filterNot(cm => cachedIds.contains(cm.matchId))
-            .foreach(cm => updateMatchData(team, cm))
+          val discovered = competitionMatches.filterNot(_.startDate.isAfter(toDate))
+          discoveredCricketTeamMatches(team).send(discovered.map(cm => cm.matchId -> cm).toMap)
         }
         .recover {
           case paFeedError: CricketFeedException =>
@@ -59,17 +54,43 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     }
   }
 
+  /** Discovered matches (across all teams) whose full data has never been fetched. */
+  private def unfetchedMatches: Seq[(CricketTeam, CompetitionMatch)] =
+    CricketTeams.teams.flatMap { team =>
+      val cachedIds = cricketMatchData(team).apply().values.map(_.matchId).toSet
+      discoveredCricketTeamMatches(team)
+        .apply()
+        .values
+        .filterNot(cm => cachedIds.contains(cm.matchId))
+        .map(cm => (team, cm))
+    }
+
+  /** Backfill the full match data for discovered matches that have never been fetched. This is done in batches to avoid
+    * overloading the cricket API.
+    */
+  def backfillMatches()(implicit executionContext: ExecutionContext): Unit = {
+    val unfetched = unfetchedMatches
+    if (unfetched.nonEmpty) {
+      unfetched.take(matchesPerCycle).foreach { case (team, cm) => updateMatchData(team, cm) }
+    }
+  }
+
   def refreshActiveMatchData()(implicit executionContext: ExecutionContext): Unit = {
-    refreshMatchData(MatchType.Active)
+    val unfetched = unfetchedMatches
+    if (unfetched.isEmpty) {
+      refreshMatchData(MatchType.Active)
+    }
   }
 
   def refreshUpcomingMatchData()(implicit executionContext: ExecutionContext): Unit = {
-    refreshMatchData(MatchType.Upcoming)
+    if (unfetchedMatches.isEmpty) {
+      refreshMatchData(MatchType.Upcoming)
+    }
   }
 
   private def refreshMatchData(band: MatchType)(implicit executionContext: ExecutionContext): Unit = {
     CricketTeams.teams.foreach { team =>
-      cricketTeamMatches(team)
+      discoveredCricketTeamMatches(team)
         .apply()
         .values
         .filter(cm => classify(cm.startDate) == band)
@@ -106,6 +127,9 @@ object CricketStatsJob {
 
     case object Historical extends MatchType
   }
+
+  // The most matches to start loading in a single backfill cycle.
+  val matchesPerCycle = 10
 
   // A match is considered "upcoming" when it starts within this many days.
   private val upcomingDays = 5L

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -75,12 +75,14 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     batchUpdateMatchData(newMatches)
   }
 
-  def refreshActiveMatchData()(implicit executionContext: ExecutionContext): Unit = {
+  def frequentMatchDataRefresh()(implicit executionContext: ExecutionContext): Unit = {
     refreshMatchData(MatchType.Active)
   }
 
-  def refreshUpcomingMatchData()(implicit executionContext: ExecutionContext): Unit = {
+  def infrequentMatchDataRefresh()(implicit executionContext: ExecutionContext): Unit = {
     refreshMatchData(MatchType.Upcoming)
+    refreshMatchData(MatchType.Future)
+    refreshMatchData(MatchType.Historical)
   }
 
   private def refreshMatchData(band: MatchType)(implicit executionContext: ExecutionContext): Unit = {

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -73,20 +73,16 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     batchUpdateMatchData(newMatches)
   }
 
-  def frequentMatchDataRefresh()(implicit executionContext: ExecutionContext): Future[Unit] = {
+  def activeMatchDataRefresh()(implicit executionContext: ExecutionContext): Future[Unit] = {
     refreshMatchData(MatchType.Active)
   }
 
+  def upcomingMatchDataRefresh()(implicit executionContext: ExecutionContext): Future[Unit] = {
+    refreshMatchData(MatchType.Upcoming)
+  }
+
   def infrequentMatchDataRefresh()(implicit executionContext: ExecutionContext): Future[Unit] = {
-    Future
-      .sequence(
-        Seq(
-          refreshMatchData(MatchType.Upcoming),
-          refreshMatchData(MatchType.Future),
-          refreshMatchData(MatchType.Historical),
-        ),
-      )
-      .map(_ => ())
+    Future.sequence(Seq(refreshMatchData(MatchType.Future), refreshMatchData(MatchType.Historical))).map(_ => ())
   }
 
   private def refreshMatchData(band: MatchType)(implicit executionContext: ExecutionContext): Future[Unit] = {

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -7,6 +7,7 @@ import jobs.CricketStatsJob._
 
 import java.time.{LocalDate, LocalDateTime}
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
@@ -38,20 +39,28 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     */
   def discoverMatches(fromDate: LocalDateTime, toDate: LocalDateTime)(implicit
       executionContext: ExecutionContext,
-  ): Unit = {
-    CricketTeams.teams.foreach { team =>
-      paFeed
-        .getCompetitionMatches(team, fromDate.toLocalDate)
-        .map { competitionMatches: Seq[CompetitionMatch] =>
-          val discovered = competitionMatches.filterNot(_.startDate.isAfter(toDate))
-          discoveredCricketTeamMatches(team).send(discovered.map(cm => cm.matchId -> cm).toMap)
-        }
-        .recover {
-          case paFeedError: CricketFeedException =>
-            log.warn(s"CricketStatsJob discovery couldn't find matches: ${paFeedError.message}")
-          case error: Exception => log.warn(error.getMessage)
-        }
-    }
+  ): Future[Unit] = {
+    Future
+      .traverse(CricketTeams.teams) { team =>
+        paFeed
+          .getCompetitionMatches(team, fromDate.toLocalDate)
+          .map { competitionMatches: Seq[CompetitionMatch] =>
+            val discovered = competitionMatches.filterNot(_.startDate.isAfter(toDate))
+            log.info(s"Discovered ${discovered.size} matches for ${team.paId} between $fromDate and $toDate")
+            discoveredCricketTeamMatches(team).send(discovered.map(cm => cm.matchId -> cm).toMap)
+
+            val cachedIds = cricketMatchData(team).apply().values.map(_.matchId).toSet
+            competitionMatches
+              .filterNot(cm => cachedIds.contains(cm.matchId))
+              .foreach(cm => updateMatchData(team, cm))
+          }
+          .recover {
+            case paFeedError: CricketFeedException =>
+              log.warn(s"CricketStatsJob discovery couldn't find matches: ${paFeedError.message}")
+            case error: Exception => log.warn(error.getMessage)
+          }
+      }
+      .map(_ => ())
   }
 
   /** Discovered matches (across all teams) whose full data has never been fetched. */
@@ -70,37 +79,44 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     */
   def backfillMatches()(implicit executionContext: ExecutionContext): Unit = {
     val unfetched = unfetchedMatches
-    if (unfetched.nonEmpty) {
-      unfetched.take(matchesPerCycle).foreach { case (team, cm) => updateMatchData(team, cm) }
-    }
+    log.info(s"Backfilling ${unfetched.size} unfetched matches")
+    batchUpdateMatchData(unfetched)
+
   }
 
   def refreshActiveMatchData()(implicit executionContext: ExecutionContext): Unit = {
-    val unfetched = unfetchedMatches
-    if (unfetched.isEmpty) {
-      refreshMatchData(MatchType.Active)
-    }
+    refreshMatchData(MatchType.Active)
   }
 
   def refreshUpcomingMatchData()(implicit executionContext: ExecutionContext): Unit = {
-    if (unfetchedMatches.isEmpty) {
-      refreshMatchData(MatchType.Upcoming)
-    }
+    refreshMatchData(MatchType.Upcoming)
   }
 
   private def refreshMatchData(band: MatchType)(implicit executionContext: ExecutionContext): Unit = {
-    CricketTeams.teams.foreach { team =>
+    val matches = CricketTeams.teams.flatMap { team =>
       discoveredCricketTeamMatches(team)
         .apply()
         .values
         .filter(cm => classify(cm.startDate) == band)
-        .foreach(cm => updateMatchData(team, cm))
+        .map(cm => (team, cm))
+    }
+
+    batchUpdateMatchData(matches)
+  }
+
+  private def batchUpdateMatchData(matches: Seq[(CricketTeam, CompetitionMatch)])(implicit
+      executionContext: ExecutionContext,
+  ): Future[Unit] = {
+    matches.grouped(matchesPerCycle).foldLeft(Future.successful(())) { (previousBatch, batch) =>
+      previousBatch.flatMap { _ =>
+        Future.traverse(batch) { case (team, cm) => updateMatchData(team, cm) }.map(_ => ())
+      }
     }
   }
 
   private def updateMatchData(team: CricketTeam, competitionMatch: CompetitionMatch)(implicit
       executionContext: ExecutionContext,
-  ): Unit = {
+  ): Future[Unit] = {
     paFeed
       .getMatch(competitionMatch)
       .map { matchData =>

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -36,9 +36,8 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     matchObjects.flatten.headOption
   }
 
-  /** Discovery: refresh the registry from the fixtures/results lists, then load
-    * (once) any newly discovered match that is not yet in the cache. This is the
-    * only place historical matches are fetched.
+  /** Discovery: refresh the registry from the fixtures/results lists, then load (once) any newly discovered match that
+    * is not yet in the cache. This is the only place historical matches are fetched.
     */
   def discoverMatches(fromDate: LocalDateTime)(implicit executionContext: ExecutionContext): Unit = {
     CricketTeams.teams.foreach { team =>
@@ -119,8 +118,9 @@ object CricketStatsJob {
   def classify(startDate: LocalDateTime): MatchType = {
     val today = LocalDateTime.now
     startDate match {
-      case d if d.isAfter(today.plusDays(upcomingDays)) => MatchType.Upcoming
-      case d if d.isBefore(today.minusDays(historicalAfterDays + 1)) => MatchType.Historical // + 1 to include the start date itself in the active band
+      case d if d.isAfter(today.plusDays(upcomingDays))              => MatchType.Upcoming
+      case d if d.isBefore(today.minusDays(historicalAfterDays + 1)) =>
+        MatchType.Historical // + 1 to include the start date itself in the active band
       case _ => MatchType.Active
     }
   }

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -5,7 +5,7 @@ import conf.cricketPa.{CompetitionMatch, CricketFeedException, CricketTeam, Cric
 import cricketModel.Match
 import jobs.CricketStatsJob._
 
-import java.time.{LocalDate}
+import java.time.{LocalDate, ZonedDateTime}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -90,7 +90,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
       discoveredCricketTeamMatches(team)
         .apply()
         .values
-        .filter(cm => classify(cm.startDate, cm.endDate) == band)
+        .filter(cm => classify(cm.startDateTime) == band)
         .map(cm => (team, cm))
     }
 
@@ -142,15 +142,23 @@ object CricketStatsJob {
   // A match is considered "upcoming" when it starts within this many days.
   private val upcomingDays = 5L
 
-  def classify(startDate: LocalDate, endDate: LocalDate): MatchType = {
-    val today = LocalDate.now
+  private val activeBufferMinutes = 30
 
-    if (!startDate.isAfter(today) && !endDate.isBefore(today)) {
-      // startDate <= today <= endDate  (covers single-day and both boundaries)
+  def classify(startDateTime: ZonedDateTime): MatchType = {
+    val endDateTime = startDateTime.plusDays(5) // cricket matches are typically max 5 days long but can be 6
+    val today = ZonedDateTime.now
+
+    if (
+      !startDateTime
+        .minusMinutes(activeBufferMinutes)
+        .isAfter(today) && !endDateTime.isBefore(today)
+    ) {
+      // a match is considered "active" from 30 minutes before it starts until it has finished, refreshed every 5 minutes
       MatchType.Active
-    } else if (startDate.isAfter(today) && startDate.isBefore(today.plusDays(upcomingDays))) {
+    } else if (startDateTime.isAfter(today) && startDateTime.isBefore(today.plusDays(upcomingDays))) {
+      // a match is considered "upcoming" if it starts within the next 5 days, refreshed every hour
       MatchType.Upcoming
-    } else if (endDate.isBefore(today)) {
+    } else if (endDateTime.isBefore(today)) {
       MatchType.Historical
     } else {
       MatchType.Future

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -73,17 +73,23 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
     batchUpdateMatchData(newMatches)
   }
 
-  def frequentMatchDataRefresh()(implicit executionContext: ExecutionContext): Unit = {
+  def frequentMatchDataRefresh()(implicit executionContext: ExecutionContext): Future[Unit] = {
     refreshMatchData(MatchType.Active)
   }
 
-  def infrequentMatchDataRefresh()(implicit executionContext: ExecutionContext): Unit = {
-    refreshMatchData(MatchType.Upcoming)
-    refreshMatchData(MatchType.Future)
-    refreshMatchData(MatchType.Historical)
+  def infrequentMatchDataRefresh()(implicit executionContext: ExecutionContext): Future[Unit] = {
+    Future
+      .sequence(
+        Seq(
+          refreshMatchData(MatchType.Upcoming),
+          refreshMatchData(MatchType.Future),
+          refreshMatchData(MatchType.Historical),
+        ),
+      )
+      .map(_ => ())
   }
 
-  private def refreshMatchData(band: MatchType)(implicit executionContext: ExecutionContext): Unit = {
+  private def refreshMatchData(band: MatchType)(implicit executionContext: ExecutionContext): Future[Unit] = {
     val matches = CricketTeams.teams.flatMap { team =>
       discoveredCricketTeamMatches(team)
         .apply()

--- a/sport/test/CricketStatsJobTest.scala
+++ b/sport/test/CricketStatsJobTest.scala
@@ -5,7 +5,7 @@ import cricketModel.{Match, Team}
 import jobs.CricketStatsJob
 import jobs.CricketStatsJob.MatchType
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
-import org.mockito.Mockito.{clearInvocations, never, verify, when}
+import org.mockito.Mockito.{clearInvocations, never, times, verify, when}
 import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -38,38 +38,71 @@ import scala.concurrent.{ExecutionContext, Future}
     CricketStatsJob.classify(today.minusDays(7)) shouldBe MatchType.Historical
   }
 
-  "discover" should "load a newly discovered match exactly once" in {
-    val paFeed = stubbedFeed(england, Seq(upcoming))
-    val job = new CricketStatsJob(paFeed)
-
-    job.discoverMatches(fromDate = today.minusMonths(2))
-
-    verify(paFeed).getMatch(eqTo(upcoming))(any())
-  }
-
-  it should "not re-fetch a match that is already cached" in {
+  "backfillMatches" should "load an unfetched match" in {
     val paFeed = stubbedFeed(england, Seq(historical))
     val job = new CricketStatsJob(paFeed)
 
-    job.discoverMatches(fromDate = today.minusMonths(2)) // loads it once
-    clearInvocations(paFeed)
-    job.discoverMatches(fromDate = today.minusMonths(2)) // already cached, so should be skipped
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
+    job.backfillMatches()
 
+    verify(paFeed).getMatch(eqTo(historical))(any())
+  }
+
+  it should "load active matches during the initial backfill" in {
+    val paFeed = stubbedFeed(england, Seq(active))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
+    job.backfillMatches()
+
+    verify(paFeed).getMatch(eqTo(active))(any())
+  }
+
+  it should "backfill no more than the per-cycle batch size, deferring the rest to later cycles" in {
+    val paFeed = stubbedFeed(england, manyHistorical)
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
+
+    job.backfillMatches()
+    verify(paFeed, times(CricketStatsJob.matchesPerCycle)).getMatch(any[CompetitionMatch])(any())
+
+    clearInvocations(paFeed)
+    job.backfillMatches()
+    verify(paFeed, times(manyHistorical.size - CricketStatsJob.matchesPerCycle))
+      .getMatch(any[CompetitionMatch])(any())
+  }
+
+  it should "not refresh active or upcoming matches until backfill is complete" in {
+    val paFeed = stubbedFeed(england, Seq(active, historical))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
+    job.backfillMatches() // backfills both active and historical
+    clearInvocations(paFeed)
+    job.refreshActiveMatchData()
+    job.refreshUpcomingMatchData()
+
+    verify(paFeed).getMatch(eqTo(active))(any())
     verify(paFeed, never).getMatch(eqTo(historical))(any())
   }
 
-  "refreshBand" should "only fetch matches in the requested band" in {
-    val paFeed = stubbedFeed(england, Seq(upcoming, active, historical))
+  it should "refresh upcoming and active matches once backfill is complete" in {
+    val paFeed = stubbedFeed(england, Seq(active, upcoming))
     val job = new CricketStatsJob(paFeed)
 
-    job.discoverMatches(fromDate = today.minusMonths(2)) // populate the registry
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
+    job.backfillMatches() // backfills both active and historical
     clearInvocations(paFeed)
-
     job.refreshUpcomingMatchData()
 
     verify(paFeed).getMatch(eqTo(upcoming))(any())
-    verify(paFeed, never).getMatch(eqTo(active))(any())
-    verify(paFeed, never).getMatch(eqTo(historical))(any())
+    verify(paFeed, times(1)).getMatch(any[CompetitionMatch])(any())
+
+    clearInvocations(paFeed)
+    job.refreshActiveMatchData()
+    verify(paFeed).getMatch(eqTo(active))(any())
+    verify(paFeed, times(1)).getMatch(any[CompetitionMatch])(any())
   }
 }
 
@@ -80,6 +113,11 @@ object CricketStatsJobTest extends MockitoSugar {
   private val upcoming = CompetitionMatch("upcoming", "c", "Comp", today.plusDays(10))
   private val active = CompetitionMatch("active", "c", "Comp", today.plusDays(1))
   private val historical = CompetitionMatch("historical", "c", "Comp", today.minusDays(30))
+
+  // More than one batch's worth of historical matches, each on a distinct date so they occupy
+  // distinct cache slots.
+  private val manyHistorical: Seq[CompetitionMatch] =
+    (1 to 15).map(i => CompetitionMatch(s"h$i", "c", "Comp", today.minusDays(30L + i)))
 
   // Run all Future callbacks inline so assertions can follow synchronously.
   private implicit val sameThread: ExecutionContext = new ExecutionContext {

--- a/sport/test/CricketStatsJobTest.scala
+++ b/sport/test/CricketStatsJobTest.scala
@@ -41,8 +41,38 @@ import scala.concurrent.{ExecutionContext, Future}
     verify(paFeed, never).getMatch(eqTo(historical))(any())
   }
 
-  "infrequentMatchDataRefresh" should "never fetches active matches" in {
+  "upcomingMatchDataRefresh" should "only fetches upcoming matches" in {
     val paFeed = stubbedFeed(england, Seq(upcoming, active, future, historical))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // populate the registry
+    clearInvocations(paFeed)
+
+    job.upcomingMatchDataRefresh()
+
+    verify(paFeed).getMatch(eqTo(upcoming))(any())
+    verify(paFeed, never).getMatch(eqTo(active))(any())
+    verify(paFeed, never).getMatch(eqTo(historical))(any())
+    verify(paFeed, never).getMatch(eqTo(future))(any())
+  }
+
+  "activeMatchDataRefresh" should "only fetches active matches" in {
+    val paFeed = stubbedFeed(england, Seq(upcoming, active, historical, future))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // populate the registry
+    clearInvocations(paFeed)
+
+    job.activeMatchDataRefresh()
+
+    verify(paFeed, never).getMatch(eqTo(upcoming))(any())
+    verify(paFeed).getMatch(eqTo(active))(any())
+    verify(paFeed, never).getMatch(eqTo(historical))(any())
+    verify(paFeed, never).getMatch(eqTo(future))(any())
+  }
+
+  "infrequentMatchDataRefresh" should "only fetches historical and future matches" in {
+    val paFeed = stubbedFeed(england, Seq(upcoming, active, historical, future))
     val job = new CricketStatsJob(paFeed)
 
     job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // populate the registry
@@ -50,21 +80,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
     job.infrequentMatchDataRefresh()
 
-    verify(paFeed, never).getMatch(eqTo(active))(any())
-  }
-
-  "frequentMatchDataRefresh" should "only fetches active matches" in {
-    val paFeed = stubbedFeed(england, Seq(upcoming, active, historical))
-    val job = new CricketStatsJob(paFeed)
-
-    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // populate the registry
-    clearInvocations(paFeed)
-
-    job.frequentMatchDataRefresh()
-
     verify(paFeed, never).getMatch(eqTo(upcoming))(any())
-    verify(paFeed).getMatch(eqTo(active))(any())
-    verify(paFeed, never).getMatch(eqTo(historical))(any())
+    verify(paFeed, never).getMatch(eqTo(active))(any())
+    verify(paFeed).getMatch(eqTo(historical))(any())
+    verify(paFeed).getMatch(eqTo(future))(any())
   }
 
   "classify" should "mark a single-day match happening today as Active" in {
@@ -117,7 +136,7 @@ object CricketStatsJobTest extends MockitoSugar {
   private val today = LocalDate.now
   private val england: CricketTeam = CricketTeams.teams.head
 
-  private val future = CompetitionMatch("upcoming", "c", "Comp", today.plusDays(10), today.plusDays(12))
+  private val future = CompetitionMatch("future", "c", "Comp", today.plusDays(10), today.plusDays(12))
   private val upcoming = CompetitionMatch("upcoming", "c", "Comp", today.plusDays(2), today.plusDays(4))
   private val active = CompetitionMatch("active", "c", "Comp", today, today.plusDays(3))
   private val historical = CompetitionMatch("historical", "c", "Comp", today.minusDays(30), today.minusDays(28))

--- a/sport/test/CricketStatsJobTest.scala
+++ b/sport/test/CricketStatsJobTest.scala
@@ -53,7 +53,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
     job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // loads it once
     clearInvocations(paFeed)
-    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // already cached, so should be skipped
+    job.discoverMatches(
+      fromDate = today.minusMonths(2),
+      toDate = today.plusMonths(2),
+    ) // already cached, so should be skipped
 
     verify(paFeed, never).getMatch(eqTo(historical))(any())
   }

--- a/sport/test/CricketStatsJobTest.scala
+++ b/sport/test/CricketStatsJobTest.scala
@@ -18,26 +18,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
   import CricketStatsJobTest._
 
-  "classify" should "treat a match starting in more than 5 days as Upcoming" in {
-    CricketStatsJob.classify(today.plusDays(6)) shouldBe MatchType.Upcoming
-  }
-
-  it should "treat a match starting exactly 5 days ahead as Active" in {
-    CricketStatsJob.classify(today.plusDays(5)) shouldBe MatchType.Active
-  }
-
-  it should "treat today's match as Active" in {
-    CricketStatsJob.classify(today) shouldBe MatchType.Active
-  }
-
-  it should "treat a match 6 days after it start as still Active (boundary)" in {
-    CricketStatsJob.classify(today.minusDays(6)) shouldBe MatchType.Active
-  }
-
-  it should "treat a match started more than 6 days ago as Historical" in {
-    CricketStatsJob.classify(today.minusDays(7)) shouldBe MatchType.Historical
-  }
-
   "discoverMatches" should "load a newly discovered match exactly once" in {
     val paFeed = stubbedFeed(england, Seq(upcoming))
     val job = new CricketStatsJob(paFeed)
@@ -89,20 +69,65 @@ import scala.concurrent.{ExecutionContext, Future}
     verify(paFeed, never).getMatch(eqTo(historical))(any())
   }
 
+  "classify" should "mark a single-day match happening today as Active" in {
+    CricketStatsJob.classify(today, today) shouldBe MatchType.Active
+  }
+
+  it should "mark a match spanning today (start before, end after) as Active" in {
+    CricketStatsJob.classify(today.minusDays(2), today.plusDays(2)) shouldBe MatchType.Active
+  }
+
+  it should "mark a match that started earlier and ends today as Active" in {
+    // Boundary: today is the final day (e.g. day 5 of a test match).
+    CricketStatsJob.classify(today.minusDays(4), today) shouldBe MatchType.Active
+  }
+
+  it should "mark a match that starts today and ends later as Active" in {
+    // Boundary: today is the first day of a multi-day match.
+    CricketStatsJob.classify(today, today.plusDays(4)) shouldBe MatchType.Active
+  }
+
+  it should "mark a match starting tomorrow as Upcoming" in {
+    CricketStatsJob.classify(today.plusDays(1), today.plusDays(3)) shouldBe MatchType.Upcoming
+  }
+
+  it should "mark a match starting within the upcoming window as Upcoming" in {
+    // upcomingDays is 5, so a start 4 days out is still upcoming.
+    CricketStatsJob.classify(today.plusDays(4), today.plusDays(6)) shouldBe MatchType.Upcoming
+  }
+
+  it should "mark a match starting exactly on the upcoming boundary as Future" in {
+    // The window is exclusive: start == today + upcomingDays (5) is not upcoming.
+    CricketStatsJob.classify(today.plusDays(5), today.plusDays(7)) shouldBe MatchType.Future
+  }
+
+  it should "mark a match starting well beyond the upcoming window as Future" in {
+    CricketStatsJob.classify(today.plusDays(30), today.plusDays(32)) shouldBe MatchType.Future
+  }
+
+  it should "mark a match that ended yesterday as Historical" in {
+    CricketStatsJob.classify(today.minusDays(3), today.minusDays(1)) shouldBe MatchType.Historical
+  }
+
+  it should "mark a match that finished well in the past as Historical" in {
+    CricketStatsJob.classify(today.minusDays(30), today.minusDays(28)) shouldBe MatchType.Historical
+  }
+
 }
 
 object CricketStatsJobTest extends MockitoSugar {
-  private val today = LocalDateTime.now
+  private val today = LocalDate.now
   private val england: CricketTeam = CricketTeams.teams.head
 
-  private val upcoming = CompetitionMatch("upcoming", "c", "Comp", today.plusDays(10))
-  private val active = CompetitionMatch("active", "c", "Comp", today.plusDays(1))
-  private val historical = CompetitionMatch("historical", "c", "Comp", today.minusDays(30))
+  private val future = CompetitionMatch("upcoming", "c", "Comp", today.plusDays(10), today.plusDays(12))
+  private val upcoming = CompetitionMatch("upcoming", "c", "Comp", today.plusDays(2), today.plusDays(4))
+  private val active = CompetitionMatch("active", "c", "Comp", today, today.plusDays(3))
+  private val historical = CompetitionMatch("historical", "c", "Comp", today.minusDays(30), today.minusDays(28))
 
   // More than one batch's worth of historical matches, each on a distinct date so they occupy
   // distinct cache slots.
   private val manyHistorical: Seq[CompetitionMatch] =
-    (1 to 15).map(i => CompetitionMatch(s"h$i", "c", "Comp", today.minusDays(30L + i)))
+    (1 to 15).map(i => CompetitionMatch(s"h$i", "c", "Comp", today.minusDays(30L + i), today.minusDays(28L + i)))
 
   // Run all Future callbacks inline so assertions can follow synchronously.
   private implicit val sameThread: ExecutionContext = new ExecutionContext {
@@ -131,7 +156,7 @@ object CricketStatsJobTest extends MockitoSugar {
     when(paFeed.getCompetitionMatches(eqTo(team), any[LocalDate])(any())).thenReturn(Future.successful(matches))
     matches.foreach { cm =>
       when(paFeed.getMatch(eqTo(cm))(any()))
-        .thenReturn(Future.successful(aMatch(cm.matchId, cm.startDate.toLocalDate.atStartOfDay)))
+        .thenReturn(Future.successful(aMatch(cm.matchId, cm.startDate.atStartOfDay)))
     }
     paFeed
   }

--- a/sport/test/CricketStatsJobTest.scala
+++ b/sport/test/CricketStatsJobTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.{LocalDate, LocalDateTime, ZonedDateTime}
 import scala.concurrent.{ExecutionContext, Future}
 
 @DoNotDiscover class CricketStatsJobTest extends AnyFlatSpec with Matchers with MockitoSugar {
@@ -86,65 +86,70 @@ import scala.concurrent.{ExecutionContext, Future}
     verify(paFeed).getMatch(eqTo(future))(any())
   }
 
-  "classify" should "mark a single-day match happening today as Active" in {
-    CricketStatsJob.classify(today, today) shouldBe MatchType.Active
+  it should "mark a match spanning today (start before, end after) as Active" in {
+    CricketStatsJob.classify(now.minusDays(2)) shouldBe MatchType.Active
   }
 
-  it should "mark a match spanning today (start before, end after) as Active" in {
-    CricketStatsJob.classify(today.minusDays(2), today.plusDays(2)) shouldBe MatchType.Active
+  it should "mark a match that starts in 30 minutes as Active" in {
+    CricketStatsJob.classify(now.plusMinutes(30)) shouldBe MatchType.Active
+  }
+
+  it should "mark a match that starts in 31 minutes as Upcoming" in {
+    CricketStatsJob.classify(now.plusMinutes(30)) shouldBe MatchType.Active
   }
 
   it should "mark a match that started earlier and ends today as Active" in {
     // Boundary: today is the final day (e.g. day 5 of a test match).
-    CricketStatsJob.classify(today.minusDays(4), today) shouldBe MatchType.Active
+    CricketStatsJob.classify(now.minusDays(4)) shouldBe MatchType.Active
   }
 
   it should "mark a match that starts today and ends later as Active" in {
     // Boundary: today is the first day of a multi-day match.
-    CricketStatsJob.classify(today, today.plusDays(4)) shouldBe MatchType.Active
+    CricketStatsJob.classify(now) shouldBe MatchType.Active
   }
 
   it should "mark a match starting tomorrow as Upcoming" in {
-    CricketStatsJob.classify(today.plusDays(1), today.plusDays(3)) shouldBe MatchType.Upcoming
+    CricketStatsJob.classify(now.plusDays(1)) shouldBe MatchType.Upcoming
   }
 
   it should "mark a match starting within the upcoming window as Upcoming" in {
     // upcomingDays is 5, so a start 4 days out is still upcoming.
-    CricketStatsJob.classify(today.plusDays(4), today.plusDays(6)) shouldBe MatchType.Upcoming
+    CricketStatsJob.classify(now.plusDays(4)) shouldBe MatchType.Upcoming
   }
 
-  it should "mark a match starting exactly on the upcoming boundary as Future" in {
+  it should "mark a match starting exactly on the upcoming boundary as Upcoming" in {
     // The window is exclusive: start == today + upcomingDays (5) is not upcoming.
-    CricketStatsJob.classify(today.plusDays(5), today.plusDays(7)) shouldBe MatchType.Future
+    CricketStatsJob.classify(now.plusDays(5)) shouldBe MatchType.Upcoming
   }
 
   it should "mark a match starting well beyond the upcoming window as Future" in {
-    CricketStatsJob.classify(today.plusDays(30), today.plusDays(32)) shouldBe MatchType.Future
+    CricketStatsJob.classify(now.plusDays(30)) shouldBe MatchType.Future
   }
 
-  it should "mark a match that ended yesterday as Historical" in {
-    CricketStatsJob.classify(today.minusDays(3), today.minusDays(1)) shouldBe MatchType.Historical
+  it should "mark a match that ended 5 days ago as Historical" in {
+    CricketStatsJob.classify(now.minusDays(5)) shouldBe MatchType.Historical
   }
 
   it should "mark a match that finished well in the past as Historical" in {
-    CricketStatsJob.classify(today.minusDays(30), today.minusDays(28)) shouldBe MatchType.Historical
+    CricketStatsJob.classify(now.minusDays(30)) shouldBe MatchType.Historical
   }
 
 }
 
 object CricketStatsJobTest extends MockitoSugar {
   private val today = LocalDate.now
+  private val now = ZonedDateTime.now
   private val england: CricketTeam = CricketTeams.teams.head
 
-  private val future = CompetitionMatch("future", "c", "Comp", today.plusDays(10), today.plusDays(12))
-  private val upcoming = CompetitionMatch("upcoming", "c", "Comp", today.plusDays(2), today.plusDays(4))
-  private val active = CompetitionMatch("active", "c", "Comp", today, today.plusDays(3))
-  private val historical = CompetitionMatch("historical", "c", "Comp", today.minusDays(30), today.minusDays(28))
+  private val future = CompetitionMatch("future", "c", "Comp", now.plusDays(10))
+  private val upcoming = CompetitionMatch("upcoming", "c", "Comp", now.plusDays(2))
+  private val active = CompetitionMatch("active", "c", "Comp", now)
+  private val historical = CompetitionMatch("historical", "c", "Comp", now.minusDays(30))
 
   // More than one batch's worth of historical matches, each on a distinct date so they occupy
   // distinct cache slots.
   private val manyHistorical: Seq[CompetitionMatch] =
-    (1 to 15).map(i => CompetitionMatch(s"h$i", "c", "Comp", today.minusDays(30L + i), today.minusDays(28L + i)))
+    (1 to 15).map(i => CompetitionMatch(s"h$i", "c", "Comp", now.minusDays(30L + i)))
 
   // Run all Future callbacks inline so assertions can follow synchronously.
   private implicit val sameThread: ExecutionContext = new ExecutionContext {
@@ -173,7 +178,7 @@ object CricketStatsJobTest extends MockitoSugar {
     when(paFeed.getCompetitionMatches(eqTo(team), any[LocalDate])(any())).thenReturn(Future.successful(matches))
     matches.foreach { cm =>
       when(paFeed.getMatch(eqTo(cm))(any()))
-        .thenReturn(Future.successful(aMatch(cm.matchId, cm.startDate.atStartOfDay)))
+        .thenReturn(Future.successful(aMatch(cm.matchId, cm.startDateTime.toLocalDateTime)))
     }
     paFeed
   }

--- a/sport/test/CricketStatsJobTest.scala
+++ b/sport/test/CricketStatsJobTest.scala
@@ -41,28 +41,26 @@ import scala.concurrent.{ExecutionContext, Future}
     verify(paFeed, never).getMatch(eqTo(historical))(any())
   }
 
-  "refreshUpcomingMatchData" should "only fetches upcoming matches" in {
-    val paFeed = stubbedFeed(england, Seq(upcoming, active, historical))
+  "infrequentMatchDataRefresh" should "never fetches active matches" in {
+    val paFeed = stubbedFeed(england, Seq(upcoming, active, future, historical))
     val job = new CricketStatsJob(paFeed)
 
     job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // populate the registry
     clearInvocations(paFeed)
 
-    job.refreshUpcomingMatchData()
+    job.infrequentMatchDataRefresh()
 
-    verify(paFeed).getMatch(eqTo(upcoming))(any())
     verify(paFeed, never).getMatch(eqTo(active))(any())
-    verify(paFeed, never).getMatch(eqTo(historical))(any())
   }
 
-  "refreshActiveMatchData" should "only fetches active matches" in {
+  "frequentMatchDataRefresh" should "only fetches active matches" in {
     val paFeed = stubbedFeed(england, Seq(upcoming, active, historical))
     val job = new CricketStatsJob(paFeed)
 
     job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // populate the registry
     clearInvocations(paFeed)
 
-    job.refreshActiveMatchData()
+    job.frequentMatchDataRefresh()
 
     verify(paFeed, never).getMatch(eqTo(upcoming))(any())
     verify(paFeed).getMatch(eqTo(active))(any())

--- a/sport/test/CricketStatsJobTest.scala
+++ b/sport/test/CricketStatsJobTest.scala
@@ -38,72 +38,54 @@ import scala.concurrent.{ExecutionContext, Future}
     CricketStatsJob.classify(today.minusDays(7)) shouldBe MatchType.Historical
   }
 
-  "backfillMatches" should "load an unfetched match" in {
+  "discoverMatches" should "load a newly discovered match exactly once" in {
+    val paFeed = stubbedFeed(england, Seq(upcoming))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // loads it once
+
+    verify(paFeed).getMatch(eqTo(upcoming))(any())
+  }
+
+  it should "not re-fetch a match that is already cached" in {
     val paFeed = stubbedFeed(england, Seq(historical))
     val job = new CricketStatsJob(paFeed)
 
-    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
-    job.backfillMatches()
-
-    verify(paFeed).getMatch(eqTo(historical))(any())
-  }
-
-  it should "load active matches during the initial backfill" in {
-    val paFeed = stubbedFeed(england, Seq(active))
-    val job = new CricketStatsJob(paFeed)
-
-    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
-    job.backfillMatches()
-
-    verify(paFeed).getMatch(eqTo(active))(any())
-  }
-
-  it should "backfill no more than the per-cycle batch size, deferring the rest to later cycles" in {
-    val paFeed = stubbedFeed(england, manyHistorical)
-    val job = new CricketStatsJob(paFeed)
-
-    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
-
-    job.backfillMatches()
-    verify(paFeed, times(CricketStatsJob.matchesPerCycle)).getMatch(any[CompetitionMatch])(any())
-
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // loads it once
     clearInvocations(paFeed)
-    job.backfillMatches()
-    verify(paFeed, times(manyHistorical.size - CricketStatsJob.matchesPerCycle))
-      .getMatch(any[CompetitionMatch])(any())
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // already cached, so should be skipped
+
+    verify(paFeed, never).getMatch(eqTo(historical))(any())
   }
 
-  it should "not refresh active or upcoming matches until backfill is complete" in {
-    val paFeed = stubbedFeed(england, Seq(active, historical))
+  "refreshUpcomingMatchData" should "only fetches upcoming matches" in {
+    val paFeed = stubbedFeed(england, Seq(upcoming, active, historical))
     val job = new CricketStatsJob(paFeed)
 
-    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
-    job.backfillMatches() // backfills both active and historical
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // populate the registry
     clearInvocations(paFeed)
-    job.refreshActiveMatchData()
+
     job.refreshUpcomingMatchData()
 
+    verify(paFeed).getMatch(eqTo(upcoming))(any())
+    verify(paFeed, never).getMatch(eqTo(active))(any())
+    verify(paFeed, never).getMatch(eqTo(historical))(any())
+  }
+
+  "refreshActiveMatchData" should "only fetches active matches" in {
+    val paFeed = stubbedFeed(england, Seq(upcoming, active, historical))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2)) // populate the registry
+    clearInvocations(paFeed)
+
+    job.refreshActiveMatchData()
+
+    verify(paFeed, never).getMatch(eqTo(upcoming))(any())
     verify(paFeed).getMatch(eqTo(active))(any())
     verify(paFeed, never).getMatch(eqTo(historical))(any())
   }
 
-  it should "refresh upcoming and active matches once backfill is complete" in {
-    val paFeed = stubbedFeed(england, Seq(active, upcoming))
-    val job = new CricketStatsJob(paFeed)
-
-    job.discoverMatches(fromDate = today.minusMonths(2), toDate = today.plusMonths(2))
-    job.backfillMatches() // backfills both active and historical
-    clearInvocations(paFeed)
-    job.refreshUpcomingMatchData()
-
-    verify(paFeed).getMatch(eqTo(upcoming))(any())
-    verify(paFeed, times(1)).getMatch(any[CompetitionMatch])(any())
-
-    clearInvocations(paFeed)
-    job.refreshActiveMatchData()
-    verify(paFeed).getMatch(eqTo(active))(any())
-    verify(paFeed, times(1)).getMatch(any[CompetitionMatch])(any())
-  }
 }
 
 object CricketStatsJobTest extends MockitoSugar {

--- a/sport/test/CricketStatsJobTest.scala
+++ b/sport/test/CricketStatsJobTest.scala
@@ -1,0 +1,115 @@
+package test
+
+import conf.cricketPa.{CompetitionMatch, CricketTeam, CricketTeams, PaFeed}
+import cricketModel.{Match, Team}
+import jobs.CricketStatsJob
+import jobs.CricketStatsJob.MatchType
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.{clearInvocations, never, verify, when}
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.time.{LocalDate, LocalDateTime}
+import scala.concurrent.{ExecutionContext, Future}
+
+@DoNotDiscover class CricketStatsJobTest extends AnyFlatSpec with Matchers with MockitoSugar {
+
+  import CricketStatsJobTest._
+
+  "classify" should "treat a match starting in more than 5 days as Upcoming" in {
+    CricketStatsJob.classify(today.plusDays(6)) shouldBe MatchType.Upcoming
+  }
+
+  it should "treat a match starting exactly 5 days ahead as Active" in {
+    CricketStatsJob.classify(today.plusDays(5)) shouldBe MatchType.Active
+  }
+
+  it should "treat today's match as Active" in {
+    CricketStatsJob.classify(today) shouldBe MatchType.Active
+  }
+
+  it should "treat a match 6 days after it start as still Active (boundary)" in {
+    CricketStatsJob.classify(today.minusDays(6)) shouldBe MatchType.Active
+  }
+
+  it should "treat a match started more than 6 days ago as Historical" in {
+    CricketStatsJob.classify(today.minusDays(7)) shouldBe MatchType.Historical
+  }
+
+  "discover" should "load a newly discovered match exactly once" in {
+    val paFeed = stubbedFeed(england, Seq(upcoming))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2))
+
+    verify(paFeed).getMatch(eqTo(upcoming))(any())
+  }
+
+  it should "not re-fetch a match that is already cached" in {
+    val paFeed = stubbedFeed(england, Seq(historical))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2)) // loads it once
+    clearInvocations(paFeed)
+    job.discoverMatches(fromDate = today.minusMonths(2)) // already cached, so should be skipped
+
+    verify(paFeed, never).getMatch(eqTo(historical))(any())
+  }
+
+  "refreshBand" should "only fetch matches in the requested band" in {
+    val paFeed = stubbedFeed(england, Seq(upcoming, active, historical))
+    val job = new CricketStatsJob(paFeed)
+
+    job.discoverMatches(fromDate = today.minusMonths(2)) // populate the registry
+    clearInvocations(paFeed)
+
+    job.refreshUpcomingMatchData()
+
+    verify(paFeed).getMatch(eqTo(upcoming))(any())
+    verify(paFeed, never).getMatch(eqTo(active))(any())
+    verify(paFeed, never).getMatch(eqTo(historical))(any())
+  }
+}
+
+object CricketStatsJobTest extends MockitoSugar {
+  private val today = LocalDateTime.now
+  private val england: CricketTeam = CricketTeams.teams.head
+
+  private val upcoming = CompetitionMatch("upcoming", "c", "Comp", today.plusDays(10))
+  private val active = CompetitionMatch("active", "c", "Comp", today.plusDays(1))
+  private val historical = CompetitionMatch("historical", "c", "Comp", today.minusDays(30))
+
+  // Run all Future callbacks inline so assertions can follow synchronously.
+  private implicit val sameThread: ExecutionContext = new ExecutionContext {
+    def execute(runnable: Runnable): Unit = runnable.run()
+    def reportFailure(cause: Throwable): Unit = throw cause
+  }
+
+  private def aMatch(matchId: String, gameDate: LocalDateTime): Match =
+    Match(
+      teams = List(Team("Home", "h", home = true, Nil, None), Team("Away", "a", home = false, Nil, None)),
+      innings = Nil,
+      competitionName = "Comp",
+      stage = "",
+      venueName = "",
+      result = "",
+      currentDay = 0,
+      totalDays = 0,
+      gameDate = gameDate,
+      officials = Nil,
+      matchId = matchId,
+    )
+
+  private def stubbedFeed(team: CricketTeam, matches: Seq[CompetitionMatch]): PaFeed = {
+    val paFeed = mock[PaFeed]
+    when(paFeed.getCompetitionMatches(any[CricketTeam], any[LocalDate])(any())).thenReturn(Future.successful(Nil))
+    when(paFeed.getCompetitionMatches(eqTo(team), any[LocalDate])(any())).thenReturn(Future.successful(matches))
+    matches.foreach { cm =>
+      when(paFeed.getMatch(eqTo(cm))(any()))
+        .thenReturn(Future.successful(aMatch(cm.matchId, cm.startDate.toLocalDate.atStartOfDay)))
+    }
+    paFeed
+  }
+}

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -31,6 +31,7 @@ class SportTestSuite
       new LeagueTablesFeatureTest,
       new MatchFeatureTest,
       new FixturesAndResultsTest,
+      new CricketStatsJobTest,
     )
     with SingleServerSuite {}
 


### PR DESCRIPTION
## What is the value of this and can you measure success?
We're making a huge amount of requests to the cricket API checking every 5 or 10 minutes  first all the fixtures and results for every team we support, then for every match in the last 2 months refetch the match details, scorecard and line-up.

The main reduction in API requests comes from reducing the cadence we fetch the index of available matches to once a day.

It also classifies matches into future, upcoming (starts within 5 days), active and historical, for fine tuning of how frequently we update each of these.

I've picked hourly for upcoming, kept 5 mins for active, and future and historical matches are once a day, but open for discussion!

Finally it more accurately works out when matches have ended using the totalDays property rather than assuming all matches are 5 days long, as many are just 1 day, and avoid pointless fetching of ended matches.

