### PR TITLE
[WIP] adds iab content tags to dcr rendering model

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -25,6 +25,22 @@ import implicits.Booleans._
 import model.liveblog.CalloutBlockElement
 import org.joda.time.DateTime
 
+// ---- IAB content category types (LLM-generated, surfaced via CAPI) ----
+
+case class IabSegment(id: String, name: String)
+object IabSegment { implicit val writes: OWrites[IabSegment] = Json.writes[IabSegment] }
+
+case class IabTaxonomy(taxonomy: String, segtax: Int, segments: List[IabSegment])
+object IabTaxonomy { implicit val writes: OWrites[IabTaxonomy] = Json.writes[IabTaxonomy] }
+
+case class IabModel(modelId: String, modelVersion: String, description: String, taxonomies: List[IabTaxonomy])
+object IabModel { implicit val writes: OWrites[IabModel] = Json.writes[IabModel] }
+
+case class IabCategories(contentId: String, models: List[IabModel])
+object IabCategories { implicit val writes: OWrites[IabCategories] = Json.writes[IabCategories] }
+
+// -----------------------------------------------------------------------
+
 sealed trait ContentType {
   def content: Content
   final def tags: Tags = content.tags
@@ -70,6 +86,9 @@ final case class Content(
     rawOpenGraphImage: Option[ImageAsset],
     schemaOrg: Option[SchemaOrg],
     listElementCampaignIds: Seq[String] = Seq.empty,
+    // LLM-generated IAB content categories surfaced via CAPI.
+    // TODO: populate from CAPI once the iabCategories field is available in the CAPI models.
+    iabCategories: Option[IabCategories] = None,
 ) {
 
   lazy val isBlog: Boolean = tags.blogs.nonEmpty
@@ -522,6 +541,9 @@ object Content {
         .orElse(trail.trailPicture.flatMap(_.largestImage)),
       schemaOrg = schemaOrg,
       listElementCampaignIds = listElementCampaignIds,
+      // TODO: replace None with apiContent.fields.flatMap(_.iabCategories) (or equivalent)
+      // once the iabCategories field has been added to the CAPI models.
+      iabCategories = None,
     )
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -23,6 +23,7 @@ import model.{
   GUDateTimeFormatNew,
   Gallery,
   GalleryPage,
+  IabCategories,
   ImageContentPage,
   ImageMedia,
   InteractivePage,
@@ -112,6 +113,7 @@ case class DotcomRenderingDataModel(
     lang: Option[String],
     isRightToLeftLang: Boolean,
     crossword: Option[CrosswordData],
+    iabCategories: Option[IabCategories],
 )
 
 object DotcomRenderingDataModel {
@@ -192,6 +194,7 @@ object DotcomRenderingDataModel {
         "lang" -> model.lang,
         "isRightToLeftLang" -> model.isRightToLeftLang,
         "crossword" -> model.crossword,
+        "iabCategories" -> model.iabCategories,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -694,6 +697,7 @@ object DotcomRenderingDataModel {
       lang = content.fields.lang,
       isRightToLeftLang = content.fields.isRightToLeftLang,
       crossword = crossword,
+      iabCategories = content.content.iabCategories,
     )
   }
 }


### PR DESCRIPTION


## What is the value of this and can you measure success?
Enables downstream systems to receive LLM-generated IAB content categories alongside article data, improving contextual targeting. Success is confirmed once IAB categories appear correctly in the DCR payload after the CAPI-side work lands.

## What does this change?
Plumbing to carry a new iabCategories field — LLM-generated from article content — through the frontend data pipeline into the DotcomRenderingModel posted to DCR.

Currently inert (field is None) until the CAPI side is ready.

<img width="203" height="417" alt="Screenshot 2026-07-08 at 10 52 26" src="https://github.com/user-attachments/assets/b7e0867a-d3ed-4fba-a44c-c8c60dc8a7b7" />

