### PR TITLE
feat: Log on successful POST to DCR

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -2,6 +2,7 @@ package renderers
 
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
+import common.LoggingField.LogField
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
@@ -84,9 +85,28 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       case None     => request.post(payload)
     }
 
-    resp.foreach(_ => {
-      DCRMetrics.DCRLatencyMetric.recordDuration(currentTimeMillis() - start)
+    resp.foreach(r => {
+      val duration: Long = currentTimeMillis() - start
+
+      DCRMetrics.DCRLatencyMetric.recordDuration(duration)
       DCRMetrics.DCRRequestCountMetric.increment()
+
+      // Looking at some of these JSON payloads, they map to case classes in `model.dotcomrendering`.
+      // Use this to view the full JSON payload by adding `.json?dcr=true`.
+      // TODO refactor the case classes to share a trait so that we can pattern match here instead.
+      val canonicalUrl: String = (payload \ "canonicalUrl").asOpt[String].getOrElse("unknown")
+
+      val markers: List[LogField] = List[LogField](
+        "internal-request.target" -> "DCR",
+        "internal-request.method" -> "POST",
+        "internal-request.status" -> r.status,
+        "internal-request.duration" -> duration,
+        "internal-request.requestUri" -> request.uri.toString,
+        "internal-request.contentLength" -> payload.toString.length,
+        "internal-request.canonicalUrl" -> canonicalUrl,
+      )
+
+      logInfoWithCustomFields(s"Request to DCR completed with status ${r.status} in ${duration}ms", markers)
     })
 
     resp.recoverWith({


### PR DESCRIPTION
> [!NOTE]
> This is a trimmed down version of https://github.com/guardian/frontend/pull/28983.

## What does this change?
Whilst load testing DCR's tag-page-rendering, we've observed a correlation between payload size and latency. This change adds a log line after a request to DCR has been made to aid debugging. The log line is [structured](https://github.com/guardian/frontend/blob/b84c7aea13f67c6ae4e93e445c74cfc5c1db523c/common/app/common/GuLogging.scala), with markers covering the URL, response code, content length and request duration.

I've attempted to namespace the markers to distinguish them from the [request logs](https://github.com/guardian/frontend/blob/b84c7aea13f67c6ae4e93e445c74cfc5c1db523c/common/app/common/RequestLogger.scala).

Whilst RelOps have been load testing DCR running on ECS, we've noticed the latency of a request is sometimes unexpectedly high. Additionally, the size of the payload sent to DCR and the size of DCR's response seem wildly different. We've a hypothesis that payload POSTed to DCR is a superset of what it needs (see also https://github.com/guardian/frontend/pull/28964 and https://github.com/guardian/frontend/pull/27894).

These logs should help us graph the size of the payload and the time taken to read it, so we can see if there's a correlation between the two.

> [!WARNING]
> This change will create a log line for each DCR request. To reduce noise, we could log only when a request is made to tag-page-rendering as that is the service we (RelOps) are currently looking at.

### Example
Take https://www.theguardian.com/tone/minutebyminute, the HTML is 357688 bytes:

```console
❯ curl -I "https://www.theguardian.com/tone/minutebyminute"
HTTP/2 200
content-length: 357688
```

However, the data POSTed to DCR for this page is 838654 bytes:

```console
❯ curl -I "https://www.theguardian.com/tone/minutebyminute.json?dcr=true"
HTTP/2 200
content-length: 838654
```

## Screenshots
After [deploying to CODE](https://riffraff.gutools.co.uk/deployment/view/95955060-bfaa-4695-8ed8-c7322ed49b43), we can see the logs in Central ELK:

<img width="1280" height="809" alt="image" src="https://github.com/user-attachments/assets/5164e398-f723-4895-a9c9-fc88a3c7b17d" />

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)