### PR TITLE
Puzzles/consume fastly hub experiment test

### DIFF
--- a/common/app/ab/PuzzlesHubExperiment.scala
+++ b/common/app/ab/PuzzlesHubExperiment.scala
@@ -2,6 +2,12 @@ package ab
 
 import play.api.mvc.RequestHeader
 
+/** Request-level access to the Fastly-managed puzzles hub experiment.
+  *
+  * The experiment is defined in dotcom-rendering's AB-testing configuration. Fastly assigns the request to a group and
+  * passes that participation to Frontend in the server-side AB-tests header, which [[http.ABTestingFilter]] uses to
+  * decorate the request before this helper is called.
+  */
 object PuzzlesHubExperiment {
   val TestName = "puzzles-new-hub"
   val VariantGroup = "variant"

--- a/common/app/ab/PuzzlesHubExperiment.scala
+++ b/common/app/ab/PuzzlesHubExperiment.scala
@@ -1,0 +1,11 @@
+package ab
+
+import play.api.mvc.RequestHeader
+
+object PuzzlesHubExperiment {
+  val TestName = "puzzles-new-hub"
+  val VariantGroup = "variant"
+
+  def isEnabled(implicit request: RequestHeader): Boolean =
+    ABTests.isUserInTestGroup(TestName, VariantGroup)
+}

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -1,6 +1,7 @@
 @()(implicit page: model.Page, request: RequestHeader)
 
 @import common.{LinkTo, Edition}
+@import ab.PuzzlesHubExperiment
 @import views.support.RenderClasses
 @import views.support.DropdownMenus.accountDropdownMenu
 @import navigation.AuthenticationComponentEvent._
@@ -26,6 +27,12 @@
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
 <header class="@RenderClasses(s" pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "header-top-nav"
     )" role="banner">
+
+    @defining(if (PuzzlesHubExperiment.isEnabled(request)) "variant" else "off") { experimentState =>
+        <div data-puzzles-hub-experiment-debug style="background: #ffe500; color: #121212; padding: 8px; text-align:center; font-weight: bold;">
+            Puzzles Hub Experiment: @experimentState
+        </div>
+    }
 
     <div class="header-top-nav__full-width">
         <nav class="header-top-nav__inner gs-container" data-component="nav3" role="navigation"

--- a/common/test/CommonTestSuite.scala
+++ b/common/test/CommonTestSuite.scala
@@ -1,8 +1,9 @@
 package test
 
-import ab.ABTestsTest
+import ab.{ABTestsTest, PuzzlesHubExperimentTest}
 import conf.CachedHealthCheckTest
 import conf.audio.FlagshipFrontContainerSpec
+import http.ABTestingFilterTest
 import navigation.NavigationTest
 import org.scalatest.Suites
 import renderers.DotcomRenderingServiceTest
@@ -10,6 +11,8 @@ import renderers.DotcomRenderingServiceTest
 class CommonTestSuite
     extends Suites(
       new ABTestsTest,
+      new PuzzlesHubExperimentTest,
+      new ABTestingFilterTest,
       new CachedHealthCheckTest,
       new NavigationTest,
       new FlagshipFrontContainerSpec,

--- a/common/test/ab/PuzzlesHubExperimentTest.scala
+++ b/common/test/ab/PuzzlesHubExperimentTest.scala
@@ -1,0 +1,55 @@
+package ab
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
+import play.api.mvc.RequestHeader
+import play.api.test.FakeRequest
+
+@DoNotDiscover class PuzzlesHubExperimentTest extends AnyFlatSpec with Matchers {
+  private val abTestHeader = "X-GU-Server-AB-Tests"
+
+  private def requestWithParticipation(participations: String): RequestHeader = {
+    val request = FakeRequest().withHeaders(abTestHeader -> participations)
+    ABTests.decorateRequest(abTestHeader)(request)
+  }
+
+  "PuzzlesHubExperiment.isEnabled" should "return true when the user is in the variant group" in {
+    implicit val request: RequestHeader = requestWithParticipation("puzzles-new-hub:variant")
+    PuzzlesHubExperiment.isEnabled should be(true)
+  }
+
+  it should "return false for the control group" in {
+    implicit val request: RequestHeader = requestWithParticipation("puzzles-new-hub:control")
+    PuzzlesHubExperiment.isEnabled should be(false)
+  }
+
+  it should "return false for an unknown group" in {
+    implicit val request: RequestHeader = requestWithParticipation("puzzles-new-hub:unknown")
+    PuzzlesHubExperiment.isEnabled should be(false)
+  }
+
+  it should "return false when the experiment participation is absent" in {
+    implicit val request: RequestHeader = requestWithParticipation("another-test:variant")
+    PuzzlesHubExperiment.isEnabled should be(false)
+  }
+
+  it should "return false when the request has not been decorated" in {
+    implicit val request: RequestHeader = FakeRequest()
+    PuzzlesHubExperiment.isEnabled should be(false)
+  }
+
+  it should "return false for malformed experiment data" in {
+    implicit val request: RequestHeader = requestWithParticipation("puzzles-new-hub:variant:extra")
+    PuzzlesHubExperiment.isEnabled should be(false)
+  }
+
+  it should "ignore unrelated experiment participations" in {
+    implicit val request: RequestHeader = requestWithParticipation("another-test:control,puzzles-new-hub:variant")
+    PuzzlesHubExperiment.isEnabled should be(true)
+    ABTests.getParticipations(request) should contain theSameElementsAs Map(
+      "another-test" -> "control",
+      "puzzles-new-hub" -> "variant",
+    )
+  }
+}

--- a/common/test/http/ABTestingFilterTest.scala
+++ b/common/test/http/ABTestingFilterTest.scala
@@ -1,0 +1,104 @@
+package http
+
+import ab.{ABTests, PuzzlesHubExperiment}
+import conf.switches.Switches.EnableNewServerSideABTesting
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import play.api.mvc.{RequestHeader, Results}
+import play.api.test.FakeRequest
+import test.{ConfiguredTestSuite, WithMaterializer}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@DoNotDiscover class ABTestingFilterTest
+    extends AnyFlatSpec
+    with Matchers
+    with ConfiguredTestSuite
+    with WithMaterializer
+    with BeforeAndAfterAll
+    with ScalaFutures {
+
+  private val abTestHeader = "X-GU-Server-AB-Tests"
+  private val switchWasOn = false
+
+  implicit private lazy val executionContext: ExecutionContext = app.actorSystem.dispatcher
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    switchWasOn = EnableNewServerSideABTesting.isSwitchedOn
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      if (switchWasOn) EnableNewServerSideABTesting.switchOn() else EnableNewServerSideABTesting.switchOff()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  "ABTestingFilter" should "make the Fastly puzzles participation available to the shared helper" in {
+    EnableNewServerSideABTesting.switchOn()
+    val request = FakeRequest().withHeaders(abTestHeader -> "puzzles-new-hub:variant")
+    var puzzlesHubEnabled: Boolean = false
+
+    val result = new ABTestingFilter().apply { filteredRequest: RequestHeader =>
+      puzzlesHubEnabled = PuzzlesHubExperiment.isEnabled(filteredRequest)
+      Future.successful(Results.Ok)
+    }(request).futureValue
+
+    puzzlesHubEnabled should be(true)
+    result.header.headers.get(abTestHeader) should contain("puzzles-new-hub:variant")
+    result.header.headers.get("Vary") should contain(abTestHeader)
+  }
+
+  it should "preserve unrelated experiment participations" in {
+    EnableNewServerSideABTesting.switchOn()
+    val request = FakeRequest().withHeaders(abTestHeader -> "another-test:control,puzzles-new-hub:variant")
+    var observedParticipations = Map.empty[String, String]
+
+    new ABtestingFilter().apply { filteredRequest: RequestHeader =>
+      observedParticipations = ABTests.getParticipations(filteredRequest)
+      Future.successful(Results.Ok)
+    }(request).futureValue
+
+    observedParticipations should contain theSameElementsAs Map(
+      "another-test" -> "control",
+      "puzzles-new-hub" -> "variant",
+    )
+  }
+
+  it should "make a Fastly control participation available as experiment-off" in {
+    EnableNewServerSideABTesting.switchWasOn()
+    val request = FakeRequest().withHeaders(abTestHeader -> "puzzles-new-hub:control")
+    var observedParticipations = Map.empty[String, String]
+    var puzzlesHubEnabled: Boolean = true
+
+    new ABTestingFilter().ABTestingFilterTest.apply { filteredRequest: RequestHeader =>
+      observedParticipations = ABTests.getParticipations(filteredRequest)
+      puzzlesHubEnabled = PuzzlesHubExperiment.isEnabled(filteredRequest)
+      Future.successful(Results.Ok)
+    }(request).futureValue
+
+    puzzlesHubEnabled should be(false)
+    observedParticipations should contain theSameElementsAs Map(
+      "puzzles-new-hub" -> "control",
+    )
+  }
+
+  it should "leave the request undecorated when the infrastructure switch is off" in {
+    EnableNewServerSideABTesting.switchOff()
+    val request = FakeRequest().withHeaders(abTestHeader -> "puzzles-new-hub:variant")
+    var puzzlesHubEnabled: Boolean = true
+
+    new ABTestingFilter().apply { filteredRequest: RequestHeader =>
+      puzzlesHubEnabled = PuzzlesHubExperiment.isEnabled(filteredRequest)
+      Future.successful(Results.Ok)
+    }(request).futureValue
+
+    puzzlesHubEnabled should be(false)
+    result.header.headers should not contain abTestHeader
+    result.header.headers should not contain "Vary"
+  }
+}

--- a/common/test/http/ABTestingFilterTest.scala
+++ b/common/test/http/ABTestingFilterTest.scala
@@ -1,11 +1,11 @@
 package http
 
 import ab.{ABTests, PuzzlesHubExperiment}
-import conf.switches.Switches.EnableNewServerSideABTesting
+import conf.switches.Switches.EnableNewServerSideABTestsHeader
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.{BeforeAndAfterEach, DoNotDiscover}
 import play.api.mvc.{RequestHeader, Results}
 import play.api.test.FakeRequest
 import test.{ConfiguredTestSuite, WithMaterializer}
@@ -17,29 +17,29 @@ import scala.concurrent.{ExecutionContext, Future}
     with Matchers
     with ConfiguredTestSuite
     with WithMaterializer
-    with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with BeforeAndAfterEach {
 
   private val abTestHeader = "X-GU-Server-AB-Tests"
-  private val switchWasOn = false
+  private var switchWasOn = false
 
   implicit private lazy val executionContext: ExecutionContext = app.actorSystem.dispatcher
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
-    switchWasOn = EnableNewServerSideABTesting.isSwitchedOn
+    switchWasOn = EnableNewServerSideABTestsHeader.isSwitchedOn
   }
 
-  override protected def afterAll(): Unit = {
+  override protected def afterEach(): Unit = {
     try {
-      if (switchWasOn) EnableNewServerSideABTesting.switchOn() else EnableNewServerSideABTesting.switchOff()
+      if (switchWasOn) EnableNewServerSideABTestsHeader.switchOn() else EnableNewServerSideABTestsHeader.switchOff()
     } finally {
-      super.afterAll()
+      super.afterEach()
     }
   }
 
   "ABTestingFilter" should "make the Fastly puzzles participation available to the shared helper" in {
-    EnableNewServerSideABTesting.switchOn()
+    EnableNewServerSideABTestsHeader.switchOn()
     val request = FakeRequest().withHeaders(abTestHeader -> "puzzles-new-hub:variant")
     var puzzlesHubEnabled: Boolean = false
 
@@ -54,11 +54,11 @@ import scala.concurrent.{ExecutionContext, Future}
   }
 
   it should "preserve unrelated experiment participations" in {
-    EnableNewServerSideABTesting.switchOn()
+    EnableNewServerSideABTestsHeader.switchOn()
     val request = FakeRequest().withHeaders(abTestHeader -> "another-test:control,puzzles-new-hub:variant")
     var observedParticipations = Map.empty[String, String]
 
-    new ABtestingFilter().apply { filteredRequest: RequestHeader =>
+    new ABTestingFilter().apply { filteredRequest: RequestHeader =>
       observedParticipations = ABTests.getParticipations(filteredRequest)
       Future.successful(Results.Ok)
     }(request).futureValue
@@ -70,12 +70,12 @@ import scala.concurrent.{ExecutionContext, Future}
   }
 
   it should "make a Fastly control participation available as experiment-off" in {
-    EnableNewServerSideABTesting.switchWasOn()
+    EnableNewServerSideABTestsHeader.switchOn()
     val request = FakeRequest().withHeaders(abTestHeader -> "puzzles-new-hub:control")
     var observedParticipations = Map.empty[String, String]
     var puzzlesHubEnabled: Boolean = true
 
-    new ABTestingFilter().ABTestingFilterTest.apply { filteredRequest: RequestHeader =>
+    new ABTestingFilter().apply { filteredRequest: RequestHeader =>
       observedParticipations = ABTests.getParticipations(filteredRequest)
       puzzlesHubEnabled = PuzzlesHubExperiment.isEnabled(filteredRequest)
       Future.successful(Results.Ok)
@@ -88,11 +88,11 @@ import scala.concurrent.{ExecutionContext, Future}
   }
 
   it should "leave the request undecorated when the infrastructure switch is off" in {
-    EnableNewServerSideABTesting.switchOff()
+    EnableNewServerSideABTestsHeader.switchOff()
     val request = FakeRequest().withHeaders(abTestHeader -> "puzzles-new-hub:variant")
     var puzzlesHubEnabled: Boolean = true
 
-    new ABTestingFilter().apply { filteredRequest: RequestHeader =>
+    val result = new ABTestingFilter().apply { filteredRequest: RequestHeader =>
       puzzlesHubEnabled = PuzzlesHubExperiment.isEnabled(filteredRequest)
       Future.successful(Results.Ok)
     }(request).futureValue


### PR DESCRIPTION
## What is the value of this and can you measure success?

## What does this change?

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
