### PR TITLE
removed big match special

### DIFF
--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -210,27 +210,6 @@ class FrontsController(
       } yield Cached(60)(RevalidatableResult.Ok(views.html.football.fronts.matchesList(liveMatches, fixtures, results)))
     }
 
-  def bigMatchSpecial(matchId: String): Action[AnyContent] =
-    Action.async { implicit request =>
-      for {
-        matchInfo <- client.matchInfo(matchId)
-        trailText = {
-          matchInfo.competition.fold("")(c => s"${c.name}, ") + matchInfo.venue.fold("")(c =>
-            s"${c.name}, ",
-          ) + matchInfo.date.format(DateTimeFormatter.ofPattern("HH:mm"))
-        }
-        snapFields = SnapFields(
-          SNAP_TYPE,
-          SNAP_CSS,
-          s"$host/football/api/big-match-special/$matchId.json",
-          s"${Configuration.site.host}/football/match-redirect/$matchId",
-          s"${matchInfo.homeTeam.name} v ${matchInfo.awayTeam.name}",
-          trailText,
-        )
-        previewContent <- previewFrontsComponent(snapFields)
-      } yield previewContent
-    }
-
   private def getCompetition(competitionId: String): FutureOpt[Season] = {
     FutureOpt {
       for {

--- a/admin/app/views/football/fronts/index.scala.html
+++ b/admin/app/views/football/fronts/index.scala.html
@@ -69,23 +69,4 @@
         <div class="col-sm-6">
         </div>
     </div>
-
-    @* Disabling for now as broken - only provides countries in drop-down regardless of competition selected *@
-    <!--<div class="row">-->
-        <!--<div class="col-sm-12">-->
-            <!--<h2>Big match special</h2>-->
-        <!--</div>-->
-    <!--</div>-->
-    <!--<div class="row">-->
-        <!--<div class="col-sm-6">-->
-            <!--<form class="form-inline" role="form" action="/admin/football/fronts/matches/redirect" method="post">-->
-                <!--@views.html.football.fragments.chooseLeague("competition", competitions)-->
-                <!--@views.html.football.fragments.chooseTeam("team1", teams)-->
-                <!--@views.html.football.fragments.chooseTeam("team2", teams)-->
-                <!--<button type="submit" class="btn btn-success">Find matches</button>-->
-            <!--</form>-->
-        <!--</div>-->
-        <!--<div class="col-sm-6">-->
-        <!--</div>-->
-    <!--</div>-->
 }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -124,6 +124,5 @@ POST        /admin/football/fronts/matches/redirect                             
 GET         /admin/football/fronts/matches/:competitionId                                           controllers.admin.FrontsController.chooseMatchForComp(competitionId)
 GET         /admin/football/fronts/matches/:competitionId/:teamId                                   controllers.admin.FrontsController.chooseMatchForCompAndTeam(competitionId, teamId)
 GET         /admin/football/fronts/matches/:competitionId/:team1Id/:team2Id                         controllers.admin.FrontsController.chooseMatchForCompAndTeams(competitionId, team1Id, team2Id)
-GET         /admin/football/fronts/match/:matchId                                                   controllers.admin.FrontsController.bigMatchSpecial(matchId)
 
 GET         /admin/football/api/squad/:teamId                                                       controllers.admin.PlayerController.squad(teamId: String)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -144,8 +144,6 @@ GET            /football/:competitionTag/overview                               
 GET            /football/:competitionTag/groups/embed                                                                            football.controllers.WallchartController.renderGroupTablesEmbed(competitionTag)
 GET            /football/:competitionTag/spider/embed                                                                            football.controllers.WallchartController.renderSpiderEmbed(competitionTag)
 
-GET            /football/api/big-match-special/:matchId.json                                                                     football.controllers.MoreOnMatchController.bigMatchSpecial(matchId)
-
 GET            /football/competitions                                                                                            football.controllers.CompetitionListController.renderCompetitionList()
 GET            /football/competitions.json                                                                                       football.controllers.CompetitionListController.renderCompetitionListJson()
 GET            /football/teams                                                                                                   football.controllers.LeagueTableController.renderTeamlist()
@@ -212,7 +210,6 @@ POST           /admin/football/fronts/matches/redirect                          
 GET            /admin/football/fronts/matches/:competitionId                                                                     controllers.admin.FrontsController.chooseMatchForComp(competitionId)
 GET            /admin/football/fronts/matches/:competitionId/:teamId                                                             controllers.admin.FrontsController.chooseMatchForCompAndTeam(competitionId, teamId)
 GET            /admin/football/fronts/matches/:competitionId/:team1Id/:team2Id                                                   controllers.admin.FrontsController.chooseMatchForCompAndTeams(competitionId, team1Id, team2Id)
-GET            /admin/football/fronts/match/:matchId                                                                             controllers.admin.FrontsController.bigMatchSpecial(matchId)
 
 GET            /admin/football/api/squad/:teamId                                                                                 controllers.admin.PlayerController.squad(teamId: String)
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -249,9 +249,6 @@ POST        /commercial/adops/ads-txt                                           
 GET         /commercial/adops/app-ads-txt                                                                                        controllers.admin.commercial.AdsDotTextEditController.renderAppAdsDotText()
 POST        /commercial/adops/app-ads-txt                                                                                        controllers.admin.commercial.AdsDotTextEditController.postAppAdsDotText()
 
-# AMP
-GET            /football-mf2/api/match-summary/:year/:month/:day/:home/:away.json                                                football.controllers.MoreOnMatchController.matchSummaryMf2(year, month, day, home, away)
-
 # Onward journeys
 GET            /series/*path.json                                                                                                controllers.SeriesController.renderSeriesStories(path)
 

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -96,8 +96,6 @@ GET        /football/api/match-header/:year/:month/:day/:home/:away.json      fo
 GET        /football/api/match-stats/:year/:month/:day/:home/:away.json       football.controllers.MoreOnMatchController.matchStatsJson(year, month, day, home, away)
 GET        /football/api/match-stats-summary/:year/:month/:day/:home/:away.json      football.controllers.MoreOnMatchController.matchStatsSummaryJson(year, month, day, home, away)
 
-GET        /football/api/big-match-special/:matchId.json                     football.controllers.MoreOnMatchController.bigMatchSpecial(matchId)
-
 GET        /football/competitions                                            football.controllers.CompetitionListController.renderCompetitionList()
 GET        /football/competitions.json                                       football.controllers.CompetitionListController.renderCompetitionListJson()
 GET        /football/teams                                                   football.controllers.LeagueTableController.renderTeamlist()

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -173,17 +173,6 @@ class MoreOnMatchController(
       canonicalRedirectForMatch(maybeMatch, request)
     }
 
-  def bigMatchSpecial(matchId: String): Action[AnyContent] =
-    Action { implicit request =>
-      val response = competitionsService.competitions
-        .find { _.matches.exists(_.id == matchId) }
-        .fold(JsonNotFound()) { competition =>
-          val fMatch = competition.matches.find(_.id == matchId).head
-          JsonComponent(football.views.html.fragments.matchSummary(fMatch, Some(competition), link = true))
-        }
-      Cached(CacheTime.FootballMediumCache)(response)
-    }
-
   private def canonicalRedirectForMatch(maybeMatch: Option[FootballMatch], request: RequestHeader)(implicit
       requestHeader: RequestHeader,
   ): Future[Result] = {

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -69,8 +69,6 @@ GET        /football/api/match-header/:year/:month/:day/:home/:away.json        
 GET        /football/api/match-stats/:year/:month/:day/:home/:away.json                        football.controllers.MoreOnMatchController.matchStatsJson(year, month, day, home, away)
 GET        /football/api/match-stats-summary/:year/:month/:day/:home/:away.json                football.controllers.MoreOnMatchController.matchStatsSummaryJson(year, month, day, home, away)
 
-GET        /football/api/big-match-special/:matchId.json                                       football.controllers.MoreOnMatchController.bigMatchSpecial(matchId)
-
 GET        /football/api/match-day                                                             football.controllers.MatchDayController.matchDayComponent()
 
 GET        /football/competitions                                                              football.controllers.CompetitionListController.renderCompetitionList()


### PR DESCRIPTION
## What is the value of this and can you measure success?

The "Big Match Special" was a banner rendered in Frontend which could also be dropped onto fronts. It was introduced here: https://github.com/guardian/frontend/pull/4249.

<img width="622" height="416" alt="Screenshot 2026-09-03 at 14 41 10" src="https://github.com/user-attachments/assets/bfa1e933-7063-46ce-8081-839f899b3c12" />

It doesn't seem to be used anymore, and the actual form for creating one in the admin app was disabled eight years ago here: https://github.com/guardian/frontend/pull/19771.

fixes https://github.com/guardian/dotcom-rendering/issues/16586

## What does this change?
As this isn't used anymore this PR removes all the routes that were pointed to it as well as the controllers associated with it. The actual html used to render the big match special is still referenced in sport/app/football/views/matchStats/matchStatsPage.scala.html which probably falls under the remit of deleting old templates rather than just this one part.

## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering