### PR TITLE
Remove two-paragraph placement constraint for affiliate disclaimer

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -22,7 +22,7 @@
 
         @fragments.galleryHeader(
             page,
-            DotcomRenderingUtils.shouldShowAffiliateDisclaimer(page.item)
+            DotcomRenderingUtils.shouldAddAffiliateLinks(page.item)
         )
 
         <div class="@RenderClasses(

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -464,8 +464,7 @@ object DotcomRenderingDataModel {
       twitterHandle = content.tags.contributors.headOption.flatMap(_.properties.twitterHandle),
     )
 
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
-    val shouldAddDisclaimer = DotcomRenderingUtils.shouldShowAffiliateDisclaimer(content, bodyBlocks)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, bodyBlocks)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(
       webPublicationDate = content.trail.webPublicationDate,
@@ -602,19 +601,14 @@ object DotcomRenderingDataModel {
 
     val matchData = makeMatchData(page, pageType)
 
-    def addAffiliateLinksDisclaimerDCR(shouldAddDisclaimer: Boolean) = {
-      if (shouldAddDisclaimer) {
-        Some("true")
-      } else {
-        None
-      }
-    }
-
     val guardianBaseURL =
       if (Environment.app == "preview") s"${Configuration.site.viewerProxyBaseUrl}" else Configuration.site.host
 
     DotcomRenderingDataModel(
-      affiliateLinksDisclaimer = addAffiliateLinksDisclaimerDCR(shouldAddDisclaimer),
+      affiliateLinksDisclaimer = {
+        if (shouldAddAffiliateLinks) Some("true")
+        else None
+      },
       audioArticleImage = audioImageBlock,
       trailPicture = trailPicture,
       author = author,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -292,8 +292,16 @@ object DotcomRenderingUtils extends DCARUrlHelper {
     }
   }
 
+  def shouldAddAffiliateLinks(content: ContentType, blocks: Seq[APIBlock]): Boolean = {
+    isEligibleForAffiliateLinks(content) && hasAffiliateLinksInContent(content, blocks)
+  }
+
   def shouldAddAffiliateLinks(content: ContentType): Boolean = {
-    AffiliateLinksCleaner.shouldAddAffiliateLinks(
+    isEligibleForAffiliateLinks(content) && hasAffiliateLinksInContent(content, Seq.empty)
+  }
+
+  private def isEligibleForAffiliateLinks(content: ContentType): Boolean = {
+    AffiliateLinksCleaner.isEligibleForAffiliateLinks(
       switchedOn = Switches.AffiliateLinks.isSwitchedOn,
       showAffiliateLinks = content.content.fields.showAffiliateLinks,
       alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
@@ -301,19 +309,7 @@ object DotcomRenderingUtils extends DCARUrlHelper {
     )
   }
 
-  def shouldShowAffiliateDisclaimer(content: ContentType, blocks: Seq[APIBlock]): Boolean = {
-    shouldAddAffiliateDisclaimerByTagging(content) && hasAffiliateLinksForDisclaimer(content, blocks)
-  }
-
-  def shouldShowAffiliateDisclaimer(content: ContentType): Boolean = {
-    shouldAddAffiliateDisclaimerByTagging(content) && hasAffiliateLinksForDisclaimer(content, Seq.empty)
-  }
-
-  private def shouldAddAffiliateDisclaimerByTagging(content: ContentType): Boolean = {
-    shouldAddAffiliateLinks(content)
-  }
-
-  private def hasAffiliateLinksForDisclaimer(content: ContentType, blocks: Seq[APIBlock]): Boolean = {
+  private def hasAffiliateLinksInContent(content: ContentType, blocks: Seq[APIBlock]): Boolean = {
     content match {
       case gallery: Gallery => gallery.lightbox.containsAffiliateableLinks
       case _                => blocks.exists(block => stringContainsAffiliateableLinks(block.bodyHtml))

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -25,7 +25,6 @@ import model.{
 }
 import org.joda.time.LocalDate
 import org.joda.time.format.DateTimeFormat
-import org.jsoup.Jsoup
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.AffiliateLinksCleaner
@@ -294,38 +293,12 @@ object DotcomRenderingUtils extends DCARUrlHelper {
   }
 
   def shouldAddAffiliateLinks(content: ContentType): Boolean = {
-    if (content.content.isGallery) {
-      // For galleries, the disclaimer is only inserted in the header so we don't need
-      // a check for paragraphs as in other articles
-      AffiliateLinksCleaner.shouldAddAffiliateLinks(
-        switchedOn = Switches.AffiliateLinks.isSwitchedOn,
-        showAffiliateLinks = content.content.fields.showAffiliateLinks,
-        alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
-        tagPaths = content.content.tags.tags.map(_.id),
-      )
-    } else {
-      val contentHtml = Jsoup.parse(content.fields.body)
-      val bodyElements = contentHtml.select("body").first().children()
-
-      /** On smaller devices, the disclaimer is inserted before paragraph 2 of the article body and floats left. This
-        * logic ensures there are two clear paragraphs of text at the top of the article. We don't support inserting the
-        * disclaimer next to other element types. It also ensures the second paragraph is long enough to accommodate the
-        * disclaimer appearing alongside it.
-        */
-      if (bodyElements.size >= 2) {
-        val firstEl = bodyElements.get(0)
-        val secondEl = bodyElements.get(1)
-        if (firstEl.tagName == "p" && secondEl.tagName == "p" && secondEl.text().length >= 150) {
-          AffiliateLinksCleaner.shouldAddAffiliateLinks(
-            switchedOn = Switches.AffiliateLinks.isSwitchedOn,
-            showAffiliateLinks = content.content.fields.showAffiliateLinks,
-            alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
-            tagPaths = content.content.tags.tags.map(_.id),
-          )
-        } else false
-      } else false
-    }
-
+    AffiliateLinksCleaner.shouldAddAffiliateLinks(
+      switchedOn = Switches.AffiliateLinks.isSwitchedOn,
+      showAffiliateLinks = content.content.fields.showAffiliateLinks,
+      alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
+      tagPaths = content.content.tags.tags.map(_.id),
+    )
   }
 
   def shouldShowAffiliateDisclaimer(content: ContentType, blocks: Seq[APIBlock]): Boolean = {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -872,7 +872,7 @@ case class AffiliateLinksCleaner(
 
   override def clean(document: Document)(implicit request: RequestHeader): Document = {
     if (
-      AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.shouldAddAffiliateLinks(
+      AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.isEligibleForAffiliateLinks(
         AffiliateLinks.isSwitchedOn,
         showAffiliateLinks,
         alwaysOffTags,
@@ -937,7 +937,7 @@ object AffiliateLinksCleaner {
     tagPaths.exists(path => alwaysOffTags.contains(path))
   }
 
-  def shouldAddAffiliateLinks(
+  def isEligibleForAffiliateLinks(
       switchedOn: Boolean,
       showAffiliateLinks: Option[Boolean],
       alwaysOffTags: Set[String],

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -191,17 +191,7 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
   private val sampleArticleBody =
     """<p>Opening paragraph.</p><p>Second paragraph with some content.</p>"""
 
-  "shouldAddAffiliateLinks" should "return true when switch is on and showAffiliateLinks is true" in {
-    Switches.AffiliateLinks.switchOn()
-    try {
-      val content = articleWithBody(sampleArticleBody)
-      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(true)
-    } finally {
-      Switches.AffiliateLinks.switchOff()
-    }
-  }
-
-  it should "return false when the affiliate links switch is off" in {
+  "shouldAddAffiliateLinks" should "return false when the affiliate links switch is off" in {
     Switches.AffiliateLinks.switchOff()
     val content = articleWithBody(sampleArticleBody)
     DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
@@ -227,7 +217,7 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
     }
   }
 
-  "shouldShowAffiliateDisclaimer" should "return false when no skimlinks exist in the blocks" in {
+  it should "return false when no skimlinks exist in the blocks" in {
     Switches.AffiliateLinks.switchOn()
     try {
       val content = articleWithBody(sampleArticleBody)
@@ -249,7 +239,7 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
         ),
       )
 
-      DotcomRenderingUtils.shouldShowAffiliateDisclaimer(content, blocks) should be(false)
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content, blocks) should be(false)
     } finally {
       Switches.AffiliateLinks.switchOff()
     }

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -168,7 +168,6 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
   }
 
   // --- Affiliate disclaimer tests ---
-  // These tests exercise the paragraph-placement logic that gates whether the disclaimer can appear.
   // Testing skimlinks detection (hasAffiliateLinksForDisclaimer) requires a SkimLinksCache refactor
   // and will be covered in a follow-up PR.
 
@@ -189,57 +188,14 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
     Article.make(Content.make(item))
   }
 
-  private val shortSecondParagraphBody =
-    """<p>Opening paragraph for an energy-bills article.</p>
-      |<p>Brief second paragraph.</p>""".stripMargin
+  private val sampleArticleBody =
+    """<p>Opening paragraph.</p><p>Second paragraph with some content.</p>"""
 
-  private val longSecondParagraphBody =
-    s"""<p>Opening paragraph.</p>
-       |<p>${"x" * 160}</p>""".stripMargin
-
-  private val bodyStartingWithNonParagraph =
-    s"""<figure><img src="hero.jpg"/></figure>
-       |<p>Opening paragraph.</p>
-       |<p>${"x" * 160}</p>""".stripMargin
-
-  private val singleParagraphBody =
-    s"""<p>${"x" * 200}</p>"""
-
-  "shouldAddAffiliateLinks" should "return false when the second paragraph is too short" in {
+  "shouldAddAffiliateLinks" should "return true when switch is on and showAffiliateLinks is true" in {
     Switches.AffiliateLinks.switchOn()
     try {
-      val content = articleWithBody(shortSecondParagraphBody)
-      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
-    } finally {
-      Switches.AffiliateLinks.switchOff()
-    }
-  }
-
-  it should "return true when there are two leading paragraphs and the second is long enough" in {
-    Switches.AffiliateLinks.switchOn()
-    try {
-      val content = articleWithBody(longSecondParagraphBody)
+      val content = articleWithBody(sampleArticleBody)
       DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(true)
-    } finally {
-      Switches.AffiliateLinks.switchOff()
-    }
-  }
-
-  it should "return false when the first element is not a paragraph" in {
-    Switches.AffiliateLinks.switchOn()
-    try {
-      val content = articleWithBody(bodyStartingWithNonParagraph)
-      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
-    } finally {
-      Switches.AffiliateLinks.switchOff()
-    }
-  }
-
-  it should "return false when there is only one element in the body" in {
-    Switches.AffiliateLinks.switchOn()
-    try {
-      val content = articleWithBody(singleParagraphBody)
-      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
     } finally {
       Switches.AffiliateLinks.switchOff()
     }
@@ -247,14 +203,14 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
 
   it should "return false when the affiliate links switch is off" in {
     Switches.AffiliateLinks.switchOff()
-    val content = articleWithBody(longSecondParagraphBody)
+    val content = articleWithBody(sampleArticleBody)
     DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
   }
 
   it should "return false when showAffiliateLinks is not set on the content" in {
     Switches.AffiliateLinks.switchOn()
     try {
-      val content = articleWithBody(longSecondParagraphBody, showAffiliateLinks = None)
+      val content = articleWithBody(sampleArticleBody, showAffiliateLinks = None)
       DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
     } finally {
       Switches.AffiliateLinks.switchOff()
@@ -264,45 +220,17 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
   it should "return false when showAffiliateLinks is explicitly false" in {
     Switches.AffiliateLinks.switchOn()
     try {
-      val content = articleWithBody(longSecondParagraphBody, showAffiliateLinks = Some(false))
+      val content = articleWithBody(sampleArticleBody, showAffiliateLinks = Some(false))
       DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
     } finally {
       Switches.AffiliateLinks.switchOff()
     }
   }
 
-  "shouldShowAffiliateDisclaimer" should "return false when the second paragraph is too short for disclaimer placement" in {
+  "shouldShowAffiliateDisclaimer" should "return false when no skimlinks exist in the blocks" in {
     Switches.AffiliateLinks.switchOn()
     try {
-      val content = articleWithBody(shortSecondParagraphBody)
-      val blocks = Seq(
-        Block(
-          id = "1",
-          bodyHtml = """<a href="https://www.example.com/product">link</a>""",
-          bodyTextSummary = "",
-          title = None,
-          attributes = BlockAttributes(),
-          published = true,
-          createdDate = None,
-          firstPublishedDate = None,
-          publishedDate = None,
-          lastModifiedDate = None,
-          createdBy = None,
-          lastModifiedBy = None,
-          elements = Seq(),
-        ),
-      )
-
-      DotcomRenderingUtils.shouldShowAffiliateDisclaimer(content, blocks) should be(false)
-    } finally {
-      Switches.AffiliateLinks.switchOff()
-    }
-  }
-
-  it should "return false when paragraph placement is valid but no skimlinks exist in the blocks" in {
-    Switches.AffiliateLinks.switchOn()
-    try {
-      val content = articleWithBody(longSecondParagraphBody)
+      val content = articleWithBody(sampleArticleBody)
       val blocks = Seq(
         Block(
           id = "1",

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -30,44 +30,44 @@ class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
     )
   }
 
-  "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
+  "isEligibleForAffiliateLinks" should "correctly determine when to add affiliate links" in {
     // the switch is respected
-    shouldAddAffiliateLinks(
+    isEligibleForAffiliateLinks(
       switchedOn = false,
       None,
       Set.empty,
       List.empty,
     ) should be(false)
     // affiliate links are not added when showAffiliateLinks is false
-    shouldAddAffiliateLinks(
+    isEligibleForAffiliateLinks(
       switchedOn = true,
       Some(false),
       Set.empty,
       List.empty,
     ) should be(false)
     // affiliate links are added when showAffiliateLinks is true and there are no alwaysOff tags present
-    shouldAddAffiliateLinks(
+    isEligibleForAffiliateLinks(
       switchedOn = true,
       Some(true),
       Set.empty,
       List.empty,
     ) should be(true)
     // affiliate links are not added when showAffiliateLinks is not defined
-    shouldAddAffiliateLinks(
+    isEligibleForAffiliateLinks(
       switchedOn = true,
       None,
       Set.empty,
       List("tech"),
     ) should be(false)
     // affiliate links are not added when an always off tag is present on the article
-    shouldAddAffiliateLinks(
+    isEligibleForAffiliateLinks(
       switchedOn = true,
       Some(true),
       Set("bereavement"),
       List("bereavement"),
     ) should be(false)
     // affiliate links are added when the tags are considered safe
-    shouldAddAffiliateLinks(
+    isEligibleForAffiliateLinks(
       switchedOn = true,
       Some(true),
       Set("bereavement"),


### PR DESCRIPTION
## Context

The affiliate disclaimer logic in Frontend currently includes a paragraph-placement constraint: it parses the article body HTML and only allows the disclaimer if the first two elements are `<p>` tags and the second paragraph is ≥150 characters. This was originally needed so the disclaimer could float alongside the second paragraph on smaller screens without breaking the layout.

DCR now handles disclaimer positioning independently, so this check is no longer needed in Frontend and unnecessarily prevents the disclaimer from appearing on articles that should have one.

## What this PR does

1. **Removes the legacy placement logic** from `shouldAddAffiliateLinks`, it no longer parses the article body HTML or checks paragraph structure. The method now delegates directly to `AffiliateLinksCleaner.shouldAddAffiliateLinks` for all content types, removing the separate gallery code path in the process.

2. **Adds tests** for the affiliate disclaimer decision logic, covering:
   - Switch on with `showAffiliateLinks` true → disclaimer allowed
   - Switch off → no disclaimer
   - `showAffiliateLinks` not set → no disclaimer
   - `showAffiliateLinks` explicitly false → no disclaimer
   - No skimlinks in blocks → no disclaimer
   
## Future work

A positive test for the skimlinks case (disclaimer shown when skimlinks are present in article blocks) is not yet possible because `SkimLinksCache` holds its domain list in a private field that can't be injected in tests. A small refactor to make the cache testable would allow this to be added in a follow-up PR.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
