### PR TITLE
register pre-existing recaptcha metrics from metrics.scala in AppLoader.scala

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -83,6 +83,10 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
     EmailSubsciptionMetrics.APINetworkError,
     EmailSubsciptionMetrics.ListIDError,
     EmailSubsciptionMetrics.AllEmailSubmission,
+    EmailSubsciptionMetrics.RecaptchaMissingTokenError,
+    EmailSubsciptionMetrics.RecaptchaValidationError,
+    EmailSubsciptionMetrics.RecaptchaAPIUnavailableError,
+    EmailSubsciptionMetrics.RecaptchaValidationSuccess,
     DCRMetrics.DCRLatencyMetric,
     DCRMetrics.DCRRequestCountMetric,
   )


### PR DESCRIPTION
## What is the value of this and can you measure success?

To get some visibility of whats going on with recaptcha

## What does this change?

4 reCAPTCHA metrics were defined in `EmailSubsciptionMetrics` and incremented in `EmailSignupController` but never registered in `appMetrics` for CloudWatch publishing. This meant that we had no visibility of the recaptcha metrics in production.

The 4 metrics that will now be published to cloudwatch are:

- email-recaptcha-validation-success
- email-recaptcha-missing-token-failure
- email-recaptcha-validation-failure
- email-recaptcha-api-unavailable-failure

Hopefully this will help with an ongoing investigation into failure rates of in article newsletter signups.
