### PR TITLE
Bump FAPI to include Test models 

### DIFF
--- a/common/app/model/PressedProperties.scala
+++ b/common/app/model/PressedProperties.scala
@@ -2,6 +2,7 @@ package model.pressed
 
 import com.gu.facia.api.utils.FaciaContentUtils
 import com.gu.facia.api.{models => fapi, utils => fapiutils}
+import com.gu.facia.client.models.Test
 import common.Edition
 import common.commercial.EditionBranding
 import services.NewsletterData
@@ -34,6 +35,7 @@ final case class PressedProperties(
     editionBrandings: Option[Seq[EditionBranding]],
     atomId: Option[String],
     newsletterData: Option[NewsletterData] = None,
+    tests: Option[List[Test]] = None,
 ) {
   lazy val isPaidFor: Boolean = editionBrandings.exists(
     _.exists(branding => branding.branding.exists(_.isPaid) && branding.edition == Edition.defaultEdition),
@@ -74,7 +76,16 @@ object PressedProperties {
         Edition.byId(editionId) map (EditionBranding(_, branding))
       }.toSeq),
       atomId = FaciaContentUtils.atomId(content),
+      tests = getTests(content),
     )
+  }
+
+  private def getTests(content: fapi.FaciaContent): Option[List[Test]] = {
+    content match {
+      case curatedContent: fapi.CuratedContent                     => curatedContent.tests
+      case supportingCuratedContent: fapi.SupportingCuratedContent => supportingCuratedContent.tests
+      case _                                                       => None
+    }
   }
 
   def getProperties(content: fapi.FaciaContent): fapiutils.ContentProperties = {

--- a/common/app/services/FaciaContentConvert.scala
+++ b/common/app/services/FaciaContentConvert.scala
@@ -41,6 +41,7 @@ object FaciaContentConvert {
         .toMap,
       atomId = None,
       mediaAtom = None,
+      tests = None,
     )
 
     PressedContent.make(curated, false)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.49.6"
   val capiVersion = "47.0.0"
-  val faciaVersion = "35.0.0"
+  val faciaVersion = "37.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?
Allows editorial tests set in facia tool to be pressed to S3 on the pressed page model, which consequently gets sent to DCR during render.

This PR bumps FAPI to  "37.0.0", the version which includes the editorial ab test models. 

As the Tests field on trails and supportingItems is an optional field, this bump is backwards compatible and should not affect existing front pressing or rendering

### Screenshots
#### Tests on pressed page
<img width="2268" height="1476" alt="Screenshot 2026-08-04 at 09 48 19" src="https://github.com/user-attachments/assets/c14fe8ab-893e-4437-af65-afb979d96f7a" />

