### PR TITLE
Update facia scala client to v41

### DIFF
--- a/common/app/model/PressedCard.scala
+++ b/common/app/model/PressedCard.scala
@@ -36,7 +36,9 @@ object PressedCard {
         supportingCuratedContent => supportingCuratedContent.content.fields.flatMap(_.lastModified),
         _ => None,
         latestSnap => latestSnap.latestContent.flatMap(_.fields.flatMap(_.lastModified)),
+        _ => None,
       ).map(_.toJodaDateTime)
+
     }
 
     def extractGalleryCount(fc: FaciaContent): Option[Int] = {
@@ -48,6 +50,7 @@ object PressedCard {
         supportingCuratedContent => countImagesInGallery(supportingCuratedContent.content),
         _ => None,
         latestSnap => latestSnap.latestContent.flatMap(countImagesInGallery),
+        _ => None,
       )
     }
 
@@ -62,6 +65,7 @@ object PressedCard {
         supportingCuratedContent => getMinutes(supportingCuratedContent.content),
         _ => None,
         latestSnap => latestSnap.latestContent.flatMap(getMinutes),
+        _ => None,
       )
 
       def audioDurationSeconds(fc: FaciaContent) = fold(fc)(
@@ -69,6 +73,7 @@ object PressedCard {
         supportingCuratedContent => getSeconds(supportingCuratedContent.content),
         _ => None,
         latestSnap => latestSnap.latestContent.flatMap(getSeconds),
+        _ => None,
       )
 
       val minutes: Option[Int] = if (audioDurationMinutes(fc).isDefined) {

--- a/common/app/model/PressedProperties.scala
+++ b/common/app/model/PressedProperties.scala
@@ -94,6 +94,22 @@ object PressedProperties {
       case supportingCuratedContent: fapi.SupportingCuratedContent => supportingCuratedContent.properties
       case linkSnap: fapi.LinkSnap                                 => linkSnap.properties
       case latestSnap: fapi.LatestSnap                             => latestSnap.properties
+      case _: fapi.EventGraphic                                    =>
+        fapiutils.ContentProperties(
+          isBreaking = false,
+          isBoosted = false,
+          boostLevel = com.gu.facia.api.utils.BoostLevel.Default,
+          isImmersive = false,
+          imageHide = false,
+          showBoostedHeadline = false,
+          showMainVideo = false,
+          showLivePlayable = false,
+          showKickerTag = false,
+          showByline = false,
+          showQuotedHeadline = false,
+          imageSlideshowReplace = false,
+          videoReplace = false,
+        )
     }
   }
 }

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -1,6 +1,7 @@
 package model.pressed
 
 import com.gu.commercial.branding.Branding
+import com.gu.facia.api.models.EventGraphic
 import com.gu.facia.api.utils.BoostLevel
 import com.gu.facia.api.{models => fapi}
 import common.Edition
@@ -81,6 +82,8 @@ object PressedContent {
         SupportingCuratedContent.make(supportingCuratedContent)
       case linkSnap: fapi.LinkSnap     => LinkSnap.make(linkSnap)
       case latestSnap: fapi.LatestSnap => LatestSnap.make(latestSnap)
+      case _: EventGraphic             =>
+        throw new RuntimeException("EventGraphic FaciaContent is not supported in PressedContent")
     }
 
   def propertiesWithoutTestPII(properties: PressedProperties): PressedProperties =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.49.6"
   val capiVersion = "49.0.0"
-  val faciaVersion = "40.0.0-PREVIEW.glupdate-custom-subnav-model.2026-09-08T2328.04cd90bc"
+  val faciaVersion = "41.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "4.31"
   val awsVersion = "2.49.6"
   val capiVersion = "49.0.0"
-  val faciaVersion = "39.0.0"
+  val faciaVersion = "40.0.0-PREVIEW.glupdate-custom-subnav-model.2026-09-08T2328.04cd90bc"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What is the value of this and can you measure success?

V41 notably updates the custom subnav data model, which we need to bump in order for DCR to render images correctly. 

This data model just gets passed through from the fronts tool data to DCR, so no other updates required for the subnav work; however this latest release brings in Event Graphics related models, which need to be handled in certain places - so the diff in PressedCard, PressedContent and PressedProperties is the simplest/minimal amount required to compile successfully. 

This has been tested with the relevant [DCR PR](https://github.com/guardian/dotcom-rendering/pull/16664)

## Checklist

- [ ] Tested locally, and on CODE if necessary
- [ ] Will not break dotcom-rendering
- [ ] Any new [test `data/database`](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) files generated by tests are committed with this PR (the tests will fail in CI if you've forgotten to do this)
- [ ] Meets our accessibility [standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/dotcom-platform to reach the team -->
