### PR TITLE
Add SkimLinksCache testability and skimlinks detection tests

### DIFF
--- a/common/app/services/SkimLinksCache.scala
+++ b/common/app/services/SkimLinksCache.scala
@@ -29,6 +29,9 @@ object SkimLinksCache extends GuLogging {
       .map(_.replace("www.", ""))
       .exists(skimLinkDomains.get().contains)
   }
+
+  /** Allows tests to inject known domains without requiring S3 access. */
+  def setDomains(domains: Set[String]): Unit = skimLinkDomains.set(domains)
 }
 
 class SkimLinksCacheLifeCycle()(implicit ec: ExecutionContext) extends LifecycleComponent {

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -13,6 +13,7 @@ import com.gu.contentapi.client.utils.format.LiveBlogDesign
 import conf.switches.Switches
 import implicits.Dates.jodaToJavaInstant
 import model.dotcomrendering.DotcomRenderingUtils
+import services.SkimLinksCache
 import model.liveblog.{BlockAttributes => LiveblogBlockAttribute, _}
 import model.{
   Article,
@@ -168,8 +169,6 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
   }
 
   // --- Affiliate disclaimer tests ---
-  // Testing skimlinks detection (hasAffiliateLinksForDisclaimer) requires a SkimLinksCache refactor
-  // and will be covered in a follow-up PR.
 
   /** Helper to build a minimal Article with a specific body HTML and showAffiliateLinks flag. */
   private def articleWithBody(bodyHtml: String, showAffiliateLinks: Option[Boolean] = Some(true)): Article = {
@@ -242,6 +241,111 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
       DotcomRenderingUtils.shouldAddAffiliateLinks(content, blocks) should be(false)
     } finally {
       Switches.AffiliateLinks.switchOff()
+    }
+  }
+
+  it should "return true when blocks contain affiliateable skimlinks" in {
+    Switches.AffiliateLinks.switchOn()
+    SkimLinksCache.setDomains(Set("amazon.co.uk"))
+    try {
+      val content = articleWithBody(sampleArticleBody)
+      val blocks = Seq(
+        Block(
+          id = "1",
+          bodyHtml = """<p>Check out <a href="https://www.amazon.co.uk/product/123">this product</a></p>""",
+          bodyTextSummary = "",
+          title = None,
+          attributes = BlockAttributes(),
+          published = true,
+          createdDate = None,
+          firstPublishedDate = None,
+          publishedDate = None,
+          lastModifiedDate = None,
+          createdBy = None,
+          lastModifiedBy = None,
+          elements = Seq(),
+        ),
+      )
+
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content, blocks) should be(true)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+      SkimLinksCache.setDomains(Set.empty)
+    }
+  }
+
+  it should "return false when blocks contain links to non-skimlink domains" in {
+    Switches.AffiliateLinks.switchOn()
+    SkimLinksCache.setDomains(Set("amazon.co.uk"))
+    try {
+      val content = articleWithBody(sampleArticleBody)
+      val blocks = Seq(
+        Block(
+          id = "1",
+          bodyHtml = """<p>Read more at <a href="https://www.theguardian.com/article">the guardian</a></p>""",
+          bodyTextSummary = "",
+          title = None,
+          attributes = BlockAttributes(),
+          published = true,
+          createdDate = None,
+          firstPublishedDate = None,
+          publishedDate = None,
+          lastModifiedDate = None,
+          createdBy = None,
+          lastModifiedBy = None,
+          elements = Seq(),
+        ),
+      )
+
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content, blocks) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+      SkimLinksCache.setDomains(Set.empty)
+    }
+  }
+
+  it should "detect skimlinks across multiple blocks" in {
+    Switches.AffiliateLinks.switchOn()
+    SkimLinksCache.setDomains(Set("amazon.co.uk"))
+    try {
+      val content = articleWithBody(sampleArticleBody)
+      val blocks = Seq(
+        Block(
+          id = "1",
+          bodyHtml = "<p>No links here.</p>",
+          bodyTextSummary = "",
+          title = None,
+          attributes = BlockAttributes(),
+          published = true,
+          createdDate = None,
+          firstPublishedDate = None,
+          publishedDate = None,
+          lastModifiedDate = None,
+          createdBy = None,
+          lastModifiedBy = None,
+          elements = Seq(),
+        ),
+        Block(
+          id = "2",
+          bodyHtml = """<p>Buy <a href="https://amazon.co.uk/item">this</a></p>""",
+          bodyTextSummary = "",
+          title = None,
+          attributes = BlockAttributes(),
+          published = true,
+          createdDate = None,
+          firstPublishedDate = None,
+          publishedDate = None,
+          lastModifiedDate = None,
+          createdBy = None,
+          lastModifiedBy = None,
+          elements = Seq(),
+        ),
+      )
+
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content, blocks) should be(true)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+      SkimLinksCache.setDomains(Set.empty)
     }
   }
 


### PR DESCRIPTION
## What is the value of this and can you measure success?

This is part of the ongoing affiliate links cleanup that began with unifying the disclaimer rendering logic and removing the legacy two-paragraph placement constraint. Previously, the skimlinks detection path (`hasAffiliateLinksInContent`) was untestable because `SkimLinksCache` is a singleton backed by S3 data. This means the "does this article actually contain affiliate links?" check had zero test coverage.

Success can be measured by:
- The three new tests passing in CI, covering positive, negative, and multi-block skimlinks detection scenarios.
- Future changes to affiliate link logic having a safety net that was previously absent.

This follows on from the following PR: https://github.com/guardian/frontend/pull/29041

## What does this change?

Adds a `setDomains` method to `SkimLinksCache`, allowing tests to inject known skimlink domains without requiring S3 access. This is a minimal addition, the object already uses a mutable `AtomicReference` internally.

Adds three new tests to `DotcomRenderingUtilsTest` exercising `shouldAddAffiliateLinks(content, blocks)`:
  - Returns `true` when body blocks contain links to known skimlink domains (e.g. `amazon.co.uk`)
  - Returns `false` when body blocks contain links to non-skimlink domains only
  - Correctly detects skimlinks spread across multiple blocks

Removes an outdated comment that said skimlinks testing required a future refactor.

No changes to runtime behaviour, this is purely a testability improvement.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
