### PR TITLE
Add minimal tests support to FapiFrontJsonMinimal 

### DIFF
--- a/facia/app/controllers/front/FapiFrontJsonMinimal.scala
+++ b/facia/app/controllers/front/FapiFrontJsonMinimal.scala
@@ -1,5 +1,6 @@
 package controllers.front
 
+import com.gu.facia.client.models.{Test, VariantMeta}
 import model.PressedPage
 import model.facia.PressedCollection
 import model.pressed._
@@ -44,11 +45,41 @@ trait FapiFrontJsonMinimal {
           "group" -> faciaContent.card.group,
           "frontPublicationDate" -> faciaContent.properties.maybeFrontPublicationDate,
           "supporting" -> getSupporting(faciaContent),
+          "tests" -> getMinimalTests(faciaContent.properties.tests),
         )
         .fields
         .filterNot { case (_, v) => v == JsNull },
     )
   }
+
+  private case class MinimalTest(
+      testUuid: String,
+      variantMeta: List[VariantMeta],
+      startDate: Option[Long],
+      expiryDate: Option[Long],
+      hasManuallyEndedOnThisTrail: Boolean,
+  )
+
+  implicit private val minimalTestWrites: Writes[MinimalTest] = Json.writes[MinimalTest]
+
+  private def getMinimalTests(tests: Option[List[Test]]): JsValue =
+    tests.filter(_.nonEmpty) match {
+      case Some(tests) =>
+        JsArray(
+          tests.map(test =>
+            Json.toJson(
+              MinimalTest(
+                testUuid = test.testUuid,
+                variantMeta = test.variantMeta,
+                startDate = test.startDate,
+                expiryDate = test.expiryDate,
+                hasManuallyEndedOnThisTrail = test.hasManuallyEndedOnThisTrail,
+              ),
+            ),
+          ),
+        )
+      case None => JsNull
+    }
 
   private def getSupporting(faciaContent: PressedContent): JsValue =
     faciaContent match {


### PR DESCRIPTION
## What is the value of this and can you measure success?
 This PR adds `Test` data on the `/lite.json` endpoint, which is polled by DAE. 

For this endpoint, the tests model has been reduced to only include the following fields, `testUuid`, `variantMeta`, `startDate`, `endDate`, `hasManuallyEndedOnThisTrail`. Any PII data has been excluded.

## Screenshots
<img width="2278" height="1332" alt="Screenshot 2026-08-13 at 11 40 43" src="https://github.com/user-attachments/assets/6640ce61-58e1-4648-8c6a-ec1dfb96c4d2" />


-->

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
