### PR TITLE
Add `customData` to `InteractiveBlockElement`

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -364,6 +364,7 @@ case class InteractiveAtomBlockElement(
     placeholderUrl: Option[String],
     role: Option[String],
     title: String,
+    customData: Option[String],
 ) extends PageElement
 object InteractiveAtomBlockElement {
   implicit val InteractiveAtomBlockElementWrites: Writes[InteractiveAtomBlockElement] =
@@ -377,7 +378,6 @@ case class InteractiveBlockElement(
     role: Option[String],
     isMandatory: Option[Boolean],
     caption: Option[String],
-    customData: Option[String],
 ) extends PageElement
 object InteractiveBlockElement {
   implicit val InteractiveBlockElementWrites: Writes[InteractiveBlockElement] = Json.writes[InteractiveBlockElement]
@@ -1097,6 +1097,12 @@ object PageElement extends GuLogging {
         role <- d.role
       } yield role
 
+    val elementCustomData: Option[String] =
+      for {
+        d <- element.contentAtomTypeData
+        customData <- d.customData
+      } yield customData
+
     element.`type` match {
       case Text =>
         val textCleaners =
@@ -1395,6 +1401,7 @@ object PageElement extends GuLogging {
                 placeholderUrl = interactive.placeholderUrl,
                 role = elementRole,
                 title = interactive.title,
+                customData = elementCustomData,
               ),
             )
           }
@@ -1602,15 +1609,7 @@ object PageElement extends GuLogging {
       case Interactive =>
         element.interactiveTypeData
           .map(d =>
-            InteractiveBlockElement(
-              d.iframeUrl,
-              d.alt,
-              d.scriptUrl.map(ensureHTTPS),
-              d.role,
-              d.isMandatory,
-              d.caption,
-              d.customData,
-            ),
+            InteractiveBlockElement(d.iframeUrl, d.alt, d.scriptUrl.map(ensureHTTPS), d.role, d.isMandatory, d.caption),
           )
           .toList
       case Table   => element.tableTypeData.map(d => TableBlockElement(d.html, Role(d.role), d.isMandatory)).toList

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -377,6 +377,7 @@ case class InteractiveBlockElement(
     role: Option[String],
     isMandatory: Option[Boolean],
     caption: Option[String],
+    customData: Option[String],
 ) extends PageElement
 object InteractiveBlockElement {
   implicit val InteractiveBlockElementWrites: Writes[InteractiveBlockElement] = Json.writes[InteractiveBlockElement]
@@ -1601,7 +1602,15 @@ object PageElement extends GuLogging {
       case Interactive =>
         element.interactiveTypeData
           .map(d =>
-            InteractiveBlockElement(d.iframeUrl, d.alt, d.scriptUrl.map(ensureHTTPS), d.role, d.isMandatory, d.caption),
+            InteractiveBlockElement(
+              d.iframeUrl,
+              d.alt,
+              d.scriptUrl.map(ensureHTTPS),
+              d.role,
+              d.isMandatory,
+              d.caption,
+              d.customData,
+            ),
           )
           .toList
       case Table   => element.tableTypeData.map(d => TableBlockElement(d.html, Role(d.role), d.isMandatory)).toList

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.49.6"
-  val capiVersion = "47.0.0"
-  val faciaVersion = "38.0.0"
+  val capiVersion = "50.0.0"
+  val faciaVersion = "39.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -33,7 +33,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.22.0"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.30"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "46.0.0"
+  val contentApiModelsJson = "com.gu" %% "content-api-models-json" % "50.0.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play30" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.49.6"
-  val capiVersion = "50.0.0"
+  val capiVersion = "49.0.0"
   val faciaVersion = "39.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
Part of the chain of work to parameterise interactive atoms, this updates the `InteractiveBlockElement` data passed on to Dotcom to include the now expected `customData` field.

https://github.com/guardian/dotcom-rendering/pull/16612 in turn will take the data and makes it available to the interactive atom when rendered in DCAR.