### PR TITLE
Remove redundant surveyPageController from the devBuild app

### DIFF
--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -50,7 +50,6 @@ trait Controllers
 
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val emailSignupController = wire[EmailSignupController]
-  lazy val surveyPageController = wire[SurveyPageController]
   lazy val signupPageController = wire[SignupPageController]
 }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

Running the `dev-build` project in frontend is currently broken, which affects local development in frontend.

This PR fixes that by removing the now deleted `SurveyPageController` from the dev-build AppLoader file

## What does this change?

Removes the `SurveyPageController` (removed in https://github.com/guardian/frontend/pull/28891/changes/4772f641d4a1aa23b6e31c79a24e4d331100468b) from the dev-build app
