### PR TITLE
Fix affiliate disclaimer placement check and add tests

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -337,12 +337,7 @@ object DotcomRenderingUtils extends DCARUrlHelper {
   }
 
   private def shouldAddAffiliateDisclaimerByTagging(content: ContentType): Boolean = {
-    AffiliateLinksCleaner.shouldAddAffiliateLinks(
-      switchedOn = Switches.AffiliateLinks.isSwitchedOn,
-      showAffiliateLinks = content.content.fields.showAffiliateLinks,
-      alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
-      tagPaths = content.content.tags.tags.map(_.id),
-    )
+    shouldAddAffiliateLinks(content)
   }
 
   private def hasAffiliateLinksForDisclaimer(content: ContentType, blocks: Seq[APIBlock]): Boolean = {

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -1,8 +1,16 @@
 package model.dotcomrendering.pageElements
 
-import com.gu.contentapi.client.model.v1.{Block, BlockAttributes, Blocks, CapiDateTime, Content => ApiContent}
+import com.gu.contentapi.client.model.v1.{
+  Block,
+  BlockAttributes,
+  Blocks,
+  CapiDateTime,
+  ContentFields,
+  Content => ApiContent,
+}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import com.gu.contentapi.client.utils.format.LiveBlogDesign
+import conf.switches.Switches
 import implicits.Dates.jodaToJavaInstant
 import model.dotcomrendering.DotcomRenderingUtils
 import model.liveblog.{BlockAttributes => LiveblogBlockAttribute, _}
@@ -157,6 +165,166 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
     when(testBlock1.attributes) thenReturn summaryBlockAttributes
 
     DotcomRenderingUtils.ensureSummaryTitle(testBlock1).title should be(Some("I have a title"))
+  }
+
+  // --- Affiliate disclaimer tests ---
+  // These tests exercise the paragraph-placement logic that gates whether the disclaimer can appear.
+  // Testing skimlinks detection (hasAffiliateLinksForDisclaimer) requires a SkimLinksCache refactor
+  // and will be covered in a follow-up PR.
+
+  /** Helper to build a minimal Article with a specific body HTML and showAffiliateLinks flag. */
+  private def articleWithBody(bodyHtml: String, showAffiliateLinks: Option[Boolean] = Some(true)): Article = {
+    val item = ApiContent(
+      id = "money/2025/nov/19/test-article",
+      sectionId = None,
+      sectionName = None,
+      webPublicationDate = Some(jodaToJavaInstant(new DateTime()).atOffset(ZoneOffset.UTC).toCapiDateTime),
+      webTitle = "Test article",
+      webUrl = "http://www.guardian.co.uk/money/2025/nov/19/test-article",
+      apiUrl = "http://content.guardianapis.com/money/2025/nov/19/test-article",
+      tags = List(),
+      elements = None,
+      fields = Some(ContentFields(body = Some(bodyHtml), showAffiliateLinks = showAffiliateLinks)),
+    )
+    Article.make(Content.make(item))
+  }
+
+  private val shortSecondParagraphBody =
+    """<p>Opening paragraph for an energy-bills article.</p>
+      |<p>Brief second paragraph.</p>""".stripMargin
+
+  private val longSecondParagraphBody =
+    s"""<p>Opening paragraph.</p>
+       |<p>${"x" * 160}</p>""".stripMargin
+
+  private val bodyStartingWithNonParagraph =
+    s"""<figure><img src="hero.jpg"/></figure>
+       |<p>Opening paragraph.</p>
+       |<p>${"x" * 160}</p>""".stripMargin
+
+  private val singleParagraphBody =
+    s"""<p>${"x" * 200}</p>"""
+
+  "shouldAddAffiliateLinks" should "return false when the second paragraph is too short" in {
+    Switches.AffiliateLinks.switchOn()
+    try {
+      val content = articleWithBody(shortSecondParagraphBody)
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+    }
+  }
+
+  it should "return true when there are two leading paragraphs and the second is long enough" in {
+    Switches.AffiliateLinks.switchOn()
+    try {
+      val content = articleWithBody(longSecondParagraphBody)
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(true)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+    }
+  }
+
+  it should "return false when the first element is not a paragraph" in {
+    Switches.AffiliateLinks.switchOn()
+    try {
+      val content = articleWithBody(bodyStartingWithNonParagraph)
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+    }
+  }
+
+  it should "return false when there is only one element in the body" in {
+    Switches.AffiliateLinks.switchOn()
+    try {
+      val content = articleWithBody(singleParagraphBody)
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+    }
+  }
+
+  it should "return false when the affiliate links switch is off" in {
+    Switches.AffiliateLinks.switchOff()
+    val content = articleWithBody(longSecondParagraphBody)
+    DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
+  }
+
+  it should "return false when showAffiliateLinks is not set on the content" in {
+    Switches.AffiliateLinks.switchOn()
+    try {
+      val content = articleWithBody(longSecondParagraphBody, showAffiliateLinks = None)
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+    }
+  }
+
+  it should "return false when showAffiliateLinks is explicitly false" in {
+    Switches.AffiliateLinks.switchOn()
+    try {
+      val content = articleWithBody(longSecondParagraphBody, showAffiliateLinks = Some(false))
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+    }
+  }
+
+  "shouldShowAffiliateDisclaimer" should "return false when the second paragraph is too short for disclaimer placement" in {
+    Switches.AffiliateLinks.switchOn()
+    try {
+      val content = articleWithBody(shortSecondParagraphBody)
+      val blocks = Seq(
+        Block(
+          id = "1",
+          bodyHtml = """<a href="https://www.example.com/product">link</a>""",
+          bodyTextSummary = "",
+          title = None,
+          attributes = BlockAttributes(),
+          published = true,
+          createdDate = None,
+          firstPublishedDate = None,
+          publishedDate = None,
+          lastModifiedDate = None,
+          createdBy = None,
+          lastModifiedBy = None,
+          elements = Seq(),
+        ),
+      )
+
+      DotcomRenderingUtils.shouldShowAffiliateDisclaimer(content, blocks) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+    }
+  }
+
+  it should "return false when paragraph placement is valid but no skimlinks exist in the blocks" in {
+    Switches.AffiliateLinks.switchOn()
+    try {
+      val content = articleWithBody(longSecondParagraphBody)
+      val blocks = Seq(
+        Block(
+          id = "1",
+          bodyHtml = "<p>No affiliate links here.</p>",
+          bodyTextSummary = "",
+          title = None,
+          attributes = BlockAttributes(),
+          published = true,
+          createdDate = None,
+          firstPublishedDate = None,
+          publishedDate = None,
+          lastModifiedDate = None,
+          createdBy = None,
+          lastModifiedBy = None,
+          elements = Seq(),
+        ),
+      )
+
+      DotcomRenderingUtils.shouldShowAffiliateDisclaimer(content, blocks) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+    }
   }
 
   def getLiveblogPageWithBlockIds(pageBlokIds: Seq[Int]) = {


### PR DESCRIPTION
## Context

The recently merged `ec-unify-affiliate-disclaimer-rendering-logic` PR introduced a regression: the affiliate disclaimer was appearing on articles where it shouldn't have been. Specifically, `shouldShowAffiliateDisclaimer` was only checking tagging rules (is the switch on? is `showAffiliateLinks` set?) but **not** the paragraph-placement constraint that ensures the disclaimer can actually be rendered properly in the article layout.

The placement rule requires:
- At least two elements at the top of the article body
- Both must be `<p>` tags
- The second paragraph must be ≥150 characters (so the disclaimer can float alongside it on smaller screens)

## What this PR does

1. **Fixes the bug** — `shouldAddAffiliateDisclaimerByTagging` now delegates to `shouldAddAffiliateLinks(content)`, which already includes the placement check. This is a one-line change.

2. **Adds tests** for the disclaimer decision logic, covering:
   - Short second paragraph → no disclaimer
   - Non-paragraph first element → no disclaimer
   - Only one body element → no disclaimer
   - Switch off → no disclaimer
   - `showAffiliateLinks` unset or false → no disclaimer
   - Valid placement + long second paragraph → disclaimer allowed
   - Valid placement but no skimlinks in blocks → no disclaimer

## Next steps

1. **Merge this PR** — fixes the regression and adds test coverage for the current disclaimer logic.
2. **Merge `remove-legacy-placement-constraint-affiliate-disclaimer`** — removes the paragraph-placement constraint entirely, as DCR will handle disclaimer positioning differently. This PR will need updating to delete the 4 placement-specific tests (`short second paragraph`, `non-paragraph first element`, `single body element`, `short paragraph disclaimer placement`) alongside the logic they cover.
3. **SkimLinksCache refactor (future PR)** — `SkimLinksCache` currently has a private domain cache that can't be injected in tests. A refactor would allow testing the positive case (disclaimer shown when skimlinks are present in article blocks).

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
