### PR TITLE
PoC: Can we add more context to our twirl template tracking?

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,8 @@ val templateTrackerAgent = Project("template-tracker-agent", file("template-trac
     ),
     assembly / packageOptions += Package.ManifestAttributes(
       "Premain-Class" -> "com.gu.templatetracker.TemplateTrackerAgent",
-      "Can-Redefine-Classes" -> "true",
+      // We only ever retransform (never redefine with supplied class files), so Can-Redefine-Classes
+      // is not required - RETRANSFORMATION needs Can-Retransform-Classes only.
       "Can-Retransform-Classes" -> "true",
     ),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,6 @@ val templateTrackerAgent = Project("template-tracker-agent", file("template-trac
     ),
     assembly / packageOptions += Package.ManifestAttributes(
       "Premain-Class" -> "com.gu.templatetracker.TemplateTrackerAgent",
-      // We only ever retransform (never redefine with supplied class files), so Can-Redefine-Classes
-      // is not required - RETRANSFORMATION needs Can-Retransform-Classes only.
       "Can-Retransform-Classes" -> "true",
     ),
   )

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -129,8 +129,6 @@ object Filters {
       new SurrogateKeyFilter,
       new AmpFilter,
       new TooManyHeadersFilter,
-      // Kept last so it is the innermost filter: its `next(rh)` invokes the action directly, so the
-      // request context is set on the thread that runs the action's synchronous prefix.
       new TemplateContextFilter,
     )
 

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -129,6 +129,9 @@ object Filters {
       new SurrogateKeyFilter,
       new AmpFilter,
       new TooManyHeadersFilter,
+      // Kept last so it is the innermost filter: its `next(rh)` invokes the action directly, so the
+      // request context is set on the thread that runs the action's synchronous prefix.
+      new TemplateContextFilter,
     )
 
   def preload(implicit

--- a/common/app/http/TemplateContextFilter.scala
+++ b/common/app/http/TemplateContextFilter.scala
@@ -1,0 +1,71 @@
+package http
+
+import org.apache.pekko.stream.Materializer
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import java.lang.reflect.Method
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+/** Seeds the template-tracker's request context (the JVM agent's `com.gu.templatetracker.RequestContext`)
+  * with a human-readable description of the current request, so that when a Twirl template is rendered -
+  * possibly on a different thread - the agent can attribute that render back to the request that
+  * triggered it.
+  *
+  * We set the context on the request thread just before invoking the action. The agent instruments
+  * `java.util.concurrent.Executor#execute(Runnable)` so the context is then carried across every async
+  * hop (CAPI lookup, future continuations, ...) to whichever thread ends up doing the render.
+  *
+  * The link to the agent is made reflectively on purpose:
+  *   - `common` needs no compile/runtime dependency on the agent jar (which is attached at runtime via
+  *     `-javaagent` and lives on the bootstrap classloader), and
+  *   - everything degrades to a no-op when the agent isn't attached (local dev, tests, CI), so this
+  *     filter is safe to leave permanently wired in.
+  */
+class TemplateContextFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
+
+  override def apply(next: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
+    TemplateContextFilter.setContext(describe(rh))
+    try
+      // The synchronous prefix of the action runs on this thread with the context set, capturing it
+      // into the first task it submits; the executor instrumentation carries it from there.
+      next(rh)
+    finally
+      // Clear immediately so we don't leak the context onto this pooled thread once the synchronous
+      // prefix has returned. The value already rode off inside the wrapped Runnable(s).
+      TemplateContextFilter.clearContext()
+  }
+
+  private def describe(rh: RequestHeader): String = {
+    val requestId = rh.headers.get("x-request-id").getOrElse("-")
+    // rh.uri already includes both the path and the query string.
+    s"${rh.method} ${rh.host}${rh.uri} [request-id=$requestId]"
+  }
+}
+
+object TemplateContextFilter {
+
+  // Resolve RequestContext.set(String) / RequestContext.clear() once. Absent agent -> None -> no-ops.
+  // Class.forName uses this (child application) classloader, which delegates parent-first and so
+  // resolves the single bootstrap-loaded copy installed by the agent.
+  private val (setMethod: Option[Method], clearMethod: Option[Method]) =
+    try {
+      val cls = Class.forName("com.gu.templatetracker.RequestContext")
+      (Some(cls.getMethod("set", classOf[String])), Some(cls.getMethod("clear")))
+    } catch {
+      case NonFatal(_) => (None, None)
+    }
+
+  private def setContext(description: String): Unit =
+    setMethod.foreach { m =>
+      try m.invoke(null, description)
+      catch { case NonFatal(_) => () }
+    }
+
+  private def clearContext(): Unit =
+    clearMethod.foreach { m =>
+      try m.invoke(null)
+      catch { case NonFatal(_) => () }
+    }
+}
+

--- a/common/app/http/TemplateContextFilter.scala
+++ b/common/app/http/TemplateContextFilter.scala
@@ -9,23 +9,22 @@ import java.util.{LinkedHashMap => JLinkedHashMap, Map => JMap}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-/** Seeds the template-tracker's request context (the JVM agent's `com.gu.templatetracker.RequestContext`)
-  * with a small map of fields describing the current request, so that when a Twirl template is rendered -
-  * possibly on a different thread - the agent can attribute that render back to the request that
-  * triggered it.
+/** Seeds the template-tracker's request context (the JVM agent's `com.gu.templatetracker.RequestContext`) with a small
+  * map of fields describing the current request, so that when a Twirl template is rendered - possibly on a different
+  * thread - the agent can attribute that render back to the request that triggered it.
   *
   * We set the context on the request thread just before invoking the action. The agent instruments
-  * `java.util.concurrent.Executor#execute(Runnable)` so the context is then carried across every async
-  * hop (CAPI lookup, future continuations, ...) to whichever thread ends up doing the render.
+  * `java.util.concurrent.Executor#execute(Runnable)` so the context is then carried across every async hop (future,
+  * etc.) to whichever thread ends up doing the render.
   *
   * The link to the agent is made reflectively on purpose:
-  *   - `common` needs no compile/runtime dependency on the agent jar (which is attached at runtime via
-  *     `-javaagent` and lives on the bootstrap classloader), and
-  *   - everything degrades to a no-op when the agent isn't attached (local dev, tests, CI), so this
-  *     filter is safe to leave permanently wired in.
+  *   - `common` needs no compile/runtime dependency on the agent jar (which is attached at runtime via `-javaagent` and
+  *     lives on the bootstrap classloader), and
+  *   - everything degrades to a no-op when the agent isn't attached (local dev, tests, CI), so this filter degrades
+  *     safely if the agent wasn't properly wired up
   *
-  * The context is a `java.util.Map[String, String]` - a JDK type, so it crosses the reflective boundary
-  * into the bootstrap-loaded agent with no shared application types.
+  * The context is a `java.util.Map[String, String]` - a JDK type, so it crosses the reflective boundary into the
+  * bootstrap-loaded agent with no shared application types.
   */
 class TemplateContextFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
 
@@ -44,24 +43,26 @@ class TemplateContextFilter(implicit val mat: Materializer, executionContext: Ex
   private def describe(rh: RequestHeader): JMap[String, String] = {
     // LinkedHashMap so the fields log in a stable, readable order.
     val context = new JLinkedHashMap[String, String]()
-    context.put("requestId", rh.headers.get("x-request-id").getOrElse("-"))
     context.put("method", rh.method)
-    context.put("host", rh.host)
-    // rh.uri already includes both the path and the query string.
-    context.put("uri", rh.uri)
-    // The `dcr` query param forces legacy (Twirl) vs DCR rendering. We normalise to the known values
-    // (`true` / `false` / `apps`), collapse any other value to `other`, and record `absent` when the
-    // param is missing - so we always log it, and the agent dedupes on a small, bounded set.
-    context.put("dcr", rh.getQueryString("dcr") match {
-      case Some(value @ ("true" | "false" | "apps")) => value
-      case Some(_)                                    => "other"
-      case None                                       => "absent"
-    })
     // The routed action, present once routing has run (absent for e.g. asset or unmatched routes).
-    // The agent also dedupes on this, so a template shared by many actions is captured once per action.
+    // The agent dedupes on this, so a template shared by many actions is captured once per action.
     rh.attrs.get(Router.Attrs.HandlerDef).foreach { handler =>
       context.put("controllerMethod", s"${handler.controller}.${handler.method}")
     }
+    // The `dcr` query param forces legacy (Twirl) vs DCR rendering. We normalise to the known values
+    // (`true` / `false` / `apps`), collapse any other value to `other`, and record `absent` when the
+    // param is missing - so we always log it, and the agent dedupes on a small, bounded set.
+    context.put(
+      "dcr",
+      rh.getQueryString("dcr") match {
+        case Some(value @ ("true" | "false" | "apps")) => value
+        case Some(_)                                   => "other"
+        case None                                      => "absent"
+      },
+    )
+    // rh.uri includes both path and query string. It's just one example URI for this deduped tuple
+    // (hence "sample"), captured from whichever request first triggered the render.
+    context.put("sampleUri", rh.uri)
     context
   }
 }
@@ -82,9 +83,6 @@ object TemplateContextFilter {
       case NonFatal(_) => (None, None)
     }
 
-  // We invoke via `invokeWithArguments` (a regular varargs method, not a signature-polymorphic
-  // `invoke`/`invokeExact`) so the call is clean and robust from Scala; it does the argument
-  // adaptation internally.
   private def setContext(context: JMap[String, String]): Unit =
     setHandle.foreach { h =>
       try { h.invokeWithArguments(context); () }
@@ -97,5 +95,3 @@ object TemplateContextFilter {
       catch { case NonFatal(_) => () }
     }
 }
-
-

--- a/common/app/http/TemplateContextFilter.scala
+++ b/common/app/http/TemplateContextFilter.scala
@@ -2,13 +2,15 @@ package http
 
 import org.apache.pekko.stream.Materializer
 import play.api.mvc.{Filter, RequestHeader, Result}
+import play.api.routing.Router
 
-import java.lang.reflect.Method
+import java.lang.invoke.{MethodHandle, MethodHandles, MethodType}
+import java.util.{LinkedHashMap => JLinkedHashMap, Map => JMap}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 /** Seeds the template-tracker's request context (the JVM agent's `com.gu.templatetracker.RequestContext`)
-  * with a human-readable description of the current request, so that when a Twirl template is rendered -
+  * with a small map of fields describing the current request, so that when a Twirl template is rendered -
   * possibly on a different thread - the agent can attribute that render back to the request that
   * triggered it.
   *
@@ -21,6 +23,9 @@ import scala.util.control.NonFatal
   *     `-javaagent` and lives on the bootstrap classloader), and
   *   - everything degrades to a no-op when the agent isn't attached (local dev, tests, CI), so this
   *     filter is safe to leave permanently wired in.
+  *
+  * The context is a `java.util.Map[String, String]` - a JDK type, so it crosses the reflective boundary
+  * into the bootstrap-loaded agent with no shared application types.
   */
 class TemplateContextFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
 
@@ -36,36 +41,61 @@ class TemplateContextFilter(implicit val mat: Materializer, executionContext: Ex
       TemplateContextFilter.clearContext()
   }
 
-  private def describe(rh: RequestHeader): String = {
-    val requestId = rh.headers.get("x-request-id").getOrElse("-")
+  private def describe(rh: RequestHeader): JMap[String, String] = {
+    // LinkedHashMap so the fields log in a stable, readable order.
+    val context = new JLinkedHashMap[String, String]()
+    context.put("requestId", rh.headers.get("x-request-id").getOrElse("-"))
+    context.put("method", rh.method)
+    context.put("host", rh.host)
     // rh.uri already includes both the path and the query string.
-    s"${rh.method} ${rh.host}${rh.uri} [request-id=$requestId]"
+    context.put("uri", rh.uri)
+    // The `dcr` query param forces legacy (Twirl) vs DCR rendering. We normalise to the known values
+    // (`true` / `false` / `apps`), collapse any other value to `other`, and record `absent` when the
+    // param is missing - so we always log it, and the agent dedupes on a small, bounded set.
+    context.put("dcr", rh.getQueryString("dcr") match {
+      case Some(value @ ("true" | "false" | "apps")) => value
+      case Some(_)                                    => "other"
+      case None                                       => "absent"
+    })
+    // The routed action, present once routing has run (absent for e.g. asset or unmatched routes).
+    // The agent also dedupes on this, so a template shared by many actions is captured once per action.
+    rh.attrs.get(Router.Attrs.HandlerDef).foreach { handler =>
+      context.put("controllerMethod", s"${handler.controller}.${handler.method}")
+    }
+    context
   }
 }
 
 object TemplateContextFilter {
 
-  // Resolve RequestContext.set(String) / RequestContext.clear() once. Absent agent -> None -> no-ops.
-  // Class.forName uses this (child application) classloader, which delegates parent-first and so
-  // resolves the single bootstrap-loaded copy installed by the agent.
-  private val (setMethod: Option[Method], clearMethod: Option[Method]) =
+  // Resolve RequestContext.set(Map) / RequestContext.clear() once, as MethodHandles. Absent agent ->
+  // None -> no-ops. Class.forName uses this (child application) classloader, which delegates
+  // parent-first and so resolves the single bootstrap-loaded copy installed by the agent.
+  private val (setHandle: Option[MethodHandle], clearHandle: Option[MethodHandle]) =
     try {
       val cls = Class.forName("com.gu.templatetracker.RequestContext")
-      (Some(cls.getMethod("set", classOf[String])), Some(cls.getMethod("clear")))
+      val lookup = MethodHandles.lookup()
+      val set = lookup.findStatic(cls, "set", MethodType.methodType(classOf[Unit], classOf[JMap[_, _]]))
+      val clear = lookup.findStatic(cls, "clear", MethodType.methodType(classOf[Unit]))
+      (Some(set), Some(clear))
     } catch {
       case NonFatal(_) => (None, None)
     }
 
-  private def setContext(description: String): Unit =
-    setMethod.foreach { m =>
-      try m.invoke(null, description)
+  // We invoke via `invokeWithArguments` (a regular varargs method, not a signature-polymorphic
+  // `invoke`/`invokeExact`) so the call is clean and robust from Scala; it does the argument
+  // adaptation internally.
+  private def setContext(context: JMap[String, String]): Unit =
+    setHandle.foreach { h =>
+      try { h.invokeWithArguments(context); () }
       catch { case NonFatal(_) => () }
     }
 
   private def clearContext(): Unit =
-    clearMethod.foreach { m =>
-      try m.invoke(null)
+    clearHandle.foreach { h =>
+      try { h.invokeWithArguments(); () }
       catch { case NonFatal(_) => () }
     }
 }
+
 

--- a/common/app/http/TemplateContextFilter.scala
+++ b/common/app/http/TemplateContextFilter.scala
@@ -83,8 +83,24 @@ object TemplateContextFilter {
       case NonFatal(_) => (None, None)
     }
 
+  // DIAGNOSTIC: confirm at startup whether the agent's RequestContext was found (i.e. the write side
+  // is armed). Remove once propagation is verified.
+  println(
+    s"""{"marker":"TEMPLATE_TRACKER_DEBUG","message":"TemplateContextFilter handles resolved","resolved":${setHandle.isDefined}}""",
+  )
+
+  // DIAGNOSTIC: log the first time we actually set a context on a request thread. Remove later.
+  private val setLogged = new java.util.concurrent.atomic.AtomicBoolean(false)
+
   private def setContext(context: JMap[String, String]): Unit =
     setHandle.foreach { h =>
+      if (setLogged.compareAndSet(false, true)) {
+        println(
+          s"""{"marker":"TEMPLATE_TRACKER_DEBUG","message":"First filter setContext","thread":"${Thread
+              .currentThread()
+              .getName}","context":"$context"}""",
+        )
+      }
       try { h.invokeWithArguments(context); () }
       catch { case NonFatal(_) => () }
     }

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/CaptureFutureContextAdvice.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/CaptureFutureContextAdvice.java
@@ -1,0 +1,36 @@
+package com.gu.templatetracker;
+
+import net.bytebuddy.asm.Advice;
+
+import java.util.Map;
+
+/**
+ * Advice inlined at the <em>exit</em> of every {@code scala.concurrent.impl.Promise$Transformation}
+ * constructor. In Scala 2.13 that single class is the {@link Runnable} behind <em>every</em> {@code Future}
+ * combinator - {@code map}, {@code flatMap}, {@code transform}, {@code onComplete}, {@code recover}, etc.
+ * It is constructed on the thread that <em>registers</em> the callback (which still carries the request
+ * context), and only later handed to an {@code Executor} - often from a thread that never carried the
+ * context (e.g. the async-HTTP I/O thread that completes a CAPI lookup).
+ *
+ * <p>That timing is exactly why capturing at {@code Executor#execute} submit time fails: by then the
+ * context is gone. Capturing it here, at construction, and stashing it on the Transformation instance
+ * (see the synthetic {@code templateTrackerContext} field added by the installer) lets it survive the
+ * async gap so {@link RestoreFutureContextAdvice} can put it back around {@code run()}.
+ *
+ * <p>References only the JDK and {@link RequestContext}, so it is safe to inline into the
+ * bootstrap-visible Scala runtime class.
+ */
+public final class CaptureFutureContextAdvice {
+
+    private CaptureFutureContextAdvice() {
+    }
+
+    @Advice.OnMethodExit
+    public static void onConstructed(
+            @Advice.FieldValue(value = "templateTrackerContext", readOnly = false) Map<String, String> stored) {
+        // Snapshot the registering thread's context (null when there is no request in flight - the
+        // vast majority of Futures - in which case restore is a no-op).
+        stored = RequestContext.get();
+    }
+}
+

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/ContextPropagatingRunnable.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/ContextPropagatingRunnable.java
@@ -1,6 +1,7 @@
 package com.gu.templatetracker;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Wraps a {@link Runnable} so that the request context captured at <em>submit</em> time (on the
@@ -25,6 +26,16 @@ import java.util.Map;
  */
 public final class ContextPropagatingRunnable implements Runnable {
 
+    // DIAGNOSTIC: log the first time we actually capture a context at an executor submit, to confirm
+    // that propagation starts at all (and on which thread). Remove once propagation is verified.
+    private static final AtomicBoolean CAPTURE_LOGGED = new AtomicBoolean(false);
+
+    // DIAGNOSTIC: log the first time execute(Runnable) is intercepted at all - BEFORE the null-context
+    // early return below - so we can tell "execute was never woven/called" (this never prints) apart
+    // from "execute is woven and called, but the context was null on this hop" (this prints with
+    // hasContext=false while CAPTURE_LOGGED stays silent). Remove once propagation is verified.
+    private static final AtomicBoolean INTERCEPT_LOGGED = new AtomicBoolean(false);
+
     private final Runnable delegate;
     private final Map<String, String> capturedContext;
 
@@ -39,12 +50,23 @@ public final class ContextPropagatingRunnable implements Runnable {
      * hot path for the (vast majority of) tasks that have no associated request.
      */
     public static Runnable wrap(Runnable delegate) {
+        if (INTERCEPT_LOGGED.compareAndSet(false, true)) {
+            System.out.println(
+                "{\"marker\":\"TEMPLATE_TRACKER_DEBUG\",\"message\":\"First execute() interception (context may be null)\","
+                    + "\"thread\":\"" + Thread.currentThread().getName() + "\",\"hasContext\":"
+                    + (RequestContext.get() != null) + "}");
+        }
         if (delegate == null || delegate instanceof ContextPropagatingRunnable) {
             return delegate;
         }
         Map<String, String> context = RequestContext.get();
         if (context == null) {
             return delegate;
+        }
+        if (CAPTURE_LOGGED.compareAndSet(false, true)) {
+            System.out.println(
+                "{\"marker\":\"TEMPLATE_TRACKER_DEBUG\",\"message\":\"First context capture at executor submit\","
+                    + "\"thread\":\"" + Thread.currentThread().getName() + "\",\"context\":\"" + context + "\"}");
         }
         return new ContextPropagatingRunnable(delegate, context);
     }

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/ContextPropagatingRunnable.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/ContextPropagatingRunnable.java
@@ -1,0 +1,65 @@
+package com.gu.templatetracker;
+
+/**
+ * Wraps a {@link Runnable} so that the request context captured at <em>submit</em> time (on the
+ * thread that hands the task to an executor) is restored around {@link #run()} on the <em>worker</em>
+ * thread, then cleaned up afterwards.
+ *
+ * <p>On its own this only bridges a single executor hop. The trick is that every executor on the
+ * request path is instrumented (see {@link PropagateContextAdvice}) to wrap tasks this way, so the
+ * context forms an unbroken chain:
+ *
+ * <pre>
+ *   thread A (filter sets context)
+ *     -&gt; submit CAPI task            (context captured here)
+ *        -&gt; thread B runs it, restores context
+ *           -&gt; future completes, submits the render continuation (context captured again)
+ *              -&gt; thread C runs it, restores context
+ *                 -&gt; Twirl render reads RequestContext.get()  == the original request
+ * </pre>
+ *
+ * <p>Like {@link RequestContext} it references only the JDK, so it can be loaded by the bootstrap
+ * classloader alongside the JDK executor classes it is woven into.
+ */
+public final class ContextPropagatingRunnable implements Runnable {
+
+    private final Runnable delegate;
+    private final String capturedContext;
+
+    private ContextPropagatingRunnable(Runnable delegate, String capturedContext) {
+        this.delegate = delegate;
+        this.capturedContext = capturedContext;
+    }
+
+    /**
+     * Wrap {@code delegate} so it carries the current thread's request context. Returns the delegate
+     * unchanged when there is nothing to carry, or it is already wrapped, keeping overhead off the
+     * hot path for the (vast majority of) tasks that have no associated request.
+     */
+    public static Runnable wrap(Runnable delegate) {
+        if (delegate == null || delegate instanceof ContextPropagatingRunnable) {
+            return delegate;
+        }
+        String context = RequestContext.get();
+        if (context == null) {
+            return delegate;
+        }
+        return new ContextPropagatingRunnable(delegate, context);
+    }
+
+    @Override
+    public void run() {
+        String previous = RequestContext.get();
+        RequestContext.set(capturedContext);
+        try {
+            delegate.run();
+        } finally {
+            if (previous != null) {
+                RequestContext.set(previous);
+            } else {
+                RequestContext.clear();
+            }
+        }
+    }
+}
+

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/ContextPropagatingRunnable.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/ContextPropagatingRunnable.java
@@ -1,5 +1,7 @@
 package com.gu.templatetracker;
 
+import java.util.Map;
+
 /**
  * Wraps a {@link Runnable} so that the request context captured at <em>submit</em> time (on the
  * thread that hands the task to an executor) is restored around {@link #run()} on the <em>worker</em>
@@ -24,9 +26,9 @@ package com.gu.templatetracker;
 public final class ContextPropagatingRunnable implements Runnable {
 
     private final Runnable delegate;
-    private final String capturedContext;
+    private final Map<String, String> capturedContext;
 
-    private ContextPropagatingRunnable(Runnable delegate, String capturedContext) {
+    private ContextPropagatingRunnable(Runnable delegate, Map<String, String> capturedContext) {
         this.delegate = delegate;
         this.capturedContext = capturedContext;
     }
@@ -40,7 +42,7 @@ public final class ContextPropagatingRunnable implements Runnable {
         if (delegate == null || delegate instanceof ContextPropagatingRunnable) {
             return delegate;
         }
-        String context = RequestContext.get();
+        Map<String, String> context = RequestContext.get();
         if (context == null) {
             return delegate;
         }
@@ -49,7 +51,7 @@ public final class ContextPropagatingRunnable implements Runnable {
 
     @Override
     public void run() {
-        String previous = RequestContext.get();
+        Map<String, String> previous = RequestContext.get();
         RequestContext.set(capturedContext);
         try {
             delegate.run();
@@ -62,4 +64,6 @@ public final class ContextPropagatingRunnable implements Runnable {
         }
     }
 }
+
+
 

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/PropagateContextAdvice.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/PropagateContextAdvice.java
@@ -1,0 +1,24 @@
+package com.gu.templatetracker;
+
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Advice inlined at the entry of {@code Executor#execute(Runnable)} (and subtypes). It replaces the
+ * submitted task with one that carries the current thread's request context to the worker thread.
+ *
+ * <p>Because it is woven into bootstrap-loaded JDK classes, everything it references
+ * ({@link ContextPropagatingRunnable}, and transitively {@link RequestContext}) must also be visible
+ * to the bootstrap classloader - which is why {@link TemplateTrackerAgent#premain} appends the agent
+ * jar to the bootstrap classloader search.
+ */
+public final class PropagateContextAdvice {
+
+    private PropagateContextAdvice() {
+    }
+
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Argument(value = 0, readOnly = false) Runnable task) {
+        task = ContextPropagatingRunnable.wrap(task);
+    }
+}
+

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/RequestContext.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/RequestContext.java
@@ -1,7 +1,18 @@
 package com.gu.templatetracker;
 
+import java.util.Map;
+
 /**
  * A JDK-only carrier for "the request currently being handled on this thread".
+ *
+ * <p>The context is a plain {@code Map<String, String>} of already-extracted, human-readable fields
+ * (request id, HTTP method, controller method, dcr param, ...). We deliberately carry a small,
+ * immutable-in-spirit snapshot rather than a rich object: the map rides along inside every
+ * queued/in-flight task (see {@link ContextPropagatingRunnable}), so keeping it a handful of short
+ * strings avoids pinning heavyweight request state alive across async hops.
+ *
+ * <p>Using {@code Map} (a JDK type) also means the Play {@code Filter} that writes the context can pass
+ * it straight through reflection with no compile-time coupling to the agent.
  *
  * <p>This class lives in the agent jar which we append to the <em>bootstrap</em> classloader (see
  * {@link TemplateTrackerAgent#premain}). That gives it a single identity that is visible to:
@@ -17,24 +28,25 @@ package com.gu.templatetracker;
  */
 public final class RequestContext {
 
-    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+    private static final ThreadLocal<Map<String, String>> CURRENT = new ThreadLocal<>();
 
     private RequestContext() {
     }
 
-    /** Set the description of the request being handled on the current thread. */
-    public static void set(String description) {
-        CURRENT.set(description);
+    /** Set the fields describing the request being handled on the current thread. */
+    public static void set(Map<String, String> context) {
+        CURRENT.set(context);
     }
 
-    /** The request description associated with the current thread, or {@code null} if none. */
-    public static String get() {
+    /** The request fields associated with the current thread, or {@code null} if none. */
+    public static Map<String, String> get() {
         return CURRENT.get();
     }
 
-    /** Remove any request description associated with the current thread. */
+    /** Remove any request fields associated with the current thread. */
     public static void clear() {
         CURRENT.remove();
     }
 }
+
 

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/RequestContext.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/RequestContext.java
@@ -1,0 +1,40 @@
+package com.gu.templatetracker;
+
+/**
+ * A JDK-only carrier for "the request currently being handled on this thread".
+ *
+ * <p>This class lives in the agent jar which we append to the <em>bootstrap</em> classloader (see
+ * {@link TemplateTrackerAgent#premain}). That gives it a single identity that is visible to:
+ * <ul>
+ *   <li>Play's child application classloader - so a Play {@code Filter} can write the context, and</li>
+ *   <li>bootstrap-loaded JDK classes (e.g. {@code java.util.concurrent.*}) - so we can propagate the
+ *       context across thread hops by instrumenting {@link java.util.concurrent.Executor}.</li>
+ * </ul>
+ *
+ * <p>It deliberately references <strong>only</strong> the JDK: were it to touch any Play/{@code common}
+ * type it could not be loaded by the bootstrap classloader, and the agent (a classloading ancestor of
+ * the app) could not see it.
+ */
+public final class RequestContext {
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    private RequestContext() {
+    }
+
+    /** Set the description of the request being handled on the current thread. */
+    public static void set(String description) {
+        CURRENT.set(description);
+    }
+
+    /** The request description associated with the current thread, or {@code null} if none. */
+    public static String get() {
+        return CURRENT.get();
+    }
+
+    /** Remove any request description associated with the current thread. */
+    public static void clear() {
+        CURRENT.remove();
+    }
+}
+

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/RequestContext.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/RequestContext.java
@@ -6,7 +6,7 @@ import java.util.Map;
  * A JDK-only carrier for "the request currently being handled on this thread".
  *
  * <p>The context is a plain {@code Map<String, String>} of already-extracted, human-readable fields
- * (request id, HTTP method, controller method, dcr param, ...). We deliberately carry a small,
+ * (HTTP method, controller method, dcr param, sample uri). We deliberately carry a small,
  * immutable-in-spirit snapshot rather than a rich object: the map rides along inside every
  * queued/in-flight task (see {@link ContextPropagatingRunnable}), so keeping it a handful of short
  * strings avoids pinning heavyweight request state alive across async hops.

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/RestoreFutureContextAdvice.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/RestoreFutureContextAdvice.java
@@ -1,0 +1,55 @@
+package com.gu.templatetracker;
+
+import net.bytebuddy.asm.Advice;
+
+import java.util.Map;
+
+/**
+ * Advice inlined around {@code scala.concurrent.impl.Promise$Transformation#run()}. The context that
+ * {@link CaptureFutureContextAdvice} stashed on this instance at construction (the thread that
+ * registered the callback) is re-installed on the current worker thread for the duration of
+ * {@code run()} - i.e. while the user's {@code map}/{@code flatMap}/... body (and therefore any Twirl
+ * render it triggers) executes - then unwound afterwards.
+ *
+ * <p>This is what actually bridges the async gap: it does not matter which thread completed the source
+ * promise or on which dispatcher the continuation runs; the context rides on the Transformation itself.
+ */
+public final class RestoreFutureContextAdvice {
+
+    private RestoreFutureContextAdvice() {
+    }
+
+    /**
+     * @return the context that was on this thread before we overwrote it, handed to {@link #onExit} via
+     *         {@link Advice.Enter}; {@code null} when there was nothing to restore (either no captured
+     *         context, or the thread was already context-free).
+     */
+    @Advice.OnMethodEnter
+    public static Map<String, String> onEnter(
+            @Advice.FieldValue("templateTrackerContext") Map<String, String> stored) {
+        if (stored == null) {
+            return null;
+        }
+        Map<String, String> previous = RequestContext.get();
+        RequestContext.set(stored);
+        return previous;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
+    public static void onExit(
+            @Advice.Enter Map<String, String> previous,
+            @Advice.FieldValue("templateTrackerContext") Map<String, String> stored) {
+        // Only unwind if we installed something on enter. `stored` is still readable here, so we use it
+        // (rather than `previous`, which is legitimately null when the thread was context-free) to tell
+        // "we set the context" apart from "there was nothing to set".
+        if (stored == null) {
+            return;
+        }
+        if (previous != null) {
+            RequestContext.set(previous);
+        } else {
+            RequestContext.clear();
+        }
+    }
+}
+

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/SimpleLogger.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/SimpleLogger.java
@@ -10,12 +10,31 @@ import java.nio.file.StandardOpenOption;
  * We don't expect a crazy volume of log so this might just about do it.
  */
 public class SimpleLogger {
-    Path path;
+    private final Path path;
 
     public SimpleLogger(Path path) {
-        this.path = path;
+        // Resolve to an absolute, normalised path up front so directory creation and every write target
+        // the exact same location, independent of the process working directory at any later moment
+        // (and so the `..` in `../logs` is collapsed rather than left for File#mkdirs, which handles it
+        // unreliably). On EC2 this is /home/<app>/logs; on a dev/staged run it sits next to the app.
+        this.path = path.toAbsolutePath().normalize();
 
-        this.path.getParent().toFile().mkdirs();
+        try {
+            // createDirectories reliably creates the whole chain and throws on failure, unlike
+            // File#mkdirs which silently returns false (which we were ignoring).
+            Files.createDirectories(this.path.getParent());
+        } catch (IOException e) {
+            System.err.println(
+                "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Could not create Twirl usage log directory\",\"path\":\""
+                    + this.path.getParent() + "\"}");
+            e.printStackTrace();
+        }
+
+        // Print the resolved absolute path once, at construction (which is the first render), so it is
+        // obvious where the log is being written.
+        System.out.println(
+            "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Twirl usage log location\",\"path\":\""
+                + this.path + "\"}");
     }
 
     public synchronized void log(String json) throws IOException {

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -21,34 +21,43 @@ public final class TemplateTracker {
     // Fields of the request context we dedupe on (in addition to the template itself), so a template
     // shared by many callers is captured once per distinct caller rather than only on its very first
     // render across the whole JVM:
-    //   - the routed controller action (e.g. "controllers.FooController.bar"), and
+    //   - the routed controller action (e.g. "controllers.FooController.bar"),
     //   - the `dcr` query param that forces legacy vs DCR rendering
-    //     ("true"/"false"/"apps"/"other"/"absent").
+    //     ("true"/"false"/"apps"/"other"/"absent"), and
+    //   - the HTTP method.
     private static final String CONTROLLER_METHOD_KEY = "controllerMethod";
     private static final String DCR_KEY = "dcr";
+    private static final String METHOD_KEY = "method";
+    private static final String SAMPLE_URI_KEY = "sampleUri";
 
     public static void recordRendering(String rawClassName) {
         String template = normalise(rawClassName);
-        // The request that triggered this render, as seeded by the Play filter and carried across any
-        // thread hops by the executor instrumentation. May be null if the render happened outside a
-        // request (startup, background job) or before the context could propagate.
+        // The request that triggered this render, as seeded by the TemplateContextFilter and carried across any
+        // thread hops by the executor instrumentation. The context (or any individual field) may be
+        // absent if the render happened outside a request (startup, background job) or before the
+        // context could propagate - in which case that field is logged as JSON null.
         Map<String, String> request = RequestContext.get();
-        String controllerMethod = request == null ? null : request.get(CONTROLLER_METHOD_KEY);
-        String dcr = request == null ? null : request.get(DCR_KEY);
+        String method = field(request, METHOD_KEY);
+        String controllerMethod = field(request, CONTROLLER_METHOD_KEY);
+        String dcr = field(request, DCR_KEY);
+        String sampleUri = field(request, SAMPLE_URI_KEY);
 
-        // Dedupe on (template, controller method, dcr). '\u0000' can't appear in any value, so it is
-        // an unambiguous separator.
-        String seenKey = template + '\u0000'
-            + (controllerMethod == null ? "" : controllerMethod) + '\u0000'
-            + (dcr == null ? "" : dcr);
-        // After the first sighting of a (template, action, dcr) tuple, `add` returns false and we do
-        // nothing further - so the hot path is a single concurrent-set membership check.
+        // Dedupe on (template, controller method, dcr, http method).
+        String seenKey = template + '|'
+            + (controllerMethod == null ? "" : controllerMethod) + '|'
+            + (dcr == null ? "" : dcr) + '|'
+            + (method == null ? "" : method);
+        // After the first sighting of this tuple, `add` returns false and we do nothing further - so
+        // the hot path is a single concurrent-set membership check.
         if (SEEN.add(seenKey)) {
             try {
                 logger.log("{" +
                     "\"marker\":\"TEMPLATE_FIRST_SEEN\"," +
                     "\"template\":\"" + jsonEscape(template) + "\"," +
-                    "\"request\":" + renderContext(request) + "," +
+                    "\"method\":" + jsonStringOrNull(method) + "," +
+                    "\"controllerMethod\":" + jsonStringOrNull(controllerMethod) + "," +
+                    "\"dcr\":" + jsonStringOrNull(dcr) + "," +
+                    "\"sampleUri\":" + jsonStringOrNull(sampleUri) + "," +
                     "\"timestamp\":\"" + formatter.format(ZonedDateTime.now()) + "\"" +
                     "}");
             } catch (IOException e) {
@@ -59,29 +68,17 @@ public final class TemplateTracker {
     }
 
     /**
-     * Render the request context map as a JSON object (or the literal {@code null} when there is no
-     * context). Keys and values are escaped; a null value is emitted as the JSON literal {@code null}.
+     * The value for {@code key}, or {@code null} when there is no context or the field is absent.
      */
-    private static String renderContext(Map<String, String> context) {
-        if (context == null || context.isEmpty()) {
-            return "null";
-        }
-        StringBuilder sb = new StringBuilder("{");
-        boolean first = true;
-        for (Map.Entry<String, String> entry : context.entrySet()) {
-            if (!first) {
-                sb.append(',');
-            }
-            first = false;
-            sb.append('"').append(jsonEscape(entry.getKey())).append("\":");
-            String value = entry.getValue();
-            if (value == null) {
-                sb.append("null");
-            } else {
-                sb.append('"').append(jsonEscape(value)).append('"');
-            }
-        }
-        return sb.append('}').toString();
+    private static String field(Map<String, String> context, String key) {
+        return context == null ? null : context.get(key);
+    }
+
+    /**
+     * Render a string field as a quoted, escaped JSON string, or the JSON literal {@code null}.
+     */
+    private static String jsonStringOrNull(String value) {
+        return value == null ? "null" : "\"" + jsonEscape(value) + "\"";
     }
 
     /**
@@ -93,11 +90,21 @@ public final class TemplateTracker {
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
             switch (c) {
-                case '"':  sb.append("\\\""); break;
-                case '\\': sb.append("\\\\"); break;
-                case '\n': sb.append("\\n"); break;
-                case '\r': sb.append("\\r"); break;
-                case '\t': sb.append("\\t"); break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
                 default:
                     if (c < 0x20) {
                         sb.append(String.format("\\u%04x", (int) c));

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -17,20 +18,37 @@ public final class TemplateTracker {
 
     private static DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
 
+    // Fields of the request context we dedupe on (in addition to the template itself), so a template
+    // shared by many callers is captured once per distinct caller rather than only on its very first
+    // render across the whole JVM:
+    //   - the routed controller action (e.g. "controllers.FooController.bar"), and
+    //   - the `dcr` query param that forces legacy vs DCR rendering
+    //     ("true"/"false"/"apps"/"other"/"absent").
+    private static final String CONTROLLER_METHOD_KEY = "controllerMethod";
+    private static final String DCR_KEY = "dcr";
+
     public static void recordRendering(String rawClassName) {
         String template = normalise(rawClassName);
-        // After the first sighting of a template, `add` returns false and we do nothing further -
-        // so the hot path for high-traffic templates is a single concurrent-set membership check.
-        if (SEEN.add(template)) {
-            // The request that triggered this render, as seeded by the Play filter and carried across
-            // any thread hops by the executor instrumentation. May be null if the render happened
-            // outside a request (startup, background job) or before the context could propagate.
-            String request = RequestContext.get();
+        // The request that triggered this render, as seeded by the Play filter and carried across any
+        // thread hops by the executor instrumentation. May be null if the render happened outside a
+        // request (startup, background job) or before the context could propagate.
+        Map<String, String> request = RequestContext.get();
+        String controllerMethod = request == null ? null : request.get(CONTROLLER_METHOD_KEY);
+        String dcr = request == null ? null : request.get(DCR_KEY);
+
+        // Dedupe on (template, controller method, dcr). '\u0000' can't appear in any value, so it is
+        // an unambiguous separator.
+        String seenKey = template + '\u0000'
+            + (controllerMethod == null ? "" : controllerMethod) + '\u0000'
+            + (dcr == null ? "" : dcr);
+        // After the first sighting of a (template, action, dcr) tuple, `add` returns false and we do
+        // nothing further - so the hot path is a single concurrent-set membership check.
+        if (SEEN.add(seenKey)) {
             try {
                 logger.log("{" +
                     "\"marker\":\"TEMPLATE_FIRST_SEEN\"," +
-                    "\"template\":\"" + jsonEscape(template) + "\", " +
-                    "\"request\":" + (request == null ? "null" : "\"" + jsonEscape(request) + "\"") + ", " +
+                    "\"template\":\"" + jsonEscape(template) + "\"," +
+                    "\"request\":" + renderContext(request) + "," +
                     "\"timestamp\":\"" + formatter.format(ZonedDateTime.now()) + "\"" +
                     "}");
             } catch (IOException e) {
@@ -38,6 +56,32 @@ public final class TemplateTracker {
                 e.printStackTrace();
             }
         }
+    }
+
+    /**
+     * Render the request context map as a JSON object (or the literal {@code null} when there is no
+     * context). Keys and values are escaped; a null value is emitted as the JSON literal {@code null}.
+     */
+    private static String renderContext(Map<String, String> context) {
+        if (context == null || context.isEmpty()) {
+            return "null";
+        }
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, String> entry : context.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append('"').append(jsonEscape(entry.getKey())).append("\":");
+            String value = entry.getValue();
+            if (value == null) {
+                sb.append("null");
+            } else {
+                sb.append('"').append(jsonEscape(value)).append('"');
+            }
+        }
+        return sb.append('}').toString();
     }
 
     /**

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -22,10 +22,15 @@ public final class TemplateTracker {
         // After the first sighting of a template, `add` returns false and we do nothing further -
         // so the hot path for high-traffic templates is a single concurrent-set membership check.
         if (SEEN.add(template)) {
+            // The request that triggered this render, as seeded by the Play filter and carried across
+            // any thread hops by the executor instrumentation. May be null if the render happened
+            // outside a request (startup, background job) or before the context could propagate.
+            String request = RequestContext.get();
             try {
                 logger.log("{" +
                     "\"marker\":\"TEMPLATE_FIRST_SEEN\"," +
-                    "\"template\":\"" + template + "\", " +
+                    "\"template\":\"" + jsonEscape(template) + "\", " +
+                    "\"request\":" + (request == null ? "null" : "\"" + jsonEscape(request) + "\"") + ", " +
                     "\"timestamp\":\"" + formatter.format(ZonedDateTime.now()) + "\"" +
                     "}");
             } catch (IOException e) {
@@ -33,6 +38,31 @@ public final class TemplateTracker {
                 e.printStackTrace();
             }
         }
+    }
+
+    /**
+     * Minimal JSON string escaping for the values we hand-roll into the log line (template class
+     * names and request URLs, which can legitimately contain quotes, backslashes or control chars).
+     */
+    private static String jsonEscape(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 16);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"':  sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
     }
 
     /**

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
@@ -1,10 +1,5 @@
 package com.gu.templatetracker;
 
-import net.bytebuddy.agent.builder.AgentBuilder;
-import net.bytebuddy.asm.Advice;
-import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
-
 import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.util.jar.JarFile;
@@ -22,35 +17,16 @@ import java.util.jar.JarFile;
  * The instrumentation is deliberately small: it inlines a single call at the entry of each
  * template's {@code apply}/{@code render} method, which delegates to {@link TemplateTracker} where a
  * first-seen {@link java.util.Set} membership check makes every render after the first essentially free.
+ * <p>
+ * This class references <strong>no ByteBuddy type</strong> on purpose: it appends its own jar (which
+ * bundles ByteBuddy) to the bootstrap classloader, after which ByteBuddy must be defined solely by the
+ * bootstrap loader. All ByteBuddy wiring therefore lives in {@link TemplateTrackerInstaller}, which is
+ * only referenced <em>after</em> the append - see that class for the full rationale.
  */
 public final class TemplateTrackerAgent {
 
     private TemplateTrackerAgent() {
     }
-
-    // We define a "Twirl template" as: classes under views.html.* that are subtypes of play.twirl.api.Template* (Template0..Template22).
-    private static ElementMatcher TWIRL_TEMPLATE_MATCHER = ElementMatchers.<net.bytebuddy.description.type.TypeDescription>nameStartsWith("views.html.")
-        .and(ElementMatchers.hasSuperType(ElementMatchers.nameStartsWith("play.twirl.api.Template")));
-
-    // This transformer inlines `TemplateTracker.recordRendering` (via RecordTemplateAdvice) at the entry of each template's `apply` and `render` methods.
-    private static AgentBuilder.Transformer RECORD_TEMPLATE_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) ->
-        builder.visit(
-            Advice.to(RecordTemplateAdvice.class)
-                .on(ElementMatchers.named("apply").or(ElementMatchers.named("render"))));
-
-    // Any type that is an Executor: ThreadPoolExecutor, ForkJoinPool (Scala's default EC), Pekko
-    // dispatchers, the CAPI/WS client pools, etc. Instrumenting `execute(Runnable)` on all of them is
-    // what lets the request context follow a logical request across every async hop.
-    private static ElementMatcher<net.bytebuddy.description.type.TypeDescription> EXECUTOR_MATCHER =
-        ElementMatchers.hasSuperType(ElementMatchers.named("java.util.concurrent.Executor"));
-
-    // Replaces the submitted Runnable with a context-carrying one (see PropagateContextAdvice).
-    private static AgentBuilder.Transformer PROPAGATE_CONTEXT_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) ->
-        builder.visit(
-            Advice.to(PropagateContextAdvice.class)
-                .on(ElementMatchers.named("execute")
-                    .and(ElementMatchers.takesArguments(1))
-                    .and(ElementMatchers.takesArgument(0, Runnable.class))));
 
     public static void premain(String args, Instrumentation instrumentation) {
         System.out.println(
@@ -62,37 +38,11 @@ public final class TemplateTrackerAgent {
         // referenced guarantees there is exactly one RequestContext (and one ThreadLocal).
         boolean bootstrapReady = appendAgentJarToBootstrap(instrumentation);
 
-        // 1. Record the first render of each Twirl template, tagged with the current request context.
-        //    Independent of the bootstrap append (it only needs TemplateTracker, loaded by the system
-        //    classloader), so we always install it.
-        new AgentBuilder.Default()
-            .type(TWIRL_TEMPLATE_MATCHER)
-            .transform(RECORD_TEMPLATE_TRANSFORMER)
-            .installOn(instrumentation);
-
-        // 2. Propagate the request context across thread hops by instrumenting every Executor.
-        //    RETRANSFORMATION lets us weave already-loaded JDK executors; disableClassFormatChanges
-        //    keeps the transform to method-body inlining only, which retransformation of JDK classes
-        //    allows. `ignore(none())` lifts the default guard that would otherwise skip JDK types.
-        //
-        //    Only install this when the bootstrap append succeeded: the woven advice references
-        //    ContextPropagatingRunnable / RequestContext, so if those classes aren't on the bootstrap
-        //    classloader the JDK executors would throw NoClassDefFoundError on their hottest path. When
-        //    the append failed we simply skip propagation - templates are still recorded, just without
-        //    a request attached once the render crosses a thread boundary.
-        if (bootstrapReady) {
-            new AgentBuilder.Default()
-                .disableClassFormatChanges()
-                .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
-                .ignore(ElementMatchers.none())
-                .type(EXECUTOR_MATCHER)
-                .transform(PROPAGATE_CONTEXT_TRANSFORMER)
-                .installOn(instrumentation);
-        } else {
-            System.err.println(
-                "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Skipping executor instrumentation; "
-                    + "cross-thread request-context propagation is disabled\"}");
-        }
+        // Delegate all ByteBuddy work to TemplateTrackerInstaller. This is an ordinary static call, so
+        // it is resolved lazily at execution time - i.e. after the append above - which means the
+        // installer and every ByteBuddy class it references are defined by the bootstrap loader (a
+        // single copy), rather than being loaded by the system loader before the append.
+        TemplateTrackerInstaller.install(instrumentation, bootstrapReady);
     }
 
     /**

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
@@ -60,9 +60,11 @@ public final class TemplateTrackerAgent {
         // bootstrap-loaded JDK executor classes we instrument below, and gives them a single identity
         // shared with Play's application classloader. Doing this before any of those classes are
         // referenced guarantees there is exactly one RequestContext (and one ThreadLocal).
-        appendAgentJarToBootstrap(instrumentation);
+        boolean bootstrapReady = appendAgentJarToBootstrap(instrumentation);
 
         // 1. Record the first render of each Twirl template, tagged with the current request context.
+        //    Independent of the bootstrap append (it only needs TemplateTracker, loaded by the system
+        //    classloader), so we always install it.
         new AgentBuilder.Default()
             .type(TWIRL_TEMPLATE_MATCHER)
             .transform(RECORD_TEMPLATE_TRANSFORMER)
@@ -72,13 +74,25 @@ public final class TemplateTrackerAgent {
         //    RETRANSFORMATION lets us weave already-loaded JDK executors; disableClassFormatChanges
         //    keeps the transform to method-body inlining only, which retransformation of JDK classes
         //    allows. `ignore(none())` lifts the default guard that would otherwise skip JDK types.
-        new AgentBuilder.Default()
-            .disableClassFormatChanges()
-            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
-            .ignore(ElementMatchers.none())
-            .type(EXECUTOR_MATCHER)
-            .transform(PROPAGATE_CONTEXT_TRANSFORMER)
-            .installOn(instrumentation);
+        //
+        //    Only install this when the bootstrap append succeeded: the woven advice references
+        //    ContextPropagatingRunnable / RequestContext, so if those classes aren't on the bootstrap
+        //    classloader the JDK executors would throw NoClassDefFoundError on their hottest path. When
+        //    the append failed we simply skip propagation - templates are still recorded, just without
+        //    a request attached once the render crosses a thread boundary.
+        if (bootstrapReady) {
+            new AgentBuilder.Default()
+                .disableClassFormatChanges()
+                .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+                .ignore(ElementMatchers.none())
+                .type(EXECUTOR_MATCHER)
+                .transform(PROPAGATE_CONTEXT_TRANSFORMER)
+                .installOn(instrumentation);
+        } else {
+            System.err.println(
+                "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Skipping executor instrumentation; "
+                    + "cross-thread request-context propagation is disabled\"}");
+        }
     }
 
     /**
@@ -87,17 +101,22 @@ public final class TemplateTrackerAgent {
      * classloader. We locate the jar via {@code TemplateTrackerAgent} (already loaded, and not shared
      * state) rather than via the carrier classes, so we don't accidentally load a second copy of them
      * on the system classloader before the bootstrap entry is in place.
+     *
+     * @return {@code true} if the jar was appended and the carrier classes are now bootstrap-visible;
+     *         {@code false} if not (in which case the caller must not install the executor advice).
      */
-    private static void appendAgentJarToBootstrap(Instrumentation instrumentation) {
+    private static boolean appendAgentJarToBootstrap(Instrumentation instrumentation) {
         try {
             File agentJar = new File(
                 TemplateTrackerAgent.class.getProtectionDomain().getCodeSource().getLocation().toURI());
             instrumentation.appendToBootstrapClassLoaderSearch(new JarFile(agentJar));
+            return true;
         } catch (Exception e) {
             System.err.println(
                 "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Could not append agent jar to bootstrap "
                     + "classloader; cross-thread request-context propagation will be disabled\"}");
             e.printStackTrace();
+            return false;
         }
     }
 }

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerAgent.java
@@ -5,7 +5,9 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
+import java.io.File;
 import java.lang.instrument.Instrumentation;
+import java.util.jar.JarFile;
 
 /**
  * A JVM agent that records, once per JVM, the first time each Twirl template is rendered.
@@ -36,14 +38,67 @@ public final class TemplateTrackerAgent {
             Advice.to(RecordTemplateAdvice.class)
                 .on(ElementMatchers.named("apply").or(ElementMatchers.named("render"))));
 
+    // Any type that is an Executor: ThreadPoolExecutor, ForkJoinPool (Scala's default EC), Pekko
+    // dispatchers, the CAPI/WS client pools, etc. Instrumenting `execute(Runnable)` on all of them is
+    // what lets the request context follow a logical request across every async hop.
+    private static ElementMatcher<net.bytebuddy.description.type.TypeDescription> EXECUTOR_MATCHER =
+        ElementMatchers.hasSuperType(ElementMatchers.named("java.util.concurrent.Executor"));
+
+    // Replaces the submitted Runnable with a context-carrying one (see PropagateContextAdvice).
+    private static AgentBuilder.Transformer PROPAGATE_CONTEXT_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) ->
+        builder.visit(
+            Advice.to(PropagateContextAdvice.class)
+                .on(ElementMatchers.named("execute")
+                    .and(ElementMatchers.takesArguments(1))
+                    .and(ElementMatchers.takesArgument(0, Runnable.class))));
+
     public static void premain(String args, Instrumentation instrumentation) {
         System.out.println(
             "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Installing Twirl template usage tracker\"}");
 
+        // MUST happen first: makes RequestContext / ContextPropagatingRunnable visible to the
+        // bootstrap-loaded JDK executor classes we instrument below, and gives them a single identity
+        // shared with Play's application classloader. Doing this before any of those classes are
+        // referenced guarantees there is exactly one RequestContext (and one ThreadLocal).
+        appendAgentJarToBootstrap(instrumentation);
+
+        // 1. Record the first render of each Twirl template, tagged with the current request context.
         new AgentBuilder.Default()
             .type(TWIRL_TEMPLATE_MATCHER)
             .transform(RECORD_TEMPLATE_TRANSFORMER)
             .installOn(instrumentation);
+
+        // 2. Propagate the request context across thread hops by instrumenting every Executor.
+        //    RETRANSFORMATION lets us weave already-loaded JDK executors; disableClassFormatChanges
+        //    keeps the transform to method-body inlining only, which retransformation of JDK classes
+        //    allows. `ignore(none())` lifts the default guard that would otherwise skip JDK types.
+        new AgentBuilder.Default()
+            .disableClassFormatChanges()
+            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+            .ignore(ElementMatchers.none())
+            .type(EXECUTOR_MATCHER)
+            .transform(PROPAGATE_CONTEXT_TRANSFORMER)
+            .installOn(instrumentation);
+    }
+
+    /**
+     * Append this agent jar to the bootstrap classloader search so that the context-carrier classes
+     * are visible both to the JDK executor classes we instrument and to Play's application
+     * classloader. We locate the jar via {@code TemplateTrackerAgent} (already loaded, and not shared
+     * state) rather than via the carrier classes, so we don't accidentally load a second copy of them
+     * on the system classloader before the bootstrap entry is in place.
+     */
+    private static void appendAgentJarToBootstrap(Instrumentation instrumentation) {
+        try {
+            File agentJar = new File(
+                TemplateTrackerAgent.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            instrumentation.appendToBootstrapClassLoaderSearch(new JarFile(agentJar));
+        } catch (Exception e) {
+            System.err.println(
+                "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Could not append agent jar to bootstrap "
+                    + "classloader; cross-thread request-context propagation will be disabled\"}");
+            e.printStackTrace();
+        }
     }
 }
 

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerInstaller.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerInstaller.java
@@ -2,10 +2,17 @@ package com.gu.templatetracker;
 
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.modifier.SyntheticState;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import java.lang.instrument.Instrumentation;
+import java.util.Map;
 
 /**
  * Holds all the ByteBuddy wiring, deliberately split out of {@link TemplateTrackerAgent}.
@@ -30,6 +37,15 @@ public final class TemplateTrackerInstaller {
     private TemplateTrackerInstaller() {
     }
 
+    // ByteBuddy inlines advice by reading the advice class's *bytecode* via a ClassFileLocator. The
+    // default locator uses the advice class's own classloader - but our advice classes are defined by
+    // the *bootstrap* loader (we append the agent jar there), and the bootstrap loader doesn't expose
+    // them as readable resources, so the default fails with:
+    //   "Could not locate class file for com.gu.templatetracker.RecordTemplateAdvice".
+    // The agent jar is also on the *system* classpath (that's how -javaagent attaches it - the same
+    // source that read the advice on main), so we read the advice bytecode from there explicitly.
+    private static final ClassFileLocator ADVICE_LOCATOR = ClassFileLocator.ForClassLoader.ofSystemLoader();
+
     // We define a "Twirl template" as: classes under views.html.* that are subtypes of play.twirl.api.Template* (Template0..Template22).
     private static ElementMatcher TWIRL_TEMPLATE_MATCHER = ElementMatchers.<net.bytebuddy.description.type.TypeDescription>nameStartsWith("views.html.")
         .and(ElementMatchers.hasSuperType(ElementMatchers.nameStartsWith("play.twirl.api.Template")));
@@ -37,7 +53,7 @@ public final class TemplateTrackerInstaller {
     // This transformer inlines `TemplateTracker.recordRendering` (via RecordTemplateAdvice) at the entry of each template's `apply` and `render` methods.
     private static AgentBuilder.Transformer RECORD_TEMPLATE_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) ->
         builder.visit(
-            Advice.to(RecordTemplateAdvice.class)
+            Advice.to(RecordTemplateAdvice.class, ADVICE_LOCATOR)
                 .on(ElementMatchers.named("apply").or(ElementMatchers.named("render"))));
 
     // Any type that is an Executor: ThreadPoolExecutor, ForkJoinPool (Scala's default EC), Pekko
@@ -47,12 +63,47 @@ public final class TemplateTrackerInstaller {
         ElementMatchers.hasSuperType(ElementMatchers.named("java.util.concurrent.Executor"));
 
     // Replaces the submitted Runnable with a context-carrying one (see PropagateContextAdvice).
-    private static AgentBuilder.Transformer PROPAGATE_CONTEXT_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) ->
-        builder.visit(
-            Advice.to(PropagateContextAdvice.class)
-                .on(ElementMatchers.named("execute")
-                    .and(ElementMatchers.takesArguments(1))
-                    .and(ElementMatchers.takesArgument(0, Runnable.class))));
+    private static final ElementMatcher.Junction<MethodDescription> EXECUTE_METHOD_MATCHER =
+        ElementMatchers.named("execute")
+            .and(ElementMatchers.takesArguments(1))
+            .and(ElementMatchers.takesArgument(0, Runnable.class));
+
+    private static AgentBuilder.Transformer PROPAGATE_CONTEXT_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) -> {
+        // DIAGNOSTIC: a "[Byte Buddy] TRANSFORM ..." line only tells us the *type* matched - not that
+        // any method was actually woven (e.g. the java.util.concurrent.Executor interface matches but
+        // its abstract execute() gets nothing). Log the concrete execute(Runnable) methods we actually
+        // instrument, so we can confirm whether the hot executors (ThreadPoolExecutor, ForkJoinPool,
+        // Pekko dispatchers) really get the advice. Remove once propagation is verified.
+        MethodList<?> matched = typeDescription.getDeclaredMethods().filter(EXECUTE_METHOD_MATCHER);
+        if (!matched.isEmpty()) {
+            System.out.println(
+                "{\"marker\":\"TEMPLATE_TRACKER_DEBUG\",\"message\":\"weaving execute(Runnable)\",\"type\":\""
+                    + typeDescription.getName() + "\",\"methods\":" + matched.size() + "}");
+        }
+        return builder.visit(Advice.to(PropagateContextAdvice.class, ADVICE_LOCATOR).on(EXECUTE_METHOD_MATCHER));
+    };
+
+    // In Scala 2.13 every Future combinator (map/flatMap/transform/onComplete/recover/...) is backed by
+    // one Runnable class: scala.concurrent.impl.Promise$Transformation. It is constructed on the thread
+    // that *registers* the callback (which still holds the request context) and only later handed to an
+    // executor - frequently by a foreign thread that never carried the context (e.g. the async-HTTP I/O
+    // thread completing a CAPI lookup). Instrumenting it lets the context ride on the callback itself,
+    // which is what actually bridges the async gap that submit-time executor capture cannot.
+    private static ElementMatcher<TypeDescription> FUTURE_TRANSFORMATION_MATCHER =
+        ElementMatchers.named("scala.concurrent.impl.Promise$Transformation");
+
+    // The synthetic field the two advices use to stash the captured context on each Transformation.
+    private static final String CONTEXT_FIELD = "templateTrackerContext";
+
+    private static AgentBuilder.Transformer FUTURE_CONTEXT_TRANSFORMER =
+        (builder, typeDescription, classLoader, module, protectionDomain) -> builder
+            // Per-instance storage for the registration-time context. Adding a field is a class-format
+            // change, so this block must weave the class on load (no retransformation) - fine, since the
+            // Scala runtime only loads Transformation once the app boots, i.e. after premain.
+            .defineField(CONTEXT_FIELD, Map.class, Visibility.PUBLIC, SyntheticState.SYNTHETIC)
+            .visit(Advice.to(CaptureFutureContextAdvice.class, ADVICE_LOCATOR).on(ElementMatchers.isConstructor()))
+            .visit(Advice.to(RestoreFutureContextAdvice.class, ADVICE_LOCATOR)
+                .on(ElementMatchers.named("run").and(ElementMatchers.takesArguments(0))));
 
     /**
      * Install the two instrumentations. Called by {@link TemplateTrackerAgent#premain} only after the
@@ -62,12 +113,22 @@ public final class TemplateTrackerInstaller {
      *                       classloader; the executor propagation is only installed when {@code true}.
      */
     public static void install(Instrumentation instrumentation, boolean bootstrapReady) {
+        System.out.println(
+            "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Installer reached; installing instrumentation\"}");
+
         // 1. Record the first render of each Twirl template, tagged with the current request context.
         //    Independent of the bootstrap append (it only needs TemplateTracker), so we always install it.
+        //    DIAGNOSTIC: the listener prints a "[Byte Buddy] TRANSFORM ..." line per woven class and a
+        //    "[Byte Buddy] ERROR ..." line for any weaving failure, so we can see whether the Twirl
+        //    templates are actually matched/transformed.
         new AgentBuilder.Default()
+            .with(AgentBuilder.Listener.StreamWriting.toSystemOut().withTransformationsOnly())
             .type(TWIRL_TEMPLATE_MATCHER)
             .transform(RECORD_TEMPLATE_TRANSFORMER)
             .installOn(instrumentation);
+
+        System.out.println(
+            "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Template recording instrumentation installed\"}");
 
         // 2. Propagate the request context across thread hops by instrumenting every Executor.
         //    RETRANSFORMATION lets us weave already-loaded JDK executors; disableClassFormatChanges
@@ -80,7 +141,12 @@ public final class TemplateTrackerInstaller {
         //    the append failed we simply skip propagation - templates are still recorded, just without
         //    a request attached once the render crosses a thread boundary.
         if (bootstrapReady) {
+            // DIAGNOSTIC: mirror block 1's listener so we can see whether executors are actually woven.
+            // withTransformationsOnly() keeps onTransformation + onError but drops the (very noisy under
+            // ignore(none())) discovery/complete events, so we get one "[Byte Buddy] TRANSFORM ..." line
+            // per woven Executor and a "[Byte Buddy] ERROR ..." line for every silent weaving failure.
             new AgentBuilder.Default()
+                .with(AgentBuilder.Listener.StreamWriting.toSystemOut().withTransformationsOnly())
                 .disableClassFormatChanges()
                 .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
                 .ignore(ElementMatchers.none())
@@ -91,6 +157,23 @@ public final class TemplateTrackerInstaller {
             System.err.println(
                 "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Skipping executor instrumentation; "
                     + "cross-thread request-context propagation is disabled\"}");
+        }
+
+        // 3. Bridge the async gap that (2) structurally cannot: capture the request context when a Scala
+        //    Future callback is *registered* (on the request thread) and restore it when it *runs*, by
+        //    instrumenting scala.concurrent.impl.Promise$Transformation. This is what makes the context
+        //    visible at render time when the render sits behind an async boundary (e.g. a CAPI lookup),
+        //    where the completing thread never carried the context. Also only meaningful when the
+        //    carrier classes are on the bootstrap loader.
+        //    DIAGNOSTIC: the listener prints a "[Byte Buddy] TRANSFORM scala.concurrent.impl.Promise$Transformation"
+        //    line confirming the class was woven (and any "[Byte Buddy] ERROR ..." if it was already
+        //    loaded at premain, in which case the on-load field addition would miss it).
+        if (bootstrapReady) {
+            new AgentBuilder.Default()
+                .with(AgentBuilder.Listener.StreamWriting.toSystemOut().withTransformationsOnly())
+                .type(FUTURE_TRANSFORMATION_MATCHER)
+                .transform(FUTURE_CONTEXT_TRANSFORMER)
+                .installOn(instrumentation);
         }
     }
 }

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerInstaller.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTrackerInstaller.java
@@ -1,0 +1,97 @@
+package com.gu.templatetracker;
+
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+import java.lang.instrument.Instrumentation;
+
+/**
+ * Holds all the ByteBuddy wiring, deliberately split out of {@link TemplateTrackerAgent}.
+ *
+ * <p><strong>Why a separate class?</strong> The agent appends its own jar - ByteBuddy included - to the
+ * bootstrap classloader (so the JDK executor classes we instrument can see the carrier classes). Once
+ * that happens, any ByteBuddy class is resolved parent-first and therefore <em>defined by the
+ * bootstrap loader</em>. The catch is that {@link TemplateTrackerAgent} is defined by the system
+ * loader, so if <em>it</em> referenced ByteBuddy types they could be defined by the system loader
+ * <em>before</em> the append runs - notably during its own static-init or bytecode verification. That
+ * would leave two copies of e.g. {@code ElementMatcher} (system + bootstrap) and the JVM would reject
+ * the mismatch with a {@code LinkageError: loader constraint violation}.
+ *
+ * <p>Keeping every ByteBuddy reference in this class avoids that: {@code premain} names no ByteBuddy
+ * type, so verifying it can't load one; and the {@code invokestatic} that calls {@link #install} is
+ * resolved lazily, at execution time - i.e. <em>after</em> the append. By then the jar is on the
+ * bootstrap, so this class and all the ByteBuddy classes it touches are defined once, by the bootstrap
+ * loader.
+ */
+public final class TemplateTrackerInstaller {
+
+    private TemplateTrackerInstaller() {
+    }
+
+    // We define a "Twirl template" as: classes under views.html.* that are subtypes of play.twirl.api.Template* (Template0..Template22).
+    private static ElementMatcher TWIRL_TEMPLATE_MATCHER = ElementMatchers.<net.bytebuddy.description.type.TypeDescription>nameStartsWith("views.html.")
+        .and(ElementMatchers.hasSuperType(ElementMatchers.nameStartsWith("play.twirl.api.Template")));
+
+    // This transformer inlines `TemplateTracker.recordRendering` (via RecordTemplateAdvice) at the entry of each template's `apply` and `render` methods.
+    private static AgentBuilder.Transformer RECORD_TEMPLATE_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) ->
+        builder.visit(
+            Advice.to(RecordTemplateAdvice.class)
+                .on(ElementMatchers.named("apply").or(ElementMatchers.named("render"))));
+
+    // Any type that is an Executor: ThreadPoolExecutor, ForkJoinPool (Scala's default EC), Pekko
+    // dispatchers, the CAPI/WS client pools, etc. Instrumenting `execute(Runnable)` on all of them is
+    // what lets the request context follow a logical request across every async hop.
+    private static ElementMatcher<net.bytebuddy.description.type.TypeDescription> EXECUTOR_MATCHER =
+        ElementMatchers.hasSuperType(ElementMatchers.named("java.util.concurrent.Executor"));
+
+    // Replaces the submitted Runnable with a context-carrying one (see PropagateContextAdvice).
+    private static AgentBuilder.Transformer PROPAGATE_CONTEXT_TRANSFORMER = (builder, typeDescription, classLoader, module, protectionDomain) ->
+        builder.visit(
+            Advice.to(PropagateContextAdvice.class)
+                .on(ElementMatchers.named("execute")
+                    .and(ElementMatchers.takesArguments(1))
+                    .and(ElementMatchers.takesArgument(0, Runnable.class))));
+
+    /**
+     * Install the two instrumentations. Called by {@link TemplateTrackerAgent#premain} only after the
+     * bootstrap append, so this class (and ByteBuddy) load via the bootstrap loader.
+     *
+     * @param bootstrapReady whether the carrier classes were successfully appended to the bootstrap
+     *                       classloader; the executor propagation is only installed when {@code true}.
+     */
+    public static void install(Instrumentation instrumentation, boolean bootstrapReady) {
+        // 1. Record the first render of each Twirl template, tagged with the current request context.
+        //    Independent of the bootstrap append (it only needs TemplateTracker), so we always install it.
+        new AgentBuilder.Default()
+            .type(TWIRL_TEMPLATE_MATCHER)
+            .transform(RECORD_TEMPLATE_TRANSFORMER)
+            .installOn(instrumentation);
+
+        // 2. Propagate the request context across thread hops by instrumenting every Executor.
+        //    RETRANSFORMATION lets us weave already-loaded JDK executors; disableClassFormatChanges
+        //    keeps the transform to method-body inlining only, which retransformation of JDK classes
+        //    allows. `ignore(none())` lifts the default guard that would otherwise skip JDK types.
+        //
+        //    Only install this when the bootstrap append succeeded: the woven advice references
+        //    ContextPropagatingRunnable / RequestContext, so if those classes aren't on the bootstrap
+        //    classloader the JDK executors would throw NoClassDefFoundError on their hottest path. When
+        //    the append failed we simply skip propagation - templates are still recorded, just without
+        //    a request attached once the render crosses a thread boundary.
+        if (bootstrapReady) {
+            new AgentBuilder.Default()
+                .disableClassFormatChanges()
+                .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+                .ignore(ElementMatchers.none())
+                .type(EXECUTOR_MATCHER)
+                .transform(PROPAGATE_CONTEXT_TRANSFORMER)
+                .installOn(instrumentation);
+        } else {
+            System.err.println(
+                "{\"marker\":\"TEMPLATE_TRACKER_INIT\",\"message\":\"Skipping executor instrumentation; "
+                    + "cross-thread request-context propagation is disabled\"}");
+        }
+    }
+}
+


### PR DESCRIPTION
## What is the value of this and can you measure success?
At this stage this PR is an experiment to see if (with the help of an LLM, as this is VERY technical) we can gather more context about what exactly triggered the rendering of a twirl template.

The extra context is:
- the controller method that triggered the rendering `controller.MyController.renderMyInfo()`
- the http method (GET, POST etc)
- the state of the `dcr` query param: `true`, `false`, `apps`, `other`, `absent`
- the url that triggered this rendering (as a sample, just for illustration purposes)

Now, because this is:
- very technical 
- AND written by an LLM 
- AND touching really really deep into the JVM
 
we're going to:
- [ ] thoroughly test that this does what it says on the tin
- [ ] ensure that if it works it does bring useful insight to how our templates are being used in production
- [ ] check any impact on CPU usage, RAM usage and latency
- [ ] thoroughly review this, possibly in a mob session (assuming we passed all the above)
- [ ] document how to remove it in this very PR

What I do like about this code:
- I think it could be extremely useful to know which controller is using which template, and if it was when we appended the `dcr` query param or not

What I do not like about this code:
- It's using techniques that are cleverer than what I could have come up with. Clever is good, but simple is better. However, there's no easy way around complexity for this feature.
- it's instrumenting sensitive code. In theory it should be harmless, but it's making me feel uncomfortable.

## What does this change?
to be completed

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
