### PR TITLE
add Midterms 26 link to US News Subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -19,6 +19,7 @@ object NavLinks {
   val indigenousAustralia = NavLink("Indigenous Australia", "/australia-news/indigenous-australians")
   val usNews = NavLink("US news", "/us-news", longTitle = Some("US news"))
   val usPolitics = NavLink("US politics", "/us-news/us-politics")
+  val usMidterms = NavLink("Midterms 2026", "/us-news/us-midterm-elections-2026")
   val usImmigration = NavLink("US immigration", "/us-news/usimmigration")
 
   val education = {
@@ -312,6 +313,7 @@ object NavLinks {
     List(
       usNews,
       usPolitics,
+      usMidterms,
       world,
       climateCrisis,
       middleEast,

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -969,6 +969,12 @@
 					"classList": []
 				},
 				{
+					"title": "Midterms 2026",
+					"url": "/us-news/us-midterm-elections-2026",
+					"children": [],
+					"classList": []
+				},
+				{
 					"title": "World",
 					"url": "/world",
 					"longTitle": "World news",


### PR DESCRIPTION
## What is the value of this and can you measure success?

This was a requested edition to the subnav.

closes #28988 

## What does this change?

Adds "Midterms 26" to the US News Subnav.
