### PR TITLE
Strip commercial tag properties for DCR tag pages

### DIFF
--- a/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
@@ -93,7 +93,7 @@ object DotcomTagPagesRenderingDataModel {
     }
 
     DotcomTagPagesRenderingDataModel(
-      contents = page.contents.map(_.faciaItem),
+      contents = page.contents.map(_.faciaItem.withoutCommercial),
       pagination = pagination,
       tags = page.tags,
       date = page.date,

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -25,12 +25,8 @@ class SwitchesTest extends AnyFlatSpec with Matchers with AppendedClues {
 
   private val testSwitchGroup = new SwitchGroup("category")
 
-  private val switchExpiryDate = {
-    val today = LocalDate.now()
-    if (today.getDayOfWeek == SATURDAY) today.plusDays(2)
-    else if (today.getDayOfWeek == SUNDAY) today.plusDays(1)
-    else today
-  }
+  // A fixed weekday far in the future, so the test switch never looks expired whatever the clock says
+  private val switchExpiryDate = LocalDate.of(2099, 1, 1)
 
   def testSwitch: Switch =
     Switch(


### PR DESCRIPTION
## What is the value of this and can you measure success?

Applies `withoutCommercial` stripping to the tag pages DCR endpoint, mirroring what was done for fronts in #27894. This will lead to reduced CPU usage and latency in the tag-page rendering service.

Let's take the response from https://www.theguardian.com/tone/minutebyminute.json?dcr=true as an example.

Every tag instance inside `contents[].properties.maybeContent.tags.tags[].properties` has 10 properties, for example:

```json
{
  "id": "football/series/saturday-clockwatch",
  "url": "/football/series/saturday-clockwatch",
  "tagType": "Series",
  "sectionId": "football",
  "sectionName": "Football",
  "webTitle": "Clockwatch",
  "webUrl": "https://www.theguardian.com/football/series/saturday-clockwatch",
  "description": "Catch up with the scores and gossip from all of the day's major football fixtures kick-offs with our minute-by-minute reports",
  "references": [],
  "commercial": {}
}
```

All of these properties show up as properties in the DCR type [`FETagType`](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/types/tag.ts#L12-L34) except for `commercial`.

As it happens, `commercial` accounts for 60% to 70% of the size of the total size of the DCR payload, and given it's not in `FETagType` it means the data being sent by Frontend, parsed, but not used by the client at all.

## How has this change been tested?

To confirm that the data isn't used in some indirect way, I tested this change by comparing the html returned by DCR with and without the commercial property using the following process.

I first obtained the JSONs from `main` and from this PR by

Deploying `main` to CODE and running
```shell
curl -s 'https://m.code.dev-theguardian.com/tone/minutebyminute.json?dcr=true' -o minute-code.json
curl -s 'https://m.code.dev-theguardian.com/tone/minutebyminute+australia-news/australia-news.json?dcr=true' -o australia-code.json
curl -s 'https://m.code.dev-theguardian.com/profile/josh-taylor.json?dcr=true&page=8' -o profile-code.json
```

Deploying this PR to CODE and running
```shell
curl -s 'https://m.code.dev-theguardian.com/tone/minutebyminute.json?dcr=true' -o minute-trimmed.json
curl -s 'https://m.code.dev-theguardian.com/tone/minutebyminute+australia-news/australia-news.json?dcr=true' -o australia-trimmed.json
curl -s 'https://m.code.dev-theguardian.com/profile/josh-taylor.json?dcr=true&page=8' -o profile-trimmed.json
```

I then individually posted all of the JSON to DCR using a series of curl calls like `curl -X POST https://localhost:9000/TagPage -H "Content-Type: application/json" -d @profile-code.json -o profile-code.html` and made sure I got the same exact number of bytes per html file both the trimmed and non-trimmed version of the JSON.

| URL | `main` JSON | HTML from DCR | PR JSON | HTML from DCR |
| --- | ---: | ---: | ---: | ---: |
| [/tone/minutebyminute.json?dcr=true](https://www.theguardian.com/tone/minutebyminute.json?dcr=true) | 651KB | 336,554 bytes | 227KB (−65%) | 336,554 bytes |
| [/tone/minutebyminute+australia-news/australia-news.json?dcr=true](https://www.theguardian.com/tone/minutebyminute+australia-news/australia-news.json?dcr=true) | 1.1MB | 289,505 bytes | 362KB (−68.5%) | 289,505 bytes |
| [/profile/josh-taylor.json?dcr=true&page=8](https://www.theguardian.com/profile/josh-taylor.json?dcr=true&page=8) | 829KB | 348,071 bytes | 281KB (−66%) | 348,071 bytes |


### Performance impact

By using the new tracing functionality (currently a WIP) we're able to see the impact quite clearly. While the request handler performance is the same, receiving the json over the network and parsing it becomes significantly quicker.

Here's a before and after using the australia news payload (which is a worst case)

**Before**
<img width="1087" height="412" alt="Screenshot 2026-08-15 at 20 19 58" src="https://github.com/user-attachments/assets/24cf534c-861f-454f-a966-75621f918587" />

**After**
<img width="1083" height="410" alt="Screenshot 2026-08-15 at 20 20 25" src="https://github.com/user-attachments/assets/1a80f0b6-b6a2-4147-8895-ce11155ac094" />

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this) => does not apply
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md) => does not apply
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
