### PR TITLE
Fix Cricket Previews

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -82,9 +82,9 @@ object DotcomRenderingUtils extends DCARUrlHelper {
       case (Some(date), Some(team), true) =>
         Some(
           DotcomRenderingMatchData(
-            matchUrl = s"${Configuration.ajax.url}/sport/cricket/match-scoreboard/$date/$team.json",
-            matchHeaderUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-header/$date/$team.json"),
-            matchStatsUrl = Some(s"${Configuration.ajax.url}/sport/cricket/match-stats-summary/$date/$team.json"),
+            matchUrl = s"${getAjaxHost}/sport/cricket/match-scoreboard/$date/$team.json",
+            matchHeaderUrl = Some(s"${getAjaxHost}/sport/cricket/match-header/$date/$team.json"),
+            matchStatsUrl = Some(s"${getAjaxHost}/sport/cricket/match-stats-summary/$date/$team.json"),
             matchType = CricketMatchType,
           ),
         )


### PR DESCRIPTION
## What is the value of this and can you measure success?

We were unable to use Preview to look at cricket blogs, this change fixes that.

Fixes #28967 

## What does this change?

Uses the pre-existing `getAjaxHost` function to find the appropriate host for the urls used for Cricket Matches, i.e. matchUrl, matchStatsUrl and matchHeaderUrl.