### PR TITLE
Add customData to live harness service

### DIFF
--- a/preview/app/utils/LiveHarness.scala
+++ b/preview/app/utils/LiveHarness.scala
@@ -15,6 +15,7 @@ case class LiveHarnessInteractiveAtom(
     js: String,
     weighting: String,
     position: Option[Int] = None, // 1-based visual index; defaults to 1 (before everything)
+    customData: Option[String] = None,
 ) {
   val atom = InteractiveAtom(
     id = id,
@@ -36,6 +37,7 @@ case class LiveHarnessInteractiveAtom(
         atomType = "interactive",
         role = Some(weighting),
         isMandatory = None,
+        customData = customData,
       ),
     ),
   )


### PR DESCRIPTION
A companion to the parameterised interactives work that's been going on lately (https://github.com/guardian/frontend/pull/29138), this updates the live harness service to accept `customData` to make local development easier.