### PR TITLE
Remove expiry of DCR hosted content switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -645,7 +645,7 @@ trait FeatureSwitches {
     description = "Render hosted content pages with DCR",
     owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2026, 8, 19)),
+    sellByDate = never,
     exposeClientSide = false,
     highImpact = false,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

DCR Hosted Content pages are live to all users but we should keep the switch in case we need to turn it off at some point in the future. This PR allows us to do that by removing the expiry date to stop the switch expiring and being deactivated

## What does this change?

Removes the expiry date of the DCR hosted content switch
