### PR TITLE
map 'international' in the country lookup to 'other' for registratrionLocation

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -72,7 +72,11 @@ class EmailFormService(wsClient: WSClient, emailEmbedAgent: NewsletterSignupAgen
       .get("X-GU-GeoLocation")
       .map(_.replace("country:", ""))
       .getOrElse("row")
-    val registrationLocation: String = CountryGroup.byFastlyCountryCode(countryCode).map(_.name).getOrElse("Other")
+    val registrationLocation: String = CountryGroup
+      .byFastlyCountryCode(countryCode)
+      .map(_.name)
+      .filterNot(_ == "International")
+      .getOrElse("Other")
     val registrationLocationState: Option[String] =
       for {
         code <- Option(countryCode).filter(Set("US", "AU").contains)

--- a/common/test/controllers/EmailFormServiceTest.scala
+++ b/common/test/controllers/EmailFormServiceTest.scala
@@ -97,6 +97,13 @@ class EmailFormServiceTest
         registrationLocation(capturePostedBody(wsRequest)) shouldBe "Other"
       }
 
+      "use 'Other' when the country resolves to International" in new Fixture {
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] =
+          FakeRequest().withHeaders("X-GU-GeoLocation" -> "country:IN")
+        service.submit(singleNewsletterBaseForm).futureValue
+        registrationLocation(capturePostedBody(wsRequest)) shouldBe "Other"
+      }
+
       "use 'Other' when the X-GU-GeoLocation header isn't present" in new Fixture {
         implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
         service.submit(singleNewsletterBaseForm).futureValue
@@ -209,6 +216,13 @@ class EmailFormServiceTest
       "use 'Other' for an unrecognised country code" in new Fixture {
         implicit val request: FakeRequest[AnyContentAsEmpty.type] =
           FakeRequest().withHeaders("X-GU-GeoLocation" -> "country:XX")
+        service.submitWithMany(multipleNewslettersBaseForm).futureValue
+        registrationLocation(capturePostedBody(wsRequest)) shouldBe "Other"
+      }
+
+      "use 'Other' when the country resolves to International" in new Fixture {
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] =
+          FakeRequest().withHeaders("X-GU-GeoLocation" -> "country:IN")
         service.submitWithMany(multipleNewslettersBaseForm).futureValue
         registrationLocation(capturePostedBody(wsRequest)) shouldBe "Other"
       }


### PR DESCRIPTION
## What is the value of this and can you measure success?
People in India and Nigeria should be able to sign up for newsletters.

## What does this change?
If the `CountryGroup.byFastlyCountryCode` method returns 'International' as the countryGroup/country name then we should map this to 'other' when used as the request value property `registrationLocation` when attempting to sign users up for newsletters.

This will then pass the registration white list check in idapi (https://github.com/guardian/identity/blob/main/identity-api/src/main/scala/com/gu/identity/api/validation/RegistrationLocationValidator.scala) and match the fastly vcl rules that we have set up.

