### PR TITLE
Add subnav agent and use in fronts

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -40,6 +40,7 @@ trait ApplicationsServices {
   lazy val ophanApi = wire[OphanApi]
   lazy val newsletterApi = wire[NewsletterApi]
   lazy val newsletterSignupAgent = wire[NewsletterSignupAgent]
+  lazy val subnavAgent = wire[SubnavAgent]
 }
 
 trait AppComponents extends FrontendComponents with ApplicationsControllers with ApplicationsServices {
@@ -51,6 +52,7 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
 
   override lazy val lifecycleComponents = List(
     wire[ConfigAgentLifecycle],
+    wire[SubnavAgentLifecycle],
     wire[CloudWatchMetricsLifecycle],
     wire[DfpAgentLifecycle],
     wire[SurgingContentAgentLifecycle],

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -20,7 +20,7 @@ import play.api.routing.Router
 import router.Routes
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent, NewsletterSignupLifecycle}
 import services.ophan.SurgingContentAgentLifecycle
-import services.{NewspaperBooksAndSectionsAutoRefresh, OphanApi, SkimLinksCacheLifeCycle}
+import services.{NewspaperBooksAndSectionsAutoRefresh, OphanApi, SkimLinksCacheLifeCycle, SubnavAgent, SubnavAgentLifecycle}
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =
@@ -38,10 +38,12 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
 
-  lazy val remoteRender = wire[renderers.DotcomRenderingService]
+  lazy val subnavAgent = wire[SubnavAgent]
 
+  lazy val remoteRender = wire[renderers.DotcomRenderingService]
   override lazy val lifecycleComponents = List(
     wire[NewspaperBooksAndSectionsAutoRefresh],
+    wire[SubnavAgentLifecycle],
     wire[DfpAgentLifecycle],
     wire[CloudWatchMetricsLifecycle],
     wire[SurgingContentAgentLifecycle],

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -20,7 +20,13 @@ import play.api.routing.Router
 import router.Routes
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent, NewsletterSignupLifecycle}
 import services.ophan.SurgingContentAgentLifecycle
-import services.{NewspaperBooksAndSectionsAutoRefresh, OphanApi, SkimLinksCacheLifeCycle, SubnavAgent, SubnavAgentLifecycle}
+import services.{
+  NewspaperBooksAndSectionsAutoRefresh,
+  OphanApi,
+  SkimLinksCacheLifeCycle,
+  SubnavAgent,
+  SubnavAgentLifecycle,
+}
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =

--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -1,5 +1,6 @@
 package model.dotcomrendering
 
+import com.gu.facia.client.models.CustomSubnav
 import common.{CanonicalLink, Edition}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
@@ -27,6 +28,7 @@ case class DotcomFrontsRenderingDataModel(
     deeplyRead: Option[Seq[Trail]],
     contributionsServiceUrl: String,
     canonicalUrl: String,
+    subnav: Option[CustomSubnav],
 )
 
 object DotcomFrontsRenderingDataModel {
@@ -38,6 +40,7 @@ object DotcomFrontsRenderingDataModel {
       pageType: PageType,
       mostViewed: Seq[RelatedContentItem],
       deeplyRead: Option[Seq[Trail]],
+      subnav: Option[CustomSubnav],
   ): DotcomFrontsRenderingDataModel = {
     val edition = Edition.edition(request)
     val nav = Nav(page, edition)
@@ -79,6 +82,7 @@ object DotcomFrontsRenderingDataModel {
       deeplyRead = deeplyRead,
       contributionsServiceUrl = Configuration.contributionsService.url,
       canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
+      subnav = subnav,
     )
   }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -2,6 +2,7 @@ package renderers
 
 import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem}
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
+import com.gu.facia.client.models.CustomSubnav
 import common.LoggingField.LogField
 import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
@@ -310,6 +311,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       pageType: PageType,
       mostViewed: Seq[RelatedContentItem],
       deeplyRead: Option[Seq[Trail]],
+      subnav: Option[CustomSubnav],
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomFrontsRenderingDataModel(
       page,
@@ -317,6 +319,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       pageType,
       mostViewed,
       deeplyRead,
+      subnav,
     )
 
     val json = DotcomFrontsRenderingDataModel.toJson(dataModel)

--- a/common/app/services/SubnavAgent.scala
+++ b/common/app/services/SubnavAgent.scala
@@ -1,10 +1,10 @@
 package services
 
 import app.LifecycleComponent
-import com.gu.facia.api.CustomSubnavService
 import com.gu.facia.api.models.PublicationStatus
-import com.gu.facia.api.models.PublicationStatus.Live
+import com.gu.facia.api.models.PublicationStatus.{Draft, Live}
 import com.gu.facia.client.ApiClient
+import com.gu.facia.client.models.TargetedPageType.Front
 import com.gu.facia.client.models.{CustomSubnav, CustomSubnavConfig}
 import common._
 import fronts.FrontsApi
@@ -30,8 +30,10 @@ class SubnavAgent extends GuLogging {
 
   /** Look up the custom subnav targeted at the given front, if any. */
   def getSubnavForFront(frontId: String, status: PublicationStatus = Live): Option[CustomSubnav] = {
-    println("SubnavAgent.getSubnavForFront: frontId=" + frontId + ", status=" + status)
-    getSubnavConfig().flatMap(config => CustomSubnavService.getSubnavForFront(config, frontId, status))
+    getSubnavConfig().flatMap { config =>
+      val candidates = (if (status == Draft) config.draft else Nil) ++ config.live
+      candidates.find(_.pages.exists(p => p.`type` == Front && p.path == frontId))
+    }
   }
 
   def getClient(implicit ec: ExecutionContext): ApiClient = FrontsApi.crossAccountClient

--- a/common/app/services/SubnavAgent.scala
+++ b/common/app/services/SubnavAgent.scala
@@ -1,0 +1,69 @@
+package services
+
+import app.LifecycleComponent
+import com.gu.facia.api.CustomSubnavService
+import com.gu.facia.api.models.PublicationStatus
+import com.gu.facia.api.models.PublicationStatus.Live
+import com.gu.facia.client.ApiClient
+import com.gu.facia.client.models.{CustomSubnav, CustomSubnavConfig}
+import common._
+import fronts.FrontsApi
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/** SubnavAgent is a cache for the custom subnav config.
+  *
+  * The config is authored in CMS Fronts and describes bespoke sub-navigations that can be targeted at specific fronts,
+  * articles or tags. It is pulled from a single file in S3 in the CMS Fronts AWS account (via the Fronts API client).
+  *
+  * The full config is cached in memory and refreshed on a schedule (see [[SubnavAgentLifecycle]]). Lookups for a given
+  * front or piece of content are performed against the cached config using `com.gu.facia.api.CustomSubnavService`.
+  */
+class SubnavAgent extends GuLogging {
+  private val subnavConfigBox = Box[Option[CustomSubnavConfig]](None)
+
+  def isLoaded(): Boolean = subnavConfigBox.get().isDefined
+
+  def getSubnavConfig(): Option[CustomSubnavConfig] = subnavConfigBox.get()
+
+  /** Look up the custom subnav targeted at the given front, if any. */
+  def getSubnavForFront(frontId: String, status: PublicationStatus = Live): Option[CustomSubnav] = {
+    println("SubnavAgent.getSubnavForFront: frontId=" + frontId + ", status=" + status)
+    getSubnavConfig().flatMap(config => CustomSubnavService.getSubnavForFront(config, frontId, status))
+  }
+
+  def getClient(implicit ec: ExecutionContext): ApiClient = FrontsApi.crossAccountClient
+
+  def refresh()(implicit ec: ExecutionContext): Future[Unit] = {
+    val futureConfig = getClient.subnavConfig()
+    futureConfig.onComplete {
+      case Success(_) => log.debug("Successfully got subnav config")
+      case Failure(t) => log.error(s"Getting subnav config failed with $t", t)
+    }
+    futureConfig.map(subnavConfigBox.send)
+  }
+}
+
+class SubnavAgentLifecycle(subnavAgent: SubnavAgent, appLifecycle: ApplicationLifecycle, jobs: JobScheduler, pekkoAsync: PekkoAsync)(
+    implicit ec: ExecutionContext,
+) extends LifecycleComponent {
+
+  appLifecycle.addStopHook { () =>
+    Future {
+      jobs.deschedule("SubnavAgentJob")
+    }
+  }
+
+  override def start(): Unit = {
+    jobs.deschedule("SubnavAgentJob")
+    jobs.schedule("SubnavAgentJob", "15 * * * * ?") {
+      subnavAgent.refresh()
+    }
+
+    pekkoAsync.after1s {
+      subnavAgent.refresh()
+    }
+  }
+}

--- a/common/app/services/SubnavAgent.scala
+++ b/common/app/services/SubnavAgent.scala
@@ -1,6 +1,7 @@
 package services
 
 import app.LifecycleComponent
+import com.gu.facia.api.CustomSubnavService
 import com.gu.facia.api.models.PublicationStatus
 import com.gu.facia.api.models.PublicationStatus.{Draft, Live}
 import com.gu.facia.client.ApiClient
@@ -28,8 +29,7 @@ class SubnavAgent extends GuLogging {
   /** Look up the custom subnav targeted at the given front, if any. */
   def getSubnavForFront(frontId: String, status: PublicationStatus = Live): Option[CustomSubnav] = {
     getSubnavConfig().flatMap { config =>
-      val candidates = (if (status == Draft) config.draft else Nil) ++ config.live
-      candidates.find(_.pages.exists(p => p.`type` == Front && p.path == frontId))
+      CustomSubnavService.getSubnavForFront(config, frontId, status)
     }
   }
 

--- a/common/app/services/SubnavAgent.scala
+++ b/common/app/services/SubnavAgent.scala
@@ -17,9 +17,6 @@ import scala.util.{Failure, Success}
   *
   * The config is authored in CMS Fronts and describes bespoke sub-navigations that can be targeted at specific fronts,
   * articles or tags. It is pulled from a single file in S3 in the CMS Fronts AWS account (via the Fronts API client).
-  *
-  * The full config is cached in memory and refreshed on a schedule (see [[SubnavAgentLifecycle]]). Lookups for a given
-  * front or piece of content are performed against the cached config using `com.gu.facia.api.CustomSubnavService`.
   */
 class SubnavAgent extends GuLogging {
   private val subnavConfigBox = Box[Option[CustomSubnavConfig]](None)
@@ -48,8 +45,13 @@ class SubnavAgent extends GuLogging {
   }
 }
 
-class SubnavAgentLifecycle(subnavAgent: SubnavAgent, appLifecycle: ApplicationLifecycle, jobs: JobScheduler, pekkoAsync: PekkoAsync)(
-    implicit ec: ExecutionContext,
+class SubnavAgentLifecycle(
+    subnavAgent: SubnavAgent,
+    appLifecycle: ApplicationLifecycle,
+    jobs: JobScheduler,
+    pekkoAsync: PekkoAsync,
+)(implicit
+    ec: ExecutionContext,
 ) extends LifecycleComponent {
 
   appLifecycle.addStopHook { () =>

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -84,6 +84,7 @@ trait AppComponents
       wire[AdminLifecycle],
       wire[OnwardJourneyLifecycle],
       wire[ConfigAgentLifecycle],
+      wire[SubnavAgentLifecycle],
       wire[SurgingContentAgentLifecycle],
       wire[SectionsLookUpLifecycle],
       wire[SwitchboardLifecycle],

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -47,9 +47,11 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   lazy val ophanApi = wire[OphanApi]
   lazy val mostViewedAgent = wire[MostViewedAgent]
   lazy val deeplyReadAgent = wire[DeeplyReadAgent]
+  lazy val subnavAgent = wire[SubnavAgent]
 
   override lazy val lifecycleComponents = List(
     wire[ConfigAgentLifecycle],
+    wire[SubnavAgentLifecycle],
     wire[CloudWatchMetricsLifecycle],
     wire[SurgingContentAgentLifecycle],
     wire[IndexListingsLifecycle],

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -2,6 +2,8 @@ package controllers
 
 import _root_.html.{BrazeEmailFormatter, HtmlTextExtractor}
 import agents.{DeeplyReadAgent, MostViewedAgent}
+import com.gu.facia.api.models.PublicationStatus.{Draft, Live}
+import com.gu.facia.client.models.CustomSubnav
 import common._
 import conf.Configuration
 import conf.switches.Switches.InlineEmailStyles
@@ -24,6 +26,7 @@ import renderers.DotcomRenderingService
 import services.dotcomrendering.{FaciaPicker, RemoteRender}
 import services.fronts.{FrontJsonFapi, FrontJsonFapiLive}
 import services.{CollectionConfigWithId, ConfigAgent}
+import services.SubnavAgent
 import utils.TargetedCollections
 import views.html.fragments.containers.facia_cards.container
 
@@ -40,6 +43,7 @@ trait FaciaController
   val ws: WSClient
   val mostViewedAgent: MostViewedAgent
   val deeplyReadAgent: DeeplyReadAgent
+  val subnavAgent: SubnavAgent
   val remoteRenderer: DotcomRenderingService = DotcomRenderingService()
   val assets: Assets
 
@@ -199,6 +203,9 @@ trait FaciaController
       targetedTerritories,
     )
 
+  private def subnavForFront(page: PressedPage, pageType: PageType): Option[CustomSubnav] =
+    subnavAgent.getSubnavForFront(page.metadata.id, if (pageType.isPreview) Draft else Live)
+
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader): Future[Result] = {
     val futureFaciaPage = getFaciaPage(path)
 
@@ -223,6 +230,7 @@ trait FaciaController
             pageType = pageType,
             mostViewed = mostViewedAgent.mostViewed(Edition(request)),
             deeplyRead = deeplyRead,
+            subnav = subnavForFront(faciaPage, pageType),
           )(request),
           targetedTerritories,
         )
@@ -238,13 +246,15 @@ trait FaciaController
           logDebugWithRequestId(
             s"Front Geo Request (237): ${Edition(request).id} ${request.headers.toSimpleMap.getOrElse("X-GU-GeoLocation", "country:row")}",
           )
+          val pageType = PageType(faciaPage, request, context)
           JsonComponent.fromWritable(
             DotcomFrontsRenderingDataModel(
               page = faciaPage,
               request = request,
-              pageType = PageType(faciaPage, request, context),
+              pageType = pageType,
               mostViewed = mostViewedAgent.mostViewed(Edition(request)),
               deeplyRead = deeplyRead,
+              subnav = subnavForFront(faciaPage, pageType),
             ),
           )
         } else JsonFront(faciaPage)
@@ -520,6 +530,7 @@ class FaciaControllerImpl(
     val ws: WSClient,
     val mostViewedAgent: MostViewedAgent,
     val deeplyReadAgent: DeeplyReadAgent,
+    val subnavAgent: SubnavAgent,
     val assets: Assets,
 )(implicit val context: ApplicationContext)
     extends FaciaController

--- a/facia/app/controllers/FaciaControllers.scala
+++ b/facia/app/controllers/FaciaControllers.scala
@@ -5,6 +5,7 @@ import com.softwaremill.macwire._
 import model.ApplicationContext
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
+import services.SubnavAgent
 import services.fronts.FrontJsonFapiLive
 
 trait FaciaControllers {
@@ -13,6 +14,7 @@ trait FaciaControllers {
   def wsClient: WSClient
   def mostViewedAgent: MostViewedAgent
   def deeplyReadAgent: DeeplyReadAgent
+  def subnavAgent: SubnavAgent
   def assets: Assets
   implicit def appContext: ApplicationContext
   lazy val faciaController = wire[FaciaControllerImpl]

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -19,7 +19,7 @@ import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.test.Helpers._
 import play.api.test._
-import services.{ConfigAgent, OphanApi}
+import services.{ConfigAgent, OphanApi, SubnavAgent}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -48,6 +48,7 @@ import scala.concurrent.{Await, Future}
     wsClient,
     new MostViewedAgent(testContentApiClient, new OphanApi(wsClient)),
     new DeeplyReadAgent(testContentApiClient, new OphanApi(wsClient)),
+    new SubnavAgent(),
     assets = assets,
   )
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json._
 import play.api.test.Helpers._
-import services.{ConfigAgent, OphanApi}
+import services.{ConfigAgent, OphanApi, SubnavAgent}
 import test._
 
 import scala.concurrent.Await
@@ -50,6 +50,7 @@ import scala.concurrent.duration._
     wsClient,
     new MostViewedAgent(testContentApiClient, new OphanApi(wsClient)),
     new DeeplyReadAgent(testContentApiClient, new OphanApi(wsClient)),
+    new SubnavAgent(),
     assets = assets,
   )
   val frontPath = "music"

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -27,7 +27,7 @@ import rugby.conf.RugbyLifecycle
 import rugby.controllers.RugbyControllers
 import services.fronts.FrontJsonFapiDraft
 import services.newsletters.NewsletterSignupLifecycle
-import services.{ConfigAgentLifecycle, OphanApi, SkimLinksCacheLifeCycle}
+import services.{ConfigAgentLifecycle, OphanApi, SkimLinksCacheLifeCycle, SubnavAgentLifecycle}
 import utils.AWSv2
 
 trait PreviewLifecycleComponents
@@ -47,6 +47,7 @@ trait PreviewLifecycleComponents
     List(
       wire[OnwardJourneyLifecycle],
       wire[ConfigAgentLifecycle],
+      wire[SubnavAgentLifecycle],
       wire[SwitchboardLifecycle],
       wire[FootballLifecycle],
       wire[CricketLifecycle],

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -9,6 +9,7 @@ import model.{ApplicationContext, PressedPage}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.ConfigAgent
+import services.SubnavAgent
 import services.fronts.FrontJsonFapiDraft
 
 import scala.concurrent.Future
@@ -21,6 +22,7 @@ class FaciaDraftController(
     val ws: WSClient,
     val mostViewedAgent: MostViewedAgent,
     val deeplyReadAgent: DeeplyReadAgent,
+    val subnavAgent: SubnavAgent,
     val assets: Assets,
 )(implicit val context: ApplicationContext)
     extends FaciaController


### PR DESCRIPTION
## What is the value of this and can you measure success?

Adds a custom subnav agent, wires this in to parts of the application (applications/preview/articles/fronts), and makes use of the agent to send a custom subnav when DCR is asked to render a front. 

Tested with https://github.com/guardian/dotcom-rendering/pull/16578

## Testing

Create a custom subnav in the fronts tool on code. Make sure you specify the assigned front path as without the prefix (i.e. `music` or `uk/sport`, not `theguardian.com/music`); you should then be able to see something like the screenshot below appear on code fronts while running this branch and the DCR one too. 


## Screenshots

<img width="970" height="776" alt="image" src="https://github.com/user-attachments/assets/16420b3a-9b36-473c-a803-f1d2e96e98cf" />


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
