### PR TITLE
Remove space from sitemap `lastmod`

### DIFF
--- a/applications/app/services/NewsSiteMap.scala
+++ b/applications/app/services/NewsSiteMap.scala
@@ -34,8 +34,7 @@ class NewsSiteMap(contentApiClient: ContentApiClient) {
     def xml(): Elem = {
       <url>
         <loc>{location}</loc>
-        <lastmod>
-          {lastModified.withZone(DateTimeZone.UTC).toISODateTimeNoMillisString}</lastmod>
+        <lastmod>{lastModified.withZone(DateTimeZone.UTC).toISODateTimeNoMillisString}</lastmod>
         <image:image>
           <image:loc>{imageUrl}</image:loc>
         </image:image>

--- a/applications/app/services/VideoSiteMap.scala
+++ b/applications/app/services/VideoSiteMap.scala
@@ -36,8 +36,7 @@ class VideoSiteMap(contentApiClient: ContentApiClient) {
     def xml(): Elem = {
       <url>
         <loc>{location}</loc>
-        <lastmod>
-          {lastModified.withZone(DateTimeZone.UTC).toISODateTimeNoMillisString}</lastmod>
+        <lastmod>{lastModified.withZone(DateTimeZone.UTC).toISODateTimeNoMillisString}</lastmod>
         <video:video>
           {thumbnail_loc.map(thumbnail => <video:thumbnail_loc>{thumbnail}</video:thumbnail_loc>).getOrElse(Nil)}
           <video:title>{title}</video:title>


### PR DESCRIPTION
## What is the value of this and can you measure success?

Mainly tidiness but there is a tiny chance this helps Google glean the correct date

## What does this change?

Removes a space from the `lastmod` field in the news sitemap

## Screenshots

Before

<img width="1768" height="512" alt="image" src="https://github.com/user-attachments/assets/b4868262-61b7-44f7-a38c-c2f65b25493c" />

After
<img width="1073" height="761" alt="image" src="https://github.com/user-attachments/assets/66fb0411-3e4c-444e-a93f-38a1bd12ca8f" />


-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
