### PR TITLE
catch recaptcha non json response for newsletter signups and log error

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -557,7 +557,15 @@ class EmailSignupController(
           RecaptchaAPIUnavailableError.increment()
           Future.failed(CaptchaVerificationUnavailableException(e))
         }
-        googleResponse = wsResponse.json.as[GoogleResponse]
+        googleResponse <- scala.util.Try(wsResponse.json.as[GoogleResponse]) match {
+          case scala.util.Success(r) => Future.successful(r)
+          case scala.util.Failure(e) =>
+            logErrorWithRequestId(
+              s"reCAPTCHA API returned non-JSON response (HTTP ${wsResponse.status}): ${e.getMessage}",
+            )
+            RecaptchaAPIUnavailableError.increment()
+            Future.failed(CaptchaVerificationUnavailableException(e))
+        }
         _ <- {
           if (googleResponse.success) {
             RecaptchaValidationSuccess.increment()


### PR DESCRIPTION
## What is the value of this and can you measure success?
Newsletter signups have been failing at a rate of around 30% with no corresponding error logs. It seems as though the google recaptcha verification API is intermittently returning an HTML response instead of json. Hopefully we can find out a bit more information with this pr.

## What does this change?

### existing behaviour:
In validateCaptcha:
```
googleResponse = wsResponse.json.as[GoogleResponse]
```
is a plain assignment (`=`) inside a for 'loop'. When the response body is HTML, wsResponse.json throws a JsonParseException. This is a synchronous throw inside a flatMap, it becomes Future.failed(JsonParseException) which is not matched by our code, play's default handler catches it and returns a 500, with no `Email-Signup-Error-Code` header, no log line, and no metric increment.

### new stuff:
We've wrapped the json parse in a `try` and handle the parse error explicitly, calling `logErrorWithRequestId` with the error message and bumping the `RecaptchaAPIUnavailableError` metric. In this case it now returns a 503 error instead of silently failing with a 500.

This won't fix anything, but hopefully it will give us a better idea of whats going on and why.
