### PR TITLE
add substitution-injury event type

### DIFF
--- a/sport/app/football/model/MatchStats.scala
+++ b/sport/app/football/model/MatchStats.scala
@@ -54,7 +54,7 @@ case class Substitution(
 )
 
 object MatchStats {
-  val reportedEventTypes = List("booking", "dismissal", "substitution")
+  val reportedEventTypes = List("booking", "dismissal", "substitution", "substitution-injury")
 
   def makePlayers(team: LineUpTeamEnhanced): Seq[Player] = {
     team.players.map { player =>


### PR DESCRIPTION
## What is the value of this and can you measure success?

In https://github.com/guardian/frontend/pull/29027 we started using the enhanced event data that the PA API offers. The enhanced events look like this:

`<event eventID="39626991" type="substitution" normalTime="52:53" addedTime="0:00" />`

We gather all events with type "substitution" and use them to find events with matching eventIDs which allows us to see which player came on and which player was replaced. However, occasionally the event type can be "substitution-injury", which we weren't filtering for, resulting in a missing substitution event (this is referenced here: https://github.com/guardian/dotcom-rendering/issues/16566). 

This PR fixes this bug. 

Fixes https://github.com/guardian/dotcom-rendering/issues/16566

## What does this change?

I've added "substitution-injury" to reportedEventTypes.

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
