### PR TITLE
Add team url to MatchDayTeam format

### DIFF
--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -66,7 +66,11 @@ private object DotcomRenderingFootballDataModelImplicits {
 
   implicit val atomFormat: Writes[InteractiveAtom] = Json.writes[InteractiveAtom]
 
-  private implicit val matchDayTeamFormat: Writes[MatchDayTeam] = Json.writes[MatchDayTeam]
+  private implicit val matchDayTeamFormat: Writes[MatchDayTeam] = Writes { matchDayTeam =>
+    withoutNull(
+      Json.writes[MatchDayTeam].writes(matchDayTeam).as[JsObject] + ("teamUrl" -> Json.toJson(TeamUrl(matchDayTeam))),
+    )
+  }
 
   // Writes for Fixture with a type discriminator
   private implicit val fixtureWrites: Writes[Fixture] = Writes { fixture =>


### PR DESCRIPTION
## What does this change?
Adding teamUrl to the MatchDayTeam format. We needed this for the football header, but rather than adding 2 new fields on the header for homeTeamUrl and awayTeamUrl, I updated the MatchDayTeam to include the teamUrl in it's fields when the response is json being returned.  

The DCAR PR relevant for this change is https://github.com/guardian/dotcom-rendering/pull/16376