### PR TITLE
Continue work on cricket preview

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -11,7 +11,25 @@ import crosswords.CrosswordPageWithContent
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements._
 import model.meta.BlocksOn
-import model.{ArticleDateTimes, Badges, CanonicalLiveBlog, ContentFormat, ContentPage, ContentType, CrosswordData, DotcomContentType, GUDateTimeFormatNew, Gallery, GalleryPage, ImageContentPage, ImageMedia, InteractivePage, LiveBlogPage, MediaPage, PageWithStoryPackage}
+import model.{
+  ArticleDateTimes,
+  Badges,
+  CanonicalLiveBlog,
+  ContentFormat,
+  ContentPage,
+  ContentType,
+  CrosswordData,
+  DotcomContentType,
+  GUDateTimeFormatNew,
+  Gallery,
+  GalleryPage,
+  ImageContentPage,
+  ImageMedia,
+  InteractivePage,
+  LiveBlogPage,
+  MediaPage,
+  PageWithStoryPackage,
+}
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
@@ -603,7 +621,7 @@ object DotcomRenderingDataModel {
       }
     }
 
-    val guardianBaseURL=
+    val guardianBaseURL =
       if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.site.host
 
     DotcomRenderingDataModel(

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -5,31 +5,13 @@ import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
-import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
+import common.{CanonicalLink, Chronos, Edition, Environment, Localisation, RichRequestHeader}
 import conf.Configuration
 import crosswords.CrosswordPageWithContent
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements._
 import model.meta.BlocksOn
-import model.{
-  ArticleDateTimes,
-  Badges,
-  CanonicalLiveBlog,
-  ContentFormat,
-  ContentPage,
-  ContentType,
-  CrosswordData,
-  DotcomContentType,
-  GUDateTimeFormatNew,
-  Gallery,
-  GalleryPage,
-  ImageContentPage,
-  ImageMedia,
-  InteractivePage,
-  LiveBlogPage,
-  MediaPage,
-  PageWithStoryPackage,
-}
+import model.{ArticleDateTimes, Badges, CanonicalLiveBlog, ContentFormat, ContentPage, ContentType, CrosswordData, DotcomContentType, GUDateTimeFormatNew, Gallery, GalleryPage, ImageContentPage, ImageMedia, InteractivePage, LiveBlogPage, MediaPage, PageWithStoryPackage}
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
@@ -621,6 +603,9 @@ object DotcomRenderingDataModel {
       }
     }
 
+    val guardianBaseURL=
+      if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.site.host
+
     DotcomRenderingDataModel(
       affiliateLinksDisclaimer = addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks, shouldAddDisclaimer),
       audioArticleImage = audioImageBlock,
@@ -638,7 +623,7 @@ object DotcomRenderingDataModel {
       editionId = edition.id,
       editionLongForm = Edition(request).displayName,
       format = modifiedFormat,
-      guardianBaseURL = Configuration.site.host,
+      guardianBaseURL = guardianBaseURL,
       hasRelated = content.content.showInRelated,
       hasStoryPackage = hasStoryPackage,
       storyPackage = storyPackage,

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -47,6 +47,9 @@ GET        /embed/card/*path                                                    
 # Sport
 GET        /sport/cricket/match/:matchDate/:teamId.json                                        cricket.controllers.CricketMatchController.renderMatchIdJson(matchDate, teamId)
 GET        /sport/cricket/match/:matchDate/:teamId                                             cricket.controllers.CricketMatchController.renderMatchId(matchDate, teamId)
+GET        /sport/cricket/match-header/:matchDate/:teamId.json                                 cricket.controllers.CricketMatchController.matchHeaderJson(matchDate, teamId)
+GET        /sport/cricket/match-stats-summary/:matchDate/:teamId.json                          cricket.controllers.CricketMatchController.matchStatsSummaryJson(matchDate, teamId)
+
 
 GET        /football/fixtures/:year/:month/:day.json                                           football.controllers.FixturesController.allFixturesForJson(year, month, day)
 GET        /football/fixtures/:year/:month/:day                                                football.controllers.FixturesController.allFixturesFor(year, month, day)

--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -1,6 +1,6 @@
 package football.model
 
-import common.{CanonicalLink, Edition}
+import common.{CanonicalLink, Edition, Environment}
 import conf.Configuration
 import cricket.controllers.CricketMatchPage
 import cricketModel.{Innings, InningsWicket, Match, Team}
@@ -43,11 +43,13 @@ object DotcomRenderingCricketDataModel {
       isPreview = pageType.isPreview,
     )
 
+    val baseUrl = if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.site.host
+
     DotcomRenderingCricketDataModel(
       page.theMatch,
       nav = nav,
       editionId = edition.id,
-      guardianBaseURL = Configuration.site.host,
+      guardianBaseURL = baseUrl,
       config = combinedConfig,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(edition)),
       isAdFreeUser = views.support.Commercial.isAdFree(request),

--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -1,6 +1,6 @@
 package football.model
 
-import common.{CanonicalLink, Edition, Environment}
+import common.{CanonicalLink, Edition}
 import conf.Configuration
 import cricket.controllers.CricketMatchPage
 import cricketModel.{Innings, InningsWicket, Match, Team}
@@ -43,14 +43,11 @@ object DotcomRenderingCricketDataModel {
       isPreview = pageType.isPreview,
     )
 
-    val baseUrl =
-      if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.site.host
-
     DotcomRenderingCricketDataModel(
       page.theMatch,
       nav = nav,
       editionId = edition.id,
-      guardianBaseURL = baseUrl,
+      guardianBaseURL = Configuration.site.host,
       config = combinedConfig,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(edition)),
       isAdFreeUser = views.support.Commercial.isAdFree(request),

--- a/sport/app/football/model/DotcomRenderingCricketDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingCricketDataModel.scala
@@ -43,7 +43,8 @@ object DotcomRenderingCricketDataModel {
       isPreview = pageType.isPreview,
     )
 
-    val baseUrl = if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.site.host
+    val baseUrl =
+      if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.site.host
 
     DotcomRenderingCricketDataModel(
       page.theMatch,


### PR DESCRIPTION
## What is the value of this and can you measure success?

Continuing work on this problem: https://github.com/guardian/frontend/issues/28967

The CricketMatchHeader keeps track of the current url by appending the current path to the guardianBaseUrl passed from Frontend. However in preview this guardianBaseUrl is empty so this URL creation was failing. 

It was also discovered that the URLs that fetched data for the match header and the match stats summary were failing as they didn't have routes in preview, so I have added those routes.

## What does this change?

I have made DCR pass a proxied URL (much like in this previous PR: https://github.com/guardian/frontend/pull/28969).

I have also added routes for the match header and the match stats summary in preview's routes.

## Testing

- [x] Tested in CODE 

