### PR TITLE
Puzzles/add hub blueprint layout provider

### DIFF
--- a/applications/conf/puzzles-layout.json
+++ b/applications/conf/puzzles-layout.json
@@ -1,0 +1,531 @@
+{
+	"filters": [
+		{
+			"id": "crosswords",
+			"title": "Crosswords",
+			"backgroundColour": "#FCE1CE"
+		},
+		{
+			"id": "logic",
+			"title": "Logic",
+			"backgroundColour": "#CDECFB"
+		},
+		{
+			"id": "word-games",
+			"title": "Word games",
+			"backgroundColour": "#F9D4E8"
+		},
+		{
+			"id": "trivia-quizzes",
+			"title": "Trivia & quizzes",
+			"backgroundColour": "#D5F3F2"
+		}
+	],
+	"containers": [
+		{
+			"title": "Monday’s featured puzzles",
+			"variant": "featured",
+			"content": {
+				"items": [
+					[
+						{
+							"title": "Quick crossword",
+							"type": "crossword",
+							"set": "quick",
+							"filterId": "crosswords",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Alex Bellos’s Monday Puzzle",
+							"type": "quiz",
+							"set": "alex-bellos-monday-puzzle",
+							"url": "/science/series/alex-bellos-monday-puzzle",
+							"filterId": "trivia-quizzes",
+							"backgroundColour": "#D5F3F2"
+						},
+						{
+							"title": "On the Ball",
+							"type": "on-the-ball",
+							"set": "all",
+							"slug": "on-the-ball",
+							"url": "https://sportsreveal.io/guardian",
+							"variant": "iframe-page",
+							"filterId": "trivia-quizzes",
+							"backgroundColour": "#D5F3F2"
+						},
+						{
+							"title": "Word wheel",
+							"type": "word-wheel",
+							"set": "all",
+							"slug": "word-wheel",
+							"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-word-wheel&embed=1&idx=1",
+							"index": 1,
+							"variant": "iframe-page",
+							"filterId": "word-games",
+							"backgroundColour": "#F9D4E8"
+						}
+					]
+				],
+				"nestedContainers": []
+			}
+		},
+		{
+			"title": "Crosswords",
+			"filterId": "crosswords",
+			"content": {
+				"items": [
+					[
+						{
+							"title": "Mini",
+							"type": "crossword",
+							"set": "mini",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Quick",
+							"type": "crossword",
+							"set": "quick",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Cryptic",
+							"type": "crossword",
+							"set": "cryptic",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Quick cryptic",
+							"type": "crossword",
+							"set": "quick-cryptic",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Weekend",
+							"type": "crossword",
+							"set": "weekend",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Prize",
+							"type": "crossword",
+							"set": "prize",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Quiptic",
+							"type": "crossword",
+							"set": "quiptic",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Sunday quick",
+							"type": "crossword",
+							"set": "sunday-quick",
+							"backgroundColour": "#FCE1CE"
+						}
+					]
+				],
+				"nestedContainers": [],
+				"archive": {
+					"title": "Crossword archive",
+					"type": "crossword",
+					"set": "all",
+					"url": "/puzzles/crosswords/archive",
+					"backgroundColour": "#FCE1CE"
+				}
+			}
+		},
+		{
+			"title": "Logic puzzles",
+			"filterId": "logic",
+			"content": {
+				"items": [],
+				"nestedContainers": [
+					{
+						"title": "Sudoku",
+						"desktopSpan": 12,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Easy sudoku",
+										"type": "sudoku",
+										"set": "easy",
+										"slug": "sudoku-easy",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"title": "Medium sudoku",
+										"type": "sudoku",
+										"set": "medium",
+										"slug": "sudoku-medium",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-medium&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"title": "Hard sudoku",
+										"type": "sudoku",
+										"set": "hard",
+										"slug": "sudoku-hard",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-hard&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"title": "Killer sudoku",
+										"type": "sudoku",
+										"set": "killer",
+										"slug": "sudoku-killer",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-killer-sudoku-medium&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Sudoku archive",
+								"type": "sudoku",
+								"set": "all",
+								"slug": "sudoku-easy",
+								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&set=guardian-sudoku-medium&set=guardian-sudoku-hard&set=guardian-killer-sudoku-medium&embed=1",
+								"variant": "archive-page",
+								"backgroundColour": "#CDECFB"
+							}
+						}
+					},
+					{
+						"title": "Futoshiki",
+						"desktopSpan": 6,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Futoshiki",
+										"type": "futoshiki",
+										"set": "all",
+										"slug": "futoshiki",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-futoshiki&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#D3F4F7"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Archive",
+								"type": "futoshiki",
+								"set": "all",
+								"slug": "futoshiki",
+								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-futoshiki&embed=1",
+								"variant": "archive-page",
+								"backgroundColour": "#D3F4F7"
+							}
+						}
+					},
+					{
+						"title": "Suguru",
+						"desktopSpan": 6,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Suguru",
+										"type": "suguru",
+										"set": "all",
+										"slug": "suguru",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-suguru&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#D6D4FA"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Archive",
+								"type": "suguru",
+								"set": "all",
+								"slug": "suguru",
+								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-suguru&embed=1",
+								"variant": "archive-page",
+								"backgroundColour": "#D6D4FA"
+							}
+						}
+					}
+				],
+				"archive": null
+			}
+		},
+		{
+			"title": "Word games",
+			"filterId": "word-games",
+			"content": {
+				"items": [],
+				"nestedContainers": [
+					{
+						"title": "Word wheel",
+						"desktopSpan": 4,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Word wheel",
+										"type": "word-wheel",
+										"set": "all",
+										"slug": "word-wheel",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-word-wheel&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#F9D4E8"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Archive",
+								"type": "word-wheel",
+								"set": "all",
+								"slug": "word-wheel",
+								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-word-wheel&embed=1",
+								"variant": "archive-page",
+								"backgroundColour": "#F9D4E8"
+							}
+						}
+					},
+					{
+						"title": "Wordiply",
+						"desktopSpan": 4,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Wordiply",
+										"type": "wordiply",
+										"set": "all",
+										"slug": "wordiply",
+										"url": "https://www.wordiply.com/",
+										"variant": "iframe-page",
+										"backgroundColour": "#F8D0C9"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Archive",
+								"type": "wordiply",
+								"set": "all",
+								"slug": "wordiply",
+								"url": "https://www.wordiply.com/",
+								"variant": "archive-page",
+								"backgroundColour": "#F8D0C9"
+							}
+						}
+					},
+					{
+						"title": "Codeword",
+						"desktopSpan": 4,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Codeword",
+										"type": "codeword",
+										"set": "all",
+										"slug": "codeword",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-codeword&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#F2D0F6"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Archive",
+								"type": "codeword",
+								"set": "all",
+								"slug": "codeword",
+								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-codeword&embed=1",
+								"variant": "archive-page",
+								"backgroundColour": "#F2D0F6"
+							}
+						}
+					}
+				]
+			}
+		},
+		{
+			"title": "Quizzes and Trivia",
+			"filterId": "trivia-quizzes",
+			"content": {
+				"items": [],
+				"nestedContainers": [
+					{
+						"title": "On the Ball",
+						"desktopSpan": 6,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "On the Ball",
+										"type": "on-the-ball",
+										"set": "all",
+										"slug": "on-the-ball",
+										"url": "https://sportsreveal.io/guardian",
+										"variant": "iframe-page",
+										"backgroundColour": "#D5F3F2"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Archive",
+								"type": "on-the-ball",
+								"set": "all",
+								"slug": "on-the-ball",
+								"url": "https://sportsreveal.io/guardian",
+								"variant": "archive-page",
+								"backgroundColour": "#D5F3F2"
+							}
+						}
+					},
+					{
+						"title": "Film reveal",
+						"desktopSpan": 6,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Film reveal",
+										"type": "film-reveal",
+										"set": "all",
+										"slug": "film-reveal",
+										"url": "https://moviegrid.io/guardian",
+										"variant": "iframe-page",
+										"backgroundColour": "#EAD8B9"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Archive",
+								"type": "film-reveal",
+								"set": "all",
+								"slug": "film-reveal",
+								"url": "https://moviegrid.io/guardian",
+								"variant": "archive-page",
+								"backgroundColour": "#EAD8B9"
+							}
+						}
+					},
+					{
+						"title": "Alex Bellos’s Monday Puzzle",
+						"desktopSpan": 4,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Alex Bellos’s Monday Puzzle",
+										"type": "quiz",
+										"set": "alex-bellos-monday-puzzle",
+										"url": "/science/series/alex-bellos-monday-puzzle",
+										"backgroundColour": "#D5F3F2"
+									}
+								]
+							],
+							"nestedContainers": []
+						}
+					},
+					{
+						"title": "Thursday quiz",
+						"desktopSpan": 4,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Thursday quiz",
+										"type": "quiz",
+										"set": "thursday-quiz",
+										"url": "/theguardian/series/the-quiz-thomas-eaton",
+										"backgroundColour": "#D5F3F2"
+									}
+								]
+							],
+							"nestedContainers": []
+						}
+					},
+					{
+						"title": "Sports quiz",
+						"desktopSpan": 4,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Sports quiz",
+										"type": "quiz",
+										"set": "sports-quiz",
+										"url": "/sport/series/sports-quiz-of-the-week",
+										"backgroundColour": "#D5F3F2"
+									}
+								]
+							],
+							"nestedContainers": []
+						}
+					},
+					{
+						"title": "Saturday quiz",
+						"desktopSpan": 6,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Saturday quiz",
+										"type": "quiz",
+										"set": "saturday-quiz",
+										"url": "/theguardian/series/the-quiz-thomas-eaton",
+										"backgroundColour": "#D5F3F2"
+									}
+								]
+							],
+							"nestedContainers": []
+						}
+					},
+					{
+						"title": "Kids’ quiz",
+						"desktopSpan": 6,
+						"content": {
+							"items": [
+								[
+									{
+										"title": "Kids’ quiz",
+										"type": "quiz",
+										"set": "kids-quiz",
+										"url": "/lifeandstyle/series/the-kids--quiz",
+										"backgroundColour": "#D5F3F2"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"title": "Archive",
+								"type": "quiz",
+								"set": "kids-quiz",
+								"url": "/lifeandstyle/series/the-kids--quiz",
+								"backgroundColour": "#D5F3F2"
+							}
+						}
+					}
+				]
+			}
+		}
+	]
+}

--- a/applications/conf/puzzles-layout.json
+++ b/applications/conf/puzzles-layout.json
@@ -7,7 +7,7 @@
 		},
 		{
 			"id": "logic",
-			"title": "Logic",
+			"title": "Sudoku",
 			"backgroundColour": "#CDECFB"
 		},
 		{
@@ -17,52 +17,36 @@
 		},
 		{
 			"id": "trivia-quizzes",
-			"title": "Trivia & quizzes",
+			"title": "Trivia",
 			"backgroundColour": "#D5F3F2"
 		}
 	],
 	"containers": [
 		{
-			"title": "Monday’s featured puzzles",
+			"title": "Today’s featured puzzles",
 			"variant": "featured",
 			"content": {
 				"items": [
 					[
 						{
-							"title": "Quick crossword",
-							"type": "crossword",
-							"set": "quick",
-							"filterId": "crosswords",
-							"backgroundColour": "#FCE1CE"
-						},
-						{
-							"title": "Alex Bellos’s Monday Puzzle",
-							"type": "quiz",
-							"set": "alex-bellos-monday-puzzle",
-							"url": "/science/series/alex-bellos-monday-puzzle",
-							"filterId": "trivia-quizzes",
-							"backgroundColour": "#D5F3F2"
-						},
-						{
-							"title": "On the Ball",
+							"title": "On the ball",
 							"type": "on-the-ball",
 							"set": "all",
 							"slug": "on-the-ball",
 							"url": "https://sportsreveal.io/guardian",
 							"variant": "iframe-page",
-							"filterId": "trivia-quizzes",
-							"backgroundColour": "#D5F3F2"
+							"backgroundColour": "#D5F3F2",
+							"filterId": "trivia-quizzes"
 						},
 						{
-							"title": "Word wheel",
-							"type": "word-wheel",
+							"title": "Film reveal",
+							"type": "film-reveal",
 							"set": "all",
-							"slug": "word-wheel",
-							"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-word-wheel&embed=1&idx=1",
-							"index": 1,
+							"slug": "film-reveal",
+							"url": "https://moviegrid.io/guardian",
 							"variant": "iframe-page",
-							"filterId": "word-games",
-							"backgroundColour": "#F9D4E8"
+							"backgroundColour": "#EAD8B9",
+							"filterId": "trivia-quizzes"
 						}
 					]
 				],
@@ -98,11 +82,13 @@
 							"type": "crossword",
 							"set": "quick-cryptic",
 							"backgroundColour": "#FCE1CE"
-						},
+						}
+					],
+					[
 						{
-							"title": "Weekend",
+							"title": "Quiptic",
 							"type": "crossword",
-							"set": "weekend",
+							"set": "quiptic",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
@@ -112,15 +98,21 @@
 							"backgroundColour": "#FCE1CE"
 						},
 						{
-							"title": "Quiptic",
+							"title": "Weekend",
 							"type": "crossword",
-							"set": "quiptic",
+							"set": "weekend",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
 							"title": "Sunday quick",
 							"type": "crossword",
 							"set": "sunday-quick",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"title": "Genius",
+							"type": "crossword",
+							"set": "genius",
 							"backgroundColour": "#FCE1CE"
 						}
 					]
@@ -136,136 +128,6 @@
 			}
 		},
 		{
-			"title": "Logic puzzles",
-			"filterId": "logic",
-			"content": {
-				"items": [],
-				"nestedContainers": [
-					{
-						"title": "Sudoku",
-						"desktopSpan": 12,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Easy sudoku",
-										"type": "sudoku",
-										"set": "easy",
-										"slug": "sudoku-easy",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"title": "Medium sudoku",
-										"type": "sudoku",
-										"set": "medium",
-										"slug": "sudoku-medium",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-medium&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"title": "Hard sudoku",
-										"type": "sudoku",
-										"set": "hard",
-										"slug": "sudoku-hard",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-hard&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"title": "Killer sudoku",
-										"type": "sudoku",
-										"set": "killer",
-										"slug": "sudoku-killer",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-killer-sudoku-medium&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									}
-								]
-							],
-							"nestedContainers": [],
-							"archive": {
-								"title": "Sudoku archive",
-								"type": "sudoku",
-								"set": "all",
-								"slug": "sudoku-easy",
-								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&set=guardian-sudoku-medium&set=guardian-sudoku-hard&set=guardian-killer-sudoku-medium&embed=1",
-								"variant": "archive-page",
-								"backgroundColour": "#CDECFB"
-							}
-						}
-					},
-					{
-						"title": "Futoshiki",
-						"desktopSpan": 6,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Futoshiki",
-										"type": "futoshiki",
-										"set": "all",
-										"slug": "futoshiki",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-futoshiki&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#D3F4F7"
-									}
-								]
-							],
-							"nestedContainers": [],
-							"archive": {
-								"title": "Archive",
-								"type": "futoshiki",
-								"set": "all",
-								"slug": "futoshiki",
-								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-futoshiki&embed=1",
-								"variant": "archive-page",
-								"backgroundColour": "#D3F4F7"
-							}
-						}
-					},
-					{
-						"title": "Suguru",
-						"desktopSpan": 6,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Suguru",
-										"type": "suguru",
-										"set": "all",
-										"slug": "suguru",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-suguru&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#D6D4FA"
-									}
-								]
-							],
-							"nestedContainers": [],
-							"archive": {
-								"title": "Archive",
-								"type": "suguru",
-								"set": "all",
-								"slug": "suguru",
-								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-suguru&embed=1",
-								"variant": "archive-page",
-								"backgroundColour": "#D6D4FA"
-							}
-						}
-					}
-				],
-				"archive": null
-			}
-		},
-		{
 			"title": "Word games",
 			"filterId": "word-games",
 			"content": {
@@ -273,7 +135,7 @@
 				"nestedContainers": [
 					{
 						"title": "Word wheel",
-						"desktopSpan": 4,
+						"desktopSpan": 6,
 						"content": {
 							"items": [
 								[
@@ -291,7 +153,7 @@
 							],
 							"nestedContainers": [],
 							"archive": {
-								"title": "Archive",
+								"title": "Word wheel archive",
 								"type": "word-wheel",
 								"set": "all",
 								"slug": "word-wheel",
@@ -303,7 +165,7 @@
 					},
 					{
 						"title": "Wordiply",
-						"desktopSpan": 4,
+						"desktopSpan": 6,
 						"content": {
 							"items": [
 								[
@@ -320,7 +182,7 @@
 							],
 							"nestedContainers": [],
 							"archive": {
-								"title": "Archive",
+								"title": "Wordiply archive",
 								"type": "wordiply",
 								"set": "all",
 								"slug": "wordiply",
@@ -329,34 +191,73 @@
 								"backgroundColour": "#F8D0C9"
 							}
 						}
-					},
+					}
+				]
+			}
+		},
+		{
+			"title": "Logic puzzles",
+			"filterId": "logic",
+			"content": {
+				"items": [],
+				"nestedContainers": [
 					{
-						"title": "Codeword",
-						"desktopSpan": 4,
+						"title": "Sudoku",
+						"desktopSpan": 12,
 						"content": {
 							"items": [
 								[
 									{
-										"title": "Codeword",
-										"type": "codeword",
-										"set": "all",
-										"slug": "codeword",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-codeword&embed=1&idx=1",
+										"title": "Sudoku easy",
+										"type": "sudoku",
+										"set": "easy",
+										"slug": "sudoku-easy",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&embed=1&idx=1",
 										"index": 1,
 										"variant": "iframe-page",
-										"backgroundColour": "#F2D0F6"
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"title": "Sudoku medium",
+										"type": "sudoku",
+										"set": "medium",
+										"slug": "sudoku-medium",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-medium&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"title": "Sudoku hard",
+										"type": "sudoku",
+										"set": "hard",
+										"slug": "sudoku-hard",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-hard&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"title": "Sudoku killer",
+										"type": "sudoku",
+										"set": "killer",
+										"slug": "sudoku-killer",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-killer-sudoku-medium&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
 									}
 								]
 							],
 							"nestedContainers": [],
 							"archive": {
-								"title": "Archive",
-								"type": "codeword",
+								"title": "Logic archive",
+								"type": "sudoku",
 								"set": "all",
-								"slug": "codeword",
-								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-codeword&embed=1",
+								"slug": "sudoku-easy",
+								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&set=guardian-sudoku-medium&set=guardian-sudoku-hard&set=guardian-killer-sudoku-medium&embed=1",
 								"variant": "archive-page",
-								"backgroundColour": "#F2D0F6"
+								"backgroundColour": "#CDECFB"
 							}
 						}
 					}
@@ -364,19 +265,19 @@
 			}
 		},
 		{
-			"title": "Quizzes and Trivia",
+			"title": "Trivia",
 			"filterId": "trivia-quizzes",
 			"content": {
 				"items": [],
 				"nestedContainers": [
 					{
-						"title": "On the Ball",
+						"title": "On the ball",
 						"desktopSpan": 6,
 						"content": {
 							"items": [
 								[
 									{
-										"title": "On the Ball",
+										"title": "On the ball",
 										"type": "on-the-ball",
 										"set": "all",
 										"slug": "on-the-ball",
@@ -388,7 +289,7 @@
 							],
 							"nestedContainers": [],
 							"archive": {
-								"title": "Archive",
+								"title": "On the ball archive",
 								"type": "on-the-ball",
 								"set": "all",
 								"slug": "on-the-ball",
@@ -417,110 +318,13 @@
 							],
 							"nestedContainers": [],
 							"archive": {
-								"title": "Archive",
+								"title": "Film reveal archive",
 								"type": "film-reveal",
 								"set": "all",
 								"slug": "film-reveal",
 								"url": "https://moviegrid.io/guardian",
 								"variant": "archive-page",
 								"backgroundColour": "#EAD8B9"
-							}
-						}
-					},
-					{
-						"title": "Alex Bellos’s Monday Puzzle",
-						"desktopSpan": 4,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Alex Bellos’s Monday Puzzle",
-										"type": "quiz",
-										"set": "alex-bellos-monday-puzzle",
-										"url": "/science/series/alex-bellos-monday-puzzle",
-										"backgroundColour": "#D5F3F2"
-									}
-								]
-							],
-							"nestedContainers": []
-						}
-					},
-					{
-						"title": "Thursday quiz",
-						"desktopSpan": 4,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Thursday quiz",
-										"type": "quiz",
-										"set": "thursday-quiz",
-										"url": "/theguardian/series/the-quiz-thomas-eaton",
-										"backgroundColour": "#D5F3F2"
-									}
-								]
-							],
-							"nestedContainers": []
-						}
-					},
-					{
-						"title": "Sports quiz",
-						"desktopSpan": 4,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Sports quiz",
-										"type": "quiz",
-										"set": "sports-quiz",
-										"url": "/sport/series/sports-quiz-of-the-week",
-										"backgroundColour": "#D5F3F2"
-									}
-								]
-							],
-							"nestedContainers": []
-						}
-					},
-					{
-						"title": "Saturday quiz",
-						"desktopSpan": 6,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Saturday quiz",
-										"type": "quiz",
-										"set": "saturday-quiz",
-										"url": "/theguardian/series/the-quiz-thomas-eaton",
-										"backgroundColour": "#D5F3F2"
-									}
-								]
-							],
-							"nestedContainers": []
-						}
-					},
-					{
-						"title": "Kids’ quiz",
-						"desktopSpan": 6,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Kids’ quiz",
-										"type": "quiz",
-										"set": "kids-quiz",
-										"url": "/lifeandstyle/series/the-kids--quiz",
-										"backgroundColour": "#D5F3F2"
-									}
-								]
-							],
-							"nestedContainers": [],
-							"archive": {
-								"title": "Archive",
-								"type": "quiz",
-								"set": "kids-quiz",
-								"url": "/lifeandstyle/series/the-kids--quiz",
-								"backgroundColour": "#D5F3F2"
 							}
 						}
 					}

--- a/applications/test/PuzzlesLayoutProviderTest.scala
+++ b/applications/test/PuzzlesLayoutProviderTest.scala
@@ -1,0 +1,89 @@
+package controllers
+
+import model.dotcomrendering.PuzzlesLayout
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.{Environment, Mode}
+
+import java.io.{ByteArrayInputStream, File, InputStream}
+import java.nio.charset.StandardCharsets
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
+
+class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers {
+  private implicit val executionContext: ExecutionContext = ExecutionContext.global
+
+  "LocalJsonPuzzlesLayoutProvider" should "load the production layout from the classpath" in {
+    val provider = new LocalJsonPuzzlesLayoutProvider(Environment.simple())
+
+    val layout = Await.result(provider.getLayout(), 5.seconds)
+
+    layout.containers should not be empty
+    layout.filters should not be empty
+    layout.containers.flatMap(_.content.nestedContainers) should not be empty
+    archives(layout) should not be empty
+  }
+
+  it should "close the resource stream after successful loading" in {
+    val json = """{"containers":[],"filters":[]}"""
+    val stream = new CloseTrackingInputStream(json)
+    val provider = new LocalJsonPuzzlesLayoutProvider(environmentReturning(Some(stream)))
+
+    Await.result(provider.getLayout(), 5.seconds) shouldBe PuzzlesLayout(Seq.empty, Seq.empty)
+    stream.wasClosed shouldBe true
+  }
+
+  it should "fail clearly and close the stream when the blueprint is invalid" in {
+    val stream = new CloseTrackingInputStream("""{"containers":[{"title":"incomplete"}]}""")
+    val provider = new LocalJsonPuzzlesLayoutProvider(environmentReturning(Some(stream)))
+
+    val error = the[IllegalArgumentException] thrownBy Await.result(provider.getLayout(), 5.seconds)
+
+    error.getMessage should include("puzzles-layout.json")
+    error.getMessage should include("is invalid")
+    stream.wasClosed shouldBe true
+  }
+
+  it should "fail clearly and close the stream when the resource contains malformed JSON" in {
+    val stream = new CloseTrackingInputStream("""{"containers": [""")
+    val provider = new LocalJsonPuzzlesLayoutProvider(environmentReturning(Some(stream)))
+
+    val error = the[IllegalArgumentException] thrownBy Await.result(provider.getLayout(), 5.seconds)
+
+    error.getMessage should include("puzzles-layout.json")
+    error.getMessage should include("could not be parsed as JSON")
+    stream.wasClosed shouldBe true
+  }
+
+  it should "fail clearly when the classpath resource is missing" in {
+    val provider = new LocalJsonPuzzlesLayoutProvider(environmentReturning(None))
+
+    val error = the[IllegalStateException] thrownBy Await.result(provider.getLayout(), 5.seconds)
+
+    error.getMessage should include("puzzles-layout.json")
+    error.getMessage should include("was not found on the classpath")
+  }
+
+  private def archives(layout: PuzzlesLayout) =
+    layout.containers.flatMap(container =>
+      container.content.archive.toSeq ++
+        container.content.nestedContainers.flatMap(nested => nested.content.archive.toSeq),
+    )
+
+  private def environmentReturning(stream: Option[InputStream]): Environment = {
+    val classLoader = new ClassLoader(null) {
+      override def getResourceAsStream(name: String): InputStream = stream.orNull
+    }
+    Environment(new File("."), classLoader, Mode.Test)
+  }
+
+  private class CloseTrackingInputStream(contents: String)
+      extends ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)) {
+    var wasClosed = false
+
+    override def close(): Unit = {
+      wasClosed = true
+      super.close()
+    }
+  }
+}

--- a/common/app/controllers/PuzzlesLayoutProvider.scala
+++ b/common/app/controllers/PuzzlesLayoutProvider.scala
@@ -1,0 +1,53 @@
+package controllers
+
+import model.dotcomrendering.PuzzlesLayout
+import play.api.Environment
+import play.api.libs.json.{JsError, JsSuccess, Json}
+
+import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.util.control.NonFatal
+
+trait PuzzlesLayoutProvider {
+  def getLayout()(implicit executionContext: ExecutionContext): Future[PuzzlesLayout]
+}
+
+class LocalJsonPuzzlesLayoutProvider(
+    environment: Environment,
+    resourceName: String = LocalJsonPuzzlesLayoutProvider.DefaultResourceName,
+) extends PuzzlesLayoutProvider {
+
+  override def getLayout()(implicit executionContext: ExecutionContext): Future[PuzzlesLayout] = Future(
+    blocking(loadLayout()),
+  )
+
+  private def loadLayout(): PuzzlesLayout = {
+    val inputStream = environment
+      .resourceAsStream(resourceName)
+      .getOrElse(
+        throw new IllegalStateException(s"Puzzles layout resource $resourceName was not found on the classpath"),
+      )
+
+    try {
+      Json.parse(inputStream).validate[PuzzlesLayout] match {
+        case JsSuccess(layout, _) => layout
+        case JsError(errors)      =>
+          throw new IllegalStateException(
+            s"Puzzles layout resource '$resourceName' is invalid: ${JsError.toJson(errors)}",
+          )
+      }
+    } catch {
+      case error: IllegalStateException => throw error
+      case NonFatal(error)              =>
+        throw new IllegalStateException(
+          s"Puzzles layout resource '$resourceName' could not be parsed as JSON",
+          error,
+        )
+    } finally {
+      inputStream.close()
+    }
+  }
+}
+
+object LocalJsonPuzzlesLayoutProvider {
+  val DefaultResourceName: String = "puzzles-layout.json"
+}

--- a/common/app/controllers/PuzzlesLayoutProvider.scala
+++ b/common/app/controllers/PuzzlesLayoutProvider.scala
@@ -31,14 +31,14 @@ class LocalJsonPuzzlesLayoutProvider(
       Json.parse(inputStream).validate[PuzzlesLayout] match {
         case JsSuccess(layout, _) => layout
         case JsError(errors)      =>
-          throw new IllegalStateException(
+          throw new IllegalArgumentException(
             s"Puzzles layout resource '$resourceName' is invalid: ${JsError.toJson(errors)}",
           )
       }
     } catch {
-      case error: IllegalStateException => throw error
-      case NonFatal(error)              =>
-        throw new IllegalStateException(
+      case error: IllegalArgumentException => throw error
+      case NonFatal(error)                 =>
+        throw new IllegalArgumentException(
           s"Puzzles layout resource '$resourceName' could not be parsed as JSON",
           error,
         )

--- a/common/app/model/PuzzlesLayout.scala
+++ b/common/app/model/PuzzlesLayout.scala
@@ -21,11 +21,12 @@ object PuzzleItem {
   private val writes: OWrites[PuzzleItem] = Json.writes[PuzzleItem].transform(removeNullFields)
   implicit val format: OFormat[PuzzleItem] = OFormat(reads, writes)
 
-  private def removeNullFields(json: JsObject): JsObject = JsObject(json.fields.filterNot(_._2 == JsNull))
+  private def removeNullFields(json: JsObject): JsObject =
+    JsObject(json.fields.filterNot(_._2 == JsNull))
 }
 
 case class PuzzleContent(
-    title: Seq[Seq[String]],
+    items: Seq[Seq[PuzzleItem]],
     nestedContainers: Seq[PuzzleContainer],
     archive: Option[PuzzleItem] = None,
 )
@@ -67,7 +68,8 @@ object PuzzleFilter {
   private val writes: OWrites[PuzzleFilter] = Json.writes[PuzzleFilter].transform(removeNullFields)
   implicit val format: OFormat[PuzzleFilter] = OFormat(reads, writes)
 
-  private def removeNullFields(json: JsObject): JsObject = JsObject(json.fields.filterNot(_._2 == JsNull))
+  private def removeNullFields(json: JsObject): JsObject =
+    JsObject(json.fields.filterNot(_._2 == JsNull))
 }
 
 case class PuzzlesLayout(

--- a/common/app/model/PuzzlesLayout.scala
+++ b/common/app/model/PuzzlesLayout.scala
@@ -1,0 +1,80 @@
+package model.dotcomrendering
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class PuzzleItem(
+    title: String,
+    `type`: String,
+    set: String,
+    url: Option[String] = None,
+    image: Option[String] = None,
+    slug: Option[String] = None,
+    index: Option[Int] = None,
+    variant: Option[String] = None,
+    backgroundColour: Option[String] = None,
+    filterId: Option[String] = None,
+)
+
+object PuzzleItem {
+  private val reads: Reads[PuzzleItem] = Json.reads[PuzzleItem]
+  private val writes: OWrites[PuzzleItem] = Json.writes[PuzzleItem].transform(removeNullFields)
+  implicit val format: OFormat[PuzzleItem] = OFormat(reads, writes)
+
+  private def removeNullFields(json: JsObject): JsObject = JsObject(json.fields.filterNot(_._2 == JsNull))
+}
+
+case class PuzzleContent(
+    title: Seq[Seq[String]],
+    nestedContainers: Seq[PuzzleContainer],
+    archive: Option[PuzzleItem] = None,
+)
+
+object PuzzleContent {
+  implicit lazy val format: OFormat[PuzzleContent] = (
+    (__ \ "items").format[Seq[Seq[PuzzleItem]]] and
+      (__ \ "nestedContainers").lazyFormat[Seq[PuzzleContainer]](Format.of[Seq[PuzzleContainer]]) and
+      (__ \ "archive").formatNullable[PuzzleItem]
+  )(PuzzleContent.apply, unlift(PuzzleContent.unapply))
+}
+
+case class PuzzleContainer(
+    title: String,
+    variant: Option[String] = None,
+    content: PuzzleContent,
+    filterId: Option[String] = None,
+    desktopSpan: Option[Int] = None,
+)
+
+object PuzzleContainer {
+  implicit lazy val format: OFormat[PuzzleContainer] = (
+    (__ \ "title").format[String] and
+      (__ \ "variant").formatNullable[String] and
+      (__ \ "content").lazyFormat[PuzzleContent](PuzzleContent.format) and
+      (__ \ "filterId").formatNullable[String] and
+      (__ \ "desktopSpan").formatNullable[Int]
+  )(PuzzleContainer.apply, unlift(PuzzleContainer.unapply))
+}
+
+case class PuzzleFilter(
+    id: String,
+    title: String,
+    backgroundColour: Option[String] = None,
+)
+
+object PuzzleFilter {
+  private val reads: Reads[PuzzleFilter] = Json.reads[PuzzleFilter]
+  private val writes: OWrites[PuzzleFilter] = Json.writes[PuzzleFilter].transform(removeNullFields)
+  implicit val format: OFormat[PuzzleFilter] = OFormat(reads, writes)
+
+  private def removeNullFields(json: JsObject): JsObject = JsObject(json.fields.filterNot(_._2 == JsNull))
+}
+
+case class PuzzlesLayout(
+    containers: Seq[PuzzleContainer],
+    filters: Seq[PuzzleFilter] = Seq.empty,
+)
+
+object PuzzlesLayout {
+  implicit lazy val format: OFormat[PuzzlesLayout] = Json.format[PuzzlesLayout]
+}

--- a/common/test/model/PuzzlesLayoutTest.scala
+++ b/common/test/model/PuzzlesLayoutTest.scala
@@ -1,0 +1,114 @@
+package model.dotcomrendering
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsError, Json}
+
+class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
+
+  private val representativeLayoutJson = Json.parse(
+    """
+      |{
+      |  "filters": [{"id":"logic","title":"Logic","backgroundColour":"#CDECFB"}],
+      |  "containers": [{
+      |    "title":"Logic puzzles",
+      |    "variant":"standard",
+      |    "filterId":"logic",
+      |    "content": {
+      |      "items": [[{
+      |        "title":"Sudoku",
+      |        "type":"sudoku",
+      |        "set":"easy",
+      |        "url":"https://example.com/sudoku",
+      |        "image":"https://example.com/sudoku.png",
+      |        "slug":"sudoku-easy",
+      |        "index":1,
+      |        "variant":"iframe-page",
+      |        "backgroundColour":"#CDECFB",
+      |        "filterId":"logic"
+      |      }]],
+      |      "nestedContainers": [{
+      |        "title":"More logic",
+      |        "desktopSpan":6,
+      |        "content": {
+      |          "items":[[{
+      |            "title":"Futoshiki",
+      |            "type":"futoshiki",
+      |            "set":"all"
+      |          }]],
+      |          "nestedContainers":[],
+      |          "archive": {
+      |            "title":"Archive",
+      |            "type":"futoshiki",
+      |            "set":"all",
+      |            "slug":"futoshiki",
+      |            "url":"https://example.com/futoshiki/archive",
+      |            "variant":"archive-page"
+      |          }
+      |        }
+      |      }]
+      |    }
+      |  }]
+      |}
+      |""".stripMargin,
+  )
+
+  "PuzzlesLayout JSON format" should "parse grouped items, nested containers, archive entries and responsive fields" in {
+    val layout = representativeLayoutJson.as[PuzzlesLayout]
+    val container = layout.containers.head
+    val item = container.content.items.head.head
+    val nested = container.content.nestedContainers.head
+
+    layout.filters.head.backgroundColour shouldBe Some("#CDECFB")
+    container.variant shouldBe Some("standard")
+    item.slug shouldBe Some("sudoku-easy")
+    item.index shouldBe Some(1)
+    item.image shouldBe Some("https://example.com/sudoku.png")
+    nested.desktopSpan shouldBe Some(6)
+    nested.content.archive.map(_.variant) shouldBe Some(Some("archive-page"))
+  }
+
+  it should "preserve the DCR payload shape when serializing" in {
+    val layout = representativeLayoutJson.as[PuzzlesLayout]
+
+    Json.toJson(layout) shouldBe representativeLayoutJson
+  }
+
+  it should "omit absent optional item, container, archive and filter fields" in {
+    val layout = PuzzlesLayout(
+      containers = Seq(
+        PuzzleContainer(
+          title = "Crosswords",
+          content = PuzzleContent(
+            items = Seq(Seq(PuzzleItem("Quick", "crossword", "quick"))),
+            nestedContainers = Seq.empty,
+          ),
+        ),
+      ),
+      filters = Seq(PuzzleFilter("crosswords", "Crosswords")),
+    )
+
+    Json.toJson(layout) shouldBe Json.parse(
+      """{
+        |  "containers":[{
+        |    "title":"Crosswords",
+        |    "content":{
+        |      "items":[[{"title":"Quick","type":"crossword","set":"quick"}]],
+        |      "nestedContainers":[]
+        |    }
+        |  }],
+        |  "filters":[{"id":"crosswords","title":"Crosswords"}]
+        |}""".stripMargin,
+    )
+  }
+
+  it should "reject a partially valid contract" in {
+    val result = Json
+      .parse(
+        """{"containers":[{"title":"Broken","content":{"items":[[{"title":"Missing fields"}]],"nestedContainers":[]}}]}""",
+      )
+      .validate[PuzzlesLayout]
+
+    result shouldBe a[JsError]
+  }
+}


### PR DESCRIPTION
## What is the value of this and can you measure success?

Provides a validated, maintainable blueprint for the new puzzles hub and a provider abstraction for future controllers.

Success is measured by contract and provider tests covering serialization, nested containers, archive entries, invalid JSON, resource loading, and stream closure.

## What does this change?

- Adds the production puzzles-layout.json blueprint.
- Adds Scala models and Play JSON formats for the DCR payload.
- Adds an asynchronous PuzzlesLayoutProvider.
- Loads and validates the blueprint from the classpath.
- Produces clear failures for missing or invalid resources.
- Adds focused unit, serialization, and provider tests.
- Keeps CAPI enrichment and controller integration outside this ticket’s scope (this will be done as part of another ticket so the PR is not too large)

## Screenshots

Not applicable. This PR adds backend contract and provider infrastructure without user-visible changes.

## Checklist

- [x] Tested locally
- [x] Will not break dotcom-rendering — payload shape is protected by serialization tests
- [x] No new test `data/database` files were generated
- [x] Accessibility checks are not applicable because there are no UI changes
  - [x] Screen reader testing not applicable
  - [x] Keyboard navigation testing not applicable
  - [x] Colour contrast testing not applicable