### PR TITLE
Bump consent-manager to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@emotion/styled": "^11.14.0",
 		"@guardian/ab-core": "8.0.0",
 		"@guardian/commercial-core": "34.0.0",
-		"@guardian/consent-manager": "2.1.0",
+		"@guardian/consent-manager": "2.1.1",
 		"@guardian/core-web-vitals": "6.0.0",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2328,9 +2328,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@guardian/consent-manager@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@guardian/consent-manager@npm:2.1.0"
+"@guardian/consent-manager@npm:2.1.1":
+  version: 2.1.1
+  resolution: "@guardian/consent-manager@npm:2.1.1"
   dependencies:
     "@guardian/libs": "npm:33.0.0"
     "@guardian/ophan-tracker-js": "npm:3.1.0"
@@ -2340,7 +2340,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/1bc4f608024a3cd39531d72076b1cdeacc0c1b31d73123ff1e37e2cafe3a359f0e16e98c585f7509363958e4f5eaca85c0fdc32746aac5ac0a6f88b944c1c726
+  checksum: 10c0/751f810c4677e69d729f8eb69fc2c6f030b34c9ade0b390aa2f1814b9cf7007111127d95929c532dba9eaa5e1488062cca44cc1eacffb80f84581c29874f7c7d
   languageName: node
   linkType: hard
 
@@ -2382,7 +2382,7 @@ __metadata:
     "@emotion/styled": "npm:^11.14.0"
     "@guardian/ab-core": "npm:8.0.0"
     "@guardian/commercial-core": "npm:34.0.0"
-    "@guardian/consent-manager": "npm:2.1.0"
+    "@guardian/consent-manager": "npm:2.1.1"
     "@guardian/core-web-vitals": "npm:6.0.0"
     "@guardian/identity-auth": "npm:6.0.1"
     "@guardian/identity-auth-frontend": "npm:8.1.0"


### PR DESCRIPTION
## What does this change?
This bumps `@guardian/consent-manager `to latest version, `2.1.1` (https://github.com/guardian/csnx/pull/2489)
## Why?
This new version includes an update to the list of US states to be included in US states.
## How has this change been tested?
Deployed to CODE

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
