### PR TITLE
Bump faciaVersion to 38.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.49.6"
   val capiVersion = "47.0.0"
-  val faciaVersion = "37.0.0"
+  val faciaVersion = "38.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?
Bumps the faciaVersion to 38.0.0 to bring in the addition of the `manuallyEndedOnThisTrailDate` field to the editorial tests model.