### PR TITLE
change the log level of the recaptcha error

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -564,7 +564,7 @@ class EmailSignupController(
             Future.successful(())
           } else {
             val errorCodes = googleResponse.`error-codes`.getOrElse(Seq.empty).mkString(",")
-            logWarnWithRequestId(s"reCAPTCHA validation failed. error-codes: [$errorCodes]")
+            logErrorWithRequestId(s"reCAPTCHA validation failed. error-codes: [$errorCodes]")
             RecaptchaValidationError.increment()
             Future.failed(InvalidCaptchaTokenException)
           }


### PR DESCRIPTION
## What is the value of this and can you measure success?
To check what kinds of recaptcha errors we are getting when newsletters signup attempts are made. Hopefully this will help us better understand the high failure rate with newsletter signups.

## What does this change?
Changes the log level of the recaptcha errors from a warning to an error. Warnings don't seem to find their way to logstash