### PR TITLE
removed world cup and football fronts from high frequency fronts

### DIFF
--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -22,8 +22,6 @@ object HighFrequency extends FrontType {
       "uk/sport",
       "us/sport",
       "au/sport",
-      "football",
-      "football/world-cup-2026",
     )
 }
 


### PR DESCRIPTION
/football and /world-cup-2026 were added to the list of high frequency fronts for the duration of the world cup, which is now over so I'm removing those from the list of high frequency fronts.

Closes #28837 

