### PR TITLE
Puzzles/align hub blueprint with target composition

### DIFF
--- a/applications/app/controllers/PuzzlesLayoutProvider.scala
+++ b/applications/app/controllers/PuzzlesLayoutProvider.scala
@@ -158,7 +158,7 @@ class LocalJsonPuzzlesLayoutProvider(
       val crosswordNumber = crossword.number
 
       CrosswordDynamicFields(
-        url = s"/puzzles/crosswords/$crosswordType/$crosswordNumber",
+        url = s"/puzzles-and-games/crosswords/$crosswordType/$crosswordNumber",
         image = s"https://api.nextgen.guardianapps.co.uk/crosswords/$crosswordType/$crosswordNumber.svg",
       )
     }

--- a/applications/app/controllers/PuzzlesLayoutProvider.scala
+++ b/applications/app/controllers/PuzzlesLayoutProvider.scala
@@ -98,7 +98,9 @@ class LocalJsonPuzzlesLayoutProvider(
     if (isLatestCrosswordCard(item)) {
       latestCrosswords
         .get(item.set)
-        .map(dynamicFields => item.copy(url = Some(dynamicFields.url), image = Some(dynamicFields.image)))
+        .map(dynamicFields =>
+          item.copy(url = Some(dynamicFields.url), image = item.image.orElse(Some(dynamicFields.image))),
+        )
         .getOrElse(item)
     } else {
       item

--- a/applications/app/controllers/PuzzlesLayoutProvider.scala
+++ b/applications/app/controllers/PuzzlesLayoutProvider.scala
@@ -4,11 +4,12 @@ import com.gu.contentapi.client.model.SearchQuery
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import common.GuLogging
 import contentapi.ContentApiClient
-import model.dotcomrendering.{PuzzleContainer, PuzzleItem, PuzzlesLayout}
+import model.dotcomrendering.{PuzzleContainer, PuzzleContent, PuzzleItem, PuzzlesLayout}
 import play.api.Environment
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import views.support.CamelCase
 
+import java.time.{Clock, DayOfWeek, LocalDate, ZoneId}
 import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.util.control.NonFatal
 
@@ -22,16 +23,35 @@ class LocalJsonPuzzlesLayoutProvider(
     environment: Environment,
     contentApiClient: ContentApiClient,
     resourceName: String = LocalJsonPuzzlesLayoutProvider.DefaultResourceName,
+    clock: Clock = Clock.systemUTC(),
 ) extends PuzzlesLayoutProvider
     with GuLogging {
 
   override def getLayout()(implicit executionContext: ExecutionContext): Future[PuzzlesLayout] =
     Future(blocking(loadLayout())).flatMap { baseLayout =>
-      enrichCrosswordItems(baseLayout).recover { case NonFatal(error) =>
-        log.warn("Failed to enrich puzzles layout with latest crosswords from CAPI using the base layout", error)
-        baseLayout
+      val scheduledLayout = applyFeaturedSchedule(baseLayout)
+      enrichCrosswordItems(scheduledLayout).recover { case NonFatal(error) =>
+        log.warn("Failed to enrich puzzles layout with latest crosswords from CAPI using the scheduled layout", error)
+        scheduledLayout
       }
     }
+
+  private def applyFeaturedSchedule(layout: PuzzlesLayout): PuzzlesLayout = {
+    val day = LocalDate.now(clock.withZone(LocalJsonPuzzlesLayoutProvider.FeaturedScheduleZone)).getDayOfWeek
+    layout.copy(containers = layout.containers.flatMap { container =>
+      if (container.variant.contains("featured") && container.enabled.contains(false)) {
+        None
+      } else if (container.variant.contains("featured") && container.enabled.contains(true)) {
+        Some(
+          container.copy(content =
+            PuzzleContent(Seq(LocalJsonPuzzlesLayoutProvider.featuredPuzzlesFor(day)), Seq.empty),
+          ),
+        )
+      } else {
+        Some(container)
+      }
+    })
+  }
 
   private def loadLayout(): PuzzlesLayout = {
     val inputStream = environment
@@ -146,6 +166,104 @@ class LocalJsonPuzzlesLayoutProvider(
 
 object LocalJsonPuzzlesLayoutProvider {
   val DefaultResourceName = "puzzles-layout.json"
+  private val FeaturedScheduleZone: ZoneId = ZoneId.of("Europe/London")
+  private val PreviewImage =
+    "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3"
+
+  private def featuredCrossword(id: String, title: String, set: String): PuzzleItem =
+    PuzzleItem(
+      id = s"featured-$id",
+      title = title,
+      `type` = "crossword",
+      set = set,
+      cardVariant = "large",
+      cadence = Some("Daily"),
+      backgroundColour = Some("#FCE1CE"),
+    )
+
+  private def featuredSudoku(id: String, title: String, set: String, amuseLabsSet: String): PuzzleItem =
+    PuzzleItem(
+      id = s"featured-$id",
+      title = title,
+      `type` = "sudoku",
+      set = set,
+      cardVariant = "large",
+      cadence = Some("Daily"),
+      url = Some(s"https://tg.amuselabs.com/guardian/date-picker?set=$amuseLabsSet&embed=1&idx=1"),
+      image = Some(PreviewImage),
+      slug = Some(id),
+      index = Some(1),
+      variant = Some("iframe-page"),
+      backgroundColour = Some("#CDECFB"),
+    )
+
+  private val filmReveal = PuzzleItem(
+    id = "featured-film-reveal",
+    title = "Film reveal",
+    `type` = "film-reveal",
+    set = "all",
+    cardVariant = "large",
+    cadence = Some("Daily"),
+    url = Some("https://moviegrid.io/guardian"),
+    image = Some(PreviewImage),
+    slug = Some("film-reveal"),
+    variant = Some("iframe-page"),
+    backgroundColour = Some("#EAD8B9"),
+  )
+
+  private val wordiply = PuzzleItem(
+    id = "featured-wordiply",
+    title = "Wordiply",
+    `type` = "wordiply",
+    set = "all",
+    cardVariant = "large",
+    cadence = Some("Daily"),
+    url = Some("https://www.wordiply.com/"),
+    image = Some("https://www.wordiply.com/share.png"),
+    slug = Some("wordiply"),
+    variant = Some("iframe-page"),
+    backgroundColour = Some("#F8D0C9"),
+  )
+
+  private val onTheBall = PuzzleItem(
+    id = "featured-on-the-ball",
+    title = "On the ball",
+    `type` = "on-the-ball",
+    set = "all",
+    cardVariant = "large",
+    cadence = Some("Daily"),
+    url = Some("https://sportsreveal.io/guardian"),
+    image = Some(PreviewImage),
+    slug = Some("on-the-ball"),
+    variant = Some("iframe-page"),
+    backgroundColour = Some("#D5F3F2"),
+  )
+
+  private[controllers] def featuredPuzzlesFor(day: DayOfWeek): Seq[PuzzleItem] = day match {
+    case DayOfWeek.MONDAY =>
+      Seq(
+        featuredCrossword("crossword-quick", "Quick crossword", "quick"),
+        featuredSudoku("sudoku-easy", "Easy sudoku", "easy", "guardian-sudoku-easy"),
+      )
+    case DayOfWeek.TUESDAY =>
+      Seq(featuredCrossword("crossword-mini", "Mini crossword", "mini"), filmReveal)
+    case DayOfWeek.WEDNESDAY =>
+      Seq(
+        featuredCrossword("crossword-cryptic", "Cryptic crossword", "cryptic"),
+        featuredSudoku("sudoku-medium", "Medium sudoku", "medium", "guardian-sudoku-medium"),
+      )
+    case DayOfWeek.THURSDAY =>
+      Seq(featuredCrossword("crossword-quick", "Quick crossword", "quick"), wordiply)
+    case DayOfWeek.FRIDAY =>
+      Seq(
+        featuredCrossword("crossword-mini", "Mini crossword", "mini"),
+        featuredSudoku("sudoku-hard", "Hard sudoku", "hard", "guardian-sudoku-hard"),
+      )
+    case DayOfWeek.SATURDAY =>
+      Seq(featuredCrossword("crossword-weekend", "General knowledge crossword", "weekend"), filmReveal)
+    case DayOfWeek.SUNDAY =>
+      Seq(featuredCrossword("crossword-quiptic", "Quiptic crossword", "quiptic"), onTheBall)
+  }
 
   private[controllers] val CrosswordSeriesTags: Map[String, String] = Map(
     "mini" -> "crosswords/series/mini-crossword",

--- a/applications/conf/puzzles-layout.json
+++ b/applications/conf/puzzles-layout.json
@@ -4,37 +4,9 @@
 			"id": "featured-puzzles",
 			"title": "Today’s featured puzzles",
 			"variant": "featured",
+			"enabled": true,
 			"content": {
-				"items": [
-					[
-						{
-							"id": "on-the-ball",
-							"title": "On the ball",
-							"type": "on-the-ball",
-							"set": "all",
-							"cardVariant": "large",
-							"cadence": "Daily",
-							"slug": "on-the-ball",
-							"url": "https://sportsreveal.io/guardian",
-							"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
-							"variant": "iframe-page",
-							"backgroundColour": "#D5F3F2"
-						},
-						{
-							"id": "film-reveal",
-							"title": "Film reveal",
-							"type": "film-reveal",
-							"set": "all",
-							"cardVariant": "large",
-							"cadence": "Daily",
-							"slug": "film-reveal",
-							"url": "https://moviegrid.io/guardian",
-							"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
-							"variant": "iframe-page",
-							"backgroundColour": "#EAD8B9"
-						}
-					]
-				],
+				"items": [],
 				"nestedContainers": []
 			}
 		},

--- a/applications/conf/puzzles-layout.json
+++ b/applications/conf/puzzles-layout.json
@@ -57,6 +57,16 @@
 			}
 		},
 		{
+			"id": "featured-ad",
+			"title": "",
+			"variant": "ad",
+			"adSlot": "inline1",
+			"content": {
+				"items": [],
+				"nestedContainers": []
+			}
+		},
+		{
 			"id": "crosswords",
 			"title": "Crosswords",
 			"variant": "standard",
@@ -162,6 +172,102 @@
 			}
 		},
 		{
+			"id": "logic-puzzles",
+			"title": "Logic puzzles",
+			"variant": "standard",
+			"filterId": "logic",
+			"content": {
+				"items": [],
+				"nestedContainers": [
+					{
+						"id": "sudoku",
+						"title": "Sudoku",
+						"desktopSpan": 12,
+						"content": {
+							"items": [
+								[
+									{
+										"id": "sudoku-easy",
+										"title": "Easy",
+										"type": "sudoku",
+										"set": "easy",
+										"cardVariant": "primary",
+										"cadence": "Daily",
+										"slug": "sudoku-easy",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"id": "sudoku-medium",
+										"title": "Medium",
+										"type": "sudoku",
+										"set": "medium",
+										"cardVariant": "primary",
+										"cadence": "Daily",
+										"slug": "sudoku-medium",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-medium&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"id": "sudoku-hard",
+										"title": "Hard",
+										"type": "sudoku",
+										"set": "hard",
+										"cardVariant": "primary",
+										"cadence": "Daily",
+										"slug": "sudoku-hard",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-hard&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"id": "sudoku-killer",
+										"title": "Killer",
+										"type": "sudoku",
+										"set": "killer",
+										"cardVariant": "primary",
+										"cadence": "Daily",
+										"slug": "sudoku-killer",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-killer-sudoku-medium&embed=1&idx=1",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									}
+								]
+							],
+							"nestedContainers": [],
+							"archive": {
+								"id": "logic-archive",
+								"title": "Logic archive",
+								"type": "sudoku",
+								"set": "all",
+								"cardVariant": "archive",
+								"slug": "sudoku-easy",
+								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&set=guardian-sudoku-medium&set=guardian-sudoku-hard&set=guardian-killer-sudoku-medium&embed=1",
+								"variant": "archive-page",
+								"backgroundColour": "#CDECFB"
+							}
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "logic-ad",
+			"title": "",
+			"variant": "ad",
+			"adSlot": "inline2",
+			"content": {
+				"items": [],
+				"nestedContainers": []
+			}
+		},
+		{
 			"id": "word-games",
 			"title": "Word games",
 			"variant": "standard",
@@ -191,18 +297,7 @@
 									}
 								]
 							],
-							"nestedContainers": [],
-							"archive": {
-								"id": "word-wheel-archive",
-								"title": "Word wheel archive",
-								"type": "word-wheel",
-								"set": "all",
-								"cardVariant": "archive",
-								"slug": "word-wheel",
-								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-word-wheel&embed=1",
-								"variant": "archive-page",
-								"backgroundColour": "#F9D4E8"
-							}
+							"nestedContainers": []
 						}
 					},
 					{
@@ -226,107 +321,19 @@
 									}
 								]
 							],
-							"nestedContainers": [],
-							"archive": {
-								"id": "wordiply-archive",
-								"title": "Wordiply archive",
-								"type": "wordiply",
-								"set": "all",
-								"cardVariant": "archive",
-								"slug": "wordiply",
-								"url": "https://www.wordiply.com/",
-								"variant": "archive-page",
-								"backgroundColour": "#F8D0C9"
-							}
+							"nestedContainers": []
 						}
 					}
-				]
-			}
-		},
-		{
-			"id": "logic-puzzles",
-			"title": "Logic puzzles",
-			"variant": "standard",
-			"filterId": "logic",
-			"content": {
-				"items": [],
-				"nestedContainers": [
-					{
-						"id": "sudoku",
-						"title": "Sudoku",
-						"desktopSpan": 12,
-						"content": {
-							"items": [
-								[
-									{
-										"id": "sudoku-easy",
-										"title": "Sudoku easy",
-										"type": "sudoku",
-										"set": "easy",
-										"cardVariant": "primary",
-										"cadence": "Daily",
-										"slug": "sudoku-easy",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"id": "sudoku-medium",
-										"title": "Sudoku medium",
-										"type": "sudoku",
-										"set": "medium",
-										"cardVariant": "primary",
-										"cadence": "Daily",
-										"slug": "sudoku-medium",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-medium&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"id": "sudoku-hard",
-										"title": "Sudoku hard",
-										"type": "sudoku",
-										"set": "hard",
-										"cardVariant": "primary",
-										"cadence": "Daily",
-										"slug": "sudoku-hard",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-hard&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"id": "sudoku-killer",
-										"title": "Sudoku killer",
-										"type": "sudoku",
-										"set": "killer",
-										"cardVariant": "primary",
-										"cadence": "Daily",
-										"slug": "sudoku-killer",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-killer-sudoku-medium&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									}
-								]
-							],
-							"nestedContainers": [],
-							"archive": {
-								"id": "logic-archive",
-								"title": "Logic archive",
-								"type": "sudoku",
-								"set": "all",
-								"cardVariant": "archive",
-								"slug": "sudoku-easy",
-								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&set=guardian-sudoku-medium&set=guardian-sudoku-hard&set=guardian-killer-sudoku-medium&embed=1",
-								"variant": "archive-page",
-								"backgroundColour": "#CDECFB"
-							}
-						}
-					}
-				]
+				],
+				"archive": {
+					"id": "word-games-archive",
+					"title": "Word games archive",
+					"type": "word-games",
+					"set": "all",
+					"cardVariant": "archive",
+					"slug": "word-wheel",
+					"variant": "archive-page"
+				}
 			}
 		}
 	]

--- a/applications/conf/puzzles-layout.json
+++ b/applications/conf/puzzles-layout.json
@@ -112,7 +112,7 @@
 						"type": "crossword",
 						"set": "mini",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=mini",
+						"url": "/crosswords/series/mini-crossword",
 						"variant": "archive-page"
 					},
 					{
@@ -121,7 +121,7 @@
 						"type": "crossword",
 						"set": "quick",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=quick",
+						"url": "/crosswords/series/quick",
 						"variant": "archive-page"
 					},
 					{
@@ -130,7 +130,7 @@
 						"type": "crossword",
 						"set": "cryptic",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=cryptic",
+						"url": "/crosswords/series/cryptic",
 						"variant": "archive-page"
 					},
 					{
@@ -139,7 +139,7 @@
 						"type": "crossword",
 						"set": "quick-cryptic",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=quick-cryptic",
+						"url": "/crosswords/series/quick-cryptic",
 						"variant": "archive-page"
 					},
 					{
@@ -148,7 +148,7 @@
 						"type": "crossword",
 						"set": "quiptic",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=quiptic",
+						"url": "/crosswords/series/quiptic",
 						"variant": "archive-page"
 					},
 					{
@@ -157,7 +157,7 @@
 						"type": "crossword",
 						"set": "weekend",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=weekend",
+						"url": "/crosswords/series/weekend-crossword",
 						"variant": "archive-page"
 					},
 					{
@@ -166,7 +166,7 @@
 						"type": "crossword",
 						"set": "prize",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=prize",
+						"url": "/crosswords/series/prize",
 						"variant": "archive-page"
 					},
 					{
@@ -175,7 +175,7 @@
 						"type": "crossword",
 						"set": "sunday-quick",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=sunday-quick",
+						"url": "/crosswords/series/sunday-quick",
 						"variant": "archive-page"
 					},
 					{
@@ -184,7 +184,7 @@
 						"type": "crossword",
 						"set": "genius",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=genius",
+						"url": "/crosswords/series/genius",
 						"variant": "archive-page"
 					},
 					{
@@ -193,7 +193,7 @@
 						"type": "crossword",
 						"set": "special",
 						"cardVariant": "archive",
-						"url": "/puzzles/crosswords/archive?type=special",
+						"url": "/crosswords/series/special",
 						"variant": "archive-page"
 					}
 				]
@@ -356,7 +356,7 @@
 				"usefulLinks": [
 					{
 						"title": "Crossword setter A–Z",
-						"url": "/puzzles/crosswords/archive"
+						"url": "/puzzles-and-games/crosswords/archive"
 					},
 					{
 						"title": "Crossword blog",

--- a/applications/conf/puzzles-layout.json
+++ b/applications/conf/puzzles-layout.json
@@ -1,24 +1,4 @@
 {
-	"filters": [
-		{
-			"id": "crosswords",
-			"title": "Crosswords",
-			"target": "#crosswords",
-			"backgroundColour": "#FCE1CE"
-		},
-		{
-			"id": "logic",
-			"title": "Logic",
-			"target": "#logic-puzzles",
-			"backgroundColour": "#CDECFB"
-		},
-		{
-			"id": "word-games",
-			"title": "Word games",
-			"target": "#word-games",
-			"backgroundColour": "#F9D4E8"
-		}
-	],
 	"containers": [
 		{
 			"id": "featured-puzzles",
@@ -36,6 +16,7 @@
 							"cadence": "Daily",
 							"slug": "on-the-ball",
 							"url": "https://sportsreveal.io/guardian",
+							"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
 							"variant": "iframe-page",
 							"backgroundColour": "#D5F3F2"
 						},
@@ -48,6 +29,7 @@
 							"cadence": "Daily",
 							"slug": "film-reveal",
 							"url": "https://moviegrid.io/guardian",
+							"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
 							"variant": "iframe-page",
 							"backgroundColour": "#EAD8B9"
 						}
@@ -61,28 +43,15 @@
 			"title": "",
 			"variant": "ad",
 			"adSlot": "inline1",
-			"content": {
-				"items": [],
-				"nestedContainers": []
-			}
+			"content": { "items": [], "nestedContainers": [] }
 		},
 		{
 			"id": "crosswords",
 			"title": "Crosswords",
 			"variant": "standard",
-			"filterId": "crosswords",
 			"content": {
 				"items": [
 					[
-						{
-							"id": "crossword-mini",
-							"title": "Mini",
-							"type": "crossword",
-							"set": "mini",
-							"cardVariant": "primary",
-							"cadence": "Daily",
-							"backgroundColour": "#FCE1CE"
-						},
 						{
 							"id": "crossword-quick",
 							"title": "Quick",
@@ -90,6 +59,17 @@
 							"set": "quick",
 							"cardVariant": "primary",
 							"cadence": "Daily",
+							"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
+							"backgroundColour": "#FCE1CE"
+						},
+						{
+							"id": "crossword-mini",
+							"title": "Mini",
+							"type": "crossword",
+							"set": "mini",
+							"cardVariant": "primary",
+							"cadence": "Daily",
+							"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
@@ -99,6 +79,7 @@
 							"set": "cryptic",
 							"cardVariant": "primary",
 							"cadence": "Daily",
+							"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
@@ -108,6 +89,7 @@
 							"set": "quick-cryptic",
 							"cardVariant": "primary",
 							"cadence": "Every Saturday",
+							"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
 							"backgroundColour": "#FCE1CE"
 						}
 					],
@@ -140,15 +122,6 @@
 							"backgroundColour": "#FCE1CE"
 						},
 						{
-							"id": "crossword-sunday-quick",
-							"title": "Sunday quick",
-							"type": "crossword",
-							"set": "sunday-quick",
-							"cardVariant": "compact",
-							"cadence": "Every Sunday",
-							"backgroundColour": "#FCE1CE"
-						},
-						{
 							"id": "crossword-genius",
 							"title": "Genius",
 							"type": "crossword",
@@ -160,118 +133,104 @@
 					]
 				],
 				"nestedContainers": [],
-				"archive": {
-					"id": "crosswords-archive",
-					"title": "Crosswords archive",
-					"type": "crossword",
-					"set": "all",
-					"cardVariant": "archive",
-					"url": "/puzzles/crosswords/archive",
-					"backgroundColour": "#FCE1CE"
-				}
-			}
-		},
-		{
-			"id": "logic-puzzles",
-			"title": "Logic puzzles",
-			"variant": "standard",
-			"filterId": "logic",
-			"content": {
-				"items": [],
-				"nestedContainers": [
+				"archiveChoices": [
 					{
-						"id": "sudoku",
-						"title": "Sudoku",
-						"desktopSpan": 12,
-						"content": {
-							"items": [
-								[
-									{
-										"id": "sudoku-easy",
-										"title": "Easy",
-										"type": "sudoku",
-										"set": "easy",
-										"cardVariant": "primary",
-										"cadence": "Daily",
-										"slug": "sudoku-easy",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"id": "sudoku-medium",
-										"title": "Medium",
-										"type": "sudoku",
-										"set": "medium",
-										"cardVariant": "primary",
-										"cadence": "Daily",
-										"slug": "sudoku-medium",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-medium&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"id": "sudoku-hard",
-										"title": "Hard",
-										"type": "sudoku",
-										"set": "hard",
-										"cardVariant": "primary",
-										"cadence": "Daily",
-										"slug": "sudoku-hard",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-hard&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									},
-									{
-										"id": "sudoku-killer",
-										"title": "Killer",
-										"type": "sudoku",
-										"set": "killer",
-										"cardVariant": "primary",
-										"cadence": "Daily",
-										"slug": "sudoku-killer",
-										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-killer-sudoku-medium&embed=1&idx=1",
-										"index": 1,
-										"variant": "iframe-page",
-										"backgroundColour": "#CDECFB"
-									}
-								]
-							],
-							"nestedContainers": [],
-							"archive": {
-								"id": "logic-archive",
-								"title": "Logic archive",
-								"type": "sudoku",
-								"set": "all",
-								"cardVariant": "archive",
-								"slug": "sudoku-easy",
-								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&set=guardian-sudoku-medium&set=guardian-sudoku-hard&set=guardian-killer-sudoku-medium&embed=1",
-								"variant": "archive-page",
-								"backgroundColour": "#CDECFB"
-							}
-						}
+						"id": "archive-mini",
+						"title": "Mini",
+						"type": "crossword",
+						"set": "mini",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=mini",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-quick",
+						"title": "Quick",
+						"type": "crossword",
+						"set": "quick",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=quick",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-cryptic",
+						"title": "Cryptic",
+						"type": "crossword",
+						"set": "cryptic",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=cryptic",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-quick-cryptic",
+						"title": "Quick cryptic",
+						"type": "crossword",
+						"set": "quick-cryptic",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=quick-cryptic",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-quiptic",
+						"title": "Quiptic",
+						"type": "crossword",
+						"set": "quiptic",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=quiptic",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-weekend",
+						"title": "Weekend",
+						"type": "crossword",
+						"set": "weekend",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=weekend",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-prize",
+						"title": "Prize",
+						"type": "crossword",
+						"set": "prize",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=prize",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-sunday-quick",
+						"title": "Sunday quick",
+						"type": "crossword",
+						"set": "sunday-quick",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=sunday-quick",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-genius",
+						"title": "Genius",
+						"type": "crossword",
+						"set": "genius",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=genius",
+						"variant": "archive-page"
+					},
+					{
+						"id": "archive-special",
+						"title": "Special",
+						"type": "crossword",
+						"set": "special",
+						"cardVariant": "archive",
+						"url": "/puzzles/crosswords/archive?type=special",
+						"variant": "archive-page"
 					}
 				]
-			}
-		},
-		{
-			"id": "logic-ad",
-			"title": "",
-			"variant": "ad",
-			"adSlot": "inline2",
-			"content": {
-				"items": [],
-				"nestedContainers": []
 			}
 		},
 		{
 			"id": "word-games",
 			"title": "Word games",
 			"variant": "standard",
-			"filterId": "word-games",
 			"content": {
 				"items": [],
 				"nestedContainers": [
@@ -291,6 +250,7 @@
 										"cadence": "Daily",
 										"slug": "word-wheel",
 										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-word-wheel&embed=1&idx=1",
+										"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
 										"index": 1,
 										"variant": "iframe-page",
 										"backgroundColour": "#F9D4E8"
@@ -316,6 +276,7 @@
 										"cadence": "Daily",
 										"slug": "wordiply",
 										"url": "https://www.wordiply.com/",
+										"image": "https://www.wordiply.com/share.png",
 										"variant": "iframe-page",
 										"backgroundColour": "#F8D0C9"
 									}
@@ -324,17 +285,150 @@
 							"nestedContainers": []
 						}
 					}
-				],
-				"archive": {
-					"id": "word-games-archive",
-					"title": "Word games archive",
-					"type": "word-games",
-					"set": "all",
-					"cardVariant": "archive",
-					"slug": "word-wheel",
-					"variant": "archive-page"
-				}
+				]
 			}
+		},
+		{
+			"id": "word-games-ad",
+			"title": "",
+			"variant": "ad",
+			"adSlot": "inline2",
+			"content": { "items": [], "nestedContainers": [] }
+		},
+		{
+			"id": "logic-puzzles",
+			"title": "Logic puzzles",
+			"variant": "standard",
+			"content": {
+				"items": [],
+				"nestedContainers": [
+					{
+						"id": "sudoku",
+						"title": "Sudoku",
+						"desktopSpan": 12,
+						"content": {
+							"items": [
+								[
+									{
+										"id": "sudoku-easy",
+										"title": "Easy sudoku",
+										"type": "sudoku",
+										"set": "easy",
+										"cardVariant": "primary",
+										"cadence": "Daily",
+										"slug": "sudoku-easy",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&embed=1&idx=1",
+										"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"id": "sudoku-medium",
+										"title": "Medium sudoku",
+										"type": "sudoku",
+										"set": "medium",
+										"cardVariant": "primary",
+										"cadence": "Daily",
+										"slug": "sudoku-medium",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-medium&embed=1&idx=1",
+										"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"id": "sudoku-hard",
+										"title": "Hard sudoku",
+										"type": "sudoku",
+										"set": "hard",
+										"cardVariant": "primary",
+										"cadence": "Daily",
+										"slug": "sudoku-hard",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-hard&embed=1&idx=1",
+										"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									},
+									{
+										"id": "sudoku-killer",
+										"title": "Killer sudoku",
+										"type": "sudoku",
+										"set": "killer",
+										"cardVariant": "primary",
+										"cadence": "Daily",
+										"slug": "sudoku-killer",
+										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-killer-sudoku-medium&embed=1&idx=1",
+										"image": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=600&dpr=1&s=none&crop=5%3A3",
+										"index": 1,
+										"variant": "iframe-page",
+										"backgroundColour": "#CDECFB"
+									}
+								]
+							],
+							"nestedContainers": []
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "puzzles-supporting",
+			"title": "",
+			"variant": "supporting",
+			"adSlot": "mostpop",
+			"content": { "items": [], "nestedContainers": [] },
+			"supporting": {
+				"usefulLinksTitle": "Useful links",
+				"usefulLinks": [
+					{
+						"title": "Crossword setter A–Z",
+						"url": "/puzzles/crosswords/archive"
+					},
+					{
+						"title": "Crossword blog",
+						"url": "https://www.theguardian.com/crosswords/crossword-blog"
+					}
+				],
+				"newsletter": {
+					"identityName": "saturday-edition",
+					"name": "Saturday Edition",
+					"frequency": "Weekly",
+					"description": "An exclusive roundup of the week’s best Guardian journalism from the editor-in-chief, Katharine Viner, free to your inbox every Saturday.",
+					"illustrationSquare": "https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3"
+				},
+				"popularTitle": "Most popular puzzles",
+				"popularGroups": [
+					{
+						"title": "Most played",
+						"itemIds": [
+							"crossword-quick",
+							"word-wheel-daily",
+							"crossword-mini",
+							"sudoku-medium",
+							"crossword-cryptic"
+						]
+					},
+					{
+						"title": "Most comments",
+						"itemIds": [
+							"crossword-cryptic",
+							"crossword-quick",
+							"crossword-prize",
+							"crossword-genius",
+							"crossword-weekend"
+						]
+					}
+				]
+			}
+		},
+		{
+			"id": "bottom-ad",
+			"title": "",
+			"variant": "ad",
+			"adSlot": "inline3",
+			"content": { "items": [], "nestedContainers": [] }
 		}
 	]
 }

--- a/applications/conf/puzzles-layout.json
+++ b/applications/conf/puzzles-layout.json
@@ -3,50 +3,53 @@
 		{
 			"id": "crosswords",
 			"title": "Crosswords",
+			"target": "#crosswords",
 			"backgroundColour": "#FCE1CE"
 		},
 		{
 			"id": "logic",
-			"title": "Sudoku",
+			"title": "Logic",
+			"target": "#logic-puzzles",
 			"backgroundColour": "#CDECFB"
 		},
 		{
 			"id": "word-games",
 			"title": "Word games",
+			"target": "#word-games",
 			"backgroundColour": "#F9D4E8"
-		},
-		{
-			"id": "trivia-quizzes",
-			"title": "Trivia",
-			"backgroundColour": "#D5F3F2"
 		}
 	],
 	"containers": [
 		{
+			"id": "featured-puzzles",
 			"title": "Today’s featured puzzles",
 			"variant": "featured",
 			"content": {
 				"items": [
 					[
 						{
+							"id": "on-the-ball",
 							"title": "On the ball",
 							"type": "on-the-ball",
 							"set": "all",
+							"cardVariant": "large",
+							"cadence": "Daily",
 							"slug": "on-the-ball",
 							"url": "https://sportsreveal.io/guardian",
 							"variant": "iframe-page",
-							"backgroundColour": "#D5F3F2",
-							"filterId": "trivia-quizzes"
+							"backgroundColour": "#D5F3F2"
 						},
 						{
+							"id": "film-reveal",
 							"title": "Film reveal",
 							"type": "film-reveal",
 							"set": "all",
+							"cardVariant": "large",
+							"cadence": "Daily",
 							"slug": "film-reveal",
 							"url": "https://moviegrid.io/guardian",
 							"variant": "iframe-page",
-							"backgroundColour": "#EAD8B9",
-							"filterId": "trivia-quizzes"
+							"backgroundColour": "#EAD8B9"
 						}
 					]
 				],
@@ -54,95 +57,132 @@
 			}
 		},
 		{
+			"id": "crosswords",
 			"title": "Crosswords",
+			"variant": "standard",
 			"filterId": "crosswords",
 			"content": {
 				"items": [
 					[
 						{
+							"id": "crossword-mini",
 							"title": "Mini",
 							"type": "crossword",
 							"set": "mini",
+							"cardVariant": "primary",
+							"cadence": "Daily",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
+							"id": "crossword-quick",
 							"title": "Quick",
 							"type": "crossword",
 							"set": "quick",
+							"cardVariant": "primary",
+							"cadence": "Daily",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
+							"id": "crossword-cryptic",
 							"title": "Cryptic",
 							"type": "crossword",
 							"set": "cryptic",
+							"cardVariant": "primary",
+							"cadence": "Daily",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
+							"id": "crossword-quick-cryptic",
 							"title": "Quick cryptic",
 							"type": "crossword",
 							"set": "quick-cryptic",
+							"cardVariant": "primary",
+							"cadence": "Every Saturday",
 							"backgroundColour": "#FCE1CE"
 						}
 					],
 					[
 						{
+							"id": "crossword-quiptic",
 							"title": "Quiptic",
 							"type": "crossword",
 							"set": "quiptic",
+							"cardVariant": "compact",
+							"cadence": "Every Saturday",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
+							"id": "crossword-prize",
 							"title": "Prize",
 							"type": "crossword",
 							"set": "prize",
+							"cardVariant": "compact",
+							"cadence": "Every Sunday",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
+							"id": "crossword-weekend",
 							"title": "Weekend",
 							"type": "crossword",
 							"set": "weekend",
+							"cardVariant": "compact",
+							"cadence": "Every Saturday",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
+							"id": "crossword-sunday-quick",
 							"title": "Sunday quick",
 							"type": "crossword",
 							"set": "sunday-quick",
+							"cardVariant": "compact",
+							"cadence": "Every Sunday",
 							"backgroundColour": "#FCE1CE"
 						},
 						{
+							"id": "crossword-genius",
 							"title": "Genius",
 							"type": "crossword",
 							"set": "genius",
+							"cardVariant": "compact",
+							"cadence": "Monthly",
 							"backgroundColour": "#FCE1CE"
 						}
 					]
 				],
 				"nestedContainers": [],
 				"archive": {
-					"title": "Crossword archive",
+					"id": "crosswords-archive",
+					"title": "Crosswords archive",
 					"type": "crossword",
 					"set": "all",
+					"cardVariant": "archive",
 					"url": "/puzzles/crosswords/archive",
 					"backgroundColour": "#FCE1CE"
 				}
 			}
 		},
 		{
+			"id": "word-games",
 			"title": "Word games",
+			"variant": "standard",
 			"filterId": "word-games",
 			"content": {
 				"items": [],
 				"nestedContainers": [
 					{
+						"id": "word-wheel",
 						"title": "Word wheel",
 						"desktopSpan": 6,
 						"content": {
 							"items": [
 								[
 									{
+										"id": "word-wheel-daily",
 										"title": "Word wheel",
 										"type": "word-wheel",
 										"set": "all",
+										"cardVariant": "primary",
+										"cadence": "Daily",
 										"slug": "word-wheel",
 										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-word-wheel&embed=1&idx=1",
 										"index": 1,
@@ -153,9 +193,11 @@
 							],
 							"nestedContainers": [],
 							"archive": {
+								"id": "word-wheel-archive",
 								"title": "Word wheel archive",
 								"type": "word-wheel",
 								"set": "all",
+								"cardVariant": "archive",
 								"slug": "word-wheel",
 								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-word-wheel&embed=1",
 								"variant": "archive-page",
@@ -164,15 +206,19 @@
 						}
 					},
 					{
+						"id": "wordiply",
 						"title": "Wordiply",
 						"desktopSpan": 6,
 						"content": {
 							"items": [
 								[
 									{
+										"id": "wordiply-daily",
 										"title": "Wordiply",
 										"type": "wordiply",
 										"set": "all",
+										"cardVariant": "primary",
+										"cadence": "Daily",
 										"slug": "wordiply",
 										"url": "https://www.wordiply.com/",
 										"variant": "iframe-page",
@@ -182,9 +228,11 @@
 							],
 							"nestedContainers": [],
 							"archive": {
+								"id": "wordiply-archive",
 								"title": "Wordiply archive",
 								"type": "wordiply",
 								"set": "all",
+								"cardVariant": "archive",
 								"slug": "wordiply",
 								"url": "https://www.wordiply.com/",
 								"variant": "archive-page",
@@ -196,21 +244,27 @@
 			}
 		},
 		{
+			"id": "logic-puzzles",
 			"title": "Logic puzzles",
+			"variant": "standard",
 			"filterId": "logic",
 			"content": {
 				"items": [],
 				"nestedContainers": [
 					{
+						"id": "sudoku",
 						"title": "Sudoku",
 						"desktopSpan": 12,
 						"content": {
 							"items": [
 								[
 									{
+										"id": "sudoku-easy",
 										"title": "Sudoku easy",
 										"type": "sudoku",
 										"set": "easy",
+										"cardVariant": "primary",
+										"cadence": "Daily",
 										"slug": "sudoku-easy",
 										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&embed=1&idx=1",
 										"index": 1,
@@ -218,9 +272,12 @@
 										"backgroundColour": "#CDECFB"
 									},
 									{
+										"id": "sudoku-medium",
 										"title": "Sudoku medium",
 										"type": "sudoku",
 										"set": "medium",
+										"cardVariant": "primary",
+										"cadence": "Daily",
 										"slug": "sudoku-medium",
 										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-medium&embed=1&idx=1",
 										"index": 1,
@@ -228,9 +285,12 @@
 										"backgroundColour": "#CDECFB"
 									},
 									{
+										"id": "sudoku-hard",
 										"title": "Sudoku hard",
 										"type": "sudoku",
 										"set": "hard",
+										"cardVariant": "primary",
+										"cadence": "Daily",
 										"slug": "sudoku-hard",
 										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-hard&embed=1&idx=1",
 										"index": 1,
@@ -238,9 +298,12 @@
 										"backgroundColour": "#CDECFB"
 									},
 									{
+										"id": "sudoku-killer",
 										"title": "Sudoku killer",
 										"type": "sudoku",
 										"set": "killer",
+										"cardVariant": "primary",
+										"cadence": "Daily",
 										"slug": "sudoku-killer",
 										"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-killer-sudoku-medium&embed=1&idx=1",
 										"index": 1,
@@ -251,80 +314,15 @@
 							],
 							"nestedContainers": [],
 							"archive": {
+								"id": "logic-archive",
 								"title": "Logic archive",
 								"type": "sudoku",
 								"set": "all",
+								"cardVariant": "archive",
 								"slug": "sudoku-easy",
 								"url": "https://tg.amuselabs.com/guardian/date-picker?set=guardian-sudoku-easy&set=guardian-sudoku-medium&set=guardian-sudoku-hard&set=guardian-killer-sudoku-medium&embed=1",
 								"variant": "archive-page",
 								"backgroundColour": "#CDECFB"
-							}
-						}
-					}
-				]
-			}
-		},
-		{
-			"title": "Trivia",
-			"filterId": "trivia-quizzes",
-			"content": {
-				"items": [],
-				"nestedContainers": [
-					{
-						"title": "On the ball",
-						"desktopSpan": 6,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "On the ball",
-										"type": "on-the-ball",
-										"set": "all",
-										"slug": "on-the-ball",
-										"url": "https://sportsreveal.io/guardian",
-										"variant": "iframe-page",
-										"backgroundColour": "#D5F3F2"
-									}
-								]
-							],
-							"nestedContainers": [],
-							"archive": {
-								"title": "On the ball archive",
-								"type": "on-the-ball",
-								"set": "all",
-								"slug": "on-the-ball",
-								"url": "https://sportsreveal.io/guardian",
-								"variant": "archive-page",
-								"backgroundColour": "#D5F3F2"
-							}
-						}
-					},
-					{
-						"title": "Film reveal",
-						"desktopSpan": 6,
-						"content": {
-							"items": [
-								[
-									{
-										"title": "Film reveal",
-										"type": "film-reveal",
-										"set": "all",
-										"slug": "film-reveal",
-										"url": "https://moviegrid.io/guardian",
-										"variant": "iframe-page",
-										"backgroundColour": "#EAD8B9"
-									}
-								]
-							],
-							"nestedContainers": [],
-							"archive": {
-								"title": "Film reveal archive",
-								"type": "film-reveal",
-								"set": "all",
-								"slug": "film-reveal",
-								"url": "https://moviegrid.io/guardian",
-								"variant": "archive-page",
-								"backgroundColour": "#EAD8B9"
 							}
 						}
 					}

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -17,8 +17,8 @@ GET        /email-newsletters.json                                              
 GET        /email-newsletters                                                   controllers.SignupPageController.renderNewsletters()
 
 # Puzzles
-GET        /puzzles.json                                                        controllers.PuzzlesPageController.renderPuzzlesJson()
-GET        /puzzles                                                             controllers.PuzzlesPageController.renderPuzzles()
+GET        /puzzles-and-games.json                                                        controllers.PuzzlesPageController.renderPuzzlesJson()
+GET        /puzzles-and-games                                                             controllers.PuzzlesPageController.renderPuzzles()
 
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
 GET        /crosswords/$crosswordType<cryptic|quick|quiptic|quick-cryptic|sunday-quick|prize|everyman|azed|special|genius|speedy|weekend|mini>/:id.svg       controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)

--- a/applications/test/PuzzlesLayoutProviderTest.scala
+++ b/applications/test/PuzzlesLayoutProviderTest.scala
@@ -17,15 +17,18 @@ import play.api.{Environment, Mode}
 
 import java.io.{ByteArrayInputStream, File, InputStream}
 import java.nio.charset.StandardCharsets
+import java.time.{Clock, Instant, ZoneOffset}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSugar {
   private implicit val executionContext: ExecutionContext = ExecutionContext.global
+  private val mondayClock = Clock.fixed(Instant.parse("2026-09-07T12:00:00Z"), ZoneOffset.UTC)
 
   "LocalJsonPuzzlesLayoutProvider" should "load the production layout from the classpath" in {
-    val provider = new LocalJsonPuzzlesLayoutProvider(Environment.simple(), emptyContentApiClient())
+    val provider =
+      new LocalJsonPuzzlesLayoutProvider(Environment.simple(), emptyContentApiClient(), clock = mondayClock)
 
     val layout = Await.result(provider.getLayout(), 5.seconds)
 
@@ -35,7 +38,8 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
   }
 
   it should "load the target hierarchy and its explicit presentation metadata" in {
-    val provider = new LocalJsonPuzzlesLayoutProvider(Environment.simple(), emptyContentApiClient())
+    val provider =
+      new LocalJsonPuzzlesLayoutProvider(Environment.simple(), emptyContentApiClient(), clock = mondayClock)
 
     val layout = Await.result(provider.getLayout(), 5.seconds)
     val featured = layout.containers.head
@@ -55,8 +59,8 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
       Some("inline3"),
     )
     featured.content.items.flatten.map(item => (item.title, item.cardVariant, item.cadence)) shouldBe Seq(
-      ("On the ball", "large", Some("Daily")),
-      ("Film reveal", "large", Some("Daily")),
+      ("Quick crossword", "large", Some("Daily")),
+      ("Easy sudoku", "large", Some("Daily")),
     )
     crosswords.content.items.map(_.map(item => item.title -> item.cardVariant)) shouldBe Seq(
       Seq("Quick", "Mini", "Cryptic", "Quick cryptic").map(_ -> "primary"),
@@ -83,6 +87,34 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
       Some(Seq("Most played", "Most comments"))
     allItems(layout).find(_.id == "wordiply-daily").flatMap(_.image) shouldBe Some("https://www.wordiply.com/share.png")
     allItems(layout).map(_.id).distinct should have size allItems(layout).size
+  }
+
+  it should "select the configured featured puzzles for each London weekday" in {
+    val expectedByDate = Seq(
+      "2026-09-07T12:00:00Z" -> Seq("Quick crossword", "Easy sudoku"),
+      "2026-09-08T12:00:00Z" -> Seq("Mini crossword", "Film reveal"),
+      "2026-09-09T12:00:00Z" -> Seq("Cryptic crossword", "Medium sudoku"),
+      "2026-09-10T12:00:00Z" -> Seq("Quick crossword", "Wordiply"),
+      "2026-09-11T12:00:00Z" -> Seq("Mini crossword", "Hard sudoku"),
+      "2026-09-12T12:00:00Z" -> Seq("General knowledge crossword", "Film reveal"),
+      "2026-09-13T12:00:00Z" -> Seq("Quiptic crossword", "On the ball"),
+    )
+
+    expectedByDate.foreach { case (instant, expectedTitles) =>
+      val provider = providerFor(
+        featuredLayout(enabled = true),
+        emptyContentApiClient(),
+        Clock.fixed(Instant.parse(instant), ZoneOffset.UTC),
+      )
+
+      firstItemRow(Await.result(provider.getLayout(), 5.seconds)).map(_.title) shouldBe expectedTitles
+    }
+  }
+
+  it should "omit the featured section when it is disabled" in {
+    val provider = providerFor(featuredLayout(enabled = false), emptyContentApiClient(), mondayClock)
+
+    Await.result(provider.getLayout(), 5.seconds).containers shouldBe empty
   }
 
   it should "close the resource stream after successful loading" in {
@@ -355,9 +387,26 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
       ),
     )
 
-  private def providerFor(layout: PuzzlesLayout, client: ContentApiClient): LocalJsonPuzzlesLayoutProvider = {
+  private def featuredLayout(enabled: Boolean): PuzzlesLayout =
+    PuzzlesLayout(
+      Seq(
+        PuzzleContainer(
+          id = "featured-puzzles",
+          title = "Today’s featured puzzles",
+          variant = Some("featured"),
+          content = PuzzleContent(Seq.empty, Seq.empty),
+          enabled = Some(enabled),
+        ),
+      ),
+    )
+
+  private def providerFor(
+      layout: PuzzlesLayout,
+      client: ContentApiClient,
+      clock: Clock = Clock.systemUTC(),
+  ): LocalJsonPuzzlesLayoutProvider = {
     val stream = new CloseTrackingInputStream(Json.stringify(Json.toJson(layout)))
-    new LocalJsonPuzzlesLayoutProvider(environmentReturning(Some(stream)), client)
+    new LocalJsonPuzzlesLayoutProvider(environmentReturning(Some(stream)), client, clock = clock)
   }
 
   private def emptyContentApiClient(): ContentApiClient = contentApiClient(Map.empty)
@@ -399,8 +448,13 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
 
   private def firstItem(layout: PuzzlesLayout): PuzzleItem = allItems(layout).head
 
+  private def firstItemRow(layout: PuzzlesLayout): Seq[PuzzleItem] = layout.containers.head.content.items.head
+
   private def allItems(layout: PuzzlesLayout): Seq[PuzzleItem] =
     layout.containers.flatMap(allItems)
+
+  private def allItems(container: PuzzleContainer): Seq[PuzzleItem] =
+    container.content.items.flatten ++ container.content.nestedContainers.flatMap(allItems)
 
   private def archives(layout: PuzzlesLayout): Seq[PuzzleItem] =
     layout.containers.flatMap(archives)

--- a/applications/test/PuzzlesLayoutProviderTest.scala
+++ b/applications/test/PuzzlesLayoutProviderTest.scala
@@ -180,7 +180,7 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
     val enrichedItem = firstItem(Await.result(provider.getLayout(), 5.seconds))
 
     enrichedItem shouldBe baseItem.copy(
-      url = Some("/puzzles/crosswords/quick-cryptic/321"),
+      url = Some("/puzzles-and-games/crosswords/quick-cryptic/321"),
       image = Some("/fallback.svg"),
     )
   }
@@ -222,7 +222,7 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
     val enriched = Await.result(provider.getLayout(), 5.seconds)
 
     queries should have size 1
-    allItems(enriched).map(_.url).distinct shouldBe Seq(Some("/puzzles/crosswords/quick/42"))
+    allItems(enriched).map(_.url).distinct shouldBe Seq(Some("/puzzles-and-games/crosswords/quick/42"))
   }
 
   it should "query the corresponding CAPI series tag for every supported crossword set" in {
@@ -314,7 +314,7 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
     queries should have size 1
     allItems(result) should contain theSameElementsInOrderAs Seq(
       latestCard.copy(
-        url = Some("/puzzles/crosswords/quick/99"),
+        url = Some("/puzzles-and-games/crosswords/quick/99"),
         image = Some("/latest-card.svg"),
       ),
       archiveInItems,
@@ -338,7 +338,7 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
 
     val result = Await.result(provider.getLayout(), 5.seconds)
 
-    allItems(result).find(_.set == "quick").flatMap(_.url) shouldBe Some("/puzzles/crosswords/quick/100")
+    allItems(result).find(_.set == "quick").flatMap(_.url) shouldBe Some("/puzzles-and-games/crosswords/quick/100")
     allItems(result).find(_.set == "cryptic") shouldBe Some(cryptic)
   }
 

--- a/applications/test/PuzzlesLayoutProviderTest.scala
+++ b/applications/test/PuzzlesLayoutProviderTest.scala
@@ -35,6 +35,38 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
     archives(layout) should not be empty
   }
 
+  it should "load the target hierarchy and its explicit presentation metadata" in {
+    val provider = new LocalJsonPuzzlesLayoutProvider(Environment.simple(), emptyContentApiClient())
+
+    val layout = Await.result(provider.getLayout(), 5.seconds)
+    val featured = layout.containers.head
+    val crosswords = layout.containers(1)
+
+    layout.filters.map(filter => filter.title -> filter.target) shouldBe Seq(
+      "Crosswords" -> "#crosswords",
+      "Logic" -> "#logic-puzzles",
+      "Word games" -> "#word-games",
+    )
+    layout.containers.map(_.title) shouldBe Seq(
+      "Today’s featured puzzles",
+      "Crosswords",
+      "Word games",
+      "Logic puzzles",
+    )
+    featured.content.items.flatten.map(item => (item.title, item.cardVariant, item.cadence)) shouldBe Seq(
+      ("On the ball", "large", Some("Daily")),
+      ("Film reveal", "large", Some("Daily")),
+    )
+    crosswords.content.items.map(_.map(item => item.title -> item.cardVariant)) shouldBe Seq(
+      Seq("Mini", "Quick", "Cryptic", "Quick cryptic").map(_ -> "primary"),
+      Seq("Quiptic", "Prize", "Weekend", "Sunday quick", "Genius").map(_ -> "compact"),
+    )
+    crosswords.content.archive.map(item => item.title -> item.cardVariant) shouldBe Some(
+      "Crosswords archive" -> "archive",
+    )
+    allItems(layout).map(_.id).distinct should have size allItems(layout).size
+  }
+
   it should "close the resource stream after successful loading" in {
     val json = """{"containers":[],"filters":[]}"""
     val stream = new CloseTrackingInputStream(json)
@@ -77,9 +109,12 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
 
   it should "replace only URL and image fields after a successful lookup" in {
     val baseItem = PuzzleItem(
+      id = "crossword-quick-cryptic",
       title = "Editorial title",
       `type` = "crossword",
       set = "quick-cryptic",
+      cardVariant = "primary",
+      cadence = Some("Every Saturday"),
       url = Some("/fallback"),
       image = Some("/fallback.svg"),
       slug = Some("editorial-slug"),
@@ -104,11 +139,18 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
   it should "discover nested cards recursively and deduplicate lookups by set" in {
     val queries = ListBuffer.empty[SearchQuery]
     val nested = PuzzleContainer(
+      id = "nested",
       title = "Nested",
-      content = PuzzleContent(items = Seq(Seq(crossword("quick", "/nested"))), nestedContainers = Seq.empty),
+      content = PuzzleContent(
+        items = Seq(Seq(crossword("quick", "/nested").copy(id = "crossword-quick-nested"))),
+        nestedContainers = Seq.empty,
+      ),
     )
     val layout = layoutWith(
-      items = Seq(crossword("quick", "/top"), crossword("quick", "/duplicate")),
+      items = Seq(
+        crossword("quick", "/top").copy(id = "crossword-quick-top"),
+        crossword("quick", "/duplicate").copy(id = "crossword-quick-duplicate"),
+      ),
       nestedContainers = Seq(nested),
     )
     val provider = providerFor(
@@ -180,10 +222,26 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
 
   it should "exclude archive and non-crossword items from lookup and enrichment" in {
     val queries = ListBuffer.empty[SearchQuery]
-    val latestCard = crossword("quick", "/latest-card")
-    val archiveInItems = crossword("quick", "/archive-card").copy(variant = Some("archive-page"))
-    val nonCrossword = PuzzleItem("Sudoku", "sudoku", "quick", url = Some("/sudoku"), image = Some("/sudoku.svg"))
-    val archive = crossword("quick", "/archive")
+    val latestCard = crossword("quick", "/latest-card").copy(id = "crossword-quick-latest")
+    val archiveInItems = crossword("quick", "/archive-card").copy(
+      id = "crossword-quick-archive-card",
+      variant = Some("archive-page"),
+    )
+    val nonCrossword = PuzzleItem(
+      "sudoku-quick",
+      "Sudoku",
+      "sudoku",
+      "quick",
+      "primary",
+      Some("Daily"),
+      url = Some("/sudoku"),
+      image = Some("/sudoku.svg"),
+    )
+    val archive = crossword("quick", "/archive").copy(
+      id = "crosswords-archive",
+      cardVariant = "archive",
+      cadence = None,
+    )
     val layout = layoutWith(items = Seq(latestCard, archiveInItems, nonCrossword), archive = Some(archive))
     val provider = providerFor(
       layout,
@@ -240,9 +298,12 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
 
   private def crossword(set: String, url: String = "/base"): PuzzleItem =
     PuzzleItem(
+      id = s"crossword-$set",
       title = set,
       `type` = "crossword",
       set = set,
+      cardVariant = "primary",
+      cadence = Some("Daily"),
       url = Some(url),
       image = Some(s"$url.svg"),
       backgroundColour = Some("#f0f0f0"),
@@ -256,6 +317,7 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
     PuzzlesLayout(
       containers = Seq(
         PuzzleContainer(
+          id = "test-container",
           title = "Test container",
           variant = Some("featured"),
           content = PuzzleContent(Seq(items), nestedContainers, archive),
@@ -263,7 +325,7 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
           desktopSpan = Some(12),
         ),
       ),
-      filters = Seq(PuzzleFilter("crosswords", "Crosswords", Some("#f0f0f0"))),
+      filters = Seq(PuzzleFilter("crosswords", "Crosswords", "#test-container", Some("#f0f0f0"))),
     )
 
   private def providerFor(layout: PuzzlesLayout, client: ContentApiClient): LocalJsonPuzzlesLayoutProvider = {

--- a/applications/test/PuzzlesLayoutProviderTest.scala
+++ b/applications/test/PuzzlesLayoutProviderTest.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.SearchQuery
 import com.gu.contentapi.client.model.v1.{Content => ApiContent, Crossword, CrosswordType, SearchResponse}
 import contentapi.ContentApiClient
 import controllers.LocalJsonPuzzlesLayoutProvider
-import model.dotcomrendering.{PuzzleContainer, PuzzleContent, PuzzleFilter, PuzzleItem, PuzzlesLayout}
+import model.dotcomrendering.{PuzzleContainer, PuzzleContent, PuzzleItem, PuzzlesLayout}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
@@ -30,7 +30,6 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
     val layout = Await.result(provider.getLayout(), 5.seconds)
 
     layout.containers should not be empty
-    layout.filters should not be empty
     layout.containers.flatMap(_.content.nestedContainers) should not be empty
     archives(layout) should not be empty
   }
@@ -40,43 +39,58 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
 
     val layout = Await.result(provider.getLayout(), 5.seconds)
     val featured = layout.containers.head
-    val crosswords = layout.containers(_.id == "crosswords").get
+    val crosswords = layout.containers.find(_.id == "crosswords").get
 
-    layout.filters.map(filter => filter.title -> filter.target) shouldBe Seq(
-      "Crosswords" -> "#crosswords",
-      "Logic" -> "#logic-puzzles",
-      "Word games" -> "#word-games",
-    )
-    layout.containers.filterNot(_.variant.contains("ad")).map(_.title) shouldBe Seq(
+    layout.containers
+      .filter(container => container.variant.exists(Set("featured", "standard")))
+      .map(_.title) shouldBe Seq(
       "Today’s featured puzzles",
       "Crosswords",
-      "Logic puzzles",
       "Word games",
+      "Logic puzzles",
     )
     layout.containers.filter(_.variant.contains("ad")).map(_.adSlot) shouldBe Seq(
       Some("inline1"),
       Some("inline2"),
+      Some("inline3"),
     )
     featured.content.items.flatten.map(item => (item.title, item.cardVariant, item.cadence)) shouldBe Seq(
       ("On the ball", "large", Some("Daily")),
       ("Film reveal", "large", Some("Daily")),
     )
     crosswords.content.items.map(_.map(item => item.title -> item.cardVariant)) shouldBe Seq(
-      Seq("Mini", "Quick", "Cryptic", "Quick cryptic").map(_ -> "primary"),
-      Seq("Quiptic", "Prize", "Weekend", "Sunday quick", "Genius").map(_ -> "compact"),
+      Seq("Quick", "Mini", "Cryptic", "Quick cryptic").map(_ -> "primary"),
+      Seq("Quiptic", "Prize", "Weekend", "Genius").map(_ -> "compact"),
     )
-    crosswords.content.archive.map(item => item.title -> item.cardVariant) shouldBe Some(
-      "Crosswords archive" -> "archive",
+    crosswords.content.archiveChoices.map(_.map(_.title)) shouldBe Some(
+      Seq(
+        "Mini",
+        "Quick",
+        "Cryptic",
+        "Quick cryptic",
+        "Quiptic",
+        "Weekend",
+        "Prize",
+        "Sunday quick",
+        "Genius",
+        "Special",
+      ),
     )
+    layout.containers
+      .find(_.variant.contains("supporting"))
+      .flatMap(_.supporting)
+      .map(_.popularGroups.map(_.title)) shouldBe
+      Some(Seq("Most played", "Most comments"))
+    allItems(layout).find(_.id == "wordiply-daily").flatMap(_.image) shouldBe Some("https://www.wordiply.com/share.png")
     allItems(layout).map(_.id).distinct should have size allItems(layout).size
   }
 
   it should "close the resource stream after successful loading" in {
-    val json = """{"containers":[],"filters":[]}"""
+    val json = """{"containers":[]}"""
     val stream = new CloseTrackingInputStream(json)
     val provider = new LocalJsonPuzzlesLayoutProvider(environmentReturning(Some(stream)), emptyContentApiClient())
 
-    Await.result(provider.getLayout(), 5.seconds) shouldBe PuzzlesLayout(Seq.empty, Seq.empty)
+    Await.result(provider.getLayout(), 5.seconds) shouldBe PuzzlesLayout(Seq.empty)
     stream.wasClosed shouldBe true
   }
 
@@ -111,7 +125,7 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
     error.getMessage should include("was not found on the classpath")
   }
 
-  it should "replace only URL and image fields after a successful lookup" in {
+  it should "replace the URL while preserving an image configured by the blueprint" in {
     val baseItem = PuzzleItem(
       id = "crossword-quick-cryptic",
       title = "Editorial title",
@@ -125,7 +139,6 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
       index = Some(7),
       variant = Some("featured"),
       backgroundColour = Some("#abcdef"),
-      filterId = Some("crosswords"),
     )
     val provider = providerFor(
       layoutWith(items = Seq(baseItem)),
@@ -136,7 +149,19 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
 
     enrichedItem shouldBe baseItem.copy(
       url = Some("/puzzles/crosswords/quick-cryptic/321"),
-      image = Some("https://api.nextgen.guardianapps.co.uk/crosswords/quick-cryptic/321.svg"),
+      image = Some("/fallback.svg"),
+    )
+  }
+
+  it should "use the enriched crossword image when the blueprint does not configure one" in {
+    val baseItem = crossword("quick", "/fallback").copy(image = None)
+    val provider = providerFor(
+      layoutWith(items = Seq(baseItem)),
+      contentApiClient(Map("crosswords/series/quick" -> Right(Some(CrosswordType.Quick -> 123)))),
+    )
+
+    firstItem(Await.result(provider.getLayout(), 5.seconds)).image shouldBe Some(
+      "https://api.nextgen.guardianapps.co.uk/crosswords/quick/123.svg",
     )
   }
 
@@ -258,7 +283,7 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
     allItems(result) should contain theSameElementsInOrderAs Seq(
       latestCard.copy(
         url = Some("/puzzles/crosswords/quick/99"),
-        image = Some("https://api.nextgen.guardianapps.co.uk/crosswords/quick/99.svg"),
+        image = Some("/latest-card.svg"),
       ),
       archiveInItems,
       nonCrossword,
@@ -325,11 +350,9 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
           title = "Test container",
           variant = Some("featured"),
           content = PuzzleContent(Seq(items), nestedContainers, archive),
-          filterId = Some("crosswords"),
           desktopSpan = Some(12),
         ),
       ),
-      filters = Seq(PuzzleFilter("crosswords", "Crosswords", "#test-container", Some("#f0f0f0"))),
     )
 
   private def providerFor(layout: PuzzlesLayout, client: ContentApiClient): LocalJsonPuzzlesLayoutProvider = {
@@ -379,14 +402,13 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
   private def allItems(layout: PuzzlesLayout): Seq[PuzzleItem] =
     layout.containers.flatMap(allItems)
 
-  private def allItems(container: PuzzleContainer): Seq[PuzzleItem] =
-    container.content.items.flatten ++ container.content.nestedContainers.flatMap(allItems)
-
   private def archives(layout: PuzzlesLayout): Seq[PuzzleItem] =
-    layout.containers.flatMap(container =>
-      container.content.archive.toSeq ++
-        container.content.nestedContainers.flatMap(nested => nested.content.archive.toSeq),
-    )
+    layout.containers.flatMap(archives)
+
+  private def archives(container: PuzzleContainer): Seq[PuzzleItem] =
+    container.content.archive.toSeq ++
+      container.content.archiveChoices.toSeq.flatten ++
+      container.content.nestedContainers.flatMap(archives)
 
   private def environmentReturning(stream: Option[InputStream]): Environment = {
     val classLoader = new ClassLoader(null) {

--- a/applications/test/PuzzlesLayoutProviderTest.scala
+++ b/applications/test/PuzzlesLayoutProviderTest.scala
@@ -40,18 +40,22 @@ class PuzzlesLayoutProviderTest extends AnyFlatSpec with Matchers with MockitoSu
 
     val layout = Await.result(provider.getLayout(), 5.seconds)
     val featured = layout.containers.head
-    val crosswords = layout.containers(1)
+    val crosswords = layout.containers(_.id == "crosswords").get
 
     layout.filters.map(filter => filter.title -> filter.target) shouldBe Seq(
       "Crosswords" -> "#crosswords",
       "Logic" -> "#logic-puzzles",
       "Word games" -> "#word-games",
     )
-    layout.containers.map(_.title) shouldBe Seq(
+    layout.containers.filterNot(_.variant.contains("ad")).map(_.title) shouldBe Seq(
       "Today’s featured puzzles",
       "Crosswords",
-      "Word games",
       "Logic puzzles",
+      "Word games",
+    )
+    layout.containers.filter(_.variant.contains("ad")).map(_.adSlot) shouldBe Seq(
+      Some("inline1"),
+      Some("inline2"),
     )
     featured.content.items.flatten.map(item => (item.title, item.cardVariant, item.cadence)) shouldBe Seq(
       ("On the ball", "large", Some("Daily")),

--- a/applications/test/PuzzlesPageControllerTest.scala
+++ b/applications/test/PuzzlesPageControllerTest.scala
@@ -68,7 +68,7 @@ import scala.concurrent.{ExecutionContext, Future}
     when(renderer.getPuzzlesPage(any[WSClient], any[JsValue])(any[RequestHeader]))
       .thenReturn(Future.successful(Results.Ok("rendered by DCR")))
 
-    val result = controller(provider, renderer).renderPuzzles()(request("/puzzles"))
+    val result = controller(provider, renderer).renderPuzzles()(request("/puzzles-and-games"))
 
     status(result) should be(OK)
     contentAsString(result) should be("rendered by DCR")
@@ -78,7 +78,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
   it should "return not found for an unsupported format" in {
     val result = controller(successfulProvider, mock[DotcomRenderingService])
-      .renderPuzzles()(request("/puzzles.json"))
+      .renderPuzzles()(request("/puzzles-and-games.json"))
 
     status(result) should be(NOT_FOUND)
   }
@@ -88,7 +88,7 @@ import scala.concurrent.{ExecutionContext, Future}
     val provider = mock[PuzzlesLayoutProvider]
     when(provider.getLayout()(any[ExecutionContext])).thenReturn(Future.failed(failure))
 
-    val result = controller(provider, mock[DotcomRenderingService]).renderPuzzles()(request("/puzzles"))
+    val result = controller(provider, mock[DotcomRenderingService]).renderPuzzles()(request("/puzzles-and-games"))
 
     result.failed.futureValue should be(failure)
   }
@@ -99,33 +99,33 @@ import scala.concurrent.{ExecutionContext, Future}
     when(renderer.getPuzzlesPage(any[WSClient], any[JsValue])(any[RequestHeader]))
       .thenReturn(Future.failed(failure))
 
-    val result = controller(successfulProvider, renderer).renderPuzzles()(request("/puzzles"))
+    val result = controller(successfulProvider, renderer).renderPuzzles()(request("/puzzles-and-games"))
 
     result.failed.futureValue should be(failure)
   }
 
   "renderPuzzlesJson" should "return the equivalent rendering data as JSON" in {
     val result = controller(successfulProvider, mock[DotcomRenderingService])
-      .renderPuzzlesJson()(request("/puzzles.json"))
+      .renderPuzzlesJson()(request("/puzzles-and-games.json"))
 
     status(result) should be(OK)
     contentType(result) should contain("application/json")
     val json = Json.parse(contentAsString(result))
-    (json \ "id").as[String] should be("/puzzles.json")
+    (json \ "id").as[String] should be("/puzzles-and-games.json")
     (json \ "webTitle").as[String] should be("Puzzles and Games")
     (json \ "layout").as[JsValue] should be(Json.toJson(layout))
   }
 
   it should "return not found when the JSON action receives an HTML request" in {
     val result = controller(successfulProvider, mock[DotcomRenderingService])
-      .renderPuzzlesJson()(request("/puzzles"))
+      .renderPuzzlesJson()(request("/puzzles-and-games"))
 
     status(result) should be(NOT_FOUND)
   }
 
   it should "return not found for another unsupported format" in {
     val result = controller(successfulProvider, mock[DotcomRenderingService])
-      .renderPuzzlesJson()(request("/puzzles.atom"))
+      .renderPuzzlesJson()(request("/puzzles-and-games.atom"))
 
     status(result) should be(NOT_FOUND)
   }
@@ -143,8 +143,8 @@ import scala.concurrent.{ExecutionContext, Future}
         val renderer = mock[DotcomRenderingService]
         val puzzlesController = controller(provider, renderer)
 
-        val htmlResult = puzzlesController.renderPuzzles()(request("/puzzles", participations))
-        val jsonResult = puzzlesController.renderPuzzlesJson()(request("/puzzles.json", participations))
+        val htmlResult = puzzlesController.renderPuzzles()(request("/puzzles-and-games", participations))
+        val jsonResult = puzzlesController.renderPuzzlesJson()(request("/puzzles-and-games.json", participations))
 
         status(htmlResult) should be(NOT_FOUND)
         status(jsonResult) should be(NOT_FOUND)

--- a/applications/test/PuzzlesPageControllerTest.scala
+++ b/applications/test/PuzzlesPageControllerTest.scala
@@ -28,9 +28,12 @@ import scala.concurrent.{ExecutionContext, Future}
   private val layout = PuzzlesLayout(
     containers = Seq(
       PuzzleContainer(
+        id = "daily-puzzles",
         title = "Daily puzzles",
         content = PuzzleContent(
-          items = Seq(Seq(PuzzleItem("Quick crossword", "crossword", "quick"))),
+          items = Seq(
+            Seq(PuzzleItem("crossword-quick", "Quick crossword", "crossword", "quick", "primary", Some("Daily"))),
+          ),
           nestedContainers = Seq.empty,
         ),
       ),

--- a/applications/test/PuzzlesPageControllerTest.scala
+++ b/applications/test/PuzzlesPageControllerTest.scala
@@ -112,7 +112,7 @@ import scala.concurrent.{ExecutionContext, Future}
     contentType(result) should contain("application/json")
     val json = Json.parse(contentAsString(result))
     (json \ "id").as[String] should be("/puzzles-and-games.json")
-    (json \ "webTitle").as[String] should be("Puzzles and Games")
+    (json \ "webTitle").as[String] should be("Puzzles and games")
     (json \ "layout").as[JsValue] should be(Json.toJson(layout))
   }
 

--- a/applications/test/PuzzlesRoutesTest.scala
+++ b/applications/test/PuzzlesRoutesTest.scala
@@ -10,13 +10,13 @@ import org.scalatest.matchers.should.Matchers
     val route = controllers.routes.PuzzlesPageController.renderPuzzles()
 
     route.method should be("GET")
-    route.url should be("/puzzles")
+    route.url should be("/puzzles-and-games")
   }
 
   it should "expose the puzzles JSON endpoint" in {
     val route = controllers.routes.PuzzlesPageController.renderPuzzlesJson()
 
     route.method should be("GET")
-    route.url should be("/puzzles.json")
+    route.url should be("/puzzles-and-games.json")
   }
 }

--- a/common/app/ab/PuzzlesHubExperiment.scala
+++ b/common/app/ab/PuzzlesHubExperiment.scala
@@ -1,5 +1,6 @@
 package ab
 
+import conf.Configuration
 import play.api.mvc.RequestHeader
 
 /** Request-level access to the Fastly-managed puzzles hub experiment.
@@ -13,5 +14,8 @@ object PuzzlesHubExperiment {
   val VariantGroup = "variant"
 
   def isEnabled(implicit request: RequestHeader): Boolean =
-    ABTests.isUserInTestGroup(TestName, VariantGroup)
+    isEnabled(Configuration.environment.isDev)
+
+  private[ab] def isEnabled(isDevelopment: Boolean)(implicit request: RequestHeader): Boolean =
+    isDevelopment || ABTests.isUserInTestGroup(TestName, VariantGroup)
 }

--- a/common/app/ab/README.md
+++ b/common/app/ab/README.md
@@ -1,27 +1,26 @@
 # Server-side AB tests in Frontend
 
 Server-side AB tests are defined in `dotcom-rendering-main/ab-testing/config/abTests.ts` and deployed to Fastly. Fastly
-assigns each participating request to a group and sends the result to Frontend in the X-GU-Server-AB-Tests header.
+assigns each participating request to a group and sends the result to Frontend in the `X-GU-Server-AB-Tests` header.
 
-ABTestingFilter decorates the Play request with those participations. Feature-specific server code should expose a
-small helper built on ABTests.isUserInTestGroup, rather than defining a duplicate experiment or switch in Frontend.
+`ABTestingFilter` decorates the Play request with those participations. Feature-specific server code should expose a
+small helper built on `ABTests.isUserInTestGroup`, rather than defining a duplicate experiment or switch in Frontend.
 
-The enable-new-server-side-tests-header infrastructure switch must be enabled in each environment where these tests
+The `enable-new-server-side-tests-header` infrastructure switch must be enabled in each environment where these tests
 are expected to run.
 
 ## Puzzles hub
 
-The puzzles hub uses the Fastly-managed puzzles-new-hub experiment. Frontend code should check
-PuzzlesHubExperiment.isEnabled, which is true only for the variant group and safely defaults to false for control,
-excluded, missing, or malformed participations outside local development. In `DEV`, the helper enables the hub
-without a Fastly participation so Frontend can render `/puzzles` through a locally running dotcom-rendering
-instance.
+The puzzles hub uses the Fastly-managed `puzzles-new-hub` experiment. Frontend code should check
+`PuzzlesHubExperiment.isEnabled`, which is true only for the `variant` group and safely defaults to false for control,
+excluded, missing, or malformed participations outside local development. In `DEV`, the helper enables the hub without
+a Fastly participation so Frontend can render `/puzzles-and-games` through a locally running dotcom-rendering instance.
 
 The existing Fastly routes can be used to force a group in CODE or PROD:
 
--   /ab-tests/opt-in/puzzles-new-hub:variant
--   /ab-tests/opt-in/puzzles-new-hub:control
--   /ab-tests/opt-out
+-   `/ab-tests/opt-in/puzzles-new-hub:variant`
+-   `/ab-tests/opt-in/puzzles-new-hub:control`
+-   `/ab-tests/opt-out`
 
-The /puzzles and /puzzles.json routes, as well as puzzles navigation, are available only to variant requests.
+The `/puzzles-and-games` and `/puzzles-and-games.json` routes, as well as puzzles navigation, are available only to variant requests.
 Development and QA can use the Fastly opt-in route above to force variant participation.

--- a/common/app/ab/README.md
+++ b/common/app/ab/README.md
@@ -13,7 +13,9 @@ are expected to run.
 
 The puzzles hub uses the Fastly-managed puzzles-new-hub experiment. Frontend code should check
 PuzzlesHubExperiment.isEnabled, which is true only for the variant group and safely defaults to false for control,
-excluded, missing, or malformed participations.
+excluded, missing, or malformed participations outside local development. In `DEV`, the helper enables the hub
+without a Fastly participation so Frontend can render `/puzzles` through a locally running dotcom-rendering
+instance.
 
 The existing Fastly routes can be used to force a group in CODE or PROD:
 

--- a/common/app/model/PuzzlesLayout.scala
+++ b/common/app/model/PuzzlesLayout.scala
@@ -4,9 +4,12 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class PuzzleItem(
+    id: String,
     title: String,
     `type`: String,
     set: String,
+    cardVariant: String,
+    cadence: Option[String] = None,
     url: Option[String] = None,
     image: Option[String] = None,
     slug: Option[String] = None,
@@ -17,7 +20,19 @@ case class PuzzleItem(
 )
 
 object PuzzleItem {
-  private val reads: Reads[PuzzleItem] = Json.reads[PuzzleItem]
+  val SupportedCardVariants: Set[String] = Set("large", "primary", "compact", "archive")
+
+  private val reads: Reads[PuzzleItem] = Json
+    .reads[PuzzleItem]
+    .filter(JsonValidationError("puzzle id must be a lowercase kebab-case identifier"))(
+      _.id.matches("[a-z0-9]+(?:-[a-z0-9]+)*"),
+    )
+    .filter(JsonValidationError(s"cardVariant must be one of ${SupportedCardVariants.toSeq.sorted.mkString(", ")}"))(
+      item => SupportedCardVariants.contains(item.cardVariant),
+    )
+    .filter(JsonValidationError("cadence is required for non-archive puzzle cards"))(item =>
+      item.cardVariant == "archive" || item.cadence.exists(_.trim.nonEmpty),
+    )
   private val writes: OWrites[PuzzleItem] = Json.writes[PuzzleItem].transform(removeNullFields)
   implicit val format: OFormat[PuzzleItem] = OFormat(reads, writes)
 
@@ -40,6 +55,7 @@ object PuzzleContent {
 }
 
 case class PuzzleContainer(
+    id: String,
     title: String,
     variant: Option[String] = None,
     content: PuzzleContent,
@@ -48,23 +64,49 @@ case class PuzzleContainer(
 )
 
 object PuzzleContainer {
-  implicit lazy val format: OFormat[PuzzleContainer] = (
-    (__ \ "title").format[String] and
-      (__ \ "variant").formatNullable[String] and
-      (__ \ "content").lazyFormat[PuzzleContent](PuzzleContent.format) and
-      (__ \ "filterId").formatNullable[String] and
-      (__ \ "desktopSpan").formatNullable[Int]
-  )(PuzzleContainer.apply, unlift(PuzzleContainer.unapply))
+  val SupportedVariants: Set[String] = Set("featured", "standard")
+
+  private lazy val reads: Reads[PuzzleContainer] = (
+    (__ \ "id").read[String] and
+      (__ \ "title").read[String] and
+      (__ \ "variant").readNullable[String] and
+      (__ \ "content").lazyRead[PuzzleContent](PuzzleContent.format) and
+      (__ \ "filterId").readNullable[String] and
+      (__ \ "desktopSpan").readNullable[Int]
+  )(PuzzleContainer.apply _).filter(JsonValidationError("container variant or desktopSpan is unsupported"))(container =>
+    container.id.matches("[a-z0-9]+(?:-[a-z0-9]+)*") &&
+      container.variant.forall(SupportedVariants.contains) &&
+      container.desktopSpan.forall(span => span >= 1 && span <= 12),
+  )
+
+  private lazy val writes: OWrites[PuzzleContainer] = (
+    (__ \ "id").write[String] and
+      (__ \ "title").write[String] and
+      (__ \ "variant").writeNullable[String] and
+      (__ \ "content").lazyWrite[PuzzleContent](PuzzleContent.format) and
+      (__ \ "filterId").writeNullable[String] and
+      (__ \ "desktopSpan").writeNullable[Int]
+  )(unlift(PuzzleContainer.unapply))
+
+  implicit lazy val format: OFormat[PuzzleContainer] = OFormat(reads, writes)
 }
 
 case class PuzzleFilter(
     id: String,
     title: String,
+    target: String,
     backgroundColour: Option[String] = None,
 )
 
 object PuzzleFilter {
-  private val reads: Reads[PuzzleFilter] = Json.reads[PuzzleFilter]
+  private val reads: Reads[PuzzleFilter] = Json
+    .reads[PuzzleFilter]
+    .filter(JsonValidationError("navigation id must be a lowercase kebab-case identifier"))(
+      _.id.matches("[a-z0-9]+(?:-[a-z0-9]+)*"),
+    )
+    .filter(JsonValidationError("navigation target must be a section anchor or an internal /puzzles path"))(filter =>
+      filter.target.startsWith("#") || filter.target.startsWith("/puzzles"),
+    )
   private val writes: OWrites[PuzzleFilter] = Json.writes[PuzzleFilter].transform(removeNullFields)
   implicit val format: OFormat[PuzzleFilter] = OFormat(reads, writes)
 
@@ -78,5 +120,54 @@ case class PuzzlesLayout(
 )
 
 object PuzzlesLayout {
-  implicit lazy val format: OFormat[PuzzlesLayout] = Json.format[PuzzlesLayout]
+  private val rawFormat: OFormat[PuzzlesLayout] = Json.format[PuzzlesLayout]
+
+  private val reads: Reads[PuzzlesLayout] = rawFormat.flatMap { layout =>
+    Reads { _ =>
+      validationErrors(layout) match {
+        case Seq()  => JsSuccess(layout)
+        case errors => JsError(errors.map(error => JsPath -> Seq(JsonValidationError(error))))
+      }
+    }
+  }
+
+  implicit lazy val format: OFormat[PuzzlesLayout] = OFormat(reads, rawFormat)
+
+  def validationErrors(layout: PuzzlesLayout): Seq[String] = {
+    val containers = flattenContainers(layout.containers)
+    val items = containers.flatMap(container => container.content.items.flatten ++ container.content.archive.toSeq)
+    val filterIds = layout.filters.map(_.id)
+    val containerIds = containers.map(_.id)
+    val itemIds = items.map(_.id)
+    val anchorTargets = layout.filters.map(_.target).filter(_.startsWith("#")).map(_.drop(1))
+    val referencedFilterIds = containers.flatMap(_.filterId) ++ items.flatMap(_.filterId)
+
+    duplicateValues("filter", filterIds) ++
+      duplicateValues("container", containerIds) ++
+      duplicateValues("puzzle", itemIds) ++
+      anchorTargets
+        .filterNot(containerIds.contains)
+        .distinct
+        .map(target => s"navigation target '#$target' has no container") ++
+      referencedFilterIds.filterNot(filterIds.contains).distinct.map(id => s"filterId '$id' is not defined") ++
+      items.collect {
+        case item if item.cardVariant == "archive" && !containers.exists(_.content.archive.contains(item)) =>
+          s"puzzle '${item.id}' uses archive presentation outside an archive slot"
+        case item if item.cardVariant != "archive" && containers.exists(_.content.archive.contains(item)) =>
+          s"archive '${item.id}' must use the archive cardVariant"
+      }
+  }
+
+  private def flattenContainers(containers: Seq[PuzzleContainer]): Seq[PuzzleContainer] =
+    containers ++ containers.flatMap(container => flattenContainers(container.content.nestedContainers))
+
+  private def duplicateValues(label: String, values: Seq[String]): Seq[String] =
+    values
+      .groupBy(identity)
+      .collect {
+        case (value, occurrences) if occurrences.size > 1 =>
+          s"duplicate $label id '$value'"
+      }
+      .toSeq
+      .sorted
 }

--- a/common/app/model/PuzzlesLayout.scala
+++ b/common/app/model/PuzzlesLayout.scala
@@ -44,13 +44,15 @@ case class PuzzleContent(
     items: Seq[Seq[PuzzleItem]],
     nestedContainers: Seq[PuzzleContainer],
     archive: Option[PuzzleItem] = None,
+    archiveChoices: Option[Seq[PuzzleItem]] = None,
 )
 
 object PuzzleContent {
   implicit lazy val format: OFormat[PuzzleContent] = (
     (__ \ "items").format[Seq[Seq[PuzzleItem]]] and
       (__ \ "nestedContainers").lazyFormat[Seq[PuzzleContainer]](Format.of[Seq[PuzzleContainer]]) and
-      (__ \ "archive").formatNullable[PuzzleItem]
+      (__ \ "archive").formatNullable[PuzzleItem] and
+      (__ \ "archiveChoices").formatNullable[Seq[PuzzleItem]]
   )(PuzzleContent.apply, unlift(PuzzleContent.unapply))
 }
 
@@ -61,10 +63,11 @@ case class PuzzleContainer(
     content: PuzzleContent,
     filterId: Option[String] = None,
     desktopSpan: Option[Int] = None,
+    adSlot: Option[String] = None,
 )
 
 object PuzzleContainer {
-  val SupportedVariants: Set[String] = Set("featured", "standard")
+  val SupportedVariants: Set[String] = Set("featured", "standard", "ad")
 
   private lazy val reads: Reads[PuzzleContainer] = (
     (__ \ "id").read[String] and
@@ -72,11 +75,14 @@ object PuzzleContainer {
       (__ \ "variant").readNullable[String] and
       (__ \ "content").lazyRead[PuzzleContent](PuzzleContent.format) and
       (__ \ "filterId").readNullable[String] and
-      (__ \ "desktopSpan").readNullable[Int]
-  )(PuzzleContainer.apply _).filter(JsonValidationError("container variant or desktopSpan is unsupported"))(container =>
-    container.id.matches("[a-z0-9]+(?:-[a-z0-9]+)*") &&
-      container.variant.forall(SupportedVariants.contains) &&
-      container.desktopSpan.forall(span => span >= 1 && span <= 12),
+      (__ \ "desktopSpan").readNullable[Int] and
+      (__ \ "adSlot").readNullable[String]
+  )(PuzzleContainer.apply _).filter(JsonValidationError("container variant, span or ad slot is unsupported"))(
+    container =>
+      container.id.matches("[a-z0-9]+(?:-[a-z0-9]+)*") &&
+        container.variant.forall(SupportedVariants.contains) &&
+        container.desktopSpan.forall(span => span >= 1 && span <= 12) &&
+        container.adSlot.forall(_.matches("inline[1-9][0-9]*")),
   )
 
   private lazy val writes: OWrites[PuzzleContainer] = (
@@ -85,7 +91,8 @@ object PuzzleContainer {
       (__ \ "variant").writeNullable[String] and
       (__ \ "content").lazyWrite[PuzzleContent](PuzzleContent.format) and
       (__ \ "filterId").writeNullable[String] and
-      (__ \ "desktopSpan").writeNullable[Int]
+      (__ \ "desktopSpan").writeNullable[Int] and
+      (__ \ "adSlot").writeNullable[String]
   )(unlift(PuzzleContainer.unapply))
 
   implicit lazy val format: OFormat[PuzzleContainer] = OFormat(reads, writes)
@@ -135,12 +142,15 @@ object PuzzlesLayout {
 
   def validationErrors(layout: PuzzlesLayout): Seq[String] = {
     val containers = flattenContainers(layout.containers)
-    val items = containers.flatMap(container => container.content.items.flatten ++ container.content.archive.toSeq)
+    val items = containers.flatMap(container =>
+      container.content.items.flatten ++ container.content.archive.toSeq ++ container.content.archiveChoices.toSeq.flatten,
+    )
     val filterIds = layout.filters.map(_.id)
     val containerIds = containers.map(_.id)
     val itemIds = items.map(_.id)
     val anchorTargets = layout.filters.map(_.target).filter(_.startsWith("#")).map(_.drop(1))
     val referencedFilterIds = containers.flatMap(_.filterId) ++ items.flatMap(_.filterId)
+    val topLevelIds = layout.containers.map(_.id).toSet
 
     duplicateValues("filter", filterIds) ++
       duplicateValues("container", containerIds) ++
@@ -150,10 +160,36 @@ object PuzzlesLayout {
         .distinct
         .map(target => s"navigation target '#$target' has no container") ++
       referencedFilterIds.filterNot(filterIds.contains).distinct.map(id => s"filterId '$id' is not defined") ++
+      containers.collect {
+        case container
+            if container.variant.contains("ad") &&
+              (container.adSlot.isEmpty || container.title.nonEmpty || container.content.items.flatten.nonEmpty ||
+                container.content.nestedContainers.nonEmpty || container.content.archive.nonEmpty ||
+                container.content.archiveChoices.exists(_.nonEmpty)) =>
+          s"ad container '${container.id}' must have an adSlot and no title or puzzle content"
+        case container if !container.variant.contains("ad") && container.adSlot.nonEmpty =>
+          s"container '${container.id}' has an adSlot without the ad variant"
+        case container if container.variant.contains("ad") && !topLevelIds.contains(container.id) =>
+          s"ad container '${container.id}' must be top-level"
+        case container if !container.variant.contains("ad") && container.title.trim.isEmpty =>
+          s"container '${container.id}' must have a title"
+      } ++
+      containers.collect {
+        case container if container.content.archive.nonEmpty && container.content.archiveChoices.exists(_.nonEmpty) =>
+          s"container '${container.id}' cannot define both archive and archiveChoices"
+        case container if container.content.archiveChoices.exists(_.size < 2) =>
+          s"container '${container.id}' archiveChoices must contain at least two destinations"
+      } ++
       items.collect {
-        case item if item.cardVariant == "archive" && !containers.exists(_.content.archive.contains(item)) =>
+        case item
+            if item.cardVariant == "archive" && !containers.exists(container =>
+              container.content.archive.contains(item) || container.content.archiveChoices.exists(_.contains(item)),
+            ) =>
           s"puzzle '${item.id}' uses archive presentation outside an archive slot"
-        case item if item.cardVariant != "archive" && containers.exists(_.content.archive.contains(item)) =>
+        case item
+            if item.cardVariant != "archive" && containers.exists(container =>
+              container.content.archive.contains(item) || container.content.archiveChoices.exists(_.contains(item)),
+            ) =>
           s"archive '${item.id}' must use the archive cardVariant"
       }
   }

--- a/common/app/model/PuzzlesLayout.scala
+++ b/common/app/model/PuzzlesLayout.scala
@@ -210,7 +210,7 @@ object PuzzlesLayout {
       } ++
       containers.flatMap(_.supporting).flatMap { supporting =>
         val invalidLinks = supporting.usefulLinks.filter(link =>
-          link.title.trim.isEmpty || !(link.url.startsWith("/puzzles") || link.url.matches("https?://.+")),
+          link.title.trim.isEmpty || !(link.url.startsWith("/puzzles-and-games") || link.url.matches("https?://.+")),
         )
         val invalidGroups = supporting.popularGroups.filter(group => group.title.trim.isEmpty || group.itemIds.isEmpty)
         val invalidNewsletter = supporting.newsletter.exists(newsletter =>

--- a/common/app/model/PuzzlesLayout.scala
+++ b/common/app/model/PuzzlesLayout.scala
@@ -16,7 +16,6 @@ case class PuzzleItem(
     index: Option[Int] = None,
     variant: Option[String] = None,
     backgroundColour: Option[String] = None,
-    filterId: Option[String] = None,
 )
 
 object PuzzleItem {
@@ -61,28 +60,28 @@ case class PuzzleContainer(
     title: String,
     variant: Option[String] = None,
     content: PuzzleContent,
-    filterId: Option[String] = None,
     desktopSpan: Option[Int] = None,
     adSlot: Option[String] = None,
+    supporting: Option[PuzzlesSupportingContent] = None,
 )
 
 object PuzzleContainer {
-  val SupportedVariants: Set[String] = Set("featured", "standard", "ad")
+  val SupportedVariants: Set[String] = Set("featured", "standard", "ad", "supporting")
 
   private lazy val reads: Reads[PuzzleContainer] = (
     (__ \ "id").read[String] and
       (__ \ "title").read[String] and
       (__ \ "variant").readNullable[String] and
       (__ \ "content").lazyRead[PuzzleContent](PuzzleContent.format) and
-      (__ \ "filterId").readNullable[String] and
       (__ \ "desktopSpan").readNullable[Int] and
-      (__ \ "adSlot").readNullable[String]
+      (__ \ "adSlot").readNullable[String] and
+      (__ \ "supporting").readNullable[PuzzlesSupportingContent]
   )(PuzzleContainer.apply _).filter(JsonValidationError("container variant, span or ad slot is unsupported"))(
     container =>
       container.id.matches("[a-z0-9]+(?:-[a-z0-9]+)*") &&
         container.variant.forall(SupportedVariants.contains) &&
         container.desktopSpan.forall(span => span >= 1 && span <= 12) &&
-        container.adSlot.forall(_.matches("inline[1-9][0-9]*")),
+        container.adSlot.forall(slot => slot.matches("inline[1-9][0-9]*") || slot == "mostpop"),
   )
 
   private lazy val writes: OWrites[PuzzleContainer] = (
@@ -90,41 +89,61 @@ object PuzzleContainer {
       (__ \ "title").write[String] and
       (__ \ "variant").writeNullable[String] and
       (__ \ "content").lazyWrite[PuzzleContent](PuzzleContent.format) and
-      (__ \ "filterId").writeNullable[String] and
       (__ \ "desktopSpan").writeNullable[Int] and
-      (__ \ "adSlot").writeNullable[String]
+      (__ \ "adSlot").writeNullable[String] and
+      (__ \ "supporting").writeNullable[PuzzlesSupportingContent]
   )(unlift(PuzzleContainer.unapply))
 
   implicit lazy val format: OFormat[PuzzleContainer] = OFormat(reads, writes)
 }
 
-case class PuzzleFilter(
-    id: String,
+case class PuzzleLink(
     title: String,
-    target: String,
-    backgroundColour: Option[String] = None,
+    url: String,
 )
 
-object PuzzleFilter {
-  private val reads: Reads[PuzzleFilter] = Json
-    .reads[PuzzleFilter]
-    .filter(JsonValidationError("navigation id must be a lowercase kebab-case identifier"))(
-      _.id.matches("[a-z0-9]+(?:-[a-z0-9]+)*"),
-    )
-    .filter(JsonValidationError("navigation target must be a section anchor or an internal /puzzles path"))(filter =>
-      filter.target.startsWith("#") || filter.target.startsWith("/puzzles"),
-    )
-  private val writes: OWrites[PuzzleFilter] = Json.writes[PuzzleFilter].transform(removeNullFields)
-  implicit val format: OFormat[PuzzleFilter] = OFormat(reads, writes)
+object PuzzleLink {
+  implicit val format: OFormat[PuzzleLink] = Json.format[PuzzleLink]
+}
+
+case class PuzzlesNewsletter(
+    identityName: String,
+    name: String,
+    frequency: String,
+    description: String,
+    illustrationSquare: Option[String] = None,
+)
+
+object PuzzlesNewsletter {
+  private val writes: OWrites[PuzzlesNewsletter] = Json.writes[PuzzlesNewsletter].transform(removeNullFields)
+  implicit val format: OFormat[PuzzlesNewsletter] = OFormat(Json.reads[PuzzlesNewsletter], writes)
 
   private def removeNullFields(json: JsObject): JsObject =
     JsObject(json.fields.filterNot(_._2 == JsNull))
 }
 
-case class PuzzlesLayout(
-    containers: Seq[PuzzleContainer],
-    filters: Seq[PuzzleFilter] = Seq.empty,
+case class PuzzlePopularityGroup(
+    title: String,
+    itemIds: Seq[String],
 )
+
+object PuzzlePopularityGroup {
+  implicit val format: OFormat[PuzzlePopularityGroup] = Json.format[PuzzlePopularityGroup]
+}
+
+case class PuzzlesSupportingContent(
+    usefulLinksTitle: String,
+    usefulLinks: Seq[PuzzleLink],
+    newsletter: Option[PuzzlesNewsletter],
+    popularTitle: String,
+    popularGroups: Seq[PuzzlePopularityGroup],
+)
+
+object PuzzlesSupportingContent {
+  implicit val format: OFormat[PuzzlesSupportingContent] = Json.format[PuzzlesSupportingContent]
+}
+
+case class PuzzlesLayout(containers: Seq[PuzzleContainer])
 
 object PuzzlesLayout {
   private val rawFormat: OFormat[PuzzlesLayout] = Json.format[PuzzlesLayout]
@@ -145,34 +164,60 @@ object PuzzlesLayout {
     val items = containers.flatMap(container =>
       container.content.items.flatten ++ container.content.archive.toSeq ++ container.content.archiveChoices.toSeq.flatten,
     )
-    val filterIds = layout.filters.map(_.id)
     val containerIds = containers.map(_.id)
     val itemIds = items.map(_.id)
-    val anchorTargets = layout.filters.map(_.target).filter(_.startsWith("#")).map(_.drop(1))
-    val referencedFilterIds = containers.flatMap(_.filterId) ++ items.flatMap(_.filterId)
     val topLevelIds = layout.containers.map(_.id).toSet
+    val supportingItemIds = containers.flatMap(_.supporting.toSeq.flatMap(_.popularGroups.flatMap(_.itemIds)))
 
-    duplicateValues("filter", filterIds) ++
-      duplicateValues("container", containerIds) ++
+    duplicateValues("container", containerIds) ++
       duplicateValues("puzzle", itemIds) ++
-      anchorTargets
-        .filterNot(containerIds.contains)
-        .distinct
-        .map(target => s"navigation target '#$target' has no container") ++
-      referencedFilterIds.filterNot(filterIds.contains).distinct.map(id => s"filterId '$id' is not defined") ++
+      supportingItemIds.filterNot(itemIds.contains).distinct.map(id => s"popular puzzle '$id' is not defined") ++
       containers.collect {
         case container
             if container.variant.contains("ad") &&
-              (container.adSlot.isEmpty || container.title.nonEmpty || container.content.items.flatten.nonEmpty ||
+              (container.adSlot.forall(!_.matches("inline[1-9][0-9]*")) || container.title.nonEmpty ||
                 container.content.nestedContainers.nonEmpty || container.content.archive.nonEmpty ||
-                container.content.archiveChoices.exists(_.nonEmpty)) =>
+                container.content.items.flatten.nonEmpty || container.content.archiveChoices.exists(_.nonEmpty) ||
+                container.supporting.nonEmpty) =>
           s"ad container '${container.id}' must have an adSlot and no title or puzzle content"
-        case container if !container.variant.contains("ad") && container.adSlot.nonEmpty =>
-          s"container '${container.id}' has an adSlot without the ad variant"
+        case container if container.variant.contains("supporting") && container.adSlot.exists(_ != "mostpop") =>
+          s"supporting container '${container.id}' has an unsupported adSlot"
+        case container
+            if !container.variant
+              .contains("ad") && !container.variant.contains("supporting") && container.adSlot.nonEmpty =>
+          s"container '${container.id}' has an adSlot without an ad variant"
         case container if container.variant.contains("ad") && !topLevelIds.contains(container.id) =>
           s"ad container '${container.id}' must be top-level"
-        case container if !container.variant.contains("ad") && container.title.trim.isEmpty =>
+        case container if container.variant.contains("supporting") && !topLevelIds.contains(container.id) =>
+          s"supporting container '${container.id}' must be top-level"
+        case container
+            if !container.variant
+              .contains("ad") && !container.variant.contains("supporting") && container.title.trim.isEmpty =>
           s"container '${container.id}' must have a title"
+        case container
+            if container.variant.contains("supporting") &&
+              (container.supporting.isEmpty || container.title.nonEmpty || container.content.items.flatten.nonEmpty ||
+                container.content.nestedContainers.nonEmpty || container.content.archive.nonEmpty ||
+                container.content.archiveChoices.exists(_.nonEmpty)) =>
+          s"supporting container '${container.id}' must have supporting content and no title or puzzle content"
+        case container if !container.variant.contains("supporting") && container.supporting.nonEmpty =>
+          s"container '${container.id}' has supporting content without the supporting variant"
+      } ++
+      containers.flatMap(_.supporting).flatMap { supporting =>
+        val invalidLinks = supporting.usefulLinks.filter(link =>
+          link.title.trim.isEmpty || !(link.url.startsWith("/puzzles") || link.url.matches("https?://.+")),
+        )
+        val invalidGroups = supporting.popularGroups.filter(group => group.title.trim.isEmpty || group.itemIds.isEmpty)
+        val invalidNewsletter = supporting.newsletter.exists(newsletter =>
+          newsletter.identityName.trim.isEmpty || newsletter.name.trim.isEmpty || newsletter.frequency.trim.isEmpty ||
+            newsletter.description.trim.isEmpty,
+        )
+
+        invalidLinks.map(link => s"supporting link '${link.title}' has an invalid title or URL") ++
+          invalidGroups.map(group => s"popular group '${group.title}' must have a title and puzzle IDs") ++
+          Option.when(
+            supporting.usefulLinksTitle.trim.isEmpty || supporting.popularTitle.trim.isEmpty || invalidNewsletter,
+          )("supporting content has incomplete headings or newsletter metadata")
       } ++
       containers.collect {
         case container if container.content.archive.nonEmpty && container.content.archiveChoices.exists(_.nonEmpty) =>

--- a/common/app/model/PuzzlesLayout.scala
+++ b/common/app/model/PuzzlesLayout.scala
@@ -60,6 +60,7 @@ case class PuzzleContainer(
     title: String,
     variant: Option[String] = None,
     content: PuzzleContent,
+    enabled: Option[Boolean] = None,
     desktopSpan: Option[Int] = None,
     adSlot: Option[String] = None,
     supporting: Option[PuzzlesSupportingContent] = None,
@@ -73,6 +74,7 @@ object PuzzleContainer {
       (__ \ "title").read[String] and
       (__ \ "variant").readNullable[String] and
       (__ \ "content").lazyRead[PuzzleContent](PuzzleContent.format) and
+      (__ \ "enabled").readNullable[Boolean] and
       (__ \ "desktopSpan").readNullable[Int] and
       (__ \ "adSlot").readNullable[String] and
       (__ \ "supporting").readNullable[PuzzlesSupportingContent]
@@ -89,6 +91,7 @@ object PuzzleContainer {
       (__ \ "title").write[String] and
       (__ \ "variant").writeNullable[String] and
       (__ \ "content").lazyWrite[PuzzleContent](PuzzleContent.format) and
+      (__ \ "enabled").writeNullable[Boolean] and
       (__ \ "desktopSpan").writeNullable[Int] and
       (__ \ "adSlot").writeNullable[String] and
       (__ \ "supporting").writeNullable[PuzzlesSupportingContent]
@@ -202,6 +205,8 @@ object PuzzlesLayout {
           s"supporting container '${container.id}' must have supporting content and no title or puzzle content"
         case container if !container.variant.contains("supporting") && container.supporting.nonEmpty =>
           s"container '${container.id}' has supporting content without the supporting variant"
+        case container if !container.variant.contains("featured") && container.enabled.nonEmpty =>
+          s"container '${container.id}' has enabled without the featured variant"
       } ++
       containers.flatMap(_.supporting).flatMap { supporting =>
         val invalidLinks = supporting.usefulLinks.filter(link =>

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -233,7 +233,7 @@ object NavLinks {
       NavLink("Special", "/crosswords/series/special"),
     ),
   )
-  val puzzles = NavLink("Puzzles and Games", "/puzzles-and-games")
+  val puzzles = NavLink("Puzzles and games", "/puzzles-and-games")
   val legacyWordiply = NavLink(
     "Wordiply",
     "https://www.wordiply.com",

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -233,15 +233,7 @@ object NavLinks {
       NavLink("Special", "/crosswords/series/special"),
     ),
   )
-  var puzzles = NavLink(
-    "Puzzles and Games",
-    "/puzzles",
-    children = List(
-      NavLink("Crossword", "/puzzles#crossword"),
-      NavLink("Logic", "/puzzles#logic"),
-      NavLink("Word games", "/puzzles#word-games"),
-    ),
-  )
+  val puzzles = NavLink("Puzzles and Games", "/puzzles-and-games")
   val legacyWordiply = NavLink(
     "Wordiply",
     "https://www.wordiply.com",

--- a/common/app/staticpages/StaticPages.scala
+++ b/common/app/staticpages/StaticPages.scala
@@ -53,7 +53,7 @@ object StaticPages {
       MetaData.make(
         id = id,
         section = Option(SectionId(value = "puzzles-and-games")),
-        webTitle = "Puzzles and Games",
+        webTitle = "Puzzles and games",
         description = None,
         contentType = Some(DotcomContentType.Tag),
         iosType = None,

--- a/common/app/staticpages/StaticPages.scala
+++ b/common/app/staticpages/StaticPages.scala
@@ -52,7 +52,7 @@ object StaticPages {
     SimplePage(
       MetaData.make(
         id = id,
-        section = Option(SectionId(value = "puzzles")),
+        section = Option(SectionId(value = "puzzles-and-games")),
         webTitle = "Puzzles and Games",
         description = None,
         contentType = Some(DotcomContentType.Tag),

--- a/common/test/ab/PuzzlesHubExperimentTest.scala
+++ b/common/test/ab/PuzzlesHubExperimentTest.scala
@@ -24,6 +24,11 @@ import play.api.test.FakeRequest
     PuzzlesHubExperiment.isEnabled should be(false)
   }
 
+  it should "return true in local development without experiment participation" in {
+    implicit val request: RequestHeader = FakeRequest()
+    PuzzlesHubExperiment.isEnabled(isDevelopment = true) should be(true)
+  }
+
   it should "return false for an unknown group" in {
     implicit val request: RequestHeader = requestWithParticipation("puzzles-new-hub:unknown")
     PuzzlesHubExperiment.isEnabled should be(false)

--- a/common/test/model/PuzzlesLayoutTest.scala
+++ b/common/test/model/PuzzlesLayoutTest.scala
@@ -190,7 +190,14 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
   }
 
   it should "support ad placements and multiple archive choices" in {
-    val archive = PuzzleItem("archive-one", "Archive one", "word-game", "all", "archive", url = Some("/puzzles/one"))
+    val archive = PuzzleItem(
+      "archive-one",
+      "Archive one",
+      "word-game",
+      "all",
+      "archive",
+      url = Some("/puzzles-and-games/one"),
+    )
     val section = PuzzleContainer(
       id = "word-games",
       title = "Word games",

--- a/common/test/model/PuzzlesLayoutTest.scala
+++ b/common/test/model/PuzzlesLayoutTest.scala
@@ -8,64 +8,81 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
 
   private val representativeLayoutJson = Json.parse(
     """
-      |{
-      |  "filters": [{"id":"logic","title":"Logic","backgroundColour":"#CDECFB"}],
-      |  "containers": [{
-      |    "title":"Logic puzzles",
-      |    "variant":"standard",
-      |    "filterId":"logic",
-      |    "content": {
-      |      "items": [[{
-      |        "title":"Sudoku",
-      |        "type":"sudoku",
-      |        "set":"easy",
-      |        "url":"https://example.com/sudoku",
-      |        "image":"https://example.com/sudoku.png",
-      |        "slug":"sudoku-easy",
-      |        "index":1,
-      |        "variant":"iframe-page",
-      |        "backgroundColour":"#CDECFB",
-      |        "filterId":"logic"
-      |      }]],
-      |      "nestedContainers": [{
-      |        "title":"More logic",
-      |        "desktopSpan":6,
-      |        "content": {
-      |          "items":[[{
-      |            "title":"Futoshiki",
-      |            "type":"futoshiki",
-      |            "set":"all"
-      |          }]],
-      |          "nestedContainers":[],
-      |          "archive": {
-      |            "title":"Archive",
-      |            "type":"futoshiki",
-      |            "set":"all",
-      |            "slug":"futoshiki",
-      |            "url":"https://example.com/futoshiki/archive",
-      |            "variant":"archive-page"
-      |          }
-      |        }
-      |      }]
-      |    }
-      |  }]
-      |}
-      |""".stripMargin,
+ |{
+ | "filters": [{
+ | "id":"logic",
+ | "title":"Logic",
+ | "target":"#logic-puzzles",
+ | "backgroundColour":"#CDECFB"
+ | }],
+ | "containers": [{
+ | "id":"logic-puzzles",
+ | "title":"Logic puzzles",
+ | "variant":"standard",
+ | "filterId":"logic",
+ | "content": {
+ | "items": [[{
+ | "id":"sudoku-easy",
+ | "title":"Sudoku",
+ | "type":"sudoku",
+ | "set":"easy",
+ | "cardVariant":"primary",
+ | "cadence":"Daily",
+ | "url":"https://example.com/sudoku",
+ | "image":"https://example.com/sudoku.png",
+ | "slug":"sudoku-easy",
+ | "index":1,
+ | "variant":"iframe-page",
+ | "backgroundColour":"#CDECFB",
+ | "filterId":"logic"
+ | }]],
+ | "nestedContainers": [{
+ | "id":"more-logic",
+ | "title":"More logic",
+ | "desktopSpan":6,
+ | "content": {
+ | "items":[[{
+ | "id":"futoshiki-daily",
+ | "title":"Futoshiki",
+ | "type":"futoshiki",
+ | "set":"all",
+ | "cardVariant":"compact",
+ | "cadence":"Daily"
+ | }]],
+ | "nestedContainers":[],
+ | "archive": {
+ | "id":"futoshiki-archive",
+ | "title":"Archive",
+ | "type":"futoshiki",
+ | "set":"all",
+ | "cardVariant":"archive",
+ | "slug":"futoshiki",
+ | "url":"https://example.com/futoshiki/archive",
+ | "variant":"archive-page"
+ | }
+ | }
+ | }]
+ | }
+ | }]
+ |}
+ |""".stripMargin,
   )
 
-  "PuzzlesLayout JSON format" should "parse grouped items, nested containers, archive entries and responsive fields" in {
+  "PuzzlesLayout JSON format" should "parse presentation metadata, grouped rows, navigation and archives" in {
     val layout = representativeLayoutJson.as[PuzzlesLayout]
     val container = layout.containers.head
     val item = container.content.items.head.head
     val nested = container.content.nestedContainers.head
 
-    layout.filters.head.backgroundColour shouldBe Some("#CDECFB")
+    layout.filters.head.target shouldBe "#logic-puzzles"
+    container.id shouldBe "logic-puzzles"
     container.variant shouldBe Some("standard")
-    item.slug shouldBe Some("sudoku-easy")
-    item.index shouldBe Some(1)
+    item.id shouldBe "sudoku-easy"
+    item.cardVariant shouldBe "primary"
+    item.cadence shouldBe Some("Daily")
     item.image shouldBe Some("https://example.com/sudoku.png")
     nested.desktopSpan shouldBe Some(6)
-    nested.content.archive.map(_.variant) shouldBe Some(Some("archive-page"))
+    nested.content.archive.map(_.cardVariant) shouldBe Some("archive")
   }
 
   it should "preserve the DCR payload shape when serializing" in {
@@ -74,38 +91,114 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
     Json.toJson(layout) shouldBe representativeLayoutJson
   }
 
-  it should "omit absent optional item, container, archive and filter fields" in {
+  it should "omit absent optional item, container, archive and navigation fields" in {
     val layout = PuzzlesLayout(
       containers = Seq(
         PuzzleContainer(
+          id = "crosswords",
           title = "Crosswords",
           content = PuzzleContent(
-            items = Seq(Seq(PuzzleItem("Quick", "crossword", "quick"))),
+            items = Seq(
+              Seq(PuzzleItem("crossword-quick", "Quick", "crossword", "quick", "primary", Some("Daily"))),
+            ),
             nestedContainers = Seq.empty,
           ),
         ),
       ),
-      filters = Seq(PuzzleFilter("crosswords", "Crosswords")),
+      filters = Seq(PuzzleFilter("crosswords", "Crosswords", "#crosswords")),
     )
 
     Json.toJson(layout) shouldBe Json.parse(
       """{
-        |  "containers":[{
-        |    "title":"Crosswords",
-        |    "content":{
-        |      "items":[[{"title":"Quick","type":"crossword","set":"quick"}]],
-        |      "nestedContainers":[]
-        |    }
-        |  }],
-        |  "filters":[{"id":"crosswords","title":"Crosswords"}]
-        |}""".stripMargin,
+ | "containers":[{
+ | "id":"crosswords",
+ | "title":"Crosswords",
+ | "content":{
+ | "items":[[{
+ | "id":"crossword-quick",
+ | "title":"Quick",
+ | "type":"crossword",
+ | "set":"quick",
+ | "cardVariant":"primary",
+ | "cadence":"Daily"
+ | }]],
+ | "nestedContainers":[]
+ | }
+ | }],
+ | "filters":[{"id":"crosswords","title":"Crosswords","target":"#crosswords"}]
+ |}""".stripMargin,
     )
+  }
+
+  it should "reject unsupported card variants and missing cadence" in {
+    val invalidVariant = representativeLayoutJson.as[play.api.libs.json.JsObject] ++ Json.obj(
+      "containers" -> Json.arr(
+        Json.obj(
+          "id" -> "broken",
+          "title" -> "Broken",
+          "content" -> Json.obj(
+            "items" -> Json.arr(
+              Json.arr(
+                Json.obj(
+                  "id" -> "broken-item",
+                  "title" -> "Broken",
+                  "type" -> "quiz",
+                  "set" -> "all",
+                  "cardVariant" -> "hero",
+                ),
+              ),
+            ),
+            "nestedContainers" -> Json.arr(),
+          ),
+        ),
+      ),
+    )
+
+    invalidVariant.validate[PuzzlesLayout] shouldBe a[JsError]
+  }
+
+  it should "reject duplicate puzzle IDs, broken navigation anchors and unknown filter references" in {
+    val duplicate = PuzzleItem("duplicate", "One", "quiz", "one", "primary", Some("Daily"))
+    val layout = PuzzlesLayout(
+      containers = Seq(
+        PuzzleContainer(
+          id = "section",
+          title = "Section",
+          content = PuzzleContent(Seq(Seq(duplicate, duplicate.copy(title = "Two"))), Seq.empty),
+          filterId = Some("missing-filter"),
+        ),
+      ),
+      filters = Seq(PuzzleFilter("navigation", "Navigation", "#missing-section")),
+    )
+
+    val errors = PuzzlesLayout.validationErrors(layout)
+
+    errors should contain("duplicate puzzle id 'duplicate'")
+    errors should contain("navigation target '#missing-section' has no container")
+    errors should contain("filterId 'missing-filter' is not defined")
+    Json.toJson(layout).validate[PuzzlesLayout] shouldBe a[JsError]
+  }
+
+  it should "reject unsupported desktop spans and navigation targets" in {
+    val json = Json.parse(
+      """{
+ | "filters":[{"id":"crosswords","title":"Crosswords","target":"/crosswords"}],
+ | "containers":[{
+ | "id":"crosswords",
+ | "title":"Crosswords",
+ | "desktopSpan":13,
+ | "content":{"items":[],"nestedContainers":[]}
+ | }]
+ |}""".stripMargin,
+    )
+
+    json.validate[PuzzlesLayout] shouldBe a[JsError]
   }
 
   it should "reject a partially valid contract" in {
     val result = Json
       .parse(
-        """{"containers":[{"title":"Broken","content":{"items":[[{"title":"Missing fields"}]],"nestedContainers":[]}}]}""",
+        """{"containers":[{"id":"broken","title":"Broken","content":{"items":[[{"title":"Missing fields"}]],"nestedContainers":[]}}]}""",
       )
       .validate[PuzzlesLayout]
 

--- a/common/test/model/PuzzlesLayoutTest.scala
+++ b/common/test/model/PuzzlesLayoutTest.scala
@@ -9,17 +9,10 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
   private val representativeLayoutJson = Json.parse(
     """
  |{
- | "filters": [{
- | "id":"logic",
- | "title":"Logic",
- | "target":"#logic-puzzles",
- | "backgroundColour":"#CDECFB"
- | }],
  | "containers": [{
  | "id":"logic-puzzles",
  | "title":"Logic puzzles",
  | "variant":"standard",
- | "filterId":"logic",
  | "content": {
  | "items": [[{
  | "id":"sudoku-easy",
@@ -33,8 +26,7 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
  | "slug":"sudoku-easy",
  | "index":1,
  | "variant":"iframe-page",
- | "backgroundColour":"#CDECFB",
- | "filterId":"logic"
+ | "backgroundColour":"#CDECFB"
  | }]],
  | "nestedContainers": [{
  | "id":"more-logic",
@@ -68,13 +60,12 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
  |""".stripMargin,
   )
 
-  "PuzzlesLayout JSON format" should "parse presentation metadata, grouped rows, navigation and archives" in {
+  "PuzzlesLayout JSON format" should "parse presentation metadata, grouped rows and archives" in {
     val layout = representativeLayoutJson.as[PuzzlesLayout]
     val container = layout.containers.head
     val item = container.content.items.head.head
     val nested = container.content.nestedContainers.head
 
-    layout.filters.head.target shouldBe "#logic-puzzles"
     container.id shouldBe "logic-puzzles"
     container.variant shouldBe Some("standard")
     item.id shouldBe "sudoku-easy"
@@ -91,7 +82,7 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
     Json.toJson(layout) shouldBe representativeLayoutJson
   }
 
-  it should "omit absent optional item, container, archive and navigation fields" in {
+  it should "omit absent optional item, container and archive fields" in {
     val layout = PuzzlesLayout(
       containers = Seq(
         PuzzleContainer(
@@ -105,7 +96,6 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
           ),
         ),
       ),
-      filters = Seq(PuzzleFilter("crosswords", "Crosswords", "#crosswords")),
     )
 
     Json.toJson(layout) shouldBe Json.parse(
@@ -124,8 +114,7 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
  | }]],
  | "nestedContainers":[]
  | }
- | }],
- | "filters":[{"id":"crosswords","title":"Crosswords","target":"#crosswords"}]
+ | }]
  |}""".stripMargin,
     )
   }
@@ -157,7 +146,7 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
     invalidVariant.validate[PuzzlesLayout] shouldBe a[JsError]
   }
 
-  it should "reject duplicate puzzle IDs, broken navigation anchors and unknown filter references" in {
+  it should "reject duplicate puzzle IDs" in {
     val duplicate = PuzzleItem("duplicate", "One", "quiz", "one", "primary", Some("Daily"))
     val layout = PuzzlesLayout(
       containers = Seq(
@@ -165,24 +154,19 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
           id = "section",
           title = "Section",
           content = PuzzleContent(Seq(Seq(duplicate, duplicate.copy(title = "Two"))), Seq.empty),
-          filterId = Some("missing-filter"),
         ),
       ),
-      filters = Seq(PuzzleFilter("navigation", "Navigation", "#missing-section")),
     )
 
     val errors = PuzzlesLayout.validationErrors(layout)
 
     errors should contain("duplicate puzzle id 'duplicate'")
-    errors should contain("navigation target '#missing-section' has no container")
-    errors should contain("filterId 'missing-filter' is not defined")
     Json.toJson(layout).validate[PuzzlesLayout] shouldBe a[JsError]
   }
 
-  it should "reject unsupported desktop spans and navigation targets" in {
+  it should "reject unsupported desktop spans" in {
     val json = Json.parse(
       """{
- | "filters":[{"id":"crosswords","title":"Crosswords","target":"/crosswords"}],
  | "containers":[{
  | "id":"crosswords",
  | "title":"Crosswords",

--- a/common/test/model/PuzzlesLayoutTest.scala
+++ b/common/test/model/PuzzlesLayoutTest.scala
@@ -204,4 +204,41 @@ class PuzzlesLayoutTest extends AnyFlatSpec with Matchers {
 
     result shouldBe a[JsError]
   }
+
+  it should "support ad placements and multiple archive choices" in {
+    val archive = PuzzleItem("archive-one", "Archive one", "word-game", "all", "archive", url = Some("/puzzles/one"))
+    val section = PuzzleContainer(
+      id = "word-games",
+      title = "Word games",
+      content = PuzzleContent(
+        items = Seq(Seq(PuzzleItem("word-game", "Word game", "word-game", "all", "primary", Some("Daily")))),
+        nestedContainers = Seq.empty,
+        archiveChoices = Some(Seq(archive, archive.copy(id = "archive-two", title = "Archive two"))),
+      ),
+    )
+    val advert = PuzzleContainer(
+      id = "inline-ad",
+      title = "",
+      variant = Some("ad"),
+      content = PuzzleContent(Seq.empty, Seq.empty),
+      adSlot = Some("inline1"),
+    )
+    val layout = PuzzlesLayout(Seq(section, advert))
+
+    PuzzlesLayout.validationErrors(layout) shouldBe empty
+    ((Json.toJson(layout) \ "containers")(1) \ "adSlot").as[String] shouldBe "inline1"
+  }
+
+  it should "reject malformed ad and archive composition" in {
+    val malformedAd = PuzzleContainer(
+      id = "ad",
+      title = "Not empty",
+      variant = Some("ad"),
+      content = PuzzleContent(Seq.empty, Seq.empty),
+      adSlot = Some("bad-slot"),
+    )
+    val layout = PuzzlesLayout(Seq(malformedAd))
+
+    Json.toJson(layout).validate[PuzzlesLayout] shouldBe a[JsError]
+  }
 }

--- a/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
@@ -13,9 +13,12 @@ import staticpages.StaticPages
   private val layout = PuzzlesLayout(
     containers = Seq(
       PuzzleContainer(
+        id = "daily-puzzles",
         title = "Daily puzzles",
         content = PuzzleContent(
-          items = Seq(Seq(PuzzleItem("Quick crossword", "crossword", "quick"))),
+          items = Seq(
+            Seq(PuzzleItem("crossword-quick", "Quick crossword", "crossword", "quick", "primary", Some("Daily"))),
+          ),
           nestedContainers = Seq.empty,
         ),
       ),

--- a/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
@@ -26,7 +26,7 @@ import staticpages.StaticPages
   )
 
   private def requestWithParticipations: RequestHeader = {
-    implicit val request: RequestHeader = FakeRequest("GET", "/puzzles")
+    implicit val request: RequestHeader = FakeRequest("GET", "/puzzles-and-games")
       .withHeaders(
         "Host" -> "www.theguardian.com",
         "X-GU-Server-AB-Tests" -> "puzzles-new-hub:variant,another-test:control",
@@ -36,30 +36,31 @@ import staticpages.StaticPages
 
   "DotcomPuzzlesPageRenderingDataModel" should "serialize the complete puzzles rendering payload" in {
     val model = DotcomPuzzlesPageRenderingDataModel(
-      StaticPages.dcrSimplePuzzlesPage("/puzzles"),
+      StaticPages.dcrSimplePuzzlesPage("/puzzles-and-games"),
       layout,
       requestWithParticipations,
     )
 
     val json = DotcomPuzzlesPageRenderingDataModel.toJson(model)
 
-    (json \ "id").as[String] should be("/puzzles")
+    (json \ "id").as[String] should be("/puzzles-and-games")
     (json \ "webTitle").as[String] should be("Puzzles and Games")
     (json \ "editionId").as[String] should not be empty
     (json \ "nav").toOption should not be empty
     (json \ "pageFooter").toOption should not be empty
     (json \ "commercialProperties").toOption should not be empty
-    (json \ "canonicalUrl").as[String] should endWith("/puzzles")
+    (json \ "canonicalUrl").as[String] should endWith("/puzzles-and-games")
     (json \ "layout").as[PuzzlesLayout] should be(layout)
     val puzzlesNav = (json \ "nav" \ "otherLinks").as[Seq[play.api.libs.json.JsObject]]
     puzzlesNav
-      .find(link => (link \ "url").as[String] == "/puzzles")
-      .map(link => (link \ "title").as[String]) should contain("Puzzles and Games")
+      .find(link => (link \ "url").as[String] == "/puzzles-and-games")
+      .map(link => (link \ "title").as[String]) should
+      contain("Puzzles and Games")
   }
 
   it should "propagate every current server-side AB-test participation" in {
     val model = DotcomPuzzlesPageRenderingDataModel(
-      StaticPages.dcrSimplePuzzlesPage("/puzzles"),
+      StaticPages.dcrSimplePuzzlesPage("/puzzles-and-games"),
       layout,
       requestWithParticipations,
     )

--- a/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
+++ b/common/test/model/dotcomrendering/DotcomPuzzlesPageRenderingDataModelTest.scala
@@ -44,7 +44,7 @@ import staticpages.StaticPages
     val json = DotcomPuzzlesPageRenderingDataModel.toJson(model)
 
     (json \ "id").as[String] should be("/puzzles-and-games")
-    (json \ "webTitle").as[String] should be("Puzzles and Games")
+    (json \ "webTitle").as[String] should be("Puzzles and games")
     (json \ "editionId").as[String] should not be empty
     (json \ "nav").toOption should not be empty
     (json \ "pageFooter").toOption should not be empty
@@ -55,7 +55,7 @@ import staticpages.StaticPages
     puzzlesNav
       .find(link => (link \ "url").as[String] == "/puzzles-and-games")
       .map(link => (link \ "title").as[String]) should
-      contain("Puzzles and Games")
+      contain("Puzzles and games")
   }
 
   it should "propagate every current server-side AB-test participation" in {

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -290,12 +290,12 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     val controlRequest = requestWithParticipations("puzzles-new-hub:control")
     val page = StaticPages.dcrSimplePuzzlesPage("/puzzles-and-games")
 
-    Nav(page, Uk, variantRequest).otherLinks should contain(puzzles)
-    Nav(page, Uk, variantRequest).otherLinks should contain(legacyCrosswords)
-    Nav(page, Uk, variantRequest).otherLinks should contain(legacyWordiply)
+    Nav(page, Uk, variantRequest, None).otherLinks should contain(puzzles)
+    Nav(page, Uk, variantRequest, None).otherLinks should contain(legacyCrosswords)
+    Nav(page, Uk, variantRequest, None).otherLinks should contain(legacyWordiply)
 
-    Nav(page, Uk, controlRequest).otherLinks should contain(legacyCrosswords)
-    Nav(page, Uk, controlRequest).otherLinks should not contain puzzles
-    Nav(page, Uk, controlRequest).otherLinks should contain(legacyWordiply)
+    Nav(page, Uk, controlRequest, None).otherLinks should not contain puzzles
+    Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyCrosswords)
+    Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyWordiply)
   }
 }

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -246,14 +246,10 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
 
   "Puzzles navigation" should "add Puzzles and Games alongside the legacy links in every edition for variant requests" in {
     val request = requestWithParticipations("puzzles-new-hub:variant")
-    puzzles.children shouldBe Seq(
-      NavLink("Crossword", "/puzzles#crossword"),
-      NavLink("Logic", "/puzzles#logic"),
-      NavLink("Word games", "/puzzles#word-games"),
-    )
+    puzzles.children shouldBe empty
 
     Edition.allEditions.foreach { edition =>
-      val menu = NavMenu(StaticPages.dcrSimplePuzzlesPage("/puzzles"), edition, request)
+      val menu = NavMenu(StaticPages.dcrSimplePuzzlesPage("/puzzles-and-games"), edition, request)
 
       menu.otherLinks should contain(puzzles)
       menu.otherLinks should contain(legacyCrosswords)
@@ -292,14 +288,14 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
   "DCR Nav" should "contain the request-selected puzzles navigation" in {
     val variantRequest = requestWithParticipations("puzzles-new-hub:variant")
     val controlRequest = requestWithParticipations("puzzles-new-hub:control")
-    val page = StaticPages.dcrSimplePuzzlesPage("/puzzles")
+    val page = StaticPages.dcrSimplePuzzlesPage("/puzzles-and-games")
 
-    Nav(page, Uk, variantRequest, None).otherLinks should contain(puzzles)
-    Nav(page, Uk, variantRequest, None).otherLinks should contain(legacyCrosswords)
-    Nav(page, Uk, variantRequest, None).otherLinks should contain(legacyWordiply)
+    Nav(page, Uk, variantRequest).otherLinks should contain(puzzles)
+    Nav(page, Uk, variantRequest).otherLinks should contain(legacyCrosswords)
+    Nav(page, Uk, variantRequest).otherLinks should contain(legacyWordiply)
 
-    Nav(page, Uk, controlRequest, None).otherLinks should not contain puzzles
-    Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyCrosswords)
-    Nav(page, Uk, controlRequest, None).otherLinks should contain(legacyWordiply)
+    Nav(page, Uk, controlRequest).otherLinks should contain(legacyCrosswords)
+    Nav(page, Uk, controlRequest).otherLinks should not contain puzzles
+    Nav(page, Uk, controlRequest).otherLinks should contain(legacyWordiply)
   }
 }

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -244,7 +244,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     ABTests.decorateRequest("X-GU-Server-AB-Tests")(request)
   }
 
-  "Puzzles navigation" should "add Puzzles and Games alongside the legacy links in every edition for variant requests" in {
+  "Puzzles navigation" should "add Puzzles and games alongside the legacy links in every edition for variant requests" in {
     val request = requestWithParticipations("puzzles-new-hub:variant")
     puzzles.children shouldBe empty
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -13,8 +13,8 @@ GET            /assets/internal/*file                                           
 GET            /assets/*path                                                                                                     dev.DevAssetsController.at(path)
 
 # Puzzles
-GET        /puzzles.json                                                                                                         controllers.PuzzlesPageController.renderPuzzlesJson()
-GET        /puzzles                                                                                                              controllers.PuzzlesPageController.renderPuzzles()
+GET        /puzzles-and-games.json                                                                                                         controllers.PuzzlesPageController.renderPuzzlesJson()
+GET        /puzzles-and-games                                                                                                              controllers.PuzzlesPageController.renderPuzzles()
 
 # Crosswords
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.


### PR DESCRIPTION
## What is the value of this and can you measure success?

This introduces a central hub where readers can discover daily crosswords, word games, logic puzzles, archives, and supporting content.

Success can be measured through:

- Visits to `/puzzles-and-games`.
- Puzzle card clicks and game starts.
- Archive engagement.
- Newsletter sign-ups from the hub. (Only UI)
- Engagement differences in the `puzzles-new-hub` experiment.

## What does this change?

- Adds the `/puzzles-and-games` and `/puzzles-and-games.json` routes.
- Adds equivalent routes to the local `dev-build`.
- Gates the hub and its navigation entry behind the Fastly-managed `puzzles-new-hub` experiment.
- Enables the experiment automatically in local development.
- Provides the Puzzles Page rendering model consumed by dotcom-rendering.
- Loads and validates the page structure from `puzzles-layout.json`.
- Selects two featured puzzles programmatically according to the current weekday in the `Europe/London` timezone.
- Uses CAPI to resolve the latest crossword number for configured crossword series.
- Generates current crossword player and image URLs while preserving configured image overrides.
- Points current crossword cards to `/puzzles-and-games/crosswords/:type/:id` by default
- Links crossword archive choices to the existing `/crosswords/series/...` pages.
- Supports configured card images, card variants, archives, ads, useful links, newsletter content, and popularity lists.
- Adds the experiment-gated “Puzzles and Games” navigation entry.
- Removes the Crossword, Logic, and Word games child links from that navigation entry. (This was previously a requirement, but we were later asked to remove it)
- Adds and updates tests for layout parsing, validation, enrichment, featured-puzzle scheduling, routes, and navigation.

This PR supplies the data model and configuration required by the corresponding dotcom-rendering implementation.


## Checklist

- [x] Tested locally, and on CODE if necessary
- [x] Will not break dotcom-rendering
- [x] Any new [test `data/database` files generated by tests](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md) are committed with this PR (no new files were generated)
- [ ] Meets our [accessibility standards](https://github.com/guardian/recommendations/blob/e647ef695199ea3116ea20d827ef0f1364270a39/accessibility.md)
  - [ ] [Tested with a screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
  - [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#Keyboard)
  - [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#colour)

## Automated verification

- Frontend Applications suite: 138 tests passed.
- Frontend Common suite: 78 tests passed.
- Coverage includes layout parsing and validation, CAPI enrichment, configured image overrides, weekday-based featured puzzles, experiment gating, navigation, and URL generation.