### PR TITLE
Remove FilterAtAGlanceTest feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -660,15 +660,4 @@ trait FeatureSwitches {
     exposeClientSide = true,
     highImpact = false,
   )
-
-  val FilterAtAGlanceTest = Switch(
-    group = SwitchGroup.Feature,
-    name = "filter-at-a-glance",
-    description = "Switch for at a glance A / B / C test",
-    owners = Seq(Owner.withEmail("thefilter.dev@guardian.co.uk")),
-    sellByDate = never,
-    safeState = Off,
-    exposeClientSide = true,
-    highImpact = false,
-  )
 }


### PR DESCRIPTION

## What does this change?

Removes old switch for the At A Glance test that finished a couple of months ago (https://github.com/guardian/dotcom-rendering/pull/15865)
