### PR TITLE
feat: Log DCR response length

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -104,6 +104,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
         "internal-request.request-uri" -> request.uri.toString,
         "internal-request.payload-content-length" -> payload.toString.length,
         "internal-request.canonical-url" -> canonicalUrl,
+        "internal-request.content-length" -> r.body.length,
       )
 
       logInfoWithCustomFields(s"Request to DCR completed with status ${r.status} in ${duration}ms", markers)

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -101,9 +101,9 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
         "internal-request.method" -> "POST",
         "internal-request.status" -> r.status,
         "internal-request.duration" -> duration,
-        "internal-request.requestUri" -> request.uri.toString,
-        "internal-request.contentLength" -> payload.toString.length,
-        "internal-request.canonicalUrl" -> canonicalUrl,
+        "internal-request.request-uri" -> request.uri.toString,
+        "internal-request.payload-content-length" -> payload.toString.length,
+        "internal-request.canonical-url" -> canonicalUrl,
       )
 
       logInfoWithCustomFields(s"Request to DCR completed with status ${r.status} in ${duration}ms", markers)


### PR DESCRIPTION
## What does this change?
Updates https://github.com/guardian/frontend/pull/28984 to include the content length of the DCR response as a marker. Also, use consistent kebab-casing.