### PR TITLE
Puzzles/gate new hub navigation and routes

### DIFF
--- a/applications/app/controllers/PuzzlesPageController.scala
+++ b/applications/app/controllers/PuzzlesPageController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import ab.PuzzlesHubExperiment
 import common.ImplicitControllerExecutionContext
 import implicits.{HtmlFormat, JsonFormat}
 import implicits.Requests.RichRequestHeader
@@ -28,34 +29,40 @@ class PuzzlesPageController(
 
   def renderPuzzles(): Action[AnyContent] =
     Action.async { implicit request =>
-      request.getRequestFormat match {
-        case HtmlFormat =>
-          val page = StaticPages.dcrSimplePuzzlesPage(request.path)
+      if (!PuzzlesHubExperiment.isEnabled) notFound
+      else
+        request.getRequestFormat match {
+          case HtmlFormat =>
+            val page = StaticPages.dcrSimplePuzzlesPage(request.path)
 
-          puzzlesLayoutProvider.getLayout().flatMap { layout =>
-            val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
-            remoteRenderer.getPuzzlesPage(
-              wsClient,
-              DotcomPuzzlesPageRenderingDataModel.toJson(renderingData),
-            )
-          }
-        case _ => notFound
-      }
+            puzzlesLayoutProvider.getLayout().flatMap { layout =>
+              val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
+              remoteRenderer.getPuzzlesPage(
+                wsClient,
+                DotcomPuzzlesPageRenderingDataModel.toJson(renderingData),
+              )
+            }
+
+          case _ => notFound
+        }
     }
 
   def renderPuzzlesJson(): Action[AnyContent] =
     Action.async { implicit request =>
-      request.getRequestFormat match {
-        case JsonFormat =>
-          val page = StaticPages.dcrSimplePuzzlesPage(request.path)
+      if (!PuzzlesHubExperiment.isEnabled) notFound
+      else
+        request.getRequestFormat match {
+          case JsonFormat =>
+            val page = StaticPages.dcrSimplePuzzlesPage(request.path)
 
-          puzzlesLayoutProvider.getLayout().map { layout =>
-            val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
-            common
-              .renderJson(DotcomPuzzlesPageRenderingDataModel.toJson(renderingData), page)
-              .as("application/json")
-          }
-        case _ => notFound
-      }
+            puzzlesLayoutProvider.getLayout().map { layout =>
+              val renderingData = DotcomPuzzlesPageRenderingDataModel(page, layout, request)
+              common
+                .renderJson(DotcomPuzzlesPageRenderingDataModel.toJson(renderingData), page)
+                .as("application/json")
+            }
+
+          case _ => notFound
+        }
     }
 }

--- a/applications/test/PuzzlesPageControllerTest.scala
+++ b/applications/test/PuzzlesPageControllerTest.scala
@@ -1,9 +1,10 @@
 package test
 
+import ab.ABTests
 import controllers.{PuzzlesLayoutProvider, PuzzlesPageController}
 import model.dotcomrendering.{PuzzleContent, PuzzleContainer, PuzzleItem, PuzzlesLayout}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{verify, verifyNoInteractions, when}
 import org.scalatest.DoNotDiscover
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -11,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
-import play.api.mvc.{RequestHeader, Results}
+import play.api.mvc.{AnyContent, Request, RequestHeader, Results}
 import play.api.test.Helpers._
 import renderers.DotcomRenderingService
 
@@ -53,13 +54,18 @@ import scala.concurrent.{ExecutionContext, Future}
     provider
   }
 
+  private def request(path: String, participations: String = "puzzles-new-hub:variant"): Request[AnyContent] = {
+    val rawRequest = TestRequest(path).withHeaders("X-GU-Server-AB-Tests" -> participations)
+    rawRequest.withAttrs(ABTests.decorateRequest("X-GU-Server-AB-Tests")(rawRequest).attrs)
+  }
+
   "renderPuzzles" should "load the layout and render the DCR puzzles page" in {
     val provider = successfulProvider
     val renderer = mock[DotcomRenderingService]
     when(renderer.getPuzzlesPage(any[WSClient], any[JsValue])(any[RequestHeader]))
       .thenReturn(Future.successful(Results.Ok("rendered by DCR")))
 
-    val result = controller(provider, renderer).renderPuzzles()(TestRequest("/puzzles"))
+    val result = controller(provider, renderer).renderPuzzles()(request("/puzzles"))
 
     status(result) should be(OK)
     contentAsString(result) should be("rendered by DCR")
@@ -69,7 +75,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
   it should "return not found for an unsupported format" in {
     val result = controller(successfulProvider, mock[DotcomRenderingService])
-      .renderPuzzles()(TestRequest("/puzzles.json"))
+      .renderPuzzles()(request("/puzzles.json"))
 
     status(result) should be(NOT_FOUND)
   }
@@ -79,7 +85,7 @@ import scala.concurrent.{ExecutionContext, Future}
     val provider = mock[PuzzlesLayoutProvider]
     when(provider.getLayout()(any[ExecutionContext])).thenReturn(Future.failed(failure))
 
-    val result = controller(provider, mock[DotcomRenderingService]).renderPuzzles()(TestRequest("/puzzles"))
+    val result = controller(provider, mock[DotcomRenderingService]).renderPuzzles()(request("/puzzles"))
 
     result.failed.futureValue should be(failure)
   }
@@ -90,14 +96,14 @@ import scala.concurrent.{ExecutionContext, Future}
     when(renderer.getPuzzlesPage(any[WSClient], any[JsValue])(any[RequestHeader]))
       .thenReturn(Future.failed(failure))
 
-    val result = controller(successfulProvider, renderer).renderPuzzles()(TestRequest("/puzzles"))
+    val result = controller(successfulProvider, renderer).renderPuzzles()(request("/puzzles"))
 
     result.failed.futureValue should be(failure)
   }
 
   "renderPuzzlesJson" should "return the equivalent rendering data as JSON" in {
     val result = controller(successfulProvider, mock[DotcomRenderingService])
-      .renderPuzzlesJson()(TestRequest("/puzzles.json"))
+      .renderPuzzlesJson()(request("/puzzles.json"))
 
     status(result) should be(OK)
     contentType(result) should contain("application/json")
@@ -109,15 +115,37 @@ import scala.concurrent.{ExecutionContext, Future}
 
   it should "return not found when the JSON action receives an HTML request" in {
     val result = controller(successfulProvider, mock[DotcomRenderingService])
-      .renderPuzzlesJson()(TestRequest("/puzzles"))
+      .renderPuzzlesJson()(request("/puzzles"))
 
     status(result) should be(NOT_FOUND)
   }
 
   it should "return not found for another unsupported format" in {
     val result = controller(successfulProvider, mock[DotcomRenderingService])
-      .renderPuzzlesJson()(TestRequest("/puzzles.atom"))
+      .renderPuzzlesJson()(request("/puzzles.atom"))
 
     status(result) should be(NOT_FOUND)
+  }
+
+  Seq(
+    "control" -> "puzzles-new-hub:control",
+    "absent" -> "",
+    "malformed" -> "puzzles-new-hub:,puzzles-new-hub:variant:extra",
+    "unknown group" -> "puzzles-new-hub:unknown",
+    "unrelated experiment" -> "another-test:variant",
+  ).foreach { case (participationCase, participations) =>
+    s"puzzles hub access with $participationCase participation" should
+      "return not found for HTML and JSON without loading the layout or calling DCR" in {
+        val provider = mock[PuzzlesLayoutProvider]
+        val renderer = mock[DotcomRenderingService]
+        val puzzlesController = controller(provider, renderer)
+
+        val htmlResult = puzzlesController.renderPuzzles()(request("/puzzles", participations))
+        val jsonResult = puzzlesController.renderPuzzlesJson()(request("/puzzles.json", participations))
+
+        status(htmlResult) should be(NOT_FOUND)
+        status(jsonResult) should be(NOT_FOUND)
+        verifyNoInteractions(provider, renderer)
+      }
   }
 }

--- a/common/app/ab/README.md
+++ b/common/app/ab/README.md
@@ -1,0 +1,25 @@
+# Server-side AB tests in Frontend
+
+Server-side AB tests are defined in `dotcom-rendering-main/ab-testing/config/abTests.ts` and deployed to Fastly. Fastly
+assigns each participating request to a group and sends the result to Frontend in the X-GU-Server-AB-Tests header.
+
+ABTestingFilter decorates the Play request with those participations. Feature-specific server code should expose a
+small helper built on ABTests.isUserInTestGroup, rather than defining a duplicate experiment or switch in Frontend.
+
+The enable-new-server-side-tests-header infrastructure switch must be enabled in each environment where these tests
+are expected to run.
+
+## Puzzles hub
+
+The puzzles hub uses the Fastly-managed puzzles-new-hub experiment. Frontend code should check
+PuzzlesHubExperiment.isEnabled, which is true only for the variant group and safely defaults to false for control,
+excluded, missing, or malformed participations.
+
+The existing Fastly routes can be used to force a group in CODE or PROD:
+
+-   /ab-tests/opt-in/puzzles-new-hub:variant
+-   /ab-tests/opt-in/puzzles-new-hub:control
+-   /ab-tests/opt-out
+
+The /puzzles and /puzzles.json routes, as well as puzzles navigation, are available only to variant requests.
+Development and QA can use the Fastly opt-in route above to force variant participation.

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -77,8 +77,8 @@ trait IndexControllerCommon
       case TagPattern(left, right) if left == right => successful(Cached(60)(redirect(left, request.isRss)))
       // This page does not exist on dotcom, and we don't want to make a CAPI request because that
       // will trigger a CAPI sections query.
-      case "sections" | "puzzles" => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
-      case _                      =>
+      case "sections" => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
+      case _          =>
         logGoogleBot(request)
         (index(Edition(request), path, inferPage(request), request.isRss) map {
           // if no content is returned (as often happens with old/expired/migrated microsites) return 404 rather than an empty page

--- a/common/app/model/DotcomPuzzlesPageRenderingDataModel.scala
+++ b/common/app/model/DotcomPuzzlesPageRenderingDataModel.scala
@@ -46,7 +46,7 @@ object DotcomPuzzlesPageRenderingDataModel {
       webTitle = page.metadata.webTitle,
       description = page.metadata.description,
       config = DotcomRenderingConfig(page, request, isPreview = false),
-      nav = Nav(page, edition, customSubnav = None),
+      nav = Nav(page, edition, request, customSubnav = None),
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(edition)),
       commercialProperties = commercialProperties,
       isAdFreeUser = views.support.Commercial.isAdFree(request),

--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -43,7 +43,7 @@ object DotcomFrontsRenderingDataModel {
       customSubnav: Option[CustomSubnav],
   ): DotcomFrontsRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition, customSubnav)
+    val nav = Nav(page, edition, request, customSubnav)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomNewslettersPageRenderingDataModel.scala
@@ -43,7 +43,7 @@ object DotcomNewslettersPageRenderingDataModel {
       request: RequestHeader,
   ): DotcomNewslettersPageRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition, customSubnav = None)
+    val nav = Nav(page, edition, request, customSubnav = None)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -657,7 +657,7 @@ object DotcomRenderingDataModel {
       matchHeaderUrl = matchData.flatMap(_.matchHeaderUrl),
       matchStatsUrl = matchData.flatMap(_.matchStatsUrl),
       matchType = matchData.map(_.matchType),
-      nav = Nav(page, edition, customSubnav = customSubnav),
+      nav = Nav(page, edition, request, customSubnav = customSubnav),
       openGraphData = page.getOpenGraphProperties,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),
       pageId = content.metadata.id,

--- a/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomTagPagesRenderingDataModel.scala
@@ -73,7 +73,7 @@ object DotcomTagPagesRenderingDataModel {
       pageType: PageType,
   ): DotcomTagPagesRenderingDataModel = {
     val edition = Edition.edition(request)
-    val nav = Nav(page, edition, customSubnav = None)
+    val nav = Nav(page, edition, request, customSubnav = None)
 
     val combinedConfig = DotcomRenderingConfig(
       page = page,

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -96,8 +96,8 @@ object Nav {
 
   implicit val writes: OWrites[Nav] = Json.writes[Nav]
 
-  def apply(page: Page, edition: Edition, customSubnav: Option[CustomSubnav]): Nav = {
-    val navMenu = NavMenu(page, edition)
+  def apply(page: Page, edition: Edition, request: RequestHeader, customSubnav: Option[CustomSubnav]): Nav = {
+    val navMenu = NavMenu(page, edition, request)
     Nav(
       currentUrl = navMenu.currentUrl,
       pillars = navMenu.pillars,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -242,7 +242,7 @@ object NavLinks {
       NavLink("Word games", "/puzzles#word-games"),
     ),
   )
-  val wordiply = NavLink(
+  val legacyWordiply = NavLink(
     "Wordiply",
     "https://www.wordiply.com",
   )
@@ -650,7 +650,7 @@ object NavLinks {
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
     legacyCrosswords,
-    wordiply,
+    legacyWordiply,
     corrections,
     tips,
   )
@@ -663,7 +663,7 @@ object NavLinks {
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Aus"),
     legacyCrosswords,
-    wordiply,
+    legacyWordiply,
     corrections,
     tips,
   )
@@ -675,7 +675,7 @@ object NavLinks {
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_US"),
     legacyCrosswords,
-    wordiply,
+    legacyWordiply,
     corrections,
     tips,
   )
@@ -689,7 +689,7 @@ object NavLinks {
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     legacyCrosswords,
-    wordiply,
+    legacyWordiply,
     corrections,
     tips,
   )
@@ -703,7 +703,7 @@ object NavLinks {
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     legacyCrosswords,
-    wordiply,
+    legacyWordiply,
     corrections,
     tips,
   )

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -216,7 +216,7 @@ object NavLinks {
   val insideTheGuardian = NavLink("Inside the Guardian", "https://www.theguardian.com/insidetheguardian")
   val weekly = NavLink("Guardian Weekly", "https://www.theguardian.com/weekly")
   val digitalNewspaperArchive = NavLink("Digital Archive", "https://theguardian.newspapers.com")
-  val crosswords = NavLink(
+  val legacyCrosswords = NavLink(
     "Crosswords",
     "/crosswords",
     children = List(
@@ -231,6 +231,15 @@ object NavLinks {
       NavLink("Genius", "/crosswords/series/genius"),
       NavLink("Weekend", "/crosswords/series/weekend-crossword"),
       NavLink("Special", "/crosswords/series/special"),
+    ),
+  )
+  var puzzles = NavLink(
+    "Puzzles and Games",
+    "/puzzles",
+    children = List(
+      NavLink("Crossword", "/puzzles#crossword"),
+      NavLink("Logic", "/puzzles#logic"),
+      NavLink("Word games", "/puzzles#word-games"),
     ),
   )
   val wordiply = NavLink(
@@ -640,7 +649,7 @@ object NavLinks {
     todaysPaper,
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
-    crosswords,
+    legacyCrosswords,
     wordiply,
     corrections,
     tips,
@@ -653,7 +662,7 @@ object NavLinks {
     newsletters,
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Aus"),
-    crosswords,
+    legacyCrosswords,
     wordiply,
     corrections,
     tips,
@@ -665,7 +674,7 @@ object NavLinks {
     pictures,
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_US"),
-    crosswords,
+    legacyCrosswords,
     wordiply,
     corrections,
     tips,
@@ -679,7 +688,7 @@ object NavLinks {
     todaysPaper,
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
-    crosswords,
+    legacyCrosswords,
     wordiply,
     corrections,
     tips,
@@ -693,7 +702,7 @@ object NavLinks {
     todaysPaper,
     insideTheGuardian,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
-    crosswords,
+    legacyCrosswords,
     wordiply,
     corrections,
     tips,

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -1,9 +1,11 @@
 package navigation
 
 import _root_.model.{NavItem, Page, Tags}
+import ab.PuzzlesHubExperiment
 import common.{Edition, editions}
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json.{Json, Writes, _}
+import play.api.mvc.RequestHandler
 
 import scala.annotation.tailrec
 
@@ -76,12 +78,17 @@ object NavMenu {
       brandExtensions: Seq[NavLink],
   )
 
-  def apply(page: Page, edition: Edition): NavMenu = {
-    val root = navRoot(edition)
+  def apply(page: Page, edition: Edition, request: RequestHandler): NavMenu = {
+    val useExperimentalPuzzlesNavigation = PuzzlesHubExperiment.isEnabled(request)
+    val root = navRoot(edition, useExperimentalPuzzlesNavigation)
     val currentUrl = getSectionOrPageUrl(page, edition)
-    val currentNavLink = findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks)
-    val currentParent = currentNavLink.flatMap(link => findParent(link, edition, root.children, root.otherLinks))
-    val currentPillar = getPillar(currentParent, edition, root.children, root.otherLinks)
+    val currentNavLink =
+      findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks, useExperimentalPuzzlesNavigation)
+    val currentParent = currentNavLink.flatMap(link =>
+      findParent(link, edition, root.children, root.otherLinks, useExperimentalPuzzlesNavigation),
+    )
+    val currentPillar =
+      getPillar(currentParent, edition, root.children, root.otherLinks, useExperimentalPuzzlesNavigation)
     val isWorldCupOverview = page.metadata.id == "football/world-cup-2026/overview"
 
     // On the world cup overview page, we want to show the special football header atom
@@ -112,11 +119,17 @@ object NavMenu {
    * want the Sports Pillar to be highlighted, even though cricket isn't in the
    * UsSportsPillar
    */
-  private[navigation] def getChildrenFromOtherEditions(edition: Edition): Seq[NavLink] = {
+  private[navigation] def getChildrenFromOtherEditions(
+      edition: Edition,
+      useExperimentalPuzzlesNavigation: Boolean = false,
+  ): Seq[NavLink] = {
     // This shouldn't be a problem as Europe won't have special NavLinks
     Edition
       .othersWithBetaEditions(edition)
-      .flatMap(edition => NavMenu.navRoot(edition).children ++ NavMenu.navRoot(edition).otherLinks)
+      .flatMap { edition =>
+        NavMenu.navRoot(edition, useExperimentalPuzzlesNavigation)
+        children ++ NavMenu.navRoot(edition).otherLinks
+      }
   }
 
   @tailrec
@@ -133,11 +146,12 @@ object NavMenu {
       edition: Edition,
       pillars: Seq[NavLink],
       otherLinks: Seq[NavLink],
+      useExperimentalPuzzlesNavigation: Boolean = false,
   ): Option[NavLink] = {
     def hasUrl(link: NavLink): Boolean = link.url == url
 
     find(pillars ++ otherLinks, hasUrl)
-      .orElse(find(getChildrenFromOtherEditions(edition), hasUrl))
+      .orElse(find(getChildrenFromOtherEditions(edition, useExperimentalPuzzlesNavigation), hasUrl))
   }
 
   def findParent(
@@ -145,6 +159,7 @@ object NavMenu {
       edition: Edition,
       pillars: Seq[NavLink],
       otherLinks: Seq[NavLink],
+      useExperimentalPuzzlesNavigation: Boolean = false,
   ): Option[NavLink] = {
 
     // When nav items can appear in two pillars, we want to ignore the least relevant one
@@ -161,7 +176,7 @@ object NavMenu {
     }
 
     find(pillars ++ otherLinks, isParent)
-      .orElse(find(getChildrenFromOtherEditions(edition), isParent))
+      .orElse(find(getChildrenFromOtherEditions(edition, useExperimentalPuzzlesNavigation), isParent))
   }
 
   def getPillar(
@@ -169,19 +184,30 @@ object NavMenu {
       edition: Edition,
       pillars: Seq[NavLink],
       otherLinks: Seq[NavLink],
+      useExperimentalPuzzlesNavigation: Boolean = false,
   ): Option[NavLink] = {
     currentParent.flatMap(parent =>
       if (otherLinks.contains(parent)) {
         None
       } else if (pillars.contains(parent)) {
         currentParent
-      } else findParent(parent, edition, pillars, otherLinks).orElse(Some(editions.Uk.navigationLinks.newsPillar)),
+      } else
+        findParent(parent, edition, pillars, otherLinks, useExperimentalPuzzlesNavigation).orElse(
+          Some(editions.Uk.navigationLinks.newsPillar),
+        ),
     )
   }
 
-  def navRoot(edition: Edition): NavRoot = {
+  def navRoot(edition: Edition, useExperimentalPuzzlesNavigation: Boolean = false): NavRoot = {
 
     val editionLinks: EditionNavLinks = edition.navigationLinks
+
+    val puzzlesLink = if (useExperimentalPuzzlesNavigation) NavLinks.puzzles else NavLinks.legacyCrosswords
+
+    val otherLinks = editionLinks.otherLinks.map {
+      case NavLinks.legacyCrosswords => puzzlesLink
+      case link                      => link
+    }
 
     NavRoot(
       Seq(
@@ -191,7 +217,7 @@ object NavMenu {
         editionLinks.culturePillar,
         editionLinks.lifestylePillar,
       ),
-      editionLinks.otherLinks,
+      otherLinks,
       editionLinks.brandExtensions,
     )
 

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -204,10 +204,12 @@ object NavMenu {
 
     val puzzlesLink = if (useExperimentalPuzzlesNavigation) NavLinks.puzzles else NavLinks.legacyCrosswords
 
-    val otherLinks = editionLinks.otherLinks.map {
-      case NavLinks.legacyCrosswords => puzzlesLink
-      case link                      => link
-    }
+    val otherLinks = editionLinks.otherLinks
+      .filterNot(link => useExperimentalPuzzlesNavigation && link == NavLinks.wordiply)
+      .map {
+        case NavLinks.legacyCrosswords => puzzlesLink
+        case link                      => link
+      }
 
     NavRoot(
       Seq(

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -78,7 +78,7 @@ object NavMenu {
       brandExtensions: Seq[NavLink],
   )
 
-  def apply(page: Page, edition: Edition, request: RequestHandler): NavMenu = {
+  def apply(page: Page, edition: Edition, request: RequestHeader): NavMenu = {
     val useExperimentalPuzzlesNavigation = PuzzlesHubExperiment.isEnabled(request)
     val root = navRoot(edition, useExperimentalPuzzlesNavigation)
     val currentUrl = getSectionOrPageUrl(page, edition)
@@ -127,8 +127,8 @@ object NavMenu {
     Edition
       .othersWithBetaEditions(edition)
       .flatMap { edition =>
-        NavMenu.navRoot(edition, useExperimentalPuzzlesNavigation)
-        children ++ NavMenu.navRoot(edition).otherLinks
+        val root = NavMenu.navRoot(edition, useExperimentalPuzzlesNavigation)
+        root.children ++ root.otherLinks
       }
   }
 

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -202,14 +202,11 @@ object NavMenu {
 
     val editionLinks: EditionNavLinks = edition.navigationLinks
 
-    val puzzlesLink = if (useExperimentalPuzzlesNavigation) NavLinks.puzzles else NavLinks.legacyCrosswords
-
-    val otherLinks = editionLinks.otherLinks
-      .filterNot(link => useExperimentalPuzzlesNavigation && link == NavLinks.wordiply)
-      .map {
-        case NavLinks.legacyCrosswords => puzzlesLink
-        case link                      => link
-      }
+    val otherLinks = editionLinks.otherLinks.flatMap {
+      case NavLinks.legacyCrosswords if useExperimentalPuzzlesNavigation =>
+        List(NavLinks.puzzles, NavLinks.legacyCrosswords)
+      case link => List(link)
+    }
 
     NavRoot(
       Seq(

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -5,7 +5,7 @@ import ab.PuzzlesHubExperiment
 import common.{Edition, editions}
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json.{Json, Writes, _}
-import play.api.mvc.RequestHandler
+import play.api.mvc.RequestHeader
 
 import scala.annotation.tailrec
 

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -11,7 +11,7 @@
     {
         "isDotcomRendering": false,
         "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage.get(item, Edition(request), context.isPreview, request)))),
-        "nav": @JavaScript(Json.stringify(Json.toJson(NavMenu(item, edition)))),
+        "nav": @JavaScript(Json.stringify(Json.toJson(NavMenu(item, edition, request)))),
         "switches" : { @{JavaScript(conf.switches.Switches.all.filter(_.exposeClientSide).map{ switch =>
             s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""}.mkString(","))}
         },

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -31,7 +31,7 @@
 
     <div class="l-footer__secondary js-footer__secondary @if(EmailInlineInFooterSwitch.isSwitchedOff) {l-footer__secondary--no-email} gs-container" role="contentinfo">
         <div class="footer__pillars u-cf">
-            @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+            @defining(NavMenu(page, Edition(request), request)) { navMenu: NavMenu =>
                 <ul class="pillars pillars--footer">
                     @navMenu.pillars.map { link =>
                         <li class="pillars__item">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -24,7 +24,7 @@
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
 
     <div class="footer__primary">
-            @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+            @defining(NavMenu(page, Edition(request), request)) { navMenu: NavMenu =>
                 @fragments.nav.subNav(navMenu, page.metadata.designType, isFooter = true)
             }
     </div>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -8,7 +8,7 @@
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, SupporterCTA}
 @import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch}
 
-@defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+@defining(NavMenu(page, Edition(request), request)) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
         "new-header--slim" -> page.metadata.hasSlimHeader
     ), s"pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "new-header")"

--- a/common/app/views/fragments/headerTopNav.scala.html
+++ b/common/app/views/fragments/headerTopNav.scala.html
@@ -23,7 +23,7 @@
 </li>
 }
 
-@defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+@defining(NavMenu(page, Edition(request), request)) { navMenu: NavMenu =>
 <header class="@RenderClasses(s" pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "header-top-nav"
     )" role="banner">
 

--- a/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
@@ -48,6 +48,10 @@ import staticpages.StaticPages
     (json \ "commercialProperties").toOption should not be empty
     (json \ "canonicalUrl").as[String] should endWith("/puzzles")
     (json \ "layout").as[PuzzlesLayout] should be(layout)
+    val puzzlesNav = (json \ "nav" \ "otherLinks").as[Seq[play.api.libs.json.JsObject]]
+    puzzlesNav
+      .find(link => (link \ "url").as[String] == "/puzzles")
+      .map(link => (link \ "title").as[String]) should contain("Puzzles and Games")
   }
 
   it should "propagate every current server-side AB-test participation" in {

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -257,6 +257,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
 
       menu.otherLinks should contain(puzzles)
       menu.otherLinks should not contain legacyCrosswords
+      menu.otherLinks should not contain wordiply
       menu.currentNavLink should contain(puzzles)
       menu.currentParent should contain(puzzles)
       menu.currentPillar shouldBe None
@@ -279,6 +280,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
 
         menu.otherLinks should contain(legacyCrosswords)
         menu.otherLinks should not contain puzzles
+        menu.otherLinks should contain(wordiply)
         menu.currentNavLink should contain(legacyCrosswords)
         menu.currentParent should contain(legacyCrosswords)
         menu.currentPillar shouldBe None
@@ -293,6 +295,11 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     val page = StaticPages.dcrSimplePuzzlesPage("/puzzles")
 
     Nav(page, Uk, variantRequest, None).otherLinks should contain(puzzles)
+    Nav(page, Uk, variantRequest, None).otherLinks should not contain wordiply
+    Nav(page, Uk, variantRequest, None).otherLinks should not contain legacyCrosswords
+
     Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyCrosswords)
+    Nav(page, Uk, controlRequest, None).otherLinks should contain(wordiply)
+    Nav(page, Uk, controlRequest, None).otherLinks should not contain puzzles
   }
 }

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -240,7 +240,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
   }
 
   private def requestWithParticipations(participations: String): RequestHeader = {
-    val request = FakeRequest().withHeader("X-GU-Server-AB-Tests" -> participations)
+    val request = FakeRequest().withHeaders("X-GU-Server-AB-Tests" -> participations)
     ABTests.decorateRequest("X-GU-Server-AB-Tests")(request)
   }
 
@@ -292,7 +292,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     val controlRequest = requestWithParticipations("puzzles-new-hub:control")
     val page = StaticPages.dcrSimplePuzzlesPage("/puzzles")
 
-    Nav(page, Uk, variantRequest).otherLinks should contain(puzzles)
-    Nav(page, Uk, controlRequest).otherLinks should contain(legacyCrosswords)
+    Nav(page, Uk, variantRequest, None).otherLinks should contain(puzzles)
+    Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyCrosswords)
   }
 }

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -1,13 +1,18 @@
 package navigation
 
+import ab.ABTests
+import common.Edition
 import common.editions._
 import NavLinks._
 import com.gu.contentapi.client.model.v1.ItemResponse
-import model.{Content, ContentPage, ContentType, MetaData, Page}
+import model.{Content, ContentPage, ContentType, MetaData, Page, SectionId}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import play.api.mvc.RequestHeader
+import play.api.test.FakeRequest
+import staticpages.StaticPages
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, WithTestWsClient}
 
 @DoNotDiscover class NavigationTest
@@ -29,6 +34,14 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
       id = "",
       section = None,
       webTitle = "",
+    )
+  }
+
+  private case class NavigationPage(sectionId: String) extends Page {
+    override val metadata = MetaData.make(
+      id = sectionId,
+      section = Some(SectionId(sectionId)),
+      webTitle = sectionId,
     )
   }
 
@@ -169,7 +182,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
 
     pillar should be(None)
 
-    subnav shouldBe Some(ParentSubnav(crosswords, crosswords.children))
+    subnav shouldBe Some(ParentSubnav(legacyCrosswords, legacyCrosswords.children))
   }
 
   "On cryptic crosswords the parent" should "be crosswords, and the pillar should be None" in {
@@ -183,7 +196,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
 
     pillar should be(None)
 
-    subnav shouldBe Some(ParentSubnav(crosswords, crosswords.children))
+    subnav shouldBe Some(ParentSubnav(legacyCrosswords, legacyCrosswords.children))
   }
 
   "On a food article, the pillar" should "be lifeStyle, and food should be highlighted" in {
@@ -196,7 +209,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     whenReady(response) { item: ItemResponse =>
       item.content.map { apiContent =>
         val page = TestPage(Content(apiContent))
-        val menu = NavMenu(page, edition)
+        val menu = NavMenu(page, edition, FakeRequest())
         val currentNavLink = menu.currentNavLink
         val pillar = menu.currentPillar
 
@@ -216,7 +229,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     whenReady(response) { item: ItemResponse =>
       item.content.map { apiContent =>
         val page = TestPage(Content(apiContent))
-        val menu = NavMenu(page, edition)
+        val menu = NavMenu(page, edition, FakeRequest())
         val currentNavLink = menu.currentNavLink
         val pillar = menu.currentPillar
 
@@ -224,5 +237,62 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
         pillar.map(_ should be(auNewsPillar))
       }
     }
+  }
+
+  private def requestWithParticipations(participations: String): RequestHeader = {
+    val request = FakeRequest().withHeader("X-GU-Server-AB-Tests" -> participations)
+    ABTests.decorateRequest("X-GU-Server-AB-Tests")(request)
+  }
+
+  "Puzzles navigation" should "use the experimental information architecture in every edition for variant requests" in {
+    val request = requestWithParticipations("puzzles-new-hub:variant")
+    puzzles.children shouldBe Seq(
+      NavLink("Crossword", "/puzzles#crossword"),
+      NavLink("Logic", "/puzzles#logic"),
+      NavLink("Word games", "/puzzles#word-games"),
+    )
+
+    Edition.allEditions.foreach { edition =>
+      val menu = NavMenu(StaticPages.dcrSimplePuzzlesPage("/puzzles"), edition, request)
+
+      menu.otherLinks should contain(puzzles)
+      menu.otherLinks should not contain legacyCrosswords
+      menu.currentNavLink should contain(puzzles)
+      menu.currentParent should contain(puzzles)
+      menu.currentPillar shouldBe None
+      menu.subNavSections should contain(ParentSubnav(puzzles, puzzles.children))
+    }
+  }
+
+  it should "keep the production crosswords navigation in every edition for non-variant requests" in {
+    Seq(
+      "puzzles-new-hub:control",
+      "",
+      "puzzles-new-hub:unknown",
+      "puzzles-new-hub:,puzzles-new-hub:variant:extra",
+      "another-test:variant",
+    ).foreach { participations =>
+      val request = requestWithParticipations(participations)
+
+      Edition.allEditions.foreach { edition =>
+        val menu = NavMenu(NavigationPage("crosswords"), edition, request)
+
+        menu.otherLinks should contain(legacyCrosswords)
+        menu.otherLinks should not contain puzzles
+        menu.currentNavLink should contain(legacyCrosswords)
+        menu.currentParent should contain(legacyCrosswords)
+        menu.currentPillar shouldBe None
+        menu.subNavSections should contain(ParentSubnav(legacyCrosswords, legacyCrosswords.children))
+      }
+    }
+  }
+
+  "DCR Nav" should "contain the request-selected puzzles navigation" in {
+    val variantRequest = requestWithParticipations("puzzles-new-hub:variant")
+    val controlRequest = requestWithParticipations("puzzles-new-hub:control")
+    val page = StaticPages.dcrSimplePuzzlesPage("/puzzles")
+
+    Nav(page, Uk, variantRequest).otherLinks should contain(puzzles)
+    Nav(page, Uk, controlRequest).otherLinks should contain(legacyCrosswords)
   }
 }

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -244,7 +244,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     ABTests.decorateRequest("X-GU-Server-AB-Tests")(request)
   }
 
-  "Puzzles navigation" should "use the experimental information architecture in every edition for variant requests" in {
+  "Puzzles navigation" should "add Puzzles and Games alongside the legacy links in every edition for variant requests" in {
     val request = requestWithParticipations("puzzles-new-hub:variant")
     puzzles.children shouldBe Seq(
       NavLink("Crossword", "/puzzles#crossword"),
@@ -256,8 +256,8 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
       val menu = NavMenu(StaticPages.dcrSimplePuzzlesPage("/puzzles"), edition, request)
 
       menu.otherLinks should contain(puzzles)
-      menu.otherLinks should not contain legacyCrosswords
-      menu.otherLinks should not contain wordiply
+      menu.otherLinks should contain(legacyCrosswords)
+      menu.otherLinks should contain(legacyWordiply)
       menu.currentNavLink should contain(puzzles)
       menu.currentParent should contain(puzzles)
       menu.currentPillar shouldBe None
@@ -265,7 +265,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     }
   }
 
-  it should "keep the production crosswords navigation in every edition for non-variant requests" in {
+  it should "keep the legacy Crosswords and Wordiply navigation in every edition for non-variant requests" in {
     Seq(
       "puzzles-new-hub:control",
       "",
@@ -280,7 +280,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
 
         menu.otherLinks should contain(legacyCrosswords)
         menu.otherLinks should not contain puzzles
-        menu.otherLinks should contain(wordiply)
+        menu.otherLinks should contain(legacyWordiply)
         menu.currentNavLink should contain(legacyCrosswords)
         menu.currentParent should contain(legacyCrosswords)
         menu.currentPillar shouldBe None
@@ -295,11 +295,11 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     val page = StaticPages.dcrSimplePuzzlesPage("/puzzles")
 
     Nav(page, Uk, variantRequest, None).otherLinks should contain(puzzles)
-    Nav(page, Uk, variantRequest, None).otherLinks should not contain wordiply
-    Nav(page, Uk, variantRequest, None).otherLinks should not contain legacyCrosswords
+    Nav(page, Uk, variantRequest, None).otherLinks should contain(legacyCrosswords)
+    Nav(page, Uk, variantRequest, None).otherLinks should contain(legacyWordiply)
 
-    Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyCrosswords)
-    Nav(page, Uk, controlRequest, None).otherLinks should contain(wordiply)
     Nav(page, Uk, controlRequest, None).otherLinks should not contain puzzles
+    Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyCrosswords)
+    Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyWordiply)
   }
 }

--- a/sport/app/football/model/DotcomRenderingFootballDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingFootballDataModel.scala
@@ -144,7 +144,7 @@ object DotcomRenderingFootballMatchListDataModel {
       context: ApplicationContext,
   ): DotcomRenderingFootballMatchListDataModel = {
     val edition = Edition(request)
-    val nav = Nav(page, edition, customSubnav = None)
+    val nav = Nav(page, edition, request, customSubnav = None)
     val combinedConfig = DotcomRenderingConfig(
       page = page,
       request = request,
@@ -308,7 +308,7 @@ object DotcomRenderingFootballTablesDataModel {
       context: ApplicationContext,
   ): DotcomRenderingFootballTablesDataModel = {
     val edition = Edition(request)
-    val nav = Nav(page, edition, customSubnav = None)
+    val nav = Nav(page, edition, request, customSubnav = None)
     val combinedConfig = DotcomRenderingConfig(
       page = page,
       request = request,
@@ -410,7 +410,7 @@ object DotcomRenderingFootballMatchSummaryDataModel extends DCARUrlHelper {
       context: ApplicationContext,
   ): DotcomRenderingFootballMatchSummaryDataModel = {
     val edition = Edition(request)
-    val nav = Nav(page, edition, customSubnav = None)
+    val nav = Nav(page, edition, request, customSubnav = None)
     val combinedConfig = DotcomRenderingConfig(
       page = page,
       request = request,

--- a/sport/app/football/model/DotcomRenderingWallchartDataModel.scala
+++ b/sport/app/football/model/DotcomRenderingWallchartDataModel.scala
@@ -40,7 +40,7 @@ object DotcomRenderingWallchartDataModel {
       context: ApplicationContext,
   ): DotcomRenderingWallchartDataModel = {
     val edition = Edition(request)
-    val nav = Nav(page, edition, customSubnav = None)
+    val nav = Nav(page, edition, request, customSubnav = None)
     val combinedConfig: JsObject = DotcomRenderingConfig(
       page = page,
       request = request,


### PR DESCRIPTION
## What is the value of this and can you measure success?

This safely introduces the new “Puzzles and Games” navigation entry only to requests participating in puzzles-new-hub:variant, while preserving the existing navigation for all other users.

Success can be measured by confirming that:

- Variant requests see “Puzzles and Games” alongside the existing “Crosswords” and “Wordiply” entries.
- Control and non-participating requests continue to see only “Crosswords” and “Wordiply”.
- Only variant requests can access the new puzzles hub endpoints.
- Existing Crosswords and Wordiply navigation remains functional.
- Server-rendered and DCR navigation remain consistent.

Once the experiment is complete, the experiment selection and the legacy Crosswords and Wordiply entries can be removed, leaving “Puzzles and Games” as the permanent navigation entry.

## What does this change?

- Adds a permanent `Puzzles and Games` navigation definition.
- Clearly identifies the existing `Crosswords` and `Wordiply` definitions as legacy navigation.
- Adds `Puzzles and Games` alongside `Crosswords` and `Wordiply` for `puzzles-new-hub:variant` requests.
- Leaves control, absent, malformed, unknown-group, and unrelated experiment requests with the existing `Crosswords` and `Wordiply` navigation unchanged.
- Applies the request-aware navigation consistently across UK, US, Australia, Europe, and International editions.
- Applies the same navigation selection to server-rendered navigation and navigation included in DCR payloads.
- Gates `/puzzles` and `/puzzles.json` through the shared experiment helper.
- Returns `404` for non-variant requests without loading the puzzles layout, querying CAPI, or calling DCR.
- Keeps the explicit puzzles routes before the generic index routes.
- Leaves existing `/crosswords` routes unchanged.
- Adds tests for navigation selection and HTML/JSON route access.

## Screenshots

Before and after with control load https://m.code.dev-theguardian.com / https://m.code.dev-theguardian.com/ab-tests/opt-in/puzzles-new-hub:control
<img width="1720" height="991" alt="Screenshot 2026-09-01 at 15 53 57" src="https://github.com/user-attachments/assets/c4ad6a58-1579-4707-b779-0af6b775d45c" />

After with variant https://m.code.dev-theguardian.com/ab-tests/opt-in/puzzles-new-hub:variant)
<img width="1722" height="983" alt="Screenshot 2026-09-01 at 15 54 19" src="https://github.com/user-attachments/assets/90b6dc00-6913-4883-8155-e00d8e4056ec" />

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR — no new database files were generated
- [x] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md) — uses the existing navigation components and link structure
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour) — no colour or styling changes in this PR