### PR TITLE
Remove PII data from Tests

### DIFF
--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -5,6 +5,7 @@ import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import conf.Configuration
 import model.{PressedPage, RelatedContentItem}
+import model.pressed.{CuratedContent, LatestSnap, LinkSnap, PressedContent, SupportingCuratedContent}
 import navigation.{FooterLinks, Nav}
 import play.api.libs.json.{JsObject, JsValue, Json, OWrites}
 import play.api.mvc.RequestHeader
@@ -52,11 +53,19 @@ object DotcomFrontsRenderingDataModel {
       .map { _.perEdition.mapKeys(_.id) }
       .getOrElse(Map.empty[String, EditionCommercialProperties])
 
+    def stripDataForDcr(content: PressedContent): PressedContent =
+      content.withoutCommercial match {
+        case curated: CuratedContent              => curated.withoutTestPII
+        case supporting: SupportingCuratedContent => supporting.withoutTestPII
+        case linkSnap: LinkSnap                   => linkSnap
+        case latestSnap: LatestSnap               => latestSnap
+      }
+
     val lighterPage = page.copy(collections =
       page.collections.map(collection =>
         collection.copy(
-          curated = collection.curated.map(content => content.withoutCommercial),
-          backfill = collection.backfill.map(content => content.withoutCommercial),
+          curated = collection.curated.map(stripDataForDcr),
+          backfill = collection.backfill.map(stripDataForDcr),
         ),
       ),
     )

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -82,6 +82,20 @@ object PressedContent {
       case linkSnap: fapi.LinkSnap     => LinkSnap.make(linkSnap)
       case latestSnap: fapi.LatestSnap => LatestSnap.make(latestSnap)
     }
+
+  def propertiesWithoutTestPII(properties: PressedProperties): PressedProperties =
+    properties.copy(
+      tests = properties.tests.map(
+        _.map(test =>
+          test.copy(
+            createdByName = "",
+            createdByEmail = "",
+            manuallyEndedOnThisTrailByName = None,
+            manuallyEndedOnThisTrailByEmail = None,
+          ),
+        ),
+      ),
+    )
 }
 
 final case class CuratedContent(
@@ -104,6 +118,16 @@ final case class CuratedContent(
   override def withoutCommercial: PressedContent = copy(
     properties = propertiesWithoutCommercial(properties),
     supportingContent = supportingContent.map(_.withoutCommercial),
+  )
+
+  def withoutTestPII: PressedContent = copy(
+    properties = PressedContent.propertiesWithoutTestPII(properties),
+    supportingContent = supportingContent.map {
+      case curated: CuratedContent              => curated.withoutTestPII
+      case supporting: SupportingCuratedContent => supporting.withoutTestPII
+      case linkSnap: LinkSnap                   => linkSnap
+      case latestSnap: LatestSnap               => latestSnap
+    },
   )
 
   override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
@@ -150,6 +174,8 @@ final case class SupportingCuratedContent(
   override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
 
   override def withoutCommercial: PressedContent = copy(properties = propertiesWithoutCommercial(properties))
+
+  def withoutTestPII: PressedContent = copy(properties = PressedContent.propertiesWithoutTestPII(properties))
 
   override def withBoostLevel(level: Option[BoostLevel]): PressedContent = copy(
     display = display.copy(boostLevel = level),


### PR DESCRIPTION
## What is the value of this and can you measure success?
Remove PII data from Tests for CuratedContent and SupportingCuratedContent from DCR request. LinkSnap and LatestSnap are passed through as is as they do not have `Tests`.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/98eb5503-29e5-466e-a6d9-07b7c37c4a0b
[after]: https://github.com/user-attachments/assets/f93f1eac-58cd-48fb-bdaf-151aa6c0ee6b



## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
