### PR TITLE
Enable twirl template instrumentation on all services

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,16 +114,22 @@ val facia = application("facia")
   .settings(
     libraryDependencies += scalaCheck,
   )
+  .settings(withTwirlInstrumentation: _*)
 
-val article = application("article").dependsOn(commonWithTests).aggregate(common)
+val article = application("article")
+  .dependsOn(commonWithTests)
+  .aggregate(common)
+  .settings(withTwirlInstrumentation: _*)
 
 val applications = application("applications")
   .dependsOn(commonWithTests)
   .aggregate(common)
+  .settings(withTwirlInstrumentation: _*)
 
 val archive = application("archive")
   .dependsOn(commonWithTests)
   .aggregate(common)
+  .settings(withTwirlInstrumentation: _*)
 
 val sport = application("sport")
   .dependsOn(commonWithTests)
@@ -133,6 +139,7 @@ val sport = application("sport")
       paClient,
     ),
   )
+  .settings(withTwirlInstrumentation: _*)
 
 val discussion = application("discussion")
   .dependsOn(commonWithTests)
@@ -159,6 +166,7 @@ val admin = application("admin")
     RoutesKeys.routesImport += "bindables._",
     RoutesKeys.routesImport += "org.joda.time.LocalDate",
   )
+  .settings(withTwirlInstrumentation: _*)
 
 val faciaPress = application("facia-press")
   .dependsOn(commonWithTests)
@@ -167,6 +175,7 @@ val faciaPress = application("facia-press")
       awsKinesis,
     ),
   )
+  .settings(withTwirlInstrumentation: _*)
 
 val identity = application("identity")
   .dependsOn(commonWithTests)
@@ -182,10 +191,17 @@ val identity = application("identity")
     PlayKeys.playDefaultPort := 9009,
     Test / testOptions += Tests.Argument("-oF"),
   )
+  .settings(withTwirlInstrumentation: _*)
 
-val commercial = application("commercial").dependsOn(commonWithTests).aggregate(common)
+val commercial = application("commercial")
+  .dependsOn(commonWithTests)
+  .aggregate(common)
+  .settings(withTwirlInstrumentation: _*)
 
-val onward = application("onward").dependsOn(commonWithTests).aggregate(common)
+val onward = application("onward")
+  .dependsOn(commonWithTests)
+  .aggregate(common)
+  .settings(withTwirlInstrumentation: _*)
 
 val dev = application("dev-build")
   .dependsOn(
@@ -217,10 +233,12 @@ val preview = application("preview")
     commercial,
     onward,
   )
+  .settings(withTwirlInstrumentation: _*)
 
 val rss = application("rss")
   .dependsOn(commonWithTests)
   .aggregate(common)
+  .settings(withTwirlInstrumentation: _*)
 
 val main = root()
   .aggregate(


### PR DESCRIPTION
## What is the value of this and can you measure success?
Enables [this](https://github.com/guardian/frontend/pull/28895) on all remaining services

## What does this change?
It enables template instrumentation which will log each time a Twirl template is used for the first time within the given JVM

Logs are shipped from [this PR](https://github.com/guardian/platform/pull/2289)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
