### PR TITLE
More context for twirl template instrumentation

### DIFF
--- a/admin/app/http/AdminHttpErrorHandler.scala
+++ b/admin/app/http/AdminHttpErrorHandler.scala
@@ -18,6 +18,6 @@ class AdminHttpErrorHandler(
 
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
     Future.successful(
-      InternalServerError(views.html.errorPage(exception)),
+      InternalServerError(views.html.errorPage(exception)(request)),
     )
 }

--- a/admin/app/jobs/ExpiringSwitchesEmailJob.scala
+++ b/admin/app/jobs/ExpiringSwitchesEmailJob.scala
@@ -1,6 +1,6 @@
 package jobs
 
-import common.GuLogging
+import common.{GuLogging, MockRequestHeader}
 import conf.Configuration.frontend.{dotcomPlatformEmail, webEngineersEmail}
 import conf.switches.{Switch, Switches}
 import services.EmailService
@@ -18,8 +18,13 @@ case class ExpiringSwitchesEmailJob(emailService: EmailService) extends GuLoggin
       val expiringSwitches = Switches.all.filter(Switch.expiry(_).expiresSoon)
 
       if (expiringSwitches.nonEmpty) {
-
-        val htmlBody = views.html.email.expiringSwitches(expiringSwitches).body.trim()
+        // These RequestHeaders are used to identify which controller is calling twirl templates
+        // We're not in the context of a controller, so we need to mock the RequestHeader
+        val mockedRequestHeader = new MockRequestHeader(
+          controller = "ExpiringSwitchesEmailJob",
+          method = "runJob",
+        )
+        val htmlBody = views.html.email.expiringSwitches(expiringSwitches)(mockedRequestHeader).body.trim()
 
         val recipients = {
           val switchOwners = expiringSwitches.flatMap(_.owners.flatMap(_.email)).distinct

--- a/admin/app/jobs/ExpiringSwitchesEmailJob.scala
+++ b/admin/app/jobs/ExpiringSwitchesEmailJob.scala
@@ -21,8 +21,8 @@ case class ExpiringSwitchesEmailJob(emailService: EmailService) extends GuLoggin
         // These RequestHeaders are used to identify which controller is calling twirl templates
         // We're not in the context of a controller, so we need to mock the RequestHeader
         val mockedRequestHeader = new MockRequestHeader(
-          controller = "ExpiringSwitchesEmailJob",
-          method = "runJob",
+          controllerName = "ExpiringSwitchesEmailJob",
+          controllerMethodName = "runJob",
         )
         val htmlBody = views.html.email.expiringSwitches(expiringSwitches)(mockedRequestHeader).body.trim()
 

--- a/admin/app/views/commercial/fragments/slot.scala.html
+++ b/admin/app/views/commercial/fragments/slot.scala.html
@@ -1,5 +1,5 @@
 @import common.dfp.LineItemReport
-@(slotReport: LineItemReport)
+@(slotReport: LineItemReport)(implicit request: play.api.mvc.RequestHeader)
 @import _root_.gam.printUniversalTime
 @import common.dfp.GuLineItem
 @import tools.DfpLink

--- a/admin/app/views/email/expiringSwitches.scala.html
+++ b/admin/app/views/email/expiringSwitches.scala.html
@@ -1,7 +1,7 @@
 @import conf.switches.Switch
 @import _root_.jobs.ExpiringSwitches
 
-@(switches: Seq[Switch])
+@(switches: Seq[Switch])(implicit request: play.api.mvc.RequestHeader)
 
 @showSwitch(switch: conf.switches.Switch, showExpirationDate: Boolean) = {
     <li style="padding-bottom: 6px">

--- a/admin/app/views/errorPage.scala.html
+++ b/admin/app/views/errorPage.scala.html
@@ -1,4 +1,4 @@
-@(e: Throwable)
+@(e: Throwable)(implicit request: play.api.mvc.RequestHeader)
 <html>
     <head>
         <title>Admin error page</title>

--- a/admin/app/views/football/fragments/chooseGroup.scala.html
+++ b/admin/app/views/football/fragments/chooseGroup.scala.html
@@ -1,4 +1,4 @@
-@(name: String)
+@(name: String)(implicit request: play.api.mvc.RequestHeader)
 
 <select name="@name" id="id-@name" class="form-control" data-placeholder="Choose group">
     <option value="">(choose group)</option>

--- a/admin/app/views/football/fragments/chooseLeague.scala.html
+++ b/admin/app/views/football/fragments/chooseLeague.scala.html
@@ -1,4 +1,4 @@
-@(fieldName: String, leagues: List[pa.Season], withEmptyValue: Boolean = false)
+@(fieldName: String, leagues: List[pa.Season], withEmptyValue: Boolean = false)(implicit request: play.api.mvc.RequestHeader)
 @import _root_.football.model.PA.competitionName
 
 <select name="@fieldName" id="id-@fieldName" class="form-control" data-placeholder="Choose league">

--- a/admin/app/views/football/fragments/choosePlayer.scala.html
+++ b/admin/app/views/football/fragments/choosePlayer.scala.html
@@ -1,4 +1,4 @@
-@(fieldName: String, players: List[pa.SquadMember])
+@(fieldName: String, players: List[pa.SquadMember])(implicit request: play.api.mvc.RequestHeader)
 <div class="form-group">
     <select name="@fieldName" id="id-@fieldName" class="form-control foot-autocomplete" data-placeholder="Choose player">
         <option value="">Choose player</option>

--- a/admin/app/views/football/fragments/chooseTeam.scala.html
+++ b/admin/app/views/football/fragments/chooseTeam.scala.html
@@ -1,4 +1,4 @@
-@(fieldName: String, teams: List[pa.Team])
+@(fieldName: String, teams: List[pa.Team])(implicit request: play.api.mvc.RequestHeader)
 <div class="form-group">
     <select name="@fieldName" id="id-@fieldName" class="form-control form-control--team foot-autocomplete" data-placeholder="Choose team">
         <option value="">Choose team</option>

--- a/admin/app/views/football/fragments/prevResults.scala.html
+++ b/admin/app/views/football/fragments/prevResults.scala.html
@@ -1,4 +1,4 @@
-@(teamResults: List[_root_.football.model.PrevResult])
+@(teamResults: List[_root_.football.model.PrevResult])(implicit request: play.api.mvc.RequestHeader)
 
 @teamResults.filter(_.hasResult).take(5).map { result =>
   @if(result.won) {

--- a/admin/app/views/fragments/dateLineChart.scala.html
+++ b/admin/app/views/fragments/dateLineChart.scala.html
@@ -1,4 +1,4 @@
-@(chart: tools.Chart[java.time.LocalDate])
+@(chart: tools.Chart[java.time.LocalDate])(implicit request: play.api.mvc.RequestHeader)
 
 @* placeholder for chart *@
 <div id="@chart.id" class="chart @chart.format.cssClass"></div>

--- a/admin/app/views/fragments/formattedChart.scala.html
+++ b/admin/app/views/fragments/formattedChart.scala.html
@@ -1,4 +1,4 @@
-@(chart: tools.FormattedChart)
+@(chart: tools.FormattedChart)(implicit request: play.api.mvc.RequestHeader)
 
 @* placeholder for chart *@
 <div id="@chart.id" class="chart @chart.format.cssClass"></div>

--- a/admin/app/views/fragments/lineChart.scala.html
+++ b/admin/app/views/fragments/lineChart.scala.html
@@ -1,4 +1,4 @@
-@(chart: tools.Chart[String])
+@(chart: tools.Chart[String])(implicit request: play.api.mvc.RequestHeader)
 
 @* placeholder for chart *@
 <div id="@chart.id" class="chart @chart.format.cssClass"></div>

--- a/applications/app/views/fragments/audioSeriesHead.scala.html
+++ b/applications/app/views/fragments/audioSeriesHead.scala.html
@@ -1,5 +1,5 @@
 
-@(seriesId: String, title: String, subscribeLinks: Map[String, String], description: String)
+@(seriesId: String, title: String, subscribeLinks: Map[String, String], description: String)(implicit request: play.api.mvc.RequestHeader)
 
 
 <section class="fc-container fc-container--first flagship-audio @seriesId">

--- a/applications/app/views/fragments/crosswords/accessibleCrosswordEntries.scala.html
+++ b/applications/app/views/fragments/crosswords/accessibleCrosswordEntries.scala.html
@@ -1,4 +1,4 @@
-@(entries: Seq[model.Entry])
+@(entries: Seq[model.Entry])(implicit request: play.api.mvc.RequestHeader)
 
 @if(entries.nonEmpty) {
     <ol class="crossword__clues-list">

--- a/applications/app/views/fragments/crosswords/accessibleCrosswordGridData.scala.html
+++ b/applications/app/views/fragments/crosswords/accessibleCrosswordGridData.scala.html
@@ -1,4 +1,4 @@
-@(blanks: List[crosswords.AccessibleCrosswordRow])
+@(blanks: List[crosswords.AccessibleCrosswordRow])(implicit request: play.api.mvc.RequestHeader)
 <ul class="crossword__accessible-blank-data">
     @for( row <- blanks) {
         <li class="crossword__accessible-row-data"><span class="crossword__accessible-row-data--row-number">Line @row.rowNumber</span>: @row.blankColumns.mkString(" ")</li>

--- a/applications/app/views/fragments/crosswords/crosswordEntries.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordEntries.scala.html
@@ -1,4 +1,4 @@
-@(entries: Seq[model.Entry])
+@(entries: Seq[model.Entry])(implicit request: play.api.mvc.RequestHeader)
 
 @if(entries.nonEmpty) {
     <ol class="crossword__clues-list">

--- a/applications/app/views/fragments/crosswords/printableCrosswordBody.scala.html
+++ b/applications/app/views/fragments/crosswords/printableCrosswordBody.scala.html
@@ -21,7 +21,7 @@
         <h3 class="printable-crossword__clues__title">Across</h3>
 
         <ul class="printable-crossword__clues__list">
-            @crosswordPage.crossword.acrossEntries.map(printableCrosswordClue.render)
+            @crosswordPage.crossword.acrossEntries.map(printableCrosswordClue.render(_, request))
         </ul>
     </div>
 
@@ -29,7 +29,7 @@
         <h3 class="printable-crossword__clues__title">Down</h3>
 
         <ul class="printable-crossword__clues__list">
-            @crosswordPage.crossword.downEntries.map(printableCrosswordClue.render)
+            @crosswordPage.crossword.downEntries.map(printableCrosswordClue.render(_, request))
         </ul>
     </div>
 

--- a/applications/app/views/fragments/crosswords/printableCrosswordClue.scala.html
+++ b/applications/app/views/fragments/crosswords/printableCrosswordClue.scala.html
@@ -1,4 +1,4 @@
-@(entry: model.Entry)
+@(entry: model.Entry)(implicit request: play.api.mvc.RequestHeader)
 
 <li>
     <span class="printable-crossword__clue__number">@entry.humanNumber</span>

--- a/archive/app/views/archive.scala.html
+++ b/archive/app/views/archive.scala.html
@@ -1,2 +1,2 @@
-@(html: Html)
+@(html: Html)(implicit request: play.api.mvc.RequestHeader)
 @html

--- a/archive/app/views/notFound.scala.html
+++ b/archive/app/views/notFound.scala.html
@@ -1,4 +1,4 @@
-@()
+@()(implicit request: play.api.mvc.RequestHeader)
 
 <!DOCTYPE html>
 <html lang="en">

--- a/article/app/views/fragments/email/emailArticleCss.scala.html
+++ b/article/app/views/fragments/email/emailArticleCss.scala.html
@@ -1,4 +1,4 @@
-@()(implicit context: model.ApplicationContext)
+@()(implicit request: play.api.mvc.RequestHeader, context: model.ApplicationContext)
 
 @Html(common.Assets.css.emailArticle)
 @* This uses Scala code to get the path to the asset, so can't be done in Sass *@

--- a/article/app/views/fragments/liveBlogHead.scala.html
+++ b/article/app/views/fragments/liveBlogHead.scala.html
@@ -1,4 +1,4 @@
-@(next: Option[String], prev: Option[String], organisation: Html, posting: Html)
+@(next: Option[String], prev: Option[String], organisation: Html, posting: Html)(implicit request: play.api.mvc.RequestHeader)
 
 @next.map { n =>
     <link rel="next" href="@n">

--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -1,7 +1,7 @@
 @import conf.Configuration
 @import model.LiveBlogCurrentPage
 
-@(id: String, currentPage: LiveBlogCurrentPage)
+@(id: String, currentPage: LiveBlogCurrentPage)(implicit request: play.api.mvc.RequestHeader)
 
 @currentPage.pagination.map { pagination =>
     <div id="liveblog-navigation" class="liveblog-navigation">

--- a/article/app/views/fragments/logo.scala.html
+++ b/article/app/views/fragments/logo.scala.html
@@ -1,5 +1,5 @@
 @import conf.Configuration
-@()
+@()(implicit request: play.api.mvc.RequestHeader)
 
 <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
     <meta itemprop="url" content="https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png">

--- a/article/app/views/liveblog/dateBlock.scala.html
+++ b/article/app/views/liveblog/dateBlock.scala.html
@@ -1,6 +1,6 @@
 @import model.liveblog.LiveBlogDate
 
-@(date: Option[LiveBlogDate], showDate: Boolean = true, showTimestamp: Boolean = true, isPinned: Boolean = false)
+@(date: Option[LiveBlogDate], showDate: Boolean = true, showTimestamp: Boolean = true, isPinned: Boolean = false)(implicit request: play.api.mvc.RequestHeader)
     @date.map { date =>
         @if(showDate) {
             <time datetime="@date.fullDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@date.ampm <span class="timezone">@date.gmt</span></time>

--- a/article/app/views/liveblog/keyEvents.scala.html
+++ b/article/app/views/liveblog/keyEvents.scala.html
@@ -1,5 +1,5 @@
 @import model.KeyEventData
-@(id: String, keyEvents: Seq[KeyEventData])
+@(id: String, keyEvents: Seq[KeyEventData])(implicit request: play.api.mvc.RequestHeader)
 
 @keyEvents.map { keyEvent =>
     <li class="timeline__item">

--- a/commercial/app/model/hosted/HostedArticleQuotes.scala
+++ b/commercial/app/model/hosted/HostedArticleQuotes.scala
@@ -1,11 +1,12 @@
 package model.hosted
 
 import org.jsoup.Jsoup
+import play.api.mvc.RequestHeader
 import views.html.fragments.inlineSvg
 
 object HostedArticleQuotes {
 
-  def prepareQuotes(html: String): String = {
+  def prepareQuotes(html: String)(implicit request: RequestHeader): String = {
 
     val doc = Jsoup.parseBodyFragment(html)
 

--- a/commercial/app/views/fragments/amp/stylesheets/glabs.scala.html
+++ b/commercial/app/views/fragments/amp/stylesheets/glabs.scala.html
@@ -1,3 +1,4 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 .paid-content {
     background-color: #d9d9d9;
 }

--- a/commercial/app/views/fragments/amp/stylesheets/hosted.scala.html
+++ b/commercial/app/views/fragments/amp/stylesheets/hosted.scala.html
@@ -1,4 +1,4 @@
-@(mainPicture: String, ctaImage: Option[String], brandColour: String)
+@(mainPicture: String, ctaImage: Option[String], brandColour: String)(implicit request: play.api.mvc.RequestHeader)
 
 .hosted-tone {
     color: @brandColour;

--- a/commercial/app/views/hosted/guardianAmpHostedGalleryImage.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedGalleryImage.scala.html
@@ -3,7 +3,7 @@
 @import views.html.hosted._
 @import common.commercial.hosted.HostedGalleryPage
 
-@(picture: model.ImageMedia, image: HostedGalleryImage, index: Int, page: HostedGalleryPage)
+@(picture: model.ImageMedia, image: HostedGalleryImage, index: Int, page: HostedGalleryPage)(implicit request: play.api.mvc.RequestHeader)
 
 @picture.largestImage.map { largestImage =>
     <amp-img src="@ImgSrc.getAmpImageUrl(picture)"

--- a/commercial/app/views/hosted/guardianHostedCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedCta.scala.html
@@ -1,6 +1,6 @@
 @import common.commercial.hosted.HostedPage
 @import common.commercial.hosted.HostedCallToAction
-@(page: HostedPage, cta: HostedCallToAction, isAMP: Boolean)
+@(page: HostedPage, cta: HostedCallToAction, isAMP: Boolean)(implicit request: play.api.mvc.RequestHeader)
     <section class="host hosted__container--full">
         <div class="hosted__banner" @if(!isAMP) {style="background-image: url(@{cta.image});"}>
             <a href="@{cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{cta.trackingCode}" target="_blank">

--- a/commercial/app/views/hosted/guardianHostedGalleryCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGalleryCta.scala.html
@@ -1,4 +1,4 @@
-@(ctaText: Option[String], ctaLink: String, buttonText: Option[String])
+@(ctaText: Option[String], ctaLink: String, buttonText: Option[String])(implicit request: play.api.mvc.RequestHeader)
     <div class="hosted-gallery__cta js-hosted-gallery-cta">
         <div class="hosted-gallery__cta-title">
             @{ctaText}

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -1,5 +1,5 @@
 @import common.commercial.hosted.HostedPage
-@(pageCssClass: String, page: HostedPage, isAMP: Boolean = false)
+@(pageCssClass: String, page: HostedPage, isAMP: Boolean = false)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="hosted__header @pageCssClass">
     <div class="hosted__headerwrap js-hosted-headerwrap">

--- a/commercial/app/views/hosted/guardianHostedShareButtons.scala.html
+++ b/commercial/app/views/hosted/guardianHostedShareButtons.scala.html
@@ -1,6 +1,6 @@
 @import common.commercial.hosted.HostedPage
 @import java.net.URLEncoder
-@(page: HostedPage)
+@(page: HostedPage)(implicit request: play.api.mvc.RequestHeader)
 
 <ul class="social social--top u-unstyled u-cf" data-component="social">
     <li class="social__item social__item--facebook" data-link-name="facebook">

--- a/commercial/app/views/hosted/hostedExplainer.scala.html
+++ b/commercial/app/views/hosted/hostedExplainer.scala.html
@@ -1,4 +1,4 @@
-@(onAmp: Boolean = false)
+@(onAmp: Boolean = false)(implicit request: play.api.mvc.RequestHeader)
 
 @buttonText() = {commercial content explainer.}
 

--- a/commercial/app/views/hosted/hostedLogo.scala.html
+++ b/commercial/app/views/hosted/hostedLogo.scala.html
@@ -1,4 +1,4 @@
-@(page: common.commercial.hosted.HostedPage, onAmp: Boolean = false)
+@(page: common.commercial.hosted.HostedPage, onAmp: Boolean = false)(implicit request: play.api.mvc.RequestHeader)
 
 <a href="@page.logo.link" data-sponsor="@page.owner.toLowerCase" target="_blank">
 @if(onAmp) {

--- a/commercial/app/views/hosted/hostedVideoAutoplay.scala.html
+++ b/commercial/app/views/hosted/hostedVideoAutoplay.scala.html
@@ -1,4 +1,4 @@
-@(trail: common.commercial.hosted.HostedPage)
+@(trail: common.commercial.hosted.HostedPage)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="hosted-next-autoplay js-hosted-next-autoplay" data-link-name="Next video autoplay">
     <div class="hosted-next-autoplay__cancel">

--- a/commercial/app/views/passback.scala.html
+++ b/commercial/app/views/passback.scala.html
@@ -1,4 +1,4 @@
-@(dfpNetworkId: String, adUnitName: String, passbackTarget: String, width: Int, height: Int)
+@(dfpNetworkId: String, adUnitName: String, passbackTarget: String, width: Int, height: Int)(implicit request: play.api.mvc.RequestHeader)
 
 <head>
   <title>Passback for '@adUnitName' Size: [[@width,@height]]</title>

--- a/common/app/common/MockRequestHeader.scala
+++ b/common/app/common/MockRequestHeader.scala
@@ -6,8 +6,8 @@ import play.api.mvc.{Headers, RequestHeader}
 import play.api.routing.HandlerDef
 
 class MockRequestHeader(
-    controller: String,
-    method: String,
+    controllerName: String,
+    controllerMethodName: String,
 ) extends RequestHeader {
   override def connection: RemoteConnection = RemoteConnection("", false, None)
   override def method: String = "GET"
@@ -20,8 +20,8 @@ class MockRequestHeader(
       HandlerDef(
         classLoader = this.getClass.getClassLoader,
         routerPackage = "mock",
-        controller = controller,
-        method = method,
+        controller = controllerName,
+        method = controllerMethodName,
         parameterTypes = Seq.empty,
         verb = "GET",
         path = "/mock/path",

--- a/common/app/common/MockRequestHeader.scala
+++ b/common/app/common/MockRequestHeader.scala
@@ -1,0 +1,31 @@
+package common
+
+import play.api.libs.typedmap.{TypedEntry, TypedKey, TypedMap}
+import play.api.mvc.request.{RemoteConnection, RequestTarget}
+import play.api.mvc.{Headers, RequestHeader}
+import play.api.routing.HandlerDef
+
+class MockRequestHeader(
+    controller: String,
+    method: String,
+) extends RequestHeader {
+  override def connection: RemoteConnection = RemoteConnection("", false, None)
+  override def method: String = "GET"
+  override def target: RequestTarget = RequestTarget("", "", Map.empty)
+  override def version: String = ""
+  override def headers: Headers = Headers.create()
+  override def attrs: TypedMap = TypedMap(
+    TypedEntry(
+      TypedKey("RequestTarget"),
+      HandlerDef(
+        classLoader = this.getClass.getClassLoader,
+        routerPackage = "mock",
+        controller = controller,
+        method = method,
+        parameterTypes = Seq.empty,
+        verb = "GET",
+        path = "/mock/path",
+      ),
+    ),
+  )
+}

--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -5,7 +5,7 @@ import conf.Configuration.{affiliateLinks => affiliateLinksConfig}
 import model.{Tag, Tags}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import views.support.{AffiliateLinksCleaner, HtmlCleaner}
+import views.support.AffiliateLinksCleaner
 
 import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
@@ -154,7 +154,7 @@ object TagLinker {
   }
 }
 
-object GalleryCaptionCleaner extends HtmlCleaner {
+object GalleryCaptionCleaner extends GalleryCaptionHtmlCleaner {
   override def clean(galleryCaption: Document): Document = {
     // There is an inconsistent number of <br> tags in gallery captions.
     // To create some consistency, re will remove them all.
@@ -182,7 +182,7 @@ case class GalleryAffiliateLinksCleaner(
     shouldAddAffiliateLinks: Boolean,
     isUSProductionOffice: Boolean,
     abTests: Map[String, String],
-) extends HtmlCleaner
+) extends GalleryCaptionHtmlCleaner
     with GuLogging {
 
   override def clean(document: Document): Document = {

--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -10,6 +10,14 @@ import views.support.{AffiliateLinksCleaner, HtmlCleaner}
 import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
 
+/** A minimal cleaner contract for the DCR gallery-caption model path. These cleaners run while building the
+  * dotcom-rendering JSON model, which is NOT a request context, and they do not render any Twirl templates, so they
+  * must not depend on a RequestHeader.
+  */
+private[pageElements] trait GalleryCaptionHtmlCleaner {
+  def clean(d: Document): Document
+}
+
 object TextCleaner {
 
   def affiliateLinks(

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -1,3 +1,4 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 <br />
 <p class="gallery__disclaimer">
 	The Guardian’s journalism is independent. We will earn a commission if you

--- a/common/app/views/fragments/atoms/chart.scala.html
+++ b/common/app/views/fragments/atoms/chart.scala.html
@@ -3,7 +3,7 @@
 @import templates.inlineJS.nonBlocking.js.{interactiveFonts, interactiveResize}
 @import play.twirl.api.HtmlFormat
 
-@(chart: ChartAtom, shouldFence: Boolean)(implicit context: model.ApplicationContext)
+@(chart: ChartAtom, shouldFence: Boolean)(implicit request: play.api.mvc.RequestHeader, context: model.ApplicationContext)
 
 @iframeBody = {
     <!DOCTYPE html>

--- a/common/app/views/fragments/atoms/interactive.scala.html
+++ b/common/app/views/fragments/atoms/interactive.scala.html
@@ -3,7 +3,7 @@
 @import templates.inlineJS.nonBlocking.js.{interactiveFonts, interactiveResize}
 @import play.twirl.api.HtmlFormat
 
-@(interactive: InteractiveAtom, shouldFence: Boolean)(implicit context: model.ApplicationContext)
+@(interactive: InteractiveAtom, shouldFence: Boolean)(implicit request: play.api.mvc.RequestHeader, context: model.ApplicationContext)
 
 @iframeBody = {
     <!DOCTYPE html>

--- a/common/app/views/fragments/commercial/containerWrapper.scala.html
+++ b/common/app/views/fragments/commercial/containerWrapper.scala.html
@@ -7,7 +7,7 @@
   optActions: Option[Html] = None,
   optStamp: Option[Html] = None,
   optBadge: Option[Html] = None
- )(title: Html)(innards: Html)
+ )(title: Html)(innards: Html)(implicit request: play.api.mvc.RequestHeader)
 
 <section class="dumathoin @classNames.map(c => s"dumathoin--$c").mkString(" ")"
     @for(dln <- dataLinkName){data-link-name="@dln"}

--- a/common/app/views/fragments/containers/facia_cards/containerScaffold.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerScaffold.scala.html
@@ -1,4 +1,4 @@
-@(title: String, dataLinkName: String)(body: Html)
+@(title: String, dataLinkName: String)(body: Html)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="l-side-margins" data-link-name="@dataLinkName">
     <div class="fc-container">

--- a/common/app/views/fragments/containers/facia_cards/cpScottHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/cpScottHeader.scala.html
@@ -1,4 +1,4 @@
-@()
+@()(implicit request: play.api.mvc.RequestHeader)
 
 @import fragments.inlineSvg
 @import views.support.{ImgSrc, Item140}

--- a/common/app/views/fragments/containers/facia_cards/showMoreButton.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/showMoreButton.scala.html
@@ -1,4 +1,4 @@
-@(containerTitle: String)
+@(containerTitle: String)(implicit request: play.api.mvc.RequestHeader)
 
 @import views.support.RenderClasses
 

--- a/common/app/views/fragments/dropdown.scala.html
+++ b/common/app/views/fragments/dropdown.scala.html
@@ -1,4 +1,4 @@
-@(name: String, modifier: Option[String] = None, isActive: Boolean = false, isClientSideTemplate: Boolean = false, isAnimated: Boolean = false)(content: Html)
+@(name: String, modifier: Option[String] = None, isActive: Boolean = false, isClientSideTemplate: Boolean = false, isAnimated: Boolean = false)(content: Html)(implicit request: play.api.mvc.RequestHeader)
 
 @defining("dropdown-"+content.hashCode){ hash =>
 <div class="dropdown dropdown-styled u-cf @modifier.map("dropdown--" + _) @if(isActive){dropdown--active} @if(isAnimated){dropdown--animated}" data-dropdown-label="@if(isClientSideTemplate) {<%=name%>} else {@name}">

--- a/common/app/views/fragments/email/brazePlaceholder.scala.html
+++ b/common/app/views/fragments/email/brazePlaceholder.scala.html
@@ -1,4 +1,4 @@
-@(name: String)
+@(name: String)(implicit request: play.api.mvc.RequestHeader)
 
 @* This will be replaced by Braze with custom content *@
 <!-- Braze Placeholder - @name -->

--- a/common/app/views/fragments/email/containerTitle.scala.html
+++ b/common/app/views/fragments/email/containerTitle.scala.html
@@ -1,4 +1,4 @@
-@(classes: Seq[String])(cellContents: Html)
+@(classes: Seq[String])(cellContents: Html)(implicit request: play.api.mvc.RequestHeader)
 
 @* This template populates a table cell so it can accept arbitrary markup including further tables *@
 <table class="ct @classes.mkString(" ")">

--- a/common/app/views/fragments/email/faciaCard.scala.html
+++ b/common/app/views/fragments/email/faciaCard.scala.html
@@ -1,4 +1,4 @@
-@(classes: Seq[String], isBranded: Boolean = false)(rows: Html)
+@(classes: Seq[String], isBranded: Boolean = false)(rows: Html)(implicit request: play.api.mvc.RequestHeader)
 
 @* This template populates a table so it expects table rows as input *@
 <table class="fc">

--- a/common/app/views/fragments/email/fullRow.scala.html
+++ b/common/app/views/fragments/email/fullRow.scala.html
@@ -1,4 +1,4 @@
-@(classes: Seq[String])(cellContents: Html)
+@(classes: Seq[String])(cellContents: Html)(implicit request: play.api.mvc.RequestHeader)
 
 @* This template populates a table cell so it can accept arbitrary markup including further tables *@
 <table class="row">

--- a/common/app/views/fragments/email/row.scala.html
+++ b/common/app/views/fragments/email/row.scala.html
@@ -1,4 +1,4 @@
-@(classes: Seq[String])(contents: Html)
+@(classes: Seq[String])(contents: Html)(implicit request: play.api.mvc.RequestHeader)
 
 <tr valign="top">
     <td @if(classes.nonEmpty) { class="@classes.mkString(" ")" }>@contents</td>

--- a/common/app/views/fragments/email/signup/emailFooterLink.scala.html
+++ b/common/app/views/fragments/email/signup/emailFooterLink.scala.html
@@ -1,4 +1,4 @@
-@( listName: String, signupPage: String)
+@( listName: String, signupPage: String)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="cta-bar__text cta-bar__text--no-border">
 	<div class="cta-bar__subheading">

--- a/common/app/views/fragments/email/signup/footer/subscriptionResultFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/subscriptionResultFooter.scala.html
@@ -1,6 +1,6 @@
 @import model.{InvalidEmail, OtherError, Subscribed, SubscriptionResult}
 
-@(result: SubscriptionResult)
+@(result: SubscriptionResult)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="email-sub email-sub--article">
     <div class="email-sub__message">

--- a/common/app/views/fragments/email/signup/recaptchaContainer.scala.html
+++ b/common/app/views/fragments/email/signup/recaptchaContainer.scala.html
@@ -1,1 +1,2 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 <div class="grecaptcha_container"></div>

--- a/common/app/views/fragments/email/signup/result/emailNonsuccess.scala.html
+++ b/common/app/views/fragments/email/signup/result/emailNonsuccess.scala.html
@@ -1,6 +1,6 @@
 @import model.{InvalidEmail, OtherError, NonsuccessResult}
 
-@(result: NonsuccessResult)
+@(result: NonsuccessResult)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="email-sub email-sub--article">
     <div class="email-sub__message">

--- a/common/app/views/fragments/email/signup/result/emailSuccess.scala.html
+++ b/common/app/views/fragments/email/signup/result/emailSuccess.scala.html
@@ -3,7 +3,7 @@
     successDescription: Option[String],
     name: String,
     frequency: String
-)
+)(implicit request: play.api.mvc.RequestHeader)
 
 @headlineText = @{
     if (emailConfirmation == true) "Check your email inbox and confirm your subscription" else "Subscription confirmed"

--- a/common/app/views/fragments/inlineSvg.scala.html
+++ b/common/app/views/fragments/inlineSvg.scala.html
@@ -1,4 +1,4 @@
-@(file: String, path: String = "", classes: Seq[String] = List(), title: Option[String] = None, isPresentation: Boolean = false)
+@(file: String, path: String = "", classes: Seq[String] = List(), title: Option[String] = None, isPresentation: Boolean = false)(implicit request: play.api.mvc.RequestHeader)
 
 @import views.support.setSvgClasses
 

--- a/common/app/views/fragments/items/elements/facia_cards/itemHeader.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/itemHeader.scala.html
@@ -1,4 +1,4 @@
-@(isFirstItemOnPage: Boolean, showQuote: Boolean)(linkHtml: Html)
+@(isFirstItemOnPage: Boolean, showQuote: Boolean)(linkHtml: Html)(implicit request: play.api.mvc.RequestHeader)
 
 @import views.support.RenderClasses
 @import views.support.KickerHtml.trim

--- a/common/app/views/fragments/media/audio.scala.html
+++ b/common/app/views/fragments/media/audio.scala.html
@@ -1,4 +1,4 @@
-@(player: model.AudioPlayer, isAdFree: Boolean)
+@(player: model.AudioPlayer, isAdFree: Boolean)(implicit request: play.api.mvc.RequestHeader)
 
 @trackingCode(target: String) = {@if(player.audio.tags.isPodcast){podcast:subscribe:}@target:@player.title}
 

--- a/common/app/views/fragments/page/body/bannerAndHeaderDiv.scala.html
+++ b/common/app/views/fragments/page/body/bannerAndHeaderDiv.scala.html
@@ -1,4 +1,4 @@
-@(content: Html)
+@(content: Html)(implicit request: play.api.mvc.RequestHeader)
 
 <div id="bannerandheader">
     @content

--- a/common/app/views/fragments/page/body/mainContent.scala.html
+++ b/common/app/views/fragments/page/body/mainContent.scala.html
@@ -1,1 +1,2 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 <div id="maincontent" tabindex="0"></div>

--- a/common/app/views/fragments/page/body/skipToMainContent.scala.html
+++ b/common/app/views/fragments/page/body/skipToMainContent.scala.html
@@ -1,1 +1,2 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>

--- a/common/app/views/fragments/page/devTakeShot.scala.html
+++ b/common/app/views/fragments/page/devTakeShot.scala.html
@@ -1,4 +1,4 @@
-@()(implicit context: model.ApplicationContext)
+@()(implicit request: play.api.mvc.RequestHeader, context: model.ApplicationContext)
 @if(context.environment.mode == play.api.Mode.Dev) {
     <script>
         if (window.callPhantom) {

--- a/common/app/views/fragments/page/email/htmlTag.scala.html
+++ b/common/app/views/fragments/page/email/htmlTag.scala.html
@@ -1,4 +1,4 @@
-@(fragments: Html*)
+@(fragments: Html*)(implicit request: play.api.mvc.RequestHeader)
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/common/app/views/fragments/page/head/checkModuleSupport.scala.html
+++ b/common/app/views/fragments/page/head/checkModuleSupport.scala.html
@@ -1,3 +1,4 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 @*
 Check for module support so that we can polyfill appropriately
 nomodule support is exactly the same as type="module"

--- a/common/app/views/fragments/page/head/fixIEReferenceErrors.scala.html
+++ b/common/app/views/fragments/page/head/fixIEReferenceErrors.scala.html
@@ -1,3 +1,4 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 @*
 Protect against ReferenceErrors in IE:
 `window.console` only exists when the dev tools are open. If you reference

--- a/common/app/views/fragments/page/head/headTag.scala.html
+++ b/common/app/views/fragments/page/head/headTag.scala.html
@@ -1,4 +1,4 @@
-@(fragments: Html*)
+@(fragments: Html*)(implicit request: play.api.mvc.RequestHeader)
 <head>
 @stacked(fragments:_*)
 </head>

--- a/common/app/views/fragments/page/head/stylesheets/criticalStyleInline.scala.html
+++ b/common/app/views/fragments/page/head/stylesheets/criticalStyleInline.scala.html
@@ -1,4 +1,4 @@
-@(styles: Html*)
+@(styles: Html*)(implicit request: play.api.mvc.RequestHeader)
 
 <style class="js-loggable">
     @stacked(styles:_*)

--- a/common/app/views/fragments/page/head/stylesheets/criticalStyleLink.scala.html
+++ b/common/app/views/fragments/page/head/stylesheets/criticalStyleLink.scala.html
@@ -1,4 +1,4 @@
-@(name: String)
+@(name: String)(implicit request: play.api.mvc.RequestHeader)
 
 @import conf.Static
 

--- a/common/app/views/fragments/share/blockLevelSharing.scala.html
+++ b/common/app/views/fragments/share/blockLevelSharing.scala.html
@@ -1,5 +1,5 @@
 @import model.DotcomContentType
-@(id: String, shareItems: Seq[model.ShareLink], contentType: DotcomContentType, isNewGallery: Boolean = false)
+@(id: String, shareItems: Seq[model.ShareLink], contentType: DotcomContentType, isNewGallery: Boolean = false)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="block-share block-share--@contentType.name.toLowerCase @if(!isNewGallery) { hide-on-mobile }" data-link-name="block share">
     @shareItems.map { item: model.ShareLink =>

--- a/common/app/views/fragments/social.scala.html
+++ b/common/app/views/fragments/social.scala.html
@@ -1,4 +1,4 @@
-@(sharelinks: model.ShareLinkMeta, position: String = "bottom", iconModifier: List[String] = Nil)
+@(sharelinks: model.ShareLinkMeta, position: String = "bottom", iconModifier: List[String] = Nil)(implicit request: play.api.mvc.RequestHeader)
 
 <ul class="social social--@position js-social--@position u-unstyled u-cf" data-component="social">
     @sharelinks.visible.map { link => @ShareLink(Nil, link) }

--- a/common/app/views/fragments/stylesheetLink.scala.html
+++ b/common/app/views/fragments/stylesheetLink.scala.html
@@ -1,4 +1,4 @@
-@(stylesheet: String, forceSyncCss: Boolean = false)
+@(stylesheet: String, forceSyncCss: Boolean = false)(implicit request: play.api.mvc.RequestHeader)
 
 @import conf.switches.Switches._
 @import conf.Static

--- a/common/app/views/stacked.scala.html
+++ b/common/app/views/stacked.scala.html
@@ -1,4 +1,4 @@
-@(fragments: Html*)
+@(fragments: Html*)(implicit request: play.api.mvc.RequestHeader)
 
 @for(f <- fragments){
     @f

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -15,19 +15,20 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element, TextNode}
 import play.api.mvc.RequestHeader
 import services.SkimLinksCache
+
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.util.Try
 
 trait HtmlCleaner {
-  def clean(d: Document): Document
+  def clean(d: Document)(implicit request: RequestHeader): Document
 }
 
 object BlockNumberCleaner extends HtmlCleaner {
 
   private val Block = """<!-- Block (\d*) -->""".r
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     document.getAllElements.asScala.foreach { element =>
       val blockComments = element.childNodes.asScala.flatMap { node =>
         node.toString.trim match {
@@ -45,7 +46,7 @@ object BlockNumberCleaner extends HtmlCleaner {
 
 object BlockquoteCleaner extends HtmlCleaner {
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     val quotedBlockquotes = document.getElementsByTag("blockquote").asScala.filter(_.hasClass("quoted"))
     val quoteSvg = views.html.fragments.inlineSvg("quote", "icon").toString()
     val wrapBlockquoteChildren = (blockquoteElement: Element) => {
@@ -65,7 +66,7 @@ object BlockquoteCleaner extends HtmlCleaner {
 
 object PullquoteCleaner extends HtmlCleaner {
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     val pullquotes = document.getElementsByTag("aside").asScala.filter(_.hasClass("element-pullquote"))
     val openingQuoteSvg = views.html.fragments.inlineSvg("quote", "icon", List("inline-tone-fill")).toString()
 
@@ -81,7 +82,7 @@ object PullquoteCleaner extends HtmlCleaner {
 
 case object R2VideoCleaner extends HtmlCleaner {
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
 
     val legacyVideos =
       document.getElementsByTag("video").asScala.filter(_.hasClass("gu-video")).filter(_.parent().tagName() != "figure")
@@ -96,7 +97,7 @@ case object R2VideoCleaner extends HtmlCleaner {
 }
 
 case class RecipeBodyImage(isRecipeArticle: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isRecipeArticle) {
       document.getElementsByClass("element-image").asScala foreach (_.remove())
       document.getElementsByTag("aside").asScala.filter(_.hasClass("element-pullquote")) foreach (_.remove())
@@ -110,7 +111,7 @@ case class PictureCleaner(article: Article)(implicit request: RequestHeader)
     extends HtmlCleaner
     with implicits.Numbers {
 
-  def clean(body: Document): Document = {
+  def clean(body: Document)(implicit request: RequestHeader): Document = {
     for {
       figure <- body.getElementsByTag("figure").asScala
       image <- figure.getElementsByTag("img").asScala.headOption
@@ -227,7 +228,7 @@ object AmpSrcCleaner extends HttpsUrl {
 
 case class InBodyLinkCleaner(dataLinkName: String)(implicit val edition: Edition, implicit val request: RequestHeader)
     extends HtmlCleaner {
-  def clean(body: Document): Document = {
+  def clean(body: Document)(implicit request: RequestHeader): Document = {
     val links = body.getElementsByAttribute("href")
 
     links.asScala.foreach { link =>
@@ -258,7 +259,7 @@ case class InBodyLinkCleaner(dataLinkName: String)(implicit val edition: Edition
 
 case class TruncateCleaner(limit: Int)(implicit val edition: Edition, implicit val request: RequestHeader)
     extends HtmlCleaner {
-  def clean(body: Document): Document = {
+  def clean(body: Document)(implicit request: RequestHeader): Document = {
 
     def truncateTextNode(charLimit: Int, textNode: TextNode): Int = {
       val newCharLimit = charLimit - textNode.text.length
@@ -285,7 +286,7 @@ case class TruncateCleaner(limit: Int)(implicit val edition: Edition, implicit v
 
 class TweetCleaner(content: Content) extends HtmlCleaner {
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
 
     document.getElementsByClass("element-tweet").asScala.foreach { tweet =>
       val tweetData: Option[Tweet] = Option(tweet.attr("data-canonical-url")).flatMap { url =>
@@ -349,7 +350,7 @@ case class TagLinker(article: Article)(implicit val edition: Edition, implicit v
     s"""(.*)( |^)($tagName)( |,|$$|$dot|$question)(.*)""".r
   }
 
-  def clean(doc: Document): Document = {
+  def clean(doc: Document)(implicit request: RequestHeader): Document = {
 
     if (article.content.showInRelated) {
 
@@ -408,7 +409,7 @@ object InBodyElementCleaner extends HtmlCleaner {
     "element-interactive",
   )
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     // this code REMOVES unsupported embeds
     if (ShowAllArticleEmbedsSwitch.isSwitchedOff) {
       val embeddedElements = document.getElementsByTag("figure").asScala.filter(_.hasClass("element"))
@@ -420,7 +421,7 @@ object InBodyElementCleaner extends HtmlCleaner {
 }
 
 case class Summary(amount: Int) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     val children = document.body().children().asScala.toList
     val para: Option[Element] = children.filter(_.nodeName() == "p").take(amount).lastOption
     // if there is are no p's, just take the first n things (could be a blog)
@@ -433,7 +434,7 @@ case class Summary(amount: Int) extends HtmlCleaner {
 }
 
 case class PhotoEssayImages(isPhotoEssay: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isPhotoEssay) {
       document.getElementsByTag("figure").asScala.filter(_.hasClass("element-image")) foreach { images =>
         images.addClass("element-image--photo-essay")
@@ -447,7 +448,7 @@ case class PhotoEssayImages(isPhotoEssay: Boolean) extends HtmlCleaner {
 }
 
 case class PhotoEssayQuotes(isPhotoEssay: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isPhotoEssay) {
       document.getElementsByClass("element-pullquote").asScala.foreach { quotes =>
         quotes.addClass("element-pullquote--photo-essay")
@@ -458,7 +459,7 @@ case class PhotoEssayQuotes(isPhotoEssay: Boolean) extends HtmlCleaner {
 }
 
 case class PhotoEssayCaptions(isPhotoEssay: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isPhotoEssay) {
       document.getElementsByClass("caption--img").asScala.foreach { captions =>
         captions.remove()
@@ -469,7 +470,7 @@ case class PhotoEssayCaptions(isPhotoEssay: Boolean) extends HtmlCleaner {
 }
 
 case class PhotoEssayHalfWidth(isPhotoEssay: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isPhotoEssay) {
       document.getElementsByTag("figure").asScala.filter(_.hasClass("element--halfWidth")).zipWithIndex.foreach {
         case (halfWidthImage, index) =>
@@ -483,7 +484,7 @@ case class PhotoEssayHalfWidth(isPhotoEssay: Boolean) extends HtmlCleaner {
 }
 
 case class PhotoEssayBlockQuote(isPhotoEssay: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isPhotoEssay) {
       document.getElementsByTag("blockquote").asScala.foreach { blockquotes =>
         if (!blockquotes.children().is(".pullquote-paragraph")) {
@@ -496,7 +497,7 @@ case class PhotoEssayBlockQuote(isPhotoEssay: Boolean) extends HtmlCleaner {
 }
 
 case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isImmersive) {
       document.getElementsByTag("a").asScala.foreach { a =>
         a.addClass("in-body-link--immersive")
@@ -507,7 +508,7 @@ case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
 }
 
 case class ImmersiveHeaders(isImmersive: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isImmersive) {
       document.getElementsByTag("h2").asScala.foreach { h2 =>
         val beforeH2 = h2.previousElementSibling()
@@ -534,7 +535,7 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean, isRecipeArticle: B
     } else p.html
   }
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isFeature && !isRecipeArticle) {
       val children = document.body().children().asScala.toList
       children.headOption match {
@@ -563,7 +564,7 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean, isRecipeArticle: B
 }
 
 case class NumberedListFurniture(isNumberedList: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (isNumberedList) {
       // Adds yellow styling to star ratings mid article
       document.select("p:containsOwn(★)").asScala.foreach { star =>
@@ -591,7 +592,7 @@ case class NumberedListFurniture(isNumberedList: Boolean) extends HtmlCleaner {
 // Gallery Caption's don't come back as structured data
 // This is a hack to serve the correct html
 object GalleryCaptionCleaner extends HtmlCleaner {
-  override def clean(galleryCaption: Document): Document = {
+  override def clean(galleryCaption: Document)(implicit request: RequestHeader): Document = {
     // There is an inconsistent number of <br> tags in gallery captions.
     // To create some consistency, re will remove them all.
     galleryCaption.getElementsByTag("br").remove()
@@ -613,7 +614,7 @@ object GalleryCaptionCleaner extends HtmlCleaner {
 }
 
 object InteractiveSrcdocCleaner extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (interactivePressing.isSwitchedOn) {
       for {
         iframe <- Option(document.getElementsByTag("iframe").first())
@@ -632,21 +633,21 @@ object InteractiveSrcdocCleaner extends HtmlCleaner {
 }
 
 object FigCaptionCleaner extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     document.getElementsByTag("figcaption").asScala.foreach { _.addClass("caption caption--img") }
     document
   }
 }
 
 object MainFigCaptionCleaner extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     document.getElementsByTag("figcaption").asScala.foreach { _.addClass("caption caption--img caption--main") }
     document
   }
 }
 
 case class RichLinkCleaner()(implicit val request: RequestHeader) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
 
     val richLinks = document.getElementsByClass("element-rich-link")
 
@@ -669,7 +670,7 @@ case class RichLinkCleaner()(implicit val request: RequestHeader) extends HtmlCl
 }
 
 object MembershipEventCleaner extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     val membershipEvents = document.getElementsByClass("element-membership")
     membershipEvents
       .addClass("element-membership--not-upgraded")
@@ -695,7 +696,7 @@ case class AtomsCleaner(
     atoms.flatMap(_.all.find(_.id == id))
   }
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (UseAtomsSwitch.isSwitchedOn) {
 
       for {
@@ -752,7 +753,7 @@ object setSvgClasses {
 }
 
 case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
 
     def hasFirstContainerThrasher(element: Element, index: Int): Boolean = {
       index == 0 && element.hasClass("fc-container--thrasher")
@@ -814,7 +815,7 @@ case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boole
     implicit val request: RequestHeader,
 ) extends HtmlCleaner {
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
 
     val containers: List[(Element, Int)] = document.getElementsByClass("fc-container").asScala.toList.zipWithIndex
 
@@ -846,9 +847,8 @@ case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boole
 }
 
 object GarnettQuoteCleaner extends HtmlCleaner {
-  val garnettQuote = views.html.fragments.inlineSvg("garnett-quote", "icon").toString
-
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
+    val garnettQuote = views.html.fragments.inlineSvg("garnett-quote", "icon").toString
     for {
       quote <- document.getElementsByClass("inline-quote").asScala
     } {
@@ -870,7 +870,7 @@ case class AffiliateLinksCleaner(
 ) extends HtmlCleaner
     with GuLogging {
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (
       AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.shouldAddAffiliateLinks(
         AffiliateLinks.isSwitchedOn,

--- a/common/app/views/support/MaybeLink.scala.html
+++ b/common/app/views/support/MaybeLink.scala.html
@@ -1,4 +1,4 @@
-@(maybeUrl: Option[String], dataLinkName: String)(inner: Html)
+@(maybeUrl: Option[String], dataLinkName: String)(inner: Html)(implicit request: play.api.mvc.RequestHeader)
 
 @maybeUrl match {
     case Some(url) => {<a href="@url" data-link-name="@dataLinkName">@inner</a>}

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -1,10 +1,12 @@
 package views.support
 
 import org.jsoup.nodes.{Document, Element}
+import play.api.mvc.RequestHeader
+
 import scala.jdk.CollectionConverters._
 
 case class TimestampCleaner(article: model.Article) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     // US Minute articles use liveblog blocks but we don't want to show timestamps
     if (article.isTheMinute) document.getElementsByClass("published-time").asScala.foreach(_.remove)
     document
@@ -33,7 +35,7 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
     "fig--has-shares",
   )
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (article.isTheMinute) {
       document.getElementsByClass("block").asScala.foreach { block =>
         val allElements = block.getAllElements

--- a/common/app/views/support/WitnessCleaner.scala
+++ b/common/app/views/support/WitnessCleaner.scala
@@ -1,10 +1,12 @@
 package views.support
 
-import org.jsoup.nodes.{Element, Document}
+import org.jsoup.nodes.{Document, Element}
+import play.api.mvc.RequestHeader
+
 import scala.jdk.CollectionConverters._
 
 object WitnessCleaner extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
 
     document.getElementsByClass("element-witness-video").asScala.foreach { embed: Element =>
       // remove height from video iframe

--- a/common/app/views/support/cleaner/AttributeCleaner.scala
+++ b/common/app/views/support/cleaner/AttributeCleaner.scala
@@ -1,10 +1,11 @@
 package views.support.cleaner
 
 import org.jsoup.nodes.Document
+import play.api.mvc.RequestHeader
 import views.support.HtmlCleaner
 
 case class AttributeCleaner(attributeName: String) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     document.select(s"[$attributeName]").removeAttr(attributeName)
     document
   }

--- a/common/app/views/support/cleaner/CmpParamCleaner.scala
+++ b/common/app/views/support/cleaner/CmpParamCleaner.scala
@@ -1,12 +1,13 @@
 package views.support.cleaner
 
 import org.jsoup.nodes.{Document, Element}
+import play.api.mvc.RequestHeader
 import views.support.HtmlCleaner
 
 import scala.jdk.CollectionConverters._
 
 object CmpParamCleaner extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     val formstackSrcValues = List(
       "guardiannewsampampmedia.formstack.com", // straight from Formstack
       "profile.theguardian.com/form/embed",

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -4,6 +4,7 @@ import java.net.{URI, URLEncoder}
 
 import model.{Article, DotcomContentType, ShareLinks, VideoElement}
 import org.jsoup.nodes.{Document, Element}
+import play.api.mvc.RequestHeader
 import views.support.{HtmlCleaner, Item640}
 
 import scala.jdk.CollectionConverters._
@@ -15,7 +16,7 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
   val facebookVideoEmbedUrl = "https://www.facebook.com/v2.3/plugins/video.php?href="
   def facebookVideoEmbedUrlFor(url: String): String = s"$facebookVideoEmbedUrl${URLEncoder.encode(url, "UTF-8")}"
 
-  def addShareButtons(document: Document): Unit = {
+  def addShareButtons(document: Document)(implicit request: RequestHeader): Unit = {
     document
       .getElementsByClass("element-video")
       .asScala
@@ -48,7 +49,7 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
       })
   }
 
-  def cleanVideo(document: Document): Unit = {
+  def cleanVideo(document: Document)(implicit request: RequestHeader): Unit = {
     if (!article.isLiveBlog) {
       addShareButtons(document)
     }
@@ -108,7 +109,7 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
     }
   }
 
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: RequestHeader): Document = {
     document
       .getElementsByClass("element-video")
       .asScala

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -140,9 +140,10 @@ object ContributorLinks {
 
 object `package` {
 
-  def withJsoup(html: Html)(cleaners: HtmlCleaner*): Html = withJsoup(html.body)(cleaners: _*)
+  def withJsoup(html: Html)(cleaners: HtmlCleaner*)(implicit request: RequestHeader): Html =
+    withJsoup(html.body)(cleaners: _*)
 
-  def withJsoup(html: String)(cleaners: HtmlCleaner*): Html = {
+  def withJsoup(html: String)(cleaners: HtmlCleaner*)(implicit request: RequestHeader): Html = {
     val cleanedHtml = cleaners.foldLeft(Jsoup.parseBodyFragment(html)) { case (html, cleaner) => cleaner.clean(html) }
     Html(cleanedHtml.body.html)
   }
@@ -213,7 +214,7 @@ object StripHtmlTagsAndUnescapeEntities {
 }
 
 object TableEmbedComplimentaryToP extends HtmlCleaner {
-  override def clean(document: Document): Document = {
+  override def clean(document: Document)(implicit request: play.api.mvc.RequestHeader): Document = {
     document.getElementsByClass("element-table").asScala.foreach { element =>
       Option(element.nextElementSibling).map { nextSibling =>
         if (nextSibling.tagName == "p") element.addClass("element-table--complimentary")

--- a/common/test/common/WitnessCleanerTest.scala
+++ b/common/test/common/WitnessCleanerTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.matchers.should.Matchers
 import views.support.{WitnessCleaner, withJsoup}
 import play.twirl.api.Html
 import org.scalatest.flatspec.AnyFlatSpec
+import play.api.test.FakeRequest
 
 class WitnessCleanerTest extends AnyFlatSpec with Matchers {
 
@@ -18,7 +19,7 @@ class WitnessCleanerTest extends AnyFlatSpec with Matchers {
         |    Some video content
         |  </figure>
         | </body>""".stripMargin,
-    ) { WitnessCleaner }
+    ) { WitnessCleaner }(FakeRequest("test", "/test"))
 
     html.body should include("element-witness-video")
     html.body should include("Some video content")

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -22,6 +22,7 @@ import scala.jdk.CollectionConverters._
 import scala.xml.XML
 
 class TemplatesTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
+  val fakeRequest = FakeRequest("test", "/test")
 
   "RemoveOuterPara" should "remove outer paragraph tags" in {
     RemoveOuterParaHtml(" <P> foo <b>bar</b> </p> ").body should be("foo <b>bar</b>")
@@ -144,8 +145,7 @@ class TemplatesTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
   }
 
   "BlockCleaner" should "insert block ids in minute by minute content" in {
-
-    val body = withJsoup(bodyWithBlocks)(BlockNumberCleaner).body.trim
+    val body = withJsoup(bodyWithBlocks)(BlockNumberCleaner)(fakeRequest).body.trim
 
     body should include("""<span id="block-14">some heading</span>""")
     body should include("""<p id="block-1">some more text</p>""")
@@ -156,27 +156,27 @@ class TemplatesTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
   }
 
   "DropCap" should "add the dropcap span to the first letter of the first paragraph" in {
-    val body = withJsoup(bodyWithoutInlines)(DropCaps(true, false)).body.trim
+    val body = withJsoup(bodyWithoutInlines)(DropCaps(true, false))(fakeRequest).body.trim
     body should include("""<span class="drop-cap__inner">""")
   }
 
   it should "not add the dropcap span when the paragraph does not begin with a letter" in {
-    val body = withJsoup(bodyWithMarkup)(DropCaps(true, false)).body.trim
+    val body = withJsoup(bodyWithMarkup)(DropCaps(true, false))(fakeRequest).body.trim
     body should not include """<span class="drop-cap__inner">"""
   }
 
   it should "not add the dropcap span when first body element is not a paragraph" in {
-    val body = withJsoup(bodyWithHeadingBeforePara)(DropCaps(true, false)).body.trim
+    val body = withJsoup(bodyWithHeadingBeforePara)(DropCaps(true, false))(fakeRequest).body.trim
     body should not include """<span class="drop-cap__inner">"""
   }
 
   it should "not add the dropcap span when when the article is not a feature" in {
-    val body = withJsoup(bodyWithoutInlines)(DropCaps(false, false)).body.trim
+    val body = withJsoup(bodyWithoutInlines)(DropCaps(false, false))(fakeRequest).body.trim
     body should not include """<span class="drop-cap__inner">"""
   }
 
   it should "add the dropcap span when the paragraph begins with a double quote mark" in {
-    val body = withJsoup(bodyStartsWithDoubleQuote)(DropCaps(true, false)).body.trim
+    val body = withJsoup(bodyStartsWithDoubleQuote)(DropCaps(true, false))(fakeRequest).body.trim
     body should include("""<span class="drop-cap__inner">“S</span>""")
   }
 

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -10,6 +10,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.test.FakeRequest
 import test.{TestRequest, WithTestApplicationContext}
 import views.support.AtomsCleaner
 
@@ -83,7 +84,7 @@ class AtomCleanerTest extends AnyFlatSpec with Matchers with WithTestApplication
 
   private def clean(document: Document): Document = {
     val cleaner = AtomsCleaner(youTubeAtom)(TestRequest(), testApplicationContext)
-    cleaner.clean(document)
+    cleaner.clean(document)(FakeRequest("test", "/test"))
     document
   }
 

--- a/common/test/views/support/cleaner/CmpParamCleanerTest.scala
+++ b/common/test/views/support/cleaner/CmpParamCleanerTest.scala
@@ -4,6 +4,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.test.FakeRequest
 
 class CmpParamCleanerTest extends AnyFlatSpec with Matchers {
 
@@ -11,7 +12,7 @@ class CmpParamCleanerTest extends AnyFlatSpec with Matchers {
     val doc =
       """<html><body><figure><iframe src="https://guardiannewsampampmedia.formstack.com/form" /></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
-    val result: Document = CmpParamCleaner.clean(document)
+    val result: Document = CmpParamCleaner.clean(document)(FakeRequest("test", "/test"))
 
     result.getElementsByClass("element-pass-cmp") should not be empty
 
@@ -21,7 +22,7 @@ class CmpParamCleanerTest extends AnyFlatSpec with Matchers {
     val doc =
       """<html><body><figure><iframe src="https://profile.theguardian.com/form/embed/blahyblah" /></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
-    val result: Document = CmpParamCleaner.clean(document)
+    val result: Document = CmpParamCleaner.clean(document)(FakeRequest("test", "/test"))
 
     result.getElementsByClass("element-pass-cmp") should not be empty
 

--- a/common/test/views/support/cleaner/StringCleaner.scala
+++ b/common/test/views/support/cleaner/StringCleaner.scala
@@ -3,6 +3,7 @@ package views.support.cleaner
 import org.apache.commons.lang.StringEscapeUtils
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import play.api.test.FakeRequest
 import views.support.HtmlCleaner
 
 object StringCleaner {
@@ -12,7 +13,7 @@ object StringCleaner {
       // The format we are using for the test data - while eminently readable - is treated as XML when toString() is run on it.
       // To parse it into a JSoup element, it is necessary to remove all the XML character encodings that have been introduced.
       val document = Jsoup.parse(StringEscapeUtils.unescapeXml(html))
-      cleaner.clean(document)
+      cleaner.clean(document)(FakeRequest("test", "/test"))
       document
     }
   }

--- a/common/test/views/support/cleaner/VideoEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/VideoEmbedCleanerTest.scala
@@ -6,6 +6,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.test.FakeRequest
 
 class VideoEmbedCleanerTest extends AnyFlatSpec with Matchers {
 
@@ -24,7 +25,7 @@ class VideoEmbedCleanerTest extends AnyFlatSpec with Matchers {
 
   def clean(doc: String): Document = {
     val document: Document = Jsoup.parse(doc)
-    val result: Document = VideoEmbedCleaner(article, 600).clean(document)
+    val result: Document = VideoEmbedCleaner(article, 600).clean(document)(FakeRequest("test", "/test"))
     result
   }
 

--- a/discussion/app/views/fragments/commentBadges.scala.html
+++ b/discussion/app/views/fragments/commentBadges.scala.html
@@ -1,4 +1,4 @@
-@(comment: discussion.model.Comment)
+@(comment: discussion.model.Comment)(implicit request: play.api.mvc.RequestHeader)
 @if(comment.profile.isStaff){
     <div class="d-comment__author-label">
         @fragments.inlineSvg("marque-36", "icon", Seq("d-comment__gu-icon")) Staff

--- a/discussion/app/views/fragments/recommendationTooltip.scala.html
+++ b/discussion/app/views/fragments/recommendationTooltip.scala.html
@@ -1,3 +1,4 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 @import conf.Configuration
 @import navigation.AuthenticationComponentEvent._
 

--- a/discussion/app/views/fragments/reportComment.scala.html
+++ b/discussion/app/views/fragments/reportComment.scala.html
@@ -1,3 +1,4 @@
+@()(implicit request: play.api.mvc.RequestHeader)
 <form hidden class="tooltip-box tooltip-box--neutral tooltip-box--width4 js-report-comment-form">
     <div hidden class="d-discussion__error js-discussion__report-comment-error">
         <i class="i i-alert"></i>

--- a/identity/app/form/IdFormHelpers.scala
+++ b/identity/app/form/IdFormHelpers.scala
@@ -3,11 +3,14 @@ package form
 import views.html.helper.FieldConstructor
 import views.html.fragments.form.fieldConstructors.{frontendFieldConstructor, multiInputFieldConstructor}
 import play.api.data.Field
+import play.api.mvc.RequestHeader
 
 object IdFormHelpers {
-  implicit val fields: FieldConstructor = FieldConstructor(frontendFieldConstructor.f)
+  implicit def fields(implicit request: RequestHeader): FieldConstructor =
+    FieldConstructor(elements => frontendFieldConstructor(elements))
 
-  val nonInputFields = FieldConstructor(multiInputFieldConstructor.f)
+  def nonInputFields(implicit request: RequestHeader): FieldConstructor =
+    FieldConstructor(elements => multiInputFieldConstructor(elements))
 
   def Password(field: Field, args: (Symbol, Any)*): Input = {
     val updatedArgs =

--- a/identity/app/http/IdentityHttpErrorHandler.scala
+++ b/identity/app/http/IdentityHttpErrorHandler.scala
@@ -22,7 +22,7 @@ class IdentityHttpErrorHandler(
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     logger.error("Serving error page", exception)
     if (environment.mode == Mode.Prod) {
-      Future.successful(InternalServerError(views.html.errors._50x()))
+      Future.successful(InternalServerError(views.html.errors._50x()(request)))
     } else {
       super.onServerError(request, exception)
     }
@@ -32,7 +32,7 @@ class IdentityHttpErrorHandler(
     def notFound = {
       logger.info(s"Serving 404, no handler found for ${request.path}")
       if (environment.mode == Mode.Prod) {
-        Future.successful(NotFound(views.html.errors._404()))
+        Future.successful(NotFound(views.html.errors._404()(request)))
       } else {
         super.onClientError(request, statusCode, message)
       }

--- a/identity/app/views/consentJourneyFragments/block.scala.html
+++ b/identity/app/views/consentJourneyFragments/block.scala.html
@@ -5,7 +5,7 @@
     block: ConsentBlock,
     isFirst: Boolean = false,
     isLast: Boolean = false
-)
+)(implicit request: play.api.mvc.RequestHeader)
 
 @showAgeStep(display: Boolean = false) = @{
     if(display){

--- a/identity/app/views/errors/_404.scala.html
+++ b/identity/app/views/errors/_404.scala.html
@@ -1,3 +1,3 @@
-@()
+@()(implicit request: play.api.mvc.RequestHeader)
 
 @errors.error("404")

--- a/identity/app/views/errors/_502.scala.html
+++ b/identity/app/views/errors/_502.scala.html
@@ -1,3 +1,3 @@
-@()
+@()(implicit request: play.api.mvc.RequestHeader)
 
 @errors.error("502")

--- a/identity/app/views/errors/_50x.scala.html
+++ b/identity/app/views/errors/_50x.scala.html
@@ -1,3 +1,3 @@
-@()
+@()(implicit request: play.api.mvc.RequestHeader)
 
 @errors.error("500")

--- a/identity/app/views/errors/error.scala.html
+++ b/identity/app/views/errors/error.scala.html
@@ -1,4 +1,4 @@
-@(code: String)
+@(code: String)(implicit request: play.api.mvc.RequestHeader)
 
 <!DOCTYPE html>
 <html lang="en">

--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -35,4 +35,4 @@
     highlighted = highlighted,
     skin = skin,
     boldTitle = boldTitle
-)(nonInputFields, messages)
+)(request, nonInputFields, messages)

--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -12,7 +12,7 @@
     boldTitle: Boolean = true,
     titleProvider: ConsentWording => String = w => w.wording,
     descriptionProvider: ConsentWording => Option[String] = w => w.description
-)(messages: play.api.i18n.Messages)
+)(messages: play.api.i18n.Messages)(implicit request: play.api.mvc.RequestHeader)
 
 @getConsentText(consentField: Field) = @{
     Consent.wording(

--- a/identity/app/views/fragments/error.scala.html
+++ b/identity/app/views/fragments/error.scala.html
@@ -1,4 +1,4 @@
-@(name: String)(contact: Html)
+@(name: String)(contact: Html)(implicit request: play.api.mvc.RequestHeader)
 <div class="is-hidden js-@{name}-error">
     <p>We were not able to fetch your details at this time, please try again later. If you are unable to access your details, please contact us.</p>
     @contact

--- a/identity/app/views/fragments/form/checkbox.scala.html
+++ b/identity/app/views/fragments/form/checkbox.scala.html
@@ -1,4 +1,4 @@
-@(field: play.api.data.Field, args: (Symbol, Any)*)
+@(field: play.api.data.Field, args: (Symbol, Any)*)(implicit request: play.api.mvc.RequestHeader)
 
 @import play.api.templates.PlayMagic.toHtmlArgs
 

--- a/identity/app/views/fragments/form/checkboxField.scala.html
+++ b/identity/app/views/fragments/form/checkboxField.scala.html
@@ -1,4 +1,4 @@
-@(idInput: form.Input)(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
+@(idInput: form.Input)(implicit request: play.api.mvc.RequestHeader, handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 @import views.html.helper.input
 @import play.api.templates.PlayMagic.toHtmlArgs

--- a/identity/app/views/fragments/form/fieldConstructors/frontendFieldConstructor.scala.html
+++ b/identity/app/views/fragments/form/fieldConstructors/frontendFieldConstructor.scala.html
@@ -1,4 +1,4 @@
-@(elements: views.html.helper.FieldElements)
+@(elements: views.html.helper.FieldElements)(implicit request: play.api.mvc.RequestHeader)
 
 @elements.args.toMap.get(Symbol("type"))
 

--- a/identity/app/views/fragments/form/fieldConstructors/multiInputFieldConstructor.scala.html
+++ b/identity/app/views/fragments/form/fieldConstructors/multiInputFieldConstructor.scala.html
@@ -1,4 +1,4 @@
-@(elements: views.html.helper.FieldElements)
+@(elements: views.html.helper.FieldElements)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="form-field @if(elements.errors.nonEmpty) {form-field--error}">
     @if(elements.infos.nonEmpty) {

--- a/identity/app/views/fragments/form/hidden.scala.html
+++ b/identity/app/views/fragments/form/hidden.scala.html
@@ -1,4 +1,4 @@
-@(field: play.api.data.Field, args: (Symbol, Any)*)
+@(field: play.api.data.Field, args: (Symbol, Any)*)(implicit request: play.api.mvc.RequestHeader)
 
 @import play.api.templates.PlayMagic.toHtmlArgs
 

--- a/identity/app/views/fragments/form/inputField.scala.html
+++ b/identity/app/views/fragments/form/inputField.scala.html
@@ -1,4 +1,4 @@
-@(idInput: form.Input)(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
+@(idInput: form.Input)(implicit request: play.api.mvc.RequestHeader, handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 @import views.html.helper.input
 @import play.api.templates.PlayMagic.toHtmlArgs

--- a/identity/app/views/fragments/form/radioField.scala.html
+++ b/identity/app/views/fragments/form/radioField.scala.html
@@ -1,4 +1,4 @@
-@(field: Field, valueAndLabel: List[(String, String)], args: (Symbol, Any)*)(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
+@(field: Field, valueAndLabel: List[(String, String)], args: (Symbol, Any)*)(implicit request: play.api.mvc.RequestHeader, handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 @*
  * This input helper should be used with the multiInputFieldConstructor

--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -12,7 +12,7 @@
     skin: Option[String] = None,
     boldTitle: Boolean = true,
     newsletterIdentityName: Option[String] = None
-)(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
+)(implicit request: play.api.mvc.RequestHeader, handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 
 @classes = @{

--- a/identity/app/views/fragments/form/textareaField.scala.html
+++ b/identity/app/views/fragments/form/textareaField.scala.html
@@ -1,4 +1,4 @@
-@(idInput: form.Input)(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
+@(idInput: form.Input)(implicit request: play.api.mvc.RequestHeader, handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 @import views.html.helper.input
 @import play.api.templates.PlayMagic.toHtmlArgs

--- a/identity/app/views/fragments/identityPageHeader.scala.html
+++ b/identity/app/views/fragments/identityPageHeader.scala.html
@@ -1,4 +1,4 @@
-@(title: String)(detail: Html)
+@(title: String)(detail: Html)(implicit request: play.api.mvc.RequestHeader)
 <div class="identity-page-header">
     <div class="identity-page-header__title">
         <h1 class="identity-title">@title</h1>

--- a/identity/app/views/fragments/modal.scala.html
+++ b/identity/app/views/fragments/modal.scala.html
@@ -1,7 +1,7 @@
 @(
     name: String,
     contents: Html
-)
+)(implicit request: play.api.mvc.RequestHeader)
 
 <div id="identity-modal--@name" class="identity-modal identity-modal--@name" role="dialog">
     <div class="identity-modal__wrap">

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -56,4 +56,4 @@
     footer = Some(buildFooter(newsletter)),
     skin = skin,
     newsletterIdentityName = Some(newsletter.identityName)
-)(nonInputFields, messages)
+)(request, nonInputFields, messages)

--- a/identity/app/views/layout/identityFlexWrap.scala.html
+++ b/identity/app/views/layout/identityFlexWrap.scala.html
@@ -1,4 +1,4 @@
-@(isFlow: Boolean)(topFragments: Html*)(contentFragments: Html*)(bottomFragments: Html*)
+@(isFlow: Boolean)(topFragments: Html*)(contentFragments: Html*)(bottomFragments: Html*)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="@views.support.RenderClasses(Map(
     ("identity-wrapper-page-flex", true),

--- a/identity/app/views/layout/identitySkinnyFooter.scala.html
+++ b/identity/app/views/layout/identitySkinnyFooter.scala.html
@@ -1,6 +1,6 @@
 @import org.joda.time.LocalDate
 
-@()
+@()(implicit request: play.api.mvc.RequestHeader)
 
 <footer class="identity-footer">
     <div class="gs-container">

--- a/identity/app/views/profile/deletion/accountDeletionForm.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletionForm.scala.html
@@ -100,7 +100,7 @@
                     "privacy"       -> "I am concerned about my privacy online",
                     "membership"    -> "I was asked to create an account in order to become member/subscriber",
                     "other"         -> "Other")
-                )(nonInputFields, messages)
+                )(request, nonInputFields, messages)
                 </p>
             </div>
 

--- a/identity/app/views/support/fragment/ConsentBlock.scala
+++ b/identity/app/views/support/fragment/ConsentBlock.scala
@@ -1,5 +1,6 @@
 package views.support.fragment
 
+import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 
 object ConsentBlock {
@@ -38,7 +39,7 @@ object ConsentBlock {
       override val show: Boolean = true,
   ) extends ConsentBlockWithHelp(show, name, help)
 
-  def renderBlocks(steps: List[ConsentBlock]): List[Html] = {
+  def renderBlocks(steps: List[ConsentBlock])(implicit request: RequestHeader): List[Html] = {
     val displaySteps = steps.filter(_.show)
     val firstHelpableBlock = steps
       .filter(_ match {

--- a/preview/app/PreviewErrorHandler.scala
+++ b/preview/app/PreviewErrorHandler.scala
@@ -18,7 +18,7 @@ class PreviewErrorHandler(
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     exception match {
       case ContentApiError(statusCode, statusMessage, _) if statusCode == 404 =>
-        Future.successful(NotFound(views.html.not_found(request.path)))
+        Future.successful(NotFound(views.html.not_found(request.path)(request)))
       case _ =>
         super.onServerError(request, exception)
     }

--- a/preview/app/controllers/ResponsiveViewerController.scala
+++ b/preview/app/controllers/ResponsiveViewerController.scala
@@ -4,6 +4,6 @@ import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 class ResponsiveViewerController(val controllerComponents: ControllerComponents) extends BaseController {
 
-  def preview(path: String): Action[AnyContent] = Action { Ok(views.html.responsive_viewer(path)) }
+  def preview(path: String): Action[AnyContent] = Action { request => Ok(views.html.responsive_viewer(path)(request)) }
 
 }

--- a/preview/app/views/not_found.scala.html
+++ b/preview/app/views/not_found.scala.html
@@ -1,4 +1,4 @@
-@(path: String)
+@(path: String)(implicit request: play.api.mvc.RequestHeader)
 <!DOCTYPE html>
 <html>
     <head>

--- a/preview/app/views/responsive_viewer.scala.html
+++ b/preview/app/views/responsive_viewer.scala.html
@@ -1,4 +1,4 @@
-@(path: String)
+@(path: String)(implicit request: play.api.mvc.RequestHeader)
 <!DOCTYPE html>
 <html>
     <head>

--- a/preview/app/views/showcase.scala.html
+++ b/preview/app/views/showcase.scala.html
@@ -1,4 +1,4 @@
-@(rundownPanelOutcomes: Either[Seq[String], common.TrailsToShowcase.RundownPanel], singleStoryPanelOutcomes: Seq[Either[Seq[String], common.TrailsToShowcase.SingleStoryPanel]], duplicateMap: Map[String, Int])
+@(rundownPanelOutcomes: Either[Seq[String], common.TrailsToShowcase.RundownPanel], singleStoryPanelOutcomes: Seq[Either[Seq[String], common.TrailsToShowcase.SingleStoryPanel]], duplicateMap: Map[String, Int])(implicit request: play.api.mvc.RequestHeader)
 <!DOCTYPE html>
 <html>
     <head>

--- a/preview/app/views/showcase_articlegroup.scala.html
+++ b/preview/app/views/showcase_articlegroup.scala.html
@@ -1,4 +1,4 @@
-@(articleGroup: common.TrailsToShowcase.ArticleGroup)
+@(articleGroup: common.TrailsToShowcase.ArticleGroup)(implicit request: play.api.mvc.RequestHeader)
 @defining(articleGroup.articles) { articles =>
     <div class="articleGroup">
         @for((article, index) <- articles.zipWithIndex) {

--- a/sport/app/football/views/fragments/status.scala.html
+++ b/sport/app/football/views/fragments/status.scala.html
@@ -1,7 +1,7 @@
 @import pa.{Fixture, FootballMatch, MatchDay}
 @import views.MatchStatus
 
-@(theMatch: FootballMatch)
+@(theMatch: FootballMatch)(implicit request: play.api.mvc.RequestHeader)
 
 @theMatch match {
     case f: Fixture     => { KO: }

--- a/sport/app/football/views/fragments/teamForm.scala.html
+++ b/sport/app/football/views/fragments/teamForm.scala.html
@@ -1,6 +1,6 @@
 @import model.CompetitionDisplayHelpers.cleanTeamName
 
-@(teamId: String, competition: model.Competition)
+@(teamId: String, competition: model.Competition)(implicit request: play.api.mvc.RequestHeader)
 
 <div class="team__results">
 @competition.teamResults(teamId).takeRight(5).map { result =>

--- a/sport/app/rugby/views/fragments/groupTable.scala.html
+++ b/sport/app/rugby/views/fragments/groupTable.scala.html
@@ -1,7 +1,7 @@
 @import rugby.model.{GroupTable, Match}
 @import views.support.RenderClasses
 
-@(theMatch: Match, group: Option[GroupTable])
+@(theMatch: Match, group: Option[GroupTable])(implicit request: play.api.mvc.RequestHeader)
 
 @if(group.isDefined) {
 <div data-component="football-table-embed" class="c-football-table table--hide-from-importance-1">

--- a/sport/app/rugby/views/fragments/matchStats.scala.html
+++ b/sport/app/rugby/views/fragments/matchStats.scala.html
@@ -2,7 +2,7 @@
 @import views.{NudgePercent, PercentMaker}
 @import views.support.RenderClasses
 
-@(theMatch: Match, matchStat: Option[MatchStat])
+@(theMatch: Match, matchStat: Option[MatchStat])(implicit request: play.api.mvc.RequestHeader)
 
 @if(matchStat.isDefined) {
 

--- a/sport/app/rugby/views/fragments/scoreEvents.scala.html
+++ b/sport/app/rugby/views/fragments/scoreEvents.scala.html
@@ -1,7 +1,7 @@
 @import rugby.model.ScoreEvent
 @import rugby.model.ScoreType
 
-@(theMatch: rugby.model.Match, homeTeamScorers: Seq[ScoreEvent], awayTeamScorers: Seq[ScoreEvent])
+@(theMatch: rugby.model.Match, homeTeamScorers: Seq[ScoreEvent], awayTeamScorers: Seq[ScoreEvent])(implicit request: play.api.mvc.RequestHeader)
 
 @scoreTypeEvents(scoreType: ScoreType.Value) = {
     <tr>

--- a/template-tracker-agent/README.md
+++ b/template-tracker-agent/README.md
@@ -11,11 +11,11 @@ As of July 2026, the migration is coming to an end and we're in a situation wher
 The JVM comes with the ability to modify classes before they are being loaded with a mechanism called "instrumentation".
 This module is a jvm instrumentation agent which makes use of this capability to detect each time one of these 490 twirl templates is being used in a given context.
 
-Each novel use is logged to a file `twirl-usage.log`, which is then uploaded to S3 by fluent bit in order to be queriable through Athena.
+Each novel use is logged to a file `twirl-usage.log`, which is then uploaded to S3 by fluent bit in order to be queryable through Athena.
 
 ## Why?
 
-This gives use visibility into which part of our rendering code is still happening in this repo. We can then decide to keep, migrate or delete depending on each situation.
+This gives us visibility into which part of our rendering code is still happening in this repo. We can then decide to keep, migrate or delete depending on each situation.
 
 ## We don't need it anymore, how do we delete it?
 

--- a/template-tracker-agent/README.md
+++ b/template-tracker-agent/README.md
@@ -1,0 +1,35 @@
+# Template tracker agent
+
+## Context
+Historically, the guardian's website was rendered using twirl templates hosted in this very repository.
+A long migration was undertaken to move to more recent technologies (server side rendered react) in a [separate repository](https://github.com/guardian/dotcom-rendering/)
+
+As of July 2026, the migration is coming to an end and we're in a situation where we don't have clear visibility as to what's still being used, and what's not.
+
+## What this module does
+
+The JVM comes with the ability to modify classes before they are being loaded with a mechanism called "instrumentation".
+This module is a jvm instrumentation agent which makes use of this capability to detect each time one of these 490 twirl templates is being used in a given context.
+
+Each novel use is logged to a file `twirl-usage.log`, which is then uploaded to S3 by fluent bit in order to be queriable through Athena.
+
+## Why?
+
+This gives use visibility into which part of our rendering code is still happening in this repo. We can then decide to keep, migrate or delete depending on each situation.
+
+## We don't need it anymore, how do we delete it?
+
+This feature was created with the following PRs:
+- https://github.com/guardian/frontend/pull/28895
+- https://github.com/guardian/platform/pull/2284
+- https://github.com/guardian/platform/pull/2289
+- https://github.com/guardian/frontend/pull/28937
+- https://github.com/guardian/platform/pull/2293
+- https://github.com/guardian/frontend/pull/28968
+
+To completely remove these capabilities you'll need to:
+- A first `frontend` PR that:
+  - deletes the `template-tracker-agent` directory at the root of this repo
+  - deletes the `templateTrackerAgent` module in sbt, and associated variables, as well as the `withTwirlInstrumentation` variables and all of its usages
+- A second `platform` PR that:
+  - Removes the custom fluent-bit configuration [introduced here](https://github.com/guardian/platform/pull/2289/changes#diff-18bd302d25fb5e54cb207c132df35e930d96714eeafdaa44508d15135a5f9e10)

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/RecordTemplateAdvice.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/RecordTemplateAdvice.java
@@ -17,8 +17,10 @@ public final class RecordTemplateAdvice {
     }
 
     @Advice.OnMethodEnter
-    public static void onEnter(@Advice.Origin("#t") String templateClassName) {
-        TemplateTracker.recordRendering(templateClassName);
+    public static void onEnter(
+        @Advice.Origin("#t") String templateClassName,
+        @Advice.AllArguments Object[] args) {
+        TemplateTracker.recordRendering(templateClassName, args);
     }
 }
 

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -67,6 +67,12 @@ public final class TemplateTracker {
      */
     private static final Set<String> ALLOWED_METHODS = Set.of("GET", "POST", "PUT");
 
+    /**
+     * controller value used when no RequestHeader argument was passed to the template, or when the
+     * request carries no routing {@code HandlerDef} (e.g. templates rendered outside a routed request).
+     */
+    private static final String CONTROLLER_UNKNOWN = "unknown";
+
     public static void recordRendering(String rawClassName, Object[] args) {
         String template = normalise(rawClassName);
 
@@ -75,9 +81,10 @@ public final class TemplateTracker {
         Object request = findRequestHeader(args);
         String dcr = deduceDcr(request);
         String method = deduceMethod(request);
+        String controller = deduceController(request);
 
-        // De-duplicate on the (template, dcr, method) triple so we capture each distinct combination once
-        String dedupeKey = template + "|" + dcr + "|" + method;
+        // De-duplicate on the (template, dcr, method, controller) tuple so we capture each distinct combination once
+        String dedupeKey = template + "|" + dcr + "|" + method + "|" + controller;
 
         // After the first sighting of a combination, `add` returns false and we do nothing further -
         // so the hot path for high-traffic templates is a single concurrent-set membership check: cheap and fast
@@ -88,6 +95,7 @@ public final class TemplateTracker {
                     "\"template\":\"" + template + "\", " +
                     "\"dcr\":\"" + dcr + "\", " +
                     "\"method\":\"" + method + "\", " +
+                    "\"controller\":\"" + controller + "\", " +
                     "\"timestamp\":\"" + formatter.format(ZonedDateTime.now()) + "\"" +
                     "}");
             } catch (IOException e) {
@@ -189,6 +197,53 @@ public final class TemplateTracker {
             return ALLOWED_METHODS.contains(raw) ? raw : METHOD_OTHER;
         } catch (ReflectiveOperationException | RuntimeException e) {
             return METHOD_UNKNOWN;
+        }
+    }
+
+    /**
+     * The fully-qualified controller action that handled the request - i.e. the routing
+     * {@code HandlerDef}'s controller class name plus its action method, e.g.
+     * {@code controllers.Application.index}. Returns {@code "unknown"} when there is no RequestHeader
+     * argument, no {@code HandlerDef} on the request, or reflection unexpectedly fails.
+     *
+     * <p>This mirrors what {@code common.RequestLogger} does in Scala:
+     * <pre>request.attrs.get(Router.Attrs.HandlerDef).map(h =&gt; h.controller + "." + h.method)</pre>
+     * but everything is done reflectively, and the Play types are resolved via the request object's
+     * own (child) classloader.
+     */
+    private static String deduceController(Object request) {
+        if (request == null) {
+            return CONTROLLER_UNKNOWN;
+        }
+        try {
+            ClassLoader cl = request.getClass().getClassLoader();
+
+            // The routing info lives under the HandlerDef key: play.api.routing.Router.Attrs.HandlerDef
+            // (`Router$Attrs$` is the compiled name of the `Router.Attrs` Scala object).
+            Class<?> attrsHolder = Class.forName("play.api.routing.Router$Attrs$", false, cl);
+            Object attrsModule = attrsHolder.getField("MODULE$").get(null);
+            Object handlerDefKey = attrsHolder.getMethod("HandlerDef").invoke(attrsModule);
+
+            // scala.Option<HandlerDef> TypedMap.get(TypedKey<HandlerDef> key)
+            Object typedMap = request.getClass().getMethod("attrs").invoke(request);
+            Class<?> typedKeyClass = Class.forName("play.api.libs.typedmap.TypedKey", false, cl);
+            Object option = typedMap.getClass()
+                .getMethod("get", typedKeyClass)
+                .invoke(typedMap, handlerDefKey);
+            if (option == null) {
+                return CONTROLLER_UNKNOWN;
+            }
+            boolean empty = (boolean) option.getClass().getMethod("isEmpty").invoke(option);
+            if (empty) {
+                return CONTROLLER_UNKNOWN;
+            }
+
+            Object handlerDef = option.getClass().getMethod("get").invoke(option);
+            Object controller = handlerDef.getClass().getMethod("controller").invoke(handlerDef);
+            Object action = handlerDef.getClass().getMethod("method").invoke(handlerDef);
+            return controller + "." + action;
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            return CONTROLLER_UNKNOWN;
         }
     }
 

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -8,7 +8,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Holds the set of Twirl templates seen so far in this JVM and logs each one the first time it is
+ * Holds the set of (template, dcr, method) combinations seen so far in this JVM and logs each
+ * combination the first time it is rendered.
+ *
+ * <p>The template arguments (which include an implicit {@code play.api.mvc.RequestHeader} for most
+ * templates) are inspected reflectively, because {@code RequestHeader} is loaded by Play's child
+ * classloader and is therefore not referenceable from this agent's classes on the system classloader.
  */
 public final class TemplateTracker {
 
@@ -17,15 +22,72 @@ public final class TemplateTracker {
 
     private static DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
 
-    public static void recordRendering(String rawClassName) {
+    /**
+     * Fully-qualified name of the Play type we look for among the template arguments.
+     */
+    private static final String REQUEST_HEADER_TYPE = "play.api.mvc.RequestHeader";
+
+    /**
+     * The standardised query param whose value we want to capture.
+     */
+    private static final String DCR_QUERY_PARAM = "dcr";
+
+    /**
+     * dcr value used when no RequestHeader argument was passed to the template.
+     */
+    private static final String DCR_UNKNOWN = "unknown";
+
+    /**
+     * dcr value used when a RequestHeader is present but the query param is missing.
+     */
+    private static final String DCR_ABSENT = "absent";
+
+    /**
+     * dcr value used when the query param is present but not one of the expected values.
+     */
+    private static final String DCR_OTHER = "other";
+
+    /**
+     * The set of expected {@code dcr} query param values.
+     */
+    private static final Set<String> ALLOWED_DCR_VALUES = Set.of("true", "false", "apps");
+
+    /**
+     * method value used when no RequestHeader argument was passed to the template.
+     */
+    private static final String METHOD_UNKNOWN = "unknown";
+
+    /**
+     * method value used for any HTTP method outside the expected set.
+     */
+    private static final String METHOD_OTHER = "OTHER";
+
+    /**
+     * The set of expected HTTP methods.
+     */
+    private static final Set<String> ALLOWED_METHODS = Set.of("GET", "POST", "PUT");
+
+    public static void recordRendering(String rawClassName, Object[] args) {
         String template = normalise(rawClassName);
-        // After the first sighting of a template, `add` returns false and we do nothing further -
-        // so the hot path for high-traffic templates is a single concurrent-set membership check.
-        if (SEEN.add(template)) {
+
+        // The RequestHeader lives in Play's child classloader, so we can only touch it via
+        // reflection - see #requestHeaderMethod / #deduceDcr.
+        Object request = findRequestHeader(args);
+        String dcr = deduceDcr(request);
+        String method = deduceMethod(request);
+
+        // De-duplicate on the (template, dcr, method) triple so we capture each distinct combination once
+        String dedupeKey = template + "|" + dcr + "|" + method;
+
+        // After the first sighting of a combination, `add` returns false and we do nothing further -
+        // so the hot path for high-traffic templates is a single concurrent-set membership check: cheap and fast
+        if (SEEN.add(dedupeKey)) {
             try {
                 logger.log("{" +
                     "\"marker\":\"TEMPLATE_FIRST_SEEN\"," +
                     "\"template\":\"" + template + "\", " +
+                    "\"dcr\":\"" + dcr + "\", " +
+                    "\"method\":\"" + method + "\", " +
                     "\"timestamp\":\"" + formatter.format(ZonedDateTime.now()) + "\"" +
                     "}");
             } catch (IOException e) {
@@ -34,6 +96,102 @@ public final class TemplateTracker {
             }
         }
     }
+
+    /**
+     * Find the first argument that is (a subtype of) {@link #REQUEST_HEADER_TYPE}, or {@code null}
+     * if none of the arguments is a RequestHeader. We match by type name rather than by position
+     * because the implicit parameter order is not guaranteed across templates and there's not compilation
+     * guarantee that the RequestHeader will be provided at all.
+     */
+    private static Object findRequestHeader(Object[] args) {
+        if (args == null) {
+            return null;
+        }
+        for (Object arg : args) {
+            if (arg != null && isRequestHeader(arg.getClass())) {
+                return arg;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Walk the class hierarchy (superclasses and interfaces) looking for {@link #REQUEST_HEADER_TYPE}.
+     * RequestHeader is a Scala trait so it shows up as an implemented interface on the concrete class.
+     */
+    private static boolean isRequestHeader(Class<?> type) {
+        if (type == null) {
+            return false;
+        }
+        if (REQUEST_HEADER_TYPE.equals(type.getName())) {
+            return true;
+        }
+        for (Class<?> iface : type.getInterfaces()) {
+            if (isRequestHeader(iface)) {
+                return true;
+            }
+        }
+        return isRequestHeader(type.getSuperclass());
+    }
+
+    /**
+     * Deduce the {@code dcr} query param value from the request:
+     * <ul>
+     *   <li>{@code "unknown"} - no RequestHeader argument was passed to the template</li>
+     *   <li>{@code "absent"} - RequestHeader present but no {@code dcr} query param</li>
+     *   <li>{@code "true"} / {@code "false"} / {@code "apps"} - the expected values</li>
+     *   <li>{@code "other"} - the param is present but holds an unexpected value</li>
+     * </ul>
+     * The return value is always from this closed set, so it needs no JSON escaping.
+     */
+    private static String deduceDcr(Object request) {
+        if (request == null) {
+            return DCR_UNKNOWN;
+        }
+        try {
+            // scala.Option<String> RequestHeader.getQueryString(String key)
+            Object option = request.getClass()
+                .getMethod("getQueryString", String.class)
+                .invoke(request, DCR_QUERY_PARAM);
+            if (option == null) {
+                return DCR_ABSENT;
+            }
+            boolean empty = (boolean) option.getClass().getMethod("isEmpty").invoke(option);
+            if (empty) {
+                return DCR_ABSENT;
+            }
+            Object value = option.getClass().getMethod("get").invoke(option);
+            String raw = String.valueOf(value);
+            return ALLOWED_DCR_VALUES.contains(raw) ? raw : DCR_OTHER;
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            // Reflection shouldn't fail, but if it does we don't want to break rendering.
+            return DCR_UNKNOWN;
+        }
+    }
+
+    /**
+     * The HTTP method of the request, normalised to one of {@code GET} / {@code POST} / {@code PUT},
+     * {@code "OTHER"} for anything else, or {@code "unknown"} when there is no RequestHeader argument
+     * (or reflection unexpectedly fails). The return value is always from this closed set, so it
+     * needs no JSON escaping.
+     */
+    private static String deduceMethod(Object request) {
+        if (request == null) {
+            return METHOD_UNKNOWN;
+        }
+        try {
+            // String RequestHeader.method()
+            Object method = request.getClass().getMethod("method").invoke(request);
+            if (method == null) {
+                return METHOD_UNKNOWN;
+            }
+            String raw = String.valueOf(method).toUpperCase();
+            return ALLOWED_METHODS.contains(raw) ? raw : METHOD_OTHER;
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            return METHOD_UNKNOWN;
+        }
+    }
+
 
     /**
      * Scala {@code object}s compile to a {@code Foo$} class; strip the trailing {@code $}.

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -208,8 +208,8 @@ public final class TemplateTracker {
      *
      * <p>This mirrors what {@code common.RequestLogger} does in Scala:
      * <pre>request.attrs.get(Router.Attrs.HandlerDef).map(h =&gt; h.controller + "." + h.method)</pre>
-     * but everything is done reflectively, and the Play types are resolved via the request object's
-     * own (child) classloader.
+     * but everything is done reflectively, as the Play types aren't available in this local class loader.
+     * This is because the agent classes are loaded before the application in a parent classloader.
      */
     private static String deduceController(Object request) {
         if (request == null) {

--- a/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
+++ b/template-tracker-agent/src/main/java/com/gu/templatetracker/TemplateTracker.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Holds the set of (template, dcr, method) combinations seen so far in this JVM and logs each
+ * Holds the set of (template, dcr, method, controller) combinations seen so far in this JVM and logs each
  * combination the first time it is rendered.
  *
  * <p>The template arguments (which include an implicit {@code play.api.mvc.RequestHeader} for most


### PR DESCRIPTION
I used Opus to assist me in writing some of the code of this PR, the description here and the readme is all me.

## What is the value of this and can you measure success?

The frontend repo is nearing the end of migrating from rendering content with twirl templates to rendering content using [DCAR](https://github.com/guardian/dotcom-rendering/). We're in a position where we do not know for sure which part of the rendering is still happening with the rendering code in frontend, and which rendering code in frontend can be removed.

In a set of previous PRs, we've started recording each time a template is used for the first time:
- https://github.com/guardian/frontend/pull/28895
- https://github.com/guardian/platform/pull/2284
- https://github.com/guardian/platform/pull/2289
- https://github.com/guardian/frontend/pull/28937
- https://github.com/guardian/platform/pull/2293

We're using instrumentation to achieve this, and prior to this PR we'd only record the name of the template being used.

However, as a twirl template can be used from multiple endpoints, and as we have specific query parameters that enable us to force rendering a template using DCAR or Twirl, we weren't getting all the context we needed.

In order to get the full picture we need to record:
- which controller triggered the rendering of this template: This tells us which path is used, and which isn't.
- which http verb was used: to differentiate between endpoints
- if there was any `dcr` query parameter, what value was it set to: this differentiate between genuine production traffic and ad-hoc tests we may be doing on our live environments.

The combination of values of template/controller/verb/dcr is then de-duplicated to limit the number of log lines produced by each instance before being shipped to S3 and queryable through Athena. We do not care so much about volume, as we care about whether a twirl template is being used or not, and in which context.

## What does this change?

The existing instrumentation inserts itself on any twirl template, and checks before being rendered if this is the first time that it is being rendered. This PR alters this behaviour and check instead if this template/controller/verb/dcr combination is encountered for the first time or not.

In order to understand which controller, verb and dcr query param were provided, we need to have access to the play `RequestHeader` at the time the template is being rendered. However:
- only a subset of templates had this implicit parameters. Out of 490 templates, 387 had the request header, and 103 were missing it. This PR adds the missing RequestHeader to the 103 templates.
- `RequestHeader` is a class provided by Play, which isn't loaded by the class loader of the agent. This means accessing the data stored in the RequestHeader object needs to be done reflectively. This isn't ideal but the logic is all isolated in the agent module `template-tracker-agent`

## Sample of logs

Here's a sample of logs that were produced when forcing an article to render with `dcr=false`, which will force the logic to go through the twirl templates:
```
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.head.checkModuleSupport", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:17.901988902Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.inlineJSBlocking", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:17.916886928Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.head.headTag", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.190691595Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.body.skipToMainContent", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.218597581Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.commercial.pageSkin", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.234477138Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.commercial.survey", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.248723603Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.body.mainContent", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.263403931Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.body.twentyFourSevenTraining", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.275034627Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.footer", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.297145092Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.email.signup.emailFooterLink", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.317112854Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.message", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.352788834Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.inlineJSNonBlocking", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.369430508Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.analytics.base", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.514961716Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.body.bodyTag", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.518676194Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.devTakeShot", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.533280583Z[Etc/UTC]"}
{"marker":"TEMPLATE_FIRST_SEEN","template":"views.html.fragments.page.htmlTag", "dcr":"false", "method":"GET", "controller":"controllers.ArticleController.renderArticle", "timestamp":"2026-07-21T08:19:19.536745314Z[Etc/UTC]"}
```

# TODO
- [x] Double check any LLM generated code and comments
- [x] Re-test on CODE now it's been rebased
- [x] ~Test specifically the `ExpiringSwitchesEmailJob` logic to ensure I haven't introduced any breakage~ => surprisingly difficult to test on CODE, will verify in PROD