### PR TITLE
Remove California Resident from Privacy Settings button

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -18,7 +18,7 @@ export const addPrivacySettingsLink = () => {
 			newPrivacyLink.dataset.linkName = 'privacy-settings';
 			newPrivacyLink.removeAttribute('href');
 			newPrivacyLink.innerText = getPrivacyFramework().usnat
-				? 'California resident – Do Not Sell'
+				? 'US resident - Do Not Sell or Share'
 				: 'Privacy settings';
 
 			const newPrivacyLinkListItem = privacyLinkListItem.cloneNode(false);


### PR DESCRIPTION
## What does this change?
This PR updates the copy for the US Privacy Settings copy from `California Residents - Do Not Sell` to `Do Not Sell or Share`
## Why?
US Team has requested this copy change.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1908" height="516" alt="Screenshot 2026-07-08 at 10 03 52" src="https://github.com/user-attachments/assets/46749dc9-0d06-4ead-8bb4-354fde81f076" /> | <img width="1496" height="500" alt="Screenshot 2026-07-21 at 12 15 06" src="https://github.com/user-attachments/assets/678a894d-322f-4a4c-8e9a-82de72f94cbc" /> |



[before]: https://example.com/before.png
[after]: https://example.com/after.png

