### PR TITLE
Unify affiliate disclaimer rendering logic across gallery and DCR paths

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -6,9 +6,7 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.{RenderClasses, RowInfo}
 @import views.GalleryCaptionCleaners
-@import views.support.AffiliateLinksCleaner
-@import conf.switches.Switches
-@import conf.Configuration
+@import model.dotcomrendering.DotcomRenderingUtils
 
 @import model.DotcomContentType
 @(page: GalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
@@ -24,12 +22,7 @@
 
         @fragments.galleryHeader(
             page,
-            page.item.lightbox.containsAffiliateableLinks && AffiliateLinksCleaner.shouldAddAffiliateLinks(
-                switchedOn = Switches.AffiliateLinks.isSwitchedOn,
-                showAffiliateLinks = page.gallery.content.fields.showAffiliateLinks,
-                alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
-                tagPaths = page.gallery.content.tags.tags.map(_.id),
-            )
+            DotcomRenderingUtils.shouldShowAffiliateDisclaimer(page.item)
         )
 
         <div class="@RenderClasses(

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -21,7 +21,6 @@ import model.{
   CrosswordData,
   DotcomContentType,
   GUDateTimeFormatNew,
-  Gallery,
   GalleryPage,
   ImageContentPage,
   ImageMedia,
@@ -465,18 +464,8 @@ object DotcomRenderingDataModel {
       twitterHandle = content.tags.contributors.headOption.flatMap(_.properties.twitterHandle),
     )
 
-    def hasAffiliateLinks(
-        content: ContentType,
-        blocks: Seq[APIBlock],
-    ): Boolean = {
-      content match {
-        case gallery: Gallery => gallery.lightbox.containsAffiliateableLinks
-        case _ => blocks.exists(block => DotcomRenderingUtils.stringContainsAffiliateableLinks(block.bodyHtml))
-      }
-    }
-
     val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
-    val shouldAddDisclaimer = hasAffiliateLinks(content, bodyBlocks)
+    val shouldAddDisclaimer = DotcomRenderingUtils.shouldShowAffiliateDisclaimer(content, bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(
       webPublicationDate = content.trail.webPublicationDate,
@@ -613,8 +602,8 @@ object DotcomRenderingDataModel {
 
     val matchData = makeMatchData(page, pageType)
 
-    def addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks: Boolean, shouldAddDisclaimer: Boolean) = {
-      if (shouldAddAffiliateLinks && shouldAddDisclaimer) {
+    def addAffiliateLinksDisclaimerDCR(shouldAddDisclaimer: Boolean) = {
+      if (shouldAddDisclaimer) {
         Some("true")
       } else {
         None
@@ -625,7 +614,7 @@ object DotcomRenderingDataModel {
       if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.site.host
 
     DotcomRenderingDataModel(
-      affiliateLinksDisclaimer = addAffiliateLinksDisclaimerDCR(shouldAddAffiliateLinks, shouldAddDisclaimer),
+      affiliateLinksDisclaimer = addAffiliateLinksDisclaimerDCR(shouldAddDisclaimer),
       audioArticleImage = audioImageBlock,
       trailPicture = trailPicture,
       author = author,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -18,6 +18,7 @@ import model.{
   ContentFormat,
   ContentPage,
   ContentType,
+  Gallery,
   GUDateTimeFormatNew,
   LiveBlogPage,
   Pillar,
@@ -325,6 +326,30 @@ object DotcomRenderingUtils extends DCARUrlHelper {
       } else false
     }
 
+  }
+
+  def shouldShowAffiliateDisclaimer(content: ContentType, blocks: Seq[APIBlock]): Boolean = {
+    shouldAddAffiliateDisclaimerByTagging(content) && hasAffiliateLinksForDisclaimer(content, blocks)
+  }
+
+  def shouldShowAffiliateDisclaimer(content: ContentType): Boolean = {
+    shouldAddAffiliateDisclaimerByTagging(content) && hasAffiliateLinksForDisclaimer(content, Seq.empty)
+  }
+
+  private def shouldAddAffiliateDisclaimerByTagging(content: ContentType): Boolean = {
+    AffiliateLinksCleaner.shouldAddAffiliateLinks(
+      switchedOn = Switches.AffiliateLinks.isSwitchedOn,
+      showAffiliateLinks = content.content.fields.showAffiliateLinks,
+      alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
+      tagPaths = content.content.tags.tags.map(_.id),
+    )
+  }
+
+  private def hasAffiliateLinksForDisclaimer(content: ContentType, blocks: Seq[APIBlock]): Boolean = {
+    content match {
+      case gallery: Gallery => gallery.lightbox.containsAffiliateableLinks
+      case _                => blocks.exists(block => stringContainsAffiliateableLinks(block.bodyHtml))
+    }
   }
 
   def contentDateTimes(content: ContentType): ArticleDateTimes = {


### PR DESCRIPTION
## What is the value of this and can you measure success?
This PR consolidates affiliate disclaimer rendering into a single shared logic path so affiliate disclaimer behaviour is consistent across gallery/filter and non-filter article flows.

## What does this change?
1. Unified disclaimer decision logic was added to `DotcomRenderingUtils.scala`.
2. DCR data model now calls the shared helper instead of its own local disclaimer logic in `DotcomRenderingDataModel.scala`.
3. Gallery rendering now uses the same shared helper in `galleryBody.scala.html`
4. DCR disclaimer flag generation was simplified (removed redundant double-gating) in `DotcomRenderingDataModel.scala`

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
