### PR TITLE
Add FeastSavedRecipesController and related routes

### DIFF
--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -23,4 +23,5 @@ trait ArticleControllers {
   lazy val articleController = wire[ArticleController]
   lazy val liveBlogController = wire[LiveBlogController]
   lazy val newsletterService = wire[NewsletterService]
+  lazy val feastSavedRecipesController = wire[FeastSavedRecipesController]
 }

--- a/article/app/controllers/FeastSavedRecipesController.scala
+++ b/article/app/controllers/FeastSavedRecipesController.scala
@@ -1,0 +1,89 @@
+package controllers
+
+import common.{GuLogging, ImplicitControllerExecutionContext}
+import conf.Configuration
+import play.api.http.HeaderNames.AUTHORIZATION
+import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+/** Server-side proxy for the Feast API's "Saved from web" feature.
+  *
+  * DCR-rendered article pages are served from Frontend's reader-facing domains (eg. www.theguardian.com), whereas the
+  * Feast API is a separate, third-party-facing origin. Browsers call these endpoints with a same-origin relative fetch,
+  * and Frontend forwards the reader's own bearer token (currently an Okta access token obtained client-side) on to the
+  * Feast API verbatim. Frontend holds no credentials of its own for this call - it is a pure pass-through - so that the
+  * Feast API never needs to support CORS for our reader-facing origins.
+  */
+class FeastSavedRecipesController(val controllerComponents: ControllerComponents, wsClient: WSClient)
+    extends BaseController
+    with GuLogging
+    with ImplicitControllerExecutionContext {
+
+  private val MaxSavedFromWebIdsPerRequest = 5
+
+  private def feastApiOrigin: String =
+    if (Configuration.environment.isProd) "https://recipes.guardianapis.com"
+    else "https://recipes.code.dev-guardianapis.com"
+
+  private def withAuthorizationHeader(request: Request[AnyContent])(
+      block: String => Future[Result],
+  ): Future[Result] =
+    request.headers.get(AUTHORIZATION) match {
+      case Some(authorizationHeader) => block(authorizationHeader)
+      case None => Future.successful(Unauthorized(Json.obj("error" -> "Missing Authorization header")))
+    }
+
+  private def upstreamErrorResult(
+      action: String,
+  )(implicit request: RequestHeader): PartialFunction[Throwable, Result] = { case NonFatal(error) =>
+    logErrorWithRequestId(s"Feast API request failed while trying to $action", error)
+    BadGateway(Json.obj("error" -> s"Failed to $action via the Feast API"))
+  }
+
+  def getSavedRecipes(ids: Option[String]): Action[AnyContent] =
+    Action.async { implicit request =>
+      ids.map(_.trim).filter(_.nonEmpty) match {
+        case None =>
+          Future.successful(BadRequest(Json.obj("error" -> "Missing required 'ids' query parameter")))
+
+        case Some(commaSeparatedIds) if commaSeparatedIds.split(",").length > MaxSavedFromWebIdsPerRequest =>
+          Future.successful(
+            BadRequest(
+              Json.obj("error" -> s"A maximum of $MaxSavedFromWebIdsPerRequest ids can be requested at once"),
+            ),
+          )
+
+        case Some(commaSeparatedIds) =>
+          withAuthorizationHeader(request) { authorizationHeader =>
+            wsClient
+              .url(s"$feastApiOrigin/v2/saved-from-web")
+              .withHttpHeaders(AUTHORIZATION -> authorizationHeader)
+              .withQueryStringParameters("ids" -> commaSeparatedIds)
+              .get()
+              .map(response => Status(response.status)(response.body).as(JSON))
+              .recover(upstreamErrorResult("fetch saved recipes"))
+          }
+      }
+    }
+
+  def saveRecipe(recipeId: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      withAuthorizationHeader(request) { authorizationHeader =>
+        wsClient
+          .url(s"$feastApiOrigin/v2/saved-from-web/$recipeId")
+          .withHttpHeaders(AUTHORIZATION -> authorizationHeader)
+          .withBody("")
+          .withMethod("PUT")
+          .execute()
+          .map { response =>
+            if (response.status == 204) NoContent
+            else Status(response.status)(response.body).as(JSON)
+          }
+          .recover(upstreamErrorResult("save recipe"))
+      }
+    }
+}

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -9,6 +9,10 @@ GET     /_healthcheck               controllers.HealthCheck.healthCheck()
 
 GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 
+# Feast API "Saved from web" proxy - see FeastSavedRecipesController for details
+GET     /api/feast-saved-recipes                controllers.FeastSavedRecipesController.getSavedRecipes(ids: Option[String])
+PUT     /api/feast-saved-recipes/:recipeId       controllers.FeastSavedRecipesController.saveRecipe(recipeId: String)
+
 # liveblogs, minutes.
 # NOTE: if updating the .json endpoint below, you must also update the fastly cache purger path used
 # See https://github.com/guardian/fastly-cache-purger/blob/master/src/main/scala/com/gu/fastly/Lambda.scala

--- a/article/test/FeastSavedRecipesControllerTest.scala
+++ b/article/test/FeastSavedRecipesControllerTest.scala
@@ -1,0 +1,133 @@
+package test
+
+import controllers.FeastSavedRecipesController
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.http.HeaderNames.AUTHORIZATION
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+@DoNotDiscover class FeastSavedRecipesControllerTest
+    extends AnyFlatSpec
+    with Matchers
+    with ConfiguredTestSuite
+    with MockitoSugar
+    with BeforeAndAfterAll
+    with WithMaterializer {
+
+  trait Fixture {
+    val wsClient: WSClient = mock[WSClient]
+    val wsRequest: WSRequest = mock[WSRequest]
+    val wsResponse: WSResponse = mock[WSResponse]
+
+    when(wsClient.url(any[String])).thenReturn(wsRequest)
+    when(wsRequest.withHttpHeaders(any[(String, String)])).thenReturn(wsRequest)
+    when(wsRequest.withQueryStringParameters(any[(String, String)])).thenReturn(wsRequest)
+    when(wsRequest.withBody(any[String])(any())).thenReturn(wsRequest)
+    when(wsRequest.withMethod(any[String])).thenReturn(wsRequest)
+
+    val controller = new FeastSavedRecipesController(stubControllerComponents(), wsClient)
+  }
+
+  "getSavedRecipes" should "return 400 when the ids query parameter is missing" in new Fixture {
+    val result = controller.getSavedRecipes(None)(FakeRequest("GET", "/api/feast-saved-recipes"))
+    status(result) shouldBe BAD_REQUEST
+    verifyNoInteractions(wsClient)
+  }
+
+  it should "return 400 when the ids query parameter is empty" in new Fixture {
+    val result = controller.getSavedRecipes(Some(""))(FakeRequest("GET", "/api/feast-saved-recipes?ids="))
+    status(result) shouldBe BAD_REQUEST
+    verifyNoInteractions(wsClient)
+  }
+
+  it should "return 400 when more than 5 ids are supplied" in new Fixture {
+    val request = FakeRequest("GET", "/api/feast-saved-recipes?ids=a,b,c,d,e,f")
+      .withHeaders(AUTHORIZATION -> "Bearer a-token")
+    val result = controller.getSavedRecipes(Some("a,b,c,d,e,f"))(request)
+    status(result) shouldBe BAD_REQUEST
+    verifyNoInteractions(wsClient)
+  }
+
+  it should "return 401 when there is no Authorization header" in new Fixture {
+    val result = controller.getSavedRecipes(Some("a,b,c"))(FakeRequest("GET", "/api/feast-saved-recipes?ids=a,b,c"))
+    status(result) shouldBe UNAUTHORIZED
+    verifyNoInteractions(wsClient)
+  }
+
+  it should "proxy the request to the Feast API, forwarding the Authorization header, and pass through the response" in new Fixture {
+    val upstreamJson = """[{"recipeId":"a","lastModified":"2024-01-01T00:00:00Z"}]"""
+    when(wsResponse.status).thenReturn(200)
+    when(wsResponse.body).thenReturn(upstreamJson)
+    when(wsRequest.get()).thenReturn(Future.successful(wsResponse))
+
+    val request = FakeRequest("GET", "/api/feast-saved-recipes?ids=a,b,c")
+      .withHeaders(AUTHORIZATION -> "Bearer a-token")
+    val result = controller.getSavedRecipes(Some("a,b,c"))(request)
+
+    status(result) shouldBe OK
+    contentAsString(result) shouldBe upstreamJson
+    verify(wsRequest).withHttpHeaders(AUTHORIZATION -> "Bearer a-token")
+    verify(wsRequest).withQueryStringParameters("ids" -> "a,b,c")
+  }
+
+  it should "return 502 when the request to the Feast API fails" in new Fixture {
+    when(wsRequest.get()).thenReturn(Future.failed(new RuntimeException("boom")))
+
+    val request = FakeRequest("GET", "/api/feast-saved-recipes?ids=a,b,c")
+      .withHeaders(AUTHORIZATION -> "Bearer a-token")
+    val result = controller.getSavedRecipes(Some("a,b,c"))(request)
+
+    status(result) shouldBe BAD_GATEWAY
+  }
+
+  "saveRecipe" should "return 401 when there is no Authorization header" in new Fixture {
+    val result = controller.saveRecipe("some-recipe-id")(FakeRequest("PUT", "/api/feast-saved-recipes/some-recipe-id"))
+    status(result) shouldBe UNAUTHORIZED
+    verifyNoInteractions(wsClient)
+  }
+
+  it should "proxy a PUT to the Feast API and return 204 when the upstream returns No Content" in new Fixture {
+    when(wsResponse.status).thenReturn(204)
+    when(wsRequest.execute()).thenReturn(Future.successful(wsResponse))
+
+    val request = FakeRequest("PUT", "/api/feast-saved-recipes/some-recipe-id")
+      .withHeaders(AUTHORIZATION -> "Bearer a-token")
+    val result = controller.saveRecipe("some-recipe-id")(request)
+
+    status(result) shouldBe NO_CONTENT
+    verify(wsClient).url("https://recipes.code.dev-guardianapis.com/v2/saved-from-web/some-recipe-id")
+    verify(wsRequest).withHttpHeaders(AUTHORIZATION -> "Bearer a-token")
+    verify(wsRequest).withMethod("PUT")
+  }
+
+  it should "pass through the upstream status and body when the upstream does not return No Content" in new Fixture {
+    when(wsResponse.status).thenReturn(200)
+    when(wsResponse.body).thenReturn("""{"recipeId":"some-recipe-id","lastModified":"2024-01-01T00:00:00Z"}""")
+    when(wsRequest.execute()).thenReturn(Future.successful(wsResponse))
+
+    val request = FakeRequest("PUT", "/api/feast-saved-recipes/some-recipe-id")
+      .withHeaders(AUTHORIZATION -> "Bearer a-token")
+    val result = controller.saveRecipe("some-recipe-id")(request)
+
+    status(result) shouldBe OK
+    contentAsString(result) shouldBe """{"recipeId":"some-recipe-id","lastModified":"2024-01-01T00:00:00Z"}"""
+  }
+
+  it should "return 502 when the request to the Feast API fails" in new Fixture {
+    when(wsRequest.execute()).thenReturn(Future.failed(new RuntimeException("boom")))
+
+    val request = FakeRequest("PUT", "/api/feast-saved-recipes/some-recipe-id")
+      .withHeaders(AUTHORIZATION -> "Bearer a-token")
+    val result = controller.saveRecipe("some-recipe-id")(request)
+
+    status(result) shouldBe BAD_GATEWAY
+  }
+}

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -13,5 +13,6 @@ class ArticleTestSuite
       new PublicationControllerTest,
       new LiveBlogControllerTest,
       new ArticlePickerTest,
+      new FeastSavedRecipesControllerTest,
     )
     with SingleServerSuite {}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -374,6 +374,10 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>                                          
 
 # articles, finished liveblogs
 
+# Feast API "Saved from web" proxy - see FeastSavedRecipesController for details
+GET     /api/feast-saved-recipes                controllers.FeastSavedRecipesController.getSavedRecipes(ids: Option[String])
+PUT     /api/feast-saved-recipes/:recipeId       controllers.FeastSavedRecipesController.saveRecipe(recipeId: String)
+
 GET     /*path.json                                                                                                              controllers.ArticleController.renderJson(path)
 GET     /*path/email                                                                                                             controllers.ArticleController.renderEmail(path)
 GET     /*path/email/headline.txt                                                                                                controllers.ArticleController.renderHeadline(path)

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -191,6 +191,11 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.rend
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt  controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String])
+
+# Feast API "Saved from web" proxy - see FeastSavedRecipesController for details
+GET     /api/feast-saved-recipes                controllers.FeastSavedRecipesController.getSavedRecipes(ids: Option[String])
+PUT     /api/feast-saved-recipes/:recipeId       controllers.FeastSavedRecipesController.saveRecipe(recipeId: String)
+
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)


### PR DESCRIPTION
- Implement FeastSavedRecipesController for proxying requests to the Feast API's "Saved from web" feature.
- Add routes for fetching and saving recipes through the Feast API.
- Include tests for the new controller to ensure proper functionality and error handling.

## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
