### PR TITLE
More custom subnav support

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -32,6 +32,7 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait ApplicationsServices {
   def wsClient: WSClient
+  def appIdentity: ApplicationIdentity
   implicit val executionContext: ExecutionContext
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   lazy val contentApiClient = wire[ContentApiClient]

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -12,6 +12,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import play.twirl.api.Html
 import renderers.DotcomRenderingService
+import services.SubnavAgent
 import services.dotcomrendering.{GalleryPicker, RemoteRender}
 import views.support.RenderOtherStatus
 
@@ -22,6 +23,7 @@ class GalleryController(
     val controllerComponents: ControllerComponents,
     wsClient: WSClient,
     remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
+    subnavAgent: SubnavAgent,
 )(implicit context: ApplicationContext)
     extends BaseController
     with RendersItemResponse
@@ -64,7 +66,7 @@ class GalleryController(
         gallery = model,
         pageType = pageType,
         blocks = blocks,
-        customSubnav = None,
+        customSubnav = subnavAgent.getSubnavForContent(model.gallery.content),
       )
     }
   }

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -83,7 +83,15 @@ class GalleryController(
   private def getDCRJson(galleryPage: GalleryPage, pageType: PageType, blocks: Blocks)(implicit
       request: RequestHeader,
   ): JsValue = {
-    DotcomRenderingDataModel.toJson(DotcomRenderingDataModel.forGallery(galleryPage, request, pageType, blocks, None))
+    DotcomRenderingDataModel.toJson(
+      DotcomRenderingDataModel.forGallery(
+        galleryPage = galleryPage,
+        request = request,
+        pageType = pageType,
+        blocks = blocks,
+        customSubnav = subnavAgent.getSubnavForContent(galleryPage.gallery.content),
+      ),
+    )
   }
 
   private def lookup(path: String, index: Int, isTrail: Boolean)(implicit

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -14,12 +14,12 @@ import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import renderers.DotcomRenderingService
-import services.ImageQuery
+import services.{ImageQuery, SubnavAgent}
 import services.dotcomrendering.{ImageContentPicker, RemoteRender}
 import views.support.RenderOtherStatus
-
 import com.gu.contentapi.client.model.Direction.Next
 import com.gu.contentapi.client.model.Direction.Previous
+
 import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
 import scala.concurrent.Future
 import scala.util.Try
@@ -29,6 +29,7 @@ class ImageContentController(
     val controllerComponents: ControllerComponents,
     wsClient: WSClient,
     remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
+    subnavAgent: SubnavAgent,
 )(implicit context: ApplicationContext)
     extends BaseController
     with RendersItemResponse
@@ -90,7 +91,7 @@ class ImageContentController(
           imageContent = content,
           pageType = pageType,
           mainBlock = mainBlock,
-          customSubnav = None,
+          customSubnav = subnavAgent.getSubnavForContent(content.image.content),
         )
     }
   }

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -63,7 +63,13 @@ class ImageContentController(
       request: RequestHeader,
   ): JsValue = {
     DotcomRenderingDataModel.toJson(
-      DotcomRenderingDataModel.forImageContent(content, request, pageType, mainBlock, None),
+      DotcomRenderingDataModel.forImageContent(
+        imageContentPage = content,
+        request = request,
+        pageType = pageType,
+        mainBlock = mainBlock,
+        customSubnav = subnavAgent.getSubnavForContent(content.image.content),
+      ),
     )
   }
 

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -13,6 +13,7 @@ import play.api.libs.json.{Format, JsObject, JsValue, Json}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import renderers.DotcomRenderingService
+import services.SubnavAgent
 import services.dotcomrendering.{MediaPicker, RemoteRender}
 import views.support.RenderOtherStatus
 
@@ -23,6 +24,7 @@ class MediaController(
     val controllerComponents: ControllerComponents,
     wsClient: WSClient,
     remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
+    subnavAgent: SubnavAgent,
 )(implicit context: ApplicationContext)
     extends BaseController
     with RendersItemResponse
@@ -125,7 +127,7 @@ class MediaController(
           mediaPage = content,
           pageType = pageType,
           blocks = blocks,
-          customSubnav = None,
+          customSubnav = subnavAgent.getSubnavForContent(content.media.content),
         )
     }
   }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -100,7 +100,15 @@ class MediaController(
   private def getDCRJson(content: MediaPage, pageType: PageType, blocks: Blocks)(implicit
       request: RequestHeader,
   ): JsValue = {
-    DotcomRenderingDataModel.toJson(DotcomRenderingDataModel.forMedia(content, request, pageType, blocks, None))
+    DotcomRenderingDataModel.toJson(
+      DotcomRenderingDataModel.forMedia(
+        mediaPage = content,
+        request = request,
+        pageType = pageType,
+        blocks = blocks,
+        customSubnav = subnavAgent.getSubnavForContent(content.media.content),
+      ),
+    )
   }
 
   private def remoteRender(content: MediaPage, blocks: Blocks)(implicit

--- a/applications/test/GalleryControllerTest.scala
+++ b/applications/test/GalleryControllerTest.scala
@@ -1,10 +1,12 @@
 package test
 
 import controllers.GalleryController
+import model.ApplicationIdentity
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import services.SubnavAgent
 
 @DoNotDiscover class GalleryControllerTest
     extends AnyFlatSpec
@@ -19,7 +21,12 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
   val galleryUrl = "news/gallery/2012/may/02/picture-desk-live-kabul-burma"
 
   lazy val galleryController =
-    new GalleryController(testContentApiClient, play.api.test.Helpers.stubControllerComponents(), wsClient)
+    new GalleryController(
+      contentApiClient = testContentApiClient,
+      controllerComponents = play.api.test.Helpers.stubControllerComponents(),
+      wsClient = wsClient,
+      subnavAgent = new SubnavAgent(ApplicationIdentity("mock")),
+    )
 
   "Gallery Controller" should "200 when content type is gallery" in {
     val result = galleryController.render(galleryUrl)(TestRequest(s"/$galleryUrl"))

--- a/applications/test/ImageContentControllerTest.scala
+++ b/applications/test/ImageContentControllerTest.scala
@@ -1,10 +1,12 @@
 package test
 
 import controllers.ImageContentController
+import model.ApplicationIdentity
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test.Helpers._
+import services.SubnavAgent
 
 @DoNotDiscover class ImageContentControllerTest
     extends AnyFlatSpec
@@ -20,7 +22,12 @@ import play.api.test.Helpers._
   val pictureUrl = "artanddesign/picture/2013/oct/08/photography"
 
   lazy val imageContentController =
-    new ImageContentController(testContentApiClient, play.api.test.Helpers.stubControllerComponents(), wsClient)
+    new ImageContentController(
+      contentApiClient = testContentApiClient,
+      controllerComponents = play.api.test.Helpers.stubControllerComponents(),
+      wsClient = wsClient,
+      subnavAgent = new SubnavAgent(ApplicationIdentity("mock")),
+    )
 
   "Image Content Controller" should "200 when content type is picture" in {
     val result = imageContentController.render(pictureUrl)(TestRequest(s"$pictureUrl?dcr=false"))

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -1,11 +1,13 @@
 package test
 
 import controllers.MediaController
+import model.ApplicationIdentity
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.jsoup.Jsoup
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import services.SubnavAgent
 
 @DoNotDiscover class MediaControllerTest
     extends AnyFlatSpec
@@ -20,7 +22,12 @@ import org.scalatest.matchers.should.Matchers
   val videoUrl = "uk/video/2012/jun/26/queen-enniskillen-northern-ireland-video"
   val videoUrlWithDodgyOctpusUrl = "football/video/2015/feb/10/manchester-united-louis-van-gaal-long-ball-video"
   lazy val mediaController =
-    new MediaController(testContentApiClient, play.api.test.Helpers.stubControllerComponents(), wsClient)
+    new MediaController(
+      contentApiClient = testContentApiClient,
+      controllerComponents = play.api.test.Helpers.stubControllerComponents(),
+      wsClient = wsClient,
+      subnavAgent = new SubnavAgent(ApplicationIdentity("mock")),
+    )
 
   "Media Controller" should "200 when content type is video" in {
     val result = mediaController.render(videoUrl)(TestRequest(videoUrl))

--- a/common/app/services/SubnavAgent.scala
+++ b/common/app/services/SubnavAgent.scala
@@ -9,7 +9,7 @@ import com.gu.facia.client.models.TargetedPageType.{Article, HasTag}
 import com.gu.facia.client.models.{CustomSubnav, CustomSubnavConfig}
 import common._
 import fronts.FrontsApi
-import model.Content
+import model.{ApplicationIdentity, Content}
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -20,21 +20,22 @@ import scala.util.{Failure, Success}
   * The config is authored in CMS Fronts and describes bespoke sub-navigations that can be targeted at specific fronts,
   * articles or tags. It is pulled from a single file in S3 in the CMS Fronts AWS account (via the Fronts API client).
   */
-class SubnavAgent extends GuLogging {
+class SubnavAgent(appIdentity: ApplicationIdentity) extends GuLogging {
   private val subnavConfigBox = Box[Option[CustomSubnavConfig]](None)
+  private val publicationStatus: PublicationStatus = if (appIdentity.name == "preview") Draft else Live
 
   def isLoaded(): Boolean = subnavConfigBox.get().isDefined
 
   def getSubnavConfig(): Option[CustomSubnavConfig] = subnavConfigBox.get()
 
   /** Look up the custom subnav targeted at the given front, if any. */
-  def getSubnavForFront(frontId: String, status: PublicationStatus = Live): Option[CustomSubnav] = {
+  def getSubnavForFront(frontId: String, status: PublicationStatus = publicationStatus): Option[CustomSubnav] = {
     getSubnavConfig().flatMap { config =>
       CustomSubnavService.getSubnavForFront(config, frontId, status)
     }
   }
 
-  def getSubnavForContent(content: Content, status: PublicationStatus = Live): Option[CustomSubnav] = {
+  def getSubnavForContent(content: Content, status: PublicationStatus = publicationStatus): Option[CustomSubnav] = {
     getSubnavConfig().flatMap { config =>
       def subnavMatchesSpecificArticle(subnav: CustomSubnav): Boolean =
         subnav.pages.exists(p => p.path == content.metadata.id && p.`type` == Article)

--- a/common/test/services/MockSubnavAgent.scala
+++ b/common/test/services/MockSubnavAgent.scala
@@ -3,11 +3,11 @@ package services
 import com.gu.facia.api.models.PublicationStatus
 import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.{CustomSubnav, CustomSubnavConfig}
-import model.Content
+import model.{ApplicationIdentity, Content}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MockSubnavAgent extends SubnavAgent {
+class MockSubnavAgent extends SubnavAgent(ApplicationIdentity("mock")) {
   override def isLoaded(): Boolean = true
   override def getSubnavConfig(): Option[CustomSubnavConfig] = None
   override def getSubnavForFront(frontId: String, status: PublicationStatus): Option[CustomSubnav] = None

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -7,7 +7,7 @@ import common.editions.{Uk, Us}
 import controllers.FaciaControllerImpl
 import helpers.FaciaTestData
 import implicits.FakeRequests
-import model.PressedPage
+import model.{ApplicationIdentity, PressedPage}
 import org.apache.pekko.stream.scaladsl.Source
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.when
@@ -48,7 +48,7 @@ import scala.concurrent.{Await, Future}
     wsClient,
     new MostViewedAgent(testContentApiClient, new OphanApi(wsClient)),
     new DeeplyReadAgent(testContentApiClient, new OphanApi(wsClient)),
-    new SubnavAgent(),
+    new SubnavAgent(ApplicationIdentity("mock")),
     assets = assets,
   )
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -5,6 +5,7 @@ import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import conf.Configuration
 import conf.switches.Switches.DCRFronts
 import controllers.FaciaControllerImpl
+import model.ApplicationIdentity
 import org.jsoup.Jsoup
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -45,12 +46,12 @@ import scala.concurrent.duration._
   }
 
   lazy val faciaController = new FaciaControllerImpl(
-    fapi,
-    play.api.test.Helpers.stubControllerComponents(),
-    wsClient,
-    new MostViewedAgent(testContentApiClient, new OphanApi(wsClient)),
-    new DeeplyReadAgent(testContentApiClient, new OphanApi(wsClient)),
-    new SubnavAgent(),
+    frontJsonFapi = fapi,
+    controllerComponents = play.api.test.Helpers.stubControllerComponents(),
+    ws = wsClient,
+    mostViewedAgent = new MostViewedAgent(testContentApiClient, new OphanApi(wsClient)),
+    deeplyReadAgent = new DeeplyReadAgent(testContentApiClient, new OphanApi(wsClient)),
+    subnavAgent = new SubnavAgent(ApplicationIdentity("mock")),
     assets = assets,
   )
   val frontPath = "music"


### PR DESCRIPTION
## What is the value of this and can you measure success?

Continue the work to support the custom subnav for more use cases, including preview

See https://github.com/guardian/frontend/pull/29122 for context

## What does this change?
Add support for galleries, images and video articles.

Also add support for preview

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
