### PR TITLE
Puzzles/add base page flow dcr integration

### DIFF
--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -14,9 +14,12 @@ trait ApplicationsControllers {
   def sectionsLookUp: SectionsLookUp
   def wsClient: WSClient
   def controllerComponents: ControllerComponents
+  def environment: Environment
   implicit def appContext: ApplicationContext
 
   lazy val remoteRender = wire[renderers.DotcomRenderingService]
+  lazy val puzzlesLayoutProvider: PuzzlesLayoutProvider = new LocalJsonPuzzlesLayoutProvider(environment)
+  lazy val puzzlesPageController = wire[PuzzlesPageController]
   lazy val siteMapController = wire[SiteMapController]
   lazy val dCARAssetsController = wire[DCARAssetsController]
   lazy val crosswordPageController = wire[CrosswordPageController]

--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -4,6 +4,7 @@ import com.softwaremill.macwire._
 import contentapi.{ContentApiClient, SectionsLookUp}
 import jobs.SiteMapJob
 import model.ApplicationContext
+import play.api.Environment
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -16,6 +16,10 @@ GET        /sitemaps/video.xml                                                  
 GET        /email-newsletters.json                                              controllers.SignupPageController.renderNewsletters()
 GET        /email-newsletters                                                   controllers.SignupPageController.renderNewsletters()
 
+# Puzzles
+GET        /puzzles.json                                                        controllers.PuzzlesPageController.renderPuzzlesJson()
+GET        /puzzles                                                             controllers.PuzzlesPageController.renderPuzzles()
+
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
 GET        /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|sunday-quick|prize|everyman|azed|special|genius|speedy|weekend|mini>/:id.svg       controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
 GET        /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|sunday-quick|prize|everyman|azed|special|genius|speedy|weekend|mini>/:id.json      controllers.CrosswordPageController.renderJson(crosswordType: String, id: Int)

--- a/applications/test/PuzzlesPageControllerTest.scala
+++ b/applications/test/PuzzlesPageControllerTest.scala
@@ -1,0 +1,123 @@
+package test
+
+import controllers.{PuzzlesLayoutProvider, PuzzlesPageController}
+import model.dotcomrendering.{PuzzleContent, PuzzleContainer, PuzzleItem, PuzzlesLayout}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.DoNotDiscover
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.WSClient
+import play.api.mvc.{RequestHeader, Results}
+import play.api.test.Helpers._
+import renderers.DotcomRenderingService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@DoNotDiscover class PuzzlesPageControllerTest
+    extends AnyFlatSpec
+    with Matchers
+    with MockitoSugar
+    with ScalaFutures
+    with WithTestApplicationContext {
+
+  private val layout = PuzzlesLayout(
+    containers = Seq(
+      PuzzleContainer(
+        title = "Daily puzzles",
+        content = PuzzleContent(
+          items = Seq(Seq(PuzzleItem("Quick crossword", "crossword", "quick"))),
+          nestedContainers = Seq.empty,
+        ),
+      ),
+    ),
+  )
+
+  private def controller(
+      provider: PuzzlesLayoutProvider,
+      renderer: DotcomRenderingService,
+  ): PuzzlesPageController =
+    new PuzzlesPageController(
+      mock[WSClient],
+      provider,
+      renderer,
+      stubControllerComponents(),
+    )
+
+  private def successfulProvider: PuzzlesLayoutProvider = {
+    val provider = mock[PuzzlesLayoutProvider]
+    when(provider.getLayout()(any[ExecutionContext])).thenReturn(Future.successful(layout))
+    provider
+  }
+
+  "renderPuzzles" should "load the layout and render the DCR puzzles page" in {
+    val provider = successfulProvider
+    val renderer = mock[DotcomRenderingService]
+    when(renderer.getPuzzlesPage(any[WSClient], any[JsValue])(any[RequestHeader]))
+      .thenReturn(Future.successful(Results.Ok("rendered by DCR")))
+
+    val result = controller(provider, renderer).renderPuzzles()(TestRequest("/puzzles"))
+
+    status(result) should be(OK)
+    contentAsString(result) should be("rendered by DCR")
+    verify(provider).getLayout()(any[ExecutionContext])
+    verify(renderer).getPuzzlesPage(any[WSClient], any[JsValue])(any[RequestHeader])
+  }
+
+  it should "return not found for an unsupported format" in {
+    val result = controller(successfulProvider, mock[DotcomRenderingService])
+      .renderPuzzles()(TestRequest("/puzzles.json"))
+
+    status(result) should be(NOT_FOUND)
+  }
+
+  it should "propagate layout provider failures" in {
+    val failure = new RuntimeException("layout failed")
+    val provider = mock[PuzzlesLayoutProvider]
+    when(provider.getLayout()(any[ExecutionContext])).thenReturn(Future.failed(failure))
+
+    val result = controller(provider, mock[DotcomRenderingService]).renderPuzzles()(TestRequest("/puzzles"))
+
+    result.failed.futureValue should be(failure)
+  }
+
+  it should "propagate DCR renderer failures" in {
+    val failure = new RuntimeException("renderer failed")
+    val renderer = mock[DotcomRenderingService]
+    when(renderer.getPuzzlesPage(any[WSClient], any[JsValue])(any[RequestHeader]))
+      .thenReturn(Future.failed(failure))
+
+    val result = controller(successfulProvider, renderer).renderPuzzles()(TestRequest("/puzzles"))
+
+    result.failed.futureValue should be(failure)
+  }
+
+  "renderPuzzlesJson" should "return the equivalent rendering data as JSON" in {
+    val result = controller(successfulProvider, mock[DotcomRenderingService])
+      .renderPuzzlesJson()(TestRequest("/puzzles.json"))
+
+    status(result) should be(OK)
+    contentType(result) should contain("application/json")
+    val json = Json.parse(contentAsString(result))
+    (json \ "id").as[String] should be("/puzzles.json")
+    (json \ "webTitle").as[String] should be("Puzzles and Games")
+    (json \ "layout").as[JsValue] should be(Json.toJson(layout))
+  }
+
+  it should "return not found when the JSON action receives an HTML request" in {
+    val result = controller(successfulProvider, mock[DotcomRenderingService])
+      .renderPuzzlesJson()(TestRequest("/puzzles"))
+
+    status(result) should be(NOT_FOUND)
+  }
+
+  it should "return not found for another unsupported format" in {
+    val result = controller(successfulProvider, mock[DotcomRenderingService])
+      .renderPuzzlesJson()(TestRequest("/puzzles.atom"))
+
+    status(result) should be(NOT_FOUND)
+  }
+}

--- a/applications/test/PuzzlesRoutesTest.scala
+++ b/applications/test/PuzzlesRoutesTest.scala
@@ -1,0 +1,22 @@
+package test
+
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+@DoNotDiscover class PuzzlesRoutesTest extends AnyFlatSpec with Matchers {
+
+  "The Applications routes" should "expose the puzzles HTML endpoint" in {
+    val route = controllers.routes.PuzzlesPageController.renderPuzzles()
+
+    route.method should be("GET")
+    route.url should be("/puzzles")
+  }
+
+  it should "expose the puzzles JSON endpoint" in {
+    val route = controllers.routes.PuzzlesPageController.renderPuzzlesJson()
+
+    route.method should be("GET")
+    route.url should be("/puzzles.json")
+  }
+}

--- a/applications/test/package.scala
+++ b/applications/test/package.scala
@@ -37,6 +37,8 @@ class ApplicationsTestSuite
       new ShareLinksTest,
       new CrosswordDataTest,
       new NewspaperControllerTest,
+      new PuzzlesPageControllerTest,
+      new PuzzlesRoutesTest,
       new IndexPageTest,
       new InteractivePickerTest,
     )

--- a/common/app/controllers/PuzzlesPageController.scala
+++ b/common/app/controllers/PuzzlesPageController.scala
@@ -1,0 +1,61 @@
+package controllers
+
+import common.ImplicitControllerExecutionContext
+import implicits.{HtmlFormat, JsonFormat}
+import implicits.Requests.RichRequestHeader
+import model.dotcomrendering.DotcomPuzzlesPageRenderingDataModel
+import model.{ApplicationContext, CacheTime, Cached}
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+import renderers.DotcomRenderingService
+import staticpages.StaticPages
+
+import scala.concurrent.Future
+
+class PuzzlesPageController(
+  wsClient: WSClient
+  puzzlesLayoutProvider: PuzzlesLayoutProvider,
+  remoteRenderer: DotcomRenderingService,
+  val controllerComponents: ControllerComponents,
+)(implicit context: ApplicationContext)
+  extends BaseController
+  with ImplicitControllerExecutionContext {
+    
+    private def notFound(implicit request: RequestHeader): Future[Result] =
+      Future.successful(
+        Cached(CacheTime.NotFound)(Cached.WithoutRevalidationResult(NotFound)),
+      )
+    
+    def renderPuzzles(): Action[AnyContent] =
+      Action.async { implicit request => 
+        request.getRequestFormat match {
+          case HtmlFormat =>
+            val page = StaticPages.dcrSimplePuzzlesPage(request.path)
+
+            puzzlesLayoutProvider.getLayout().flatMap { layout => 
+              val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
+              remoteRenderer.getPuzzlesPage(
+                wsClient,
+                DotcomPuzzlesPageRenderingDataModel.toJson(renderingData),
+              )
+            }
+          case _ => notFound
+        }
+      }
+    
+    def renderPuzzlesJson(): Action[AnyContent] =
+      Action.async { implicit request => 
+        request.getRequestFormat match {
+          case JsonFormat => 
+            val page = StaticPages.dcrSimplesPuzzlesPage(request.path)
+
+            puzzlesLayoutProvider.getLayout().map { layout => 
+              val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
+              common
+                .renderJson(DotcomPuzzlesPageRenderingDataModel.toJson(renderingData), page)
+                .as("application/json")
+            }
+          case _ => notFound
+        }
+      }
+  }

--- a/common/app/controllers/PuzzlesPageController.scala
+++ b/common/app/controllers/PuzzlesPageController.scala
@@ -13,49 +13,49 @@ import staticpages.StaticPages
 import scala.concurrent.Future
 
 class PuzzlesPageController(
-  wsClient: WSClient
-  puzzlesLayoutProvider: PuzzlesLayoutProvider,
-  remoteRenderer: DotcomRenderingService,
-  val controllerComponents: ControllerComponents,
+    wsClient: WSClient,
+    puzzlesLayoutProvider: PuzzlesLayoutProvider,
+    remoteRenderer: DotcomRenderingService,
+    val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
-  extends BaseController
-  with ImplicitControllerExecutionContext {
-    
-    private def notFound(implicit request: RequestHeader): Future[Result] =
-      Future.successful(
-        Cached(CacheTime.NotFound)(Cached.WithoutRevalidationResult(NotFound)),
-      )
-    
-    def renderPuzzles(): Action[AnyContent] =
-      Action.async { implicit request => 
-        request.getRequestFormat match {
-          case HtmlFormat =>
-            val page = StaticPages.dcrSimplePuzzlesPage(request.path)
+    extends BaseController
+    with ImplicitControllerExecutionContext {
 
-            puzzlesLayoutProvider.getLayout().flatMap { layout => 
-              val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
-              remoteRenderer.getPuzzlesPage(
-                wsClient,
-                DotcomPuzzlesPageRenderingDataModel.toJson(renderingData),
-              )
-            }
-          case _ => notFound
-        }
-      }
-    
-    def renderPuzzlesJson(): Action[AnyContent] =
-      Action.async { implicit request => 
-        request.getRequestFormat match {
-          case JsonFormat => 
-            val page = StaticPages.dcrSimplesPuzzlesPage(request.path)
+  private def notFound(implicit request: RequestHeader): Future[Result] =
+    Future.successful(
+      Cached(CacheTime.NotFound)(Cached.WithoutRevalidationResult(NotFound)),
+    )
 
-            puzzlesLayoutProvider.getLayout().map { layout => 
-              val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
-              common
-                .renderJson(DotcomPuzzlesPageRenderingDataModel.toJson(renderingData), page)
-                .as("application/json")
-            }
-          case _ => notFound
-        }
+  def renderPuzzles(): Action[AnyContent] =
+    Action.async { implicit request =>
+      request.getRequestFormat match {
+        case HtmlFormat =>
+          val page = StaticPages.dcrSimplePuzzlesPage(request.path)
+
+          puzzlesLayoutProvider.getLayout().flatMap { layout =>
+            val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
+            remoteRenderer.getPuzzlesPage(
+              wsClient,
+              DotcomPuzzlesPageRenderingDataModel.toJson(renderingData),
+            )
+          }
+        case _ => notFound
       }
-  }
+    }
+
+  def renderPuzzlesJson(): Action[AnyContent] =
+    Action.async { implicit request =>
+      request.getRequestFormat match {
+        case JsonFormat =>
+          val page = StaticPages.dcrSimplesPuzzlesPage(request.path)
+
+          puzzlesLayoutProvider.getLayout().map { layout =>
+            val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
+            common
+              .renderJson(DotcomPuzzlesPageRenderingDataModel.toJson(renderingData), page)
+              .as("application/json")
+          }
+        case _ => notFound
+      }
+    }
+}

--- a/common/app/controllers/PuzzlesPageController.scala
+++ b/common/app/controllers/PuzzlesPageController.scala
@@ -47,7 +47,7 @@ class PuzzlesPageController(
     Action.async { implicit request =>
       request.getRequestFormat match {
         case JsonFormat =>
-          val page = StaticPages.dcrSimplesPuzzlesPage(request.path)
+          val page = StaticPages.dcrSimplePuzzlesPage(request.path)
 
           puzzlesLayoutProvider.getLayout().map { layout =>
             val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)

--- a/common/app/model/DotcomPuzzlesPageRenderingDataModel.scala
+++ b/common/app/model/DotcomPuzzlesPageRenderingDataModel.scala
@@ -46,7 +46,7 @@ object DotcomPuzzlesPageRenderingDataModel {
       webTitle = page.metadata.webTitle,
       description = page.metadata.description,
       config = DotcomRenderingConfig(page, request, isPreview = false),
-      nav = Nav(page, edition),
+      nav = Nav(page, edition, customSubnav = None),
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(edition)),
       commercialProperties = commercialProperties,
       isAdFreeUser = views.support.Commercial.isAdFree(request),

--- a/common/app/model/DotcomPuzzlesPageRenderingDataModel.scala
+++ b/common/app/model/DotcomPuzzlesPageRenderingDataModel.scala
@@ -33,7 +33,7 @@ object DotcomPuzzlesPageRenderingDataModel {
       layout: PuzzlesLayout,
       request: RequestHeader,
   ): DotcomPuzzlesPageRenderingDataModel = {
-    val edition = Edition.editon(request)
+    val edition = Edition.edition(request)
     val commercialProperties = page.metadata.commercial
       .map(_.perEdition.map { case (key, value) => key.id -> value })
       .getOrElse(Map.empty)

--- a/common/app/model/DotcomPuzzlesPageRenderingDataModel.scala
+++ b/common/app/model/DotcomPuzzlesPageRenderingDataModel.scala
@@ -1,0 +1,60 @@
+package model.dotcomrendering
+
+import common.commercial.EditionCommercialProperties
+import common.{CanonicalLink, Edition}
+import conf.Configuration
+import model.SimplePage
+import navigation.{FooterLinks, Nav}
+import play.api.libs.json.{JsObject, JsValue, Json, OWrites}
+import play.api.mvc.RequestHeader
+
+case class DotcomPuzzlesPageRenderingDataModel(
+    id: String,
+    editionId: String,
+    editionLongForm: String,
+    contributionsServiceUrl: String,
+    webTitle: String,
+    description: Option[String],
+    config: JsObject,
+    nav: Nav,
+    pageFooter: PageFooter,
+    commercialProperties: Map[String, EditionCommercialProperties],
+    isAdFreeUser: Boolean,
+    canonicalUrl: String,
+    layout: PuzzlesLayout,
+)
+
+object DotcomPuzzlesPageRenderingDataModel {
+  implicit val writes: OWrites[DotcomPuzzlesPageRenderingDataModel] =
+    Json.writes[DotcomPuzzlesPageRenderingDataModel]
+
+  def apply(
+      page: SimplePage,
+      layout: PuzzlesLayout,
+      request: RequestHeader,
+  ): DotcomPuzzlesPageRenderingDataModel = {
+    val edition = Edition.editon(request)
+    val commercialProperties = page.metadata.commercial
+      .map(_.perEdition.map { case (key, value) => key.id -> value })
+      .getOrElse(Map.empty)
+
+    DotcomPuzzlesPageRenderingDataModel(
+      id = page.metadata.id,
+      editionId = edition.id,
+      editionLongForm = edition.displayName,
+      contributionsServiceUrl = Configuration.contributionsService.url,
+      webTitle = page.metadata.webTitle,
+      description = page.metadata.description,
+      config = DotcomRenderingConfig(page, request, isPreview = false),
+      nav = Nav(page, edition),
+      pageFooter = PageFooter(FooterLinks.getFooterByEdition(edition)),
+      commercialProperties = commercialProperties,
+      isAdFreeUser = views.support.Commercial.isAdFree(request),
+      canonicalUrl = CanonicalLink(request, page.metadata.webUrl),
+      layout = layout,
+    )
+  }
+
+  def toJson(model: DotcomPuzzlesPageRenderingDataModel): JsValue =
+    DotcomRenderingUtils.withoutNull(Json.toJson(model))
+}

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -493,7 +493,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       ws: WSClient,
       json: JsValue,
   )(implicit request: RequestHeader): Future[Result] =
-    post(ws, json, Configuration.renderign.articleBaseURL + "/PuzzlesPage", CacheTime.Default)
+    post(ws, json, Configuration.rendering.articleBaseURL + "/PuzzlesPage", CacheTime.Default)
 
   def getEditionsCrossword(
       ws: WSClient,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -489,6 +489,12 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     post(ws, json, Configuration.rendering.articleBaseURL + "/Article", CacheTime.Crosswords)
   }
 
+  def getPuzzlesPage(
+      ws: WSClient,
+      json: JsValue,
+  )(implicit request: RequestHeader): Future[Result] =
+    post(ws, json, Configuration.renderign.articleBaseURL + "/PuzzlesPage", CacheTime.Default)
+
   def getEditionsCrossword(
       ws: WSClient,
       crosswords: EditionsCrosswordRenderingDataModel,

--- a/common/app/staticpages/StaticPages.scala
+++ b/common/app/staticpages/StaticPages.scala
@@ -47,4 +47,16 @@ object StaticPages {
         shouldGoogleIndex = true,
       ),
     )
+
+  def dcrSimplePuzzlesPage(id: String): SimplePage =
+    SimplePage(
+      MetaData.make(
+        id = id,
+        section = Option(SectionId(value = "puzzles")) webTitle = "Puzzles and Games",
+        description = None,
+        contentType = Some(DotcomContentType.Tag),
+        iosType = None,
+        shouldGoogleIndex = true,
+      ),
+    )
 }

--- a/common/app/staticpages/StaticPages.scala
+++ b/common/app/staticpages/StaticPages.scala
@@ -52,7 +52,8 @@ object StaticPages {
     SimplePage(
       MetaData.make(
         id = id,
-        section = Option(SectionId(value = "puzzles")) webTitle = "Puzzles and Games",
+        section = Option(SectionId(value = "puzzles")),
+        webTitle = "Puzzles and Games",
         description = None,
         contentType = Some(DotcomContentType.Tag),
         iosType = None,

--- a/common/test/CommonTestSuite.scala
+++ b/common/test/CommonTestSuite.scala
@@ -5,6 +5,7 @@ import conf.CachedHealthCheckTest
 import conf.audio.FlagshipFrontContainerSpec
 import http.ABTestingFilterTest
 import navigation.NavigationTest
+import model.dotcomrendering.DotcomPuzzlesPageRenderingDataModelTest
 import org.scalatest.Suites
 import renderers.DotcomRenderingServiceTest
 
@@ -15,6 +16,7 @@ class CommonTestSuite
       new ABTestingFilterTest,
       new CachedHealthCheckTest,
       new NavigationTest,
+      new DotcomPuzzlesPageRenderingDataModelTest,
       new FlagshipFrontContainerSpec,
       new DotcomRenderingServiceTest,
     )

--- a/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
@@ -1,0 +1,68 @@
+package model.dotcomrendering
+
+import ab.ABTests
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.mvc.RequestHeader
+import play.api.test.FakeRequest
+import staticpages.StaticPages
+
+@DoNotDiscover class DotcomPuzzlesPageRenderingDataModelTest extends AnyFlatSpec with Matchers {
+
+  private val layout = PuzzlesLayout(
+    containers = Seq(
+      PuzzleContainer(
+        title = "Daily puzzles",
+        content = PuzzleContent(
+          items = Seq(Seq(PuzzleItem("Quick crossword", "crossword", "quick"))),
+          nestedContainers = Seq.empty,
+        ),
+      ),
+    ),
+  )
+
+  private def requestWithParticipations: RequestHeader = {
+    implicit val request: RequestHeader = FakeRequest("GET", "/puzzles")
+      .withHeaders(
+        "Host" -> "www.theguardian.com",
+        "X-GU-Server-AB-Tests" -> "puzzles-new-hub:variant,another-test:control",
+      )
+    ABTests.decorateRequest("X-GU-Server-AB-Tests")
+  }
+
+  "DotcomPuzzlesPageRenderingDataModel" should "serialize the complete puzzles rendering payload" in {
+    val model = DotcomPuzzlesPageRenderingDataModel(
+      StaticPages.dcrSimplePuzzlesPage("/puzzles"),
+      layout,
+      requestWithParticipations,
+    )
+
+    val json = DotcomPuzzlesPageRenderingDataModel.toJson(model)
+
+    (json \ "id").as[String] should be("/puzzles")
+    (json \ "webTitle").as[String] should be("Puzzles and Games")
+    (json \ "editionId").as[String] should not be empty
+    (json \ "nav").toOption should not be empty
+    (json \ "pageFooter").toOption should not be empty
+    (json \ "commercialProperties").toOption should not be empty
+    (json \ "canonicalUrl").as[String] should endWith("/puzzles")
+    (json \ "layout").as[PuzzlesLayout] should be(layout)
+  }
+
+  it should "propagate every current server-side AB-test participation" in {
+    val model = DotcomPuzzlesPageRenderingDataModel(
+      StaticPages.dcrSimplePuzzlesPage("/puzzles"),
+      layout,
+      requestWithParticipations,
+    )
+
+    val participations = (DotcomPuzzlesPageRenderingDataModel.toJson(model) \ "config" \ "serverSideABTests")
+      .as[Map[String, String]]
+
+    participations should contain theSameElementsAs Map(
+      "puzzles-new-hub" -> "variant",
+      "another-test" -> "control",
+    )
+  }
+}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -12,6 +12,10 @@ GET            /assets/admin/*file                                              
 GET            /assets/internal/*file                                                                                            controllers.Assets.at(path="/public", file)
 GET            /assets/*path                                                                                                     dev.DevAssetsController.at(path)
 
+# Puzzles
+GET        /puzzles.json                                                                                                         controllers.PuzzlesPageController.renderPuzzlesJson()
+GET        /puzzles                                                                                                              controllers.PuzzlesPageController.renderPuzzles()
+
 # Crosswords
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
 GET            /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|sunday-quick|prize|everyman|azed|special|genius|speedy|weekend|mini>/:id.svg               controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)


### PR DESCRIPTION
## What is the value of this and can you measure success?

This establishes the base Frontend flow for the new puzzles hub and connects it to Dotcom Rendering.

Success can be measured by:

- GET /puzzles loading the configured puzzles layout and rendering it through DCR.
- GET /puzzles.json returning the equivalent rendering payload as JSON.
- Both endpoints remaining accessible regardless of puzzles-new-hub experiment participation.
- The DCR payload containing the expected metadata, navigation, footer, commercial configuration, canonical URL, layout, and server-side AB-test participations.
- Controller, route, rendering-model, and existing aggregate test suites passing.

## What does this change?

- Adds PuzzlesPageController with separate HTML and JSON actions.
- Wires the controller, layout provider, DCR service, HTTP client, and Play controller components through ApplicationsControllers.
- Adds /puzzles and /puzzles.json to the Applications and dev-build route tables.
- Adds DotcomPuzzlesPageRenderingDataModel, which builds the complete DCR payload from:
  - puzzles hub metadata
  - edition
  - navigation and footer
  - Frontend configuration
  - commercial properties
  - canonical URL
  - the puzzles layout
  - current server-side AB-test participations
- Defines the puzzles hub metadata in StaticPages.
- Adds the dedicated internal DCR /PuzzlesPage rendering call.
- Returns Frontend's conventional cached not-found response for unsupported formats.
- Keeps the routes directly accessible without checking experiment participation. Discovery and navigation gating will be handled separately.
- Adds controller tests for HTML and JSON success, unsupported formats, layout-provider failures, and DCR-renderer failures.
- Adds route tests for /puzzles and /puzzles.json.
- Adds rendering-model tests for serialization and AB-test propagation.

## Screenshots

Not applicable. This PR establishes the Frontend endpoint, rendering payload, and DCR integration. It does not introduce Frontend-rendered UI or styling.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (no new test database files were generated)
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md) — no UI, styling, or interaction changes are introduced by this PR
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader) — not applicable to this backend integration
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard) — not applicable to this backend integration
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour) — not applicable, no visual changes
