### PR TITLE
Adding Skimlinks function to captions.

### DIFF
--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -69,7 +69,7 @@ object DotcomBlocksRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
   ): DotcomBlocksRenderingDataModel = {
     val content = page.item
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, bodyBlocks)
     val contentDateTimes = DotcomRenderingUtils.contentDateTimes(content)
 
     val edition = Edition(request)

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -478,7 +478,8 @@ object DotcomRenderingDataModel {
       twitterHandle = content.tags.contributors.headOption.flatMap(_.properties.twitterHandle),
     )
 
-    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content, bodyBlocks)
+    val shouldAddAffiliateLinks =
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content, bodyBlocks ++ mainBlock.toSeq ++ pinnedPost.toSeq)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(
       webPublicationDate = content.trail.webPublicationDate,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -301,8 +301,14 @@ object DotcomRenderingUtils extends DCARUrlHelper {
   private def hasAffiliateLinksInContent(content: ContentType, blocks: Seq[APIBlock]): Boolean = {
     content match {
       case gallery: Gallery => gallery.lightbox.containsAffiliateableLinks
-      case _                => blocks.exists(block => stringContainsAffiliateableLinks(block.bodyHtml))
+      case _                => blocks.exists(blockContainsAffiliateableLinks)
     }
+  }
+
+  // Editors put affiliate links in image captions as well as body copy, so check both.
+  private def blockContainsAffiliateableLinks(block: APIBlock): Boolean = {
+    stringContainsAffiliateableLinks(block.bodyHtml) ||
+    block.elements.exists(_.imageTypeData.flatMap(_.caption).exists(stringContainsAffiliateableLinks))
   }
 
   def contentDateTimes(content: ContentType): ArticleDateTimes = {

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -2320,7 +2320,7 @@ object PageElement extends GuLogging {
           if (isGallery) {
             d.caption.map(TextCleaner.cleanGalleryCaption(_, pageUrl, addAffiliateLinks, isUSProductionOffice, abTests))
           } else {
-            d.caption
+            d.caption.map(TextCleaner.affiliateLinks(pageUrl, addAffiliateLinks, isUSProductionOffice, abTests))
           }
         },
         "credit" -> d.credit,

--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -29,24 +29,28 @@ object TextCleaner {
       html: String,
   ): String = {
     if (addAffiliateLinks) {
-      val doc = Jsoup.parseBodyFragment(html)
-      val links = AffiliateLinksCleaner.getAffiliateableLinks(doc)
       val skimlinksId =
         if (isUSProductionOffice) affiliateLinksConfig.skimlinksUSId else affiliateLinksConfig.skimlinksDefaultId
-      links.foreach(el => {
-        el.attr(
-          "href",
-          AffiliateLinksCleaner.linkToSkimLink(el.attr("href"), pageUrl, skimlinksId, abTests),
-        ).attr("rel", "sponsored")
-      })
-
-      if (links.nonEmpty) {
-        doc.body().html()
-      } else {
-        html
-      }
+      rewriteAffiliateLinks(html, pageUrl, skimlinksId, abTests)
     } else {
       html
+    }
+  }
+
+  /** Rewrites affiliateable links in an HTML fragment (body copy or an image caption) to skimlinks. Pure: no config
+    * access. Returns `html` unchanged when it contains no affiliateable links.
+    */
+  def rewriteAffiliateLinks(
+      html: String,
+      pageUrl: String,
+      skimlinksId: String,
+      abTests: Map[String, String],
+  ): String = {
+    val doc = Jsoup.parseBodyFragment(html)
+    if (AffiliateLinksCleaner.getAffiliateableLinks(doc).isEmpty) {
+      html
+    } else {
+      AffiliateLinksCleaner.replaceLinksInHtml(doc, pageUrl, skimlinksId, abTests).body().html()
     }
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -898,7 +898,8 @@ object AffiliateLinksCleaner {
   ): Document = {
     val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(html)
     linksToReplace.foreach { el =>
-      el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId, abTests)).attr("rel", "sponsored")
+      el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId, abTests))
+        .attr("rel", "sponsored noreferrer noopener")
     }
     html
   }

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -3,9 +3,12 @@ package model.dotcomrendering.pageElements
 import com.gu.contentapi.client.model.v1.{
   Block,
   BlockAttributes,
+  BlockElement,
   Blocks,
   CapiDateTime,
   ContentFields,
+  ElementType,
+  ImageElementFields,
   Content => ApiContent,
 }
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
@@ -343,6 +346,81 @@ class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSug
       )
 
       DotcomRenderingUtils.shouldAddAffiliateLinks(content, blocks) should be(true)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+      SkimLinksCache.setDomains(Set.empty)
+    }
+  }
+
+  private def blockWith(id: String, bodyHtml: String, elements: Seq[BlockElement] = Seq.empty): Block =
+    Block(
+      id = id,
+      bodyHtml = bodyHtml,
+      bodyTextSummary = "",
+      title = None,
+      attributes = BlockAttributes(),
+      published = true,
+      createdDate = None,
+      firstPublishedDate = None,
+      publishedDate = None,
+      lastModifiedDate = None,
+      createdBy = None,
+      lastModifiedBy = None,
+      elements = elements,
+    )
+
+  private def imageElement(caption: String): BlockElement =
+    BlockElement(`type` = ElementType.Image, imageTypeData = Some(ImageElementFields(caption = Some(caption))))
+
+  it should "detect skimlinks in image captions when the block body has none" in {
+    Switches.AffiliateLinks.switchOn()
+    SkimLinksCache.setDomains(Set("amazon.co.uk"))
+    try {
+      val content = articleWithBody(sampleArticleBody)
+      val blocks = Seq(
+        blockWith(
+          "1",
+          "<p>No links here.</p>",
+          Seq(imageElement("""Photo of <a href="https://www.amazon.co.uk/product/123">the thing</a>""")),
+        ),
+      )
+
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content, blocks) should be(true)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+      SkimLinksCache.setDomains(Set.empty)
+    }
+  }
+
+  it should "return false when image captions only link to non-skimlink domains" in {
+    Switches.AffiliateLinks.switchOn()
+    SkimLinksCache.setDomains(Set("amazon.co.uk"))
+    try {
+      val content = articleWithBody(sampleArticleBody)
+      val blocks = Seq(
+        blockWith(
+          "1",
+          "<p>No links here.</p>",
+          Seq(imageElement("""Photo of <a href="https://www.theguardian.com/help">something</a>""")),
+        ),
+      )
+
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content, blocks) should be(false)
+    } finally {
+      Switches.AffiliateLinks.switchOff()
+      SkimLinksCache.setDomains(Set.empty)
+    }
+  }
+
+  it should "detect skimlinks in a main media caption with no body blocks" in {
+    Switches.AffiliateLinks.switchOn()
+    SkimLinksCache.setDomains(Set("amazon.co.uk"))
+    try {
+      val content = articleWithBody(sampleArticleBody)
+      val mainBlock =
+        blockWith("main", "", Seq(imageElement("""<a href="https://amazon.co.uk/item">Buy this</a>""")))
+
+      DotcomRenderingUtils.shouldAddAffiliateLinks(content, Seq(mainBlock)) should be(true)
     } finally {
       Switches.AffiliateLinks.switchOff()
       SkimLinksCache.setDomains(Set.empty)

--- a/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
@@ -2,7 +2,9 @@ package model.dotcomrendering.pageElements
 
 import com.gu.contentapi.client.model.v1.EmbedTracksType.{DoesNotTrack, EnumUnknownEmbedTracksType, Tracks, Unknown}
 import com.gu.contentapi.client.model.v1._
+import common.editions.Uk
 import model.dotcomrendering.pageElements.PageElement.containsThirdPartyTracking
+import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
@@ -81,5 +83,35 @@ class PageElementTest extends AnyFlatSpec with Matchers {
       }
     """)
     json.validate[RecipeBlockElement].isError should be(true)
+  }
+
+  "PageElement.make" should "pass a non-gallery image caption through unchanged when affiliate links are off" in {
+    val caption = """Photo of <a href="https://www.amazon.co.uk/product/123">the thing</a>"""
+    val element = BlockElement(
+      `type` = ElementType.Image,
+      imageTypeData = Some(ImageElementFields(caption = Some(caption), alt = Some("The thing"))),
+    )
+
+    val got = PageElement.make(
+      element = element,
+      addAffiliateLinks = false,
+      pageUrl = "/money/2025/nov/19/test-article",
+      atoms = Nil,
+      isMainBlock = false,
+      isImmersive = false,
+      campaigns = None,
+      calloutsUrl = None,
+      overrideImage = None,
+      edition = Uk,
+      webPublicationDate = new DateTime(),
+      isGallery = false,
+      isUSProductionOffice = false,
+      abTests = Map.empty,
+    )
+
+    got match {
+      case List(image: ImageBlockElement) => image.data("caption") should equal(caption)
+      case other                          => fail(s"expected a single ImageBlockElement but got $other")
+    }
   }
 }

--- a/common/test/model/dotcomrendering/pageElements/TextCleanerTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/TextCleanerTest.scala
@@ -8,6 +8,8 @@ import conf.Configuration
 import model.dotcomrendering.pageElements.{TagLinker, TextBlockElement, TextCleaner}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import services.SkimLinksCache
+import views.support.AffiliateLinksCleaner
 
 class TextCleanerTest extends AnyFlatSpec with Matchers {
 
@@ -208,5 +210,47 @@ class TextCleanerTest extends AnyFlatSpec with Matchers {
     val got = TextCleaner.sanitiseLinks(Uk)(original)
 
     got shouldBe original
+  }
+
+  "rewriteAffiliateLinks" should "rewrite affiliateable links in an image caption to skimlinks" in {
+    SkimLinksCache.setDomains(Set("amazon.co.uk"))
+    try {
+      val pageUrl = "/money/2025/nov/19/test-article"
+      val productUrl = "https://www.amazon.co.uk/product/123"
+      val caption = s"""Photo of <a href="$productUrl">the thing</a>. Photograph: Someone"""
+
+      val got = TextCleaner.rewriteAffiliateLinks(caption, pageUrl, "123", Map.empty)
+
+      // Jsoup serialises '&' in attribute values as '&amp;'
+      val expectedHref =
+        AffiliateLinksCleaner.linkToSkimLink(productUrl, pageUrl, "123", Map.empty).replace("&", "&amp;")
+      got should include("https://go.skimresources.com/")
+      got should include(s"""href="$expectedHref"""")
+      got should include("""rel="sponsored"""")
+      got should include("Photograph: Someone")
+    } finally {
+      SkimLinksCache.setDomains(Set.empty)
+    }
+  }
+
+  it should "return the caption unchanged when it has no affiliateable links" in {
+    SkimLinksCache.setDomains(Set("amazon.co.uk"))
+    try {
+      val caption = """Photo of <a href="https://www.theguardian.com/help">something</a>. Photograph: Someone"""
+
+      val got = TextCleaner.rewriteAffiliateLinks(caption, "/money/2025/nov/19/test-article", "123", Map.empty)
+
+      got should be theSameInstanceAs caption
+    } finally {
+      SkimLinksCache.setDomains(Set.empty)
+    }
+  }
+
+  "affiliateLinks" should "return the html unchanged when affiliate links are not to be added" in {
+    val caption = """Photo of <a href="https://www.amazon.co.uk/product/123">the thing</a>"""
+
+    val got = TextCleaner.affiliateLinks("/money/2025/nov/19/test-article", false, false, Map.empty)(caption)
+
+    got should be theSameInstanceAs caption
   }
 }

--- a/common/test/model/dotcomrendering/pageElements/TextCleanerTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/TextCleanerTest.scala
@@ -226,7 +226,7 @@ class TextCleanerTest extends AnyFlatSpec with Matchers {
         AffiliateLinksCleaner.linkToSkimLink(productUrl, pageUrl, "123", Map.empty).replace("&", "&amp;")
       got should include("https://go.skimresources.com/")
       got should include(s"""href="$expectedHref"""")
-      got should include("""rel="sponsored"""")
+      got should include("""rel="sponsored noreferrer noopener"""")
       got should include("Photograph: Someone")
     } finally {
       SkimLinksCache.setDomains(Set.empty)


### PR DESCRIPTION
## What does this change?
As well as adding skimmable links to the body copy, editors also sometimes add them to the captions in images. This runs the skimlinks function over the image caption as well. Built with AI.

## Screenshots
### Before
<img width="1224" height="399" alt="Screenshot 2026-09-03 at 10 22 16" src="https://github.com/user-attachments/assets/2fd2ed25-555b-4d29-a8a4-97caf76da4ba" />

### After
<img width="1224" height="399" alt="Screenshot 2026-09-03 at 10 46 08" src="https://github.com/user-attachments/assets/10b5212f-a926-4005-ae11-badfeb476043" />


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218099703103654