### PR TITLE
feat: Add structured logging for requests made to DCR and CAPI

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -12,19 +12,17 @@ import com.gu.contentapi.client.{
   ScheduledExecutor,
   ContentApiClient => CapiContentApiClient,
 }
+import common.LoggingField.LogField
 import common._
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.Configuration.contentApi
 import conf.switches.Switches.CircuitBreakerSwitch
-import net.logstash.logback.marker.Markers.appendEntries
-import play.api.MarkerContext
 
 import java.lang.System.currentTimeMillis
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-import scala.jdk.CollectionConverters._
 
 object QueryDefaults {
   // NOTE - do NOT add body to this list
@@ -161,21 +159,16 @@ final case class CircuitBreakingContentApiClient(
     resp.foreach((r: HttpResponse) => {
       val duration: Long = currentTimeMillis() - start
 
-      val markers = MarkerContext(
-        appendEntries(
-          Map(
-            "internal-request" -> Map(
-              "target" -> "CAPI",
-              "method" -> "GET",
-              "status" -> r.statusCode,
-              "duration" -> duration,
-              "requestUri" -> url,
-              "contentLength" -> r.body.length,
-            ),
-          ).asJava,
-        ),
+      val markers: List[LogField] = List[LogField](
+        "internal-request.target" -> "CAPI",
+        "internal-request.method" -> "GET",
+        "internal-request.status" -> r.statusCode,
+        "internal-request.duration" -> duration,
+        "internal-request.requestUri" -> url.toString,
+        "internal-request.contentLength" -> r.body.length,
       )
-      log.info(s"Request to Content API took ${duration}ms")(markers)
+
+      logInfoWithCustomFields(s"Request to CAPI completed with status ${r.statusCode} in ${duration}ms", markers)
     })
 
     resp

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -164,11 +164,14 @@ final case class CircuitBreakingContentApiClient(
       val markers = MarkerContext(
         appendEntries(
           Map(
-            "method" -> "GET",
-            "status" -> r.statusCode,
-            "duration" -> duration,
-            "requestUri" -> url,
-            "contentLength" -> r.body.length,
+            "internal-request" -> Map(
+              "target" -> "CAPI",
+              "method" -> "GET",
+              "status" -> r.statusCode,
+              "duration" -> duration,
+              "requestUri" -> url,
+              "contentLength" -> r.body.length,
+            ),
           ).asJava,
         ),
       )

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -1,7 +1,6 @@
 package contentapi
 
 import java.util.concurrent.TimeUnit
-
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import com.github.nscala_time.time.Implicits._
 import com.gu.contentapi.client.model._
@@ -18,10 +17,14 @@ import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.Configuration.contentApi
 import conf.switches.Switches.CircuitBreakerSwitch
+import net.logstash.logback.marker.Markers.appendEntries
+import play.api.MarkerContext
 
+import java.lang.System.currentTimeMillis
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
+import scala.jdk.CollectionConverters._
 
 object QueryDefaults {
   // NOTE - do NOT add body to this list
@@ -146,11 +149,33 @@ final case class CircuitBreakingContentApiClient(
   override def get(url: String, headers: Map[String, String])(implicit
       executionContext: ExecutionContext,
   ): Future[HttpResponse] = {
-    if (CircuitBreakerSwitch.isSwitchedOn) {
-      circuitBreaker.withCircuitBreaker(super.get(url, headers)(executionContext))
-    } else {
-      super.get(url, headers)
-    }
+    val start = currentTimeMillis()
+
+    val resp =
+      if (CircuitBreakerSwitch.isSwitchedOn) {
+        circuitBreaker.withCircuitBreaker(super.get(url, headers)(executionContext))
+      } else {
+        super.get(url, headers)
+      }
+
+    resp.foreach((r: HttpResponse) => {
+      val duration: Long = currentTimeMillis() - start
+
+      val markers = MarkerContext(
+        appendEntries(
+          Map(
+            "method" -> "GET",
+            "status" -> r.statusCode,
+            "duration" -> duration,
+            "requestUri" -> url,
+            "contentLength" -> r.body.length,
+          ).asJava,
+        ),
+      )
+      log.info(s"Request to Content API took ${duration}ms")(markers)
+    })
+
+    resp
   }
 }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -26,6 +26,7 @@ import model.{
   RelatedContentItem,
   SimplePage,
 }
+import net.logstash.logback.marker.Markers.appendEntries
 import play.api.libs.json.{JsObject, JsValue}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
@@ -40,6 +41,8 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import play.api.MarkerContext
+import scala.jdk.CollectionConverters._
 
 // Introduced as CAPI error handling elsewhere would smother these otherwise
 case class DCRLocalConnectException(message: String) extends ConnectException(message)
@@ -84,9 +87,25 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       case None     => request.post(payload)
     }
 
-    resp.foreach(_ => {
-      DCRMetrics.DCRLatencyMetric.recordDuration(currentTimeMillis() - start)
+    resp.foreach((r: WSResponse) => {
+      val duration: Long = currentTimeMillis() - start
+
+      DCRMetrics.DCRLatencyMetric.recordDuration(duration)
       DCRMetrics.DCRRequestCountMetric.increment()
+
+      val markers = MarkerContext(
+        appendEntries(
+          Map(
+            "method" -> "POST",
+            "status" -> r.status,
+            "duration" -> duration,
+            "requestUri" -> request.uri,
+            "contentLength" -> payload.toString().length,
+          ).asJava,
+        ),
+      )
+
+      log.info(s"Request to DCR took ${duration}ms")(markers)
     })
 
     resp.recoverWith({

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -2,6 +2,7 @@ package renderers
 
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
+import common.LoggingField.LogField
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
@@ -26,7 +27,6 @@ import model.{
   RelatedContentItem,
   SimplePage,
 }
-import net.logstash.logback.marker.Markers.appendEntries
 import play.api.libs.json.{JsObject, JsValue}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
@@ -41,8 +41,6 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import play.api.MarkerContext
-import scala.jdk.CollectionConverters._
 
 // Introduced as CAPI error handling elsewhere would smother these otherwise
 case class DCRLocalConnectException(message: String) extends ConnectException(message)
@@ -93,22 +91,16 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       DCRMetrics.DCRLatencyMetric.recordDuration(duration)
       DCRMetrics.DCRRequestCountMetric.increment()
 
-      val markers = MarkerContext(
-        appendEntries(
-          Map(
-            "internal-request" -> Map(
-              "target" -> "DCR",
-              "method" -> "POST",
-              "status" -> r.status,
-              "duration" -> duration,
-              "requestUri" -> request.uri,
-              "contentLength" -> payload.toString().length,
-            ),
-          ).asJava,
-        ),
+      val markers: List[LogField] = List[LogField](
+        "internal-request.target" -> "DCR",
+        "internal-request.method" -> "POST",
+        "internal-request.status" -> r.status,
+        "internal-request.duration" -> duration,
+        "internal-request.requestUri" -> request.uri.toString,
+        "internal-request.contentLength" -> payload.toString.length,
       )
 
-      log.info(s"Request to DCR took ${duration}ms")(markers)
+      logInfoWithCustomFields(s"Request to DCR completed with status ${r.status} in ${duration}ms", markers)
     })
 
     resp.recoverWith({

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -96,11 +96,14 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       val markers = MarkerContext(
         appendEntries(
           Map(
-            "method" -> "POST",
-            "status" -> r.status,
-            "duration" -> duration,
-            "requestUri" -> request.uri,
-            "contentLength" -> payload.toString().length,
+            "internal-request" -> Map(
+              "target" -> "DCR",
+              "method" -> "POST",
+              "status" -> r.status,
+              "duration" -> duration,
+              "requestUri" -> request.uri,
+              "contentLength" -> payload.toString().length,
+            ),
           ).asJava,
         ),
       )


### PR DESCRIPTION
## What does this change?
This change adds a log after making a GET request to CAPI or a POST request to DCR. The log line is [structured](https://github.com/guardian/frontend/blob/b84c7aea13f67c6ae4e93e445c74cfc5c1db523c/common/app/common/GuLogging.scala), with markers covering the URL, response code, content length and request duration. We can use this to monitor the performance of these requests and identify any issues with them.

I've attempted to namespace the markers to distinguish them from the [request logs](https://github.com/guardian/frontend/blob/b84c7aea13f67c6ae4e93e445c74cfc5c1db523c/common/app/common/RequestLogger.scala).

For example, in the project to run DCR on ECS, we've been doing some load testing to right-size the ECS cluster.
Whilst doing this, we've noticed the latency of a request is sometimes unexpectedly high.

In https://github.com/guardian/dotcom-rendering/pull/16408, we've added tracing and the results show a significant time is spent reading the POST body and parsing it as JSON.

We've a hypothesis that payload POSTed to DCR is a superset of what it needs (see also https://github.com/guardian/frontend/pull/28964 and https://github.com/guardian/frontend/pull/27894).
These logs should help us graph the size of the payload and the time taken to read it, so we can see if there's a correlation between the two.

> [!NOTE]
> Ideally, we'd log the request-id as a marker too as that would allow us to relate a CAPI log line with a DCR log line. There are some [helpers](https://github.com/guardian/frontend/blob/b84c7aea13f67c6ae4e93e445c74cfc5c1db523c/common/app/common/GuLogging.scala#L27-L29) for this, however it requires an `implicit headers: RequestHeader` which isn't available in `ContentApiClient.scala`.
> 
> I couldn't cleanly satisfy this requirement, so I've left it out for now. My Scala is pretty rusty these days, so any help is most welcomed!

## Screenshots
After [deploying to CODE](https://riffraff.gutools.co.uk/deployment/view/c408929d-e8ff-4d19-acb4-6419decd4eb7), we can see the logs in Central ELK:

<img width="1280" height="740" alt="image" src="https://github.com/user-attachments/assets/0910e59d-82ac-43e6-80cf-2ee1c38601e2" />

## Checklist
- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
    - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
    - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
    - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)
